### PR TITLE
fix: commit reasoning budget transitions through engine state

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,10 +203,11 @@ Two serving-side additions since: **P16 persistent prefix cache** (opt-in,
 P8 stable prefix to disk -- restart TTFT **8.15 s -> 1.20 s** on a 26,700-token
 prompt, bitwise-identical continuations, with an optional pinned host-RAM tier
 above it (`--prefix-cache-ram-gb`). And a **reasoning-token budget**, ON by
-default whenever a `<think>` block is served: the block is force-closed at half
-the request's `max_tokens` and the model still answers, because an A/B over 240
-scenarios found unbudgeted block mode truncating 28 times against inline's 0
-while scoring level on raw accuracy. See Serving for both.
+default when the rendered prompt begins inside a `<think>` block: the block is
+force-closed at half the request's `max_tokens` and the model still answers,
+because an A/B over 240 scenarios found unbudgeted block mode truncating 28
+times against inline's 0 while scoring level on raw accuracy. Later model-
+generated reasoning is capped only when explicitly armed. See Serving for both.
 
 ### Reference numbers (v0.2.0, 2026-07-16, vanilla model, 5090)
 
@@ -609,17 +610,32 @@ answer. When a client omits `max_tokens` the server defaults it to 8192
 thinking trace wants more, set it explicitly.
 
 **Reasoning budget (2026-07-30).** Tokens generated inside a prompt-seeded
-`<think>` block are capped; on trip the block is force-closed and the model
+`<think>` block are budgeted; on trip the block is force-closed and the model
 answers with what it has. It is not a hard stop -- truncating the request
-instead would reproduce the failure the cap exists to prevent. The default is
+instead would reproduce the failure the budget exists to prevent. The default is
 **half the request's `max_tokens`**, so the answer still fits after the close.
-Ordinary no-think requests remain unbounded and retain full sampled speculative
-decode width. `--think-budget N` with `N>0` explicitly arms that cap even for a
-later model-generated block; `--think-budget 0` opts out. Requests can likewise
-arm or override the budget, gated behind `--request-think`:
+The prompt-seeded scope is intentional: standard thinking-enabled serving
+starts inside the template-provided reasoning block, while a later model-
+generated block is capped only when explicitly armed. `--think-budget N` with
+`N>0` arms that later-block cap; `--think-budget 0` opts out. Requests can
+likewise arm or override the budget, gated behind `--request-think`:
 `thinking.budget_tokens` (Anthropic), `thinking_token_budget` (OpenAI/Qwen), or
-`chat_template_kwargs.thinking_budget` (llama.cpp). A trip is reported as
-`usage.reasoning_tokens` and `usage.reasoning_budget_exceeded`.
+`chat_template_kwargs.thinking_budget` (llama.cpp). Chat Completions and
+Messages report a trip as `usage.reasoning_tokens` and
+`usage.reasoning_budget_exceeded`; Responses reports the same fields under
+`usage.output_tokens_details`.
+
+Greedy checks land after the accepted speculative round, so the reasoning count
+may exceed the configured limit by that round's accepted width. A natural close
+later in the same round ends normally rather than reporting a budget trip.
+
+Bounded sampled requests intentionally use one-token acceptance rounds so every
+accepted token is a coherent budget-observation point. This disables
+speculative acceptance for the bounded request: on the reviewed RTX 5090 run,
+the exact tip measured 56.9 t/s bounded versus 143.1 t/s unbounded, a 2.51x
+reduction. Unbounded sampled requests retain normal speculative width. Restoring
+speculative width without weakening transition semantics is follow-up work.
+
 
 Why it defaults on: an 11-pack / 240-scenario A/B (BUILDLOG 2026-07-28, rescored
 07-30) found unbudgeted block mode truncating **28 times against inline's 0**

--- a/README.md
+++ b/README.md
@@ -608,18 +608,18 @@ answer. When a client omits `max_tokens` the server defaults it to 8192
 (unified across all three API shapes, clamped to the context window); a long
 thinking trace wants more, set it explicitly.
 
-**Reasoning budget (2026-07-30, ON by default whenever a block is served).**
-Tokens generated inside the `<think>` block are capped; on trip the block is
-force-closed and the model answers with what it has. It is not a hard stop --
-truncating the request instead would reproduce the failure the cap exists to
-prevent. Default is **half the request's `max_tokens`**, so the answer still
-fits after the close; `--think-budget N` sets an absolute cap and
-`--think-budget 0` opts out. Requests can bound it too, symmetric with the
-enable conventions above and gated behind the same `--request-think`:
+**Reasoning budget (2026-07-30).** Tokens generated inside a prompt-seeded
+`<think>` block are capped; on trip the block is force-closed and the model
+answers with what it has. It is not a hard stop -- truncating the request
+instead would reproduce the failure the cap exists to prevent. The default is
+**half the request's `max_tokens`**, so the answer still fits after the close.
+Ordinary no-think requests remain unbounded and retain full sampled speculative
+decode width. `--think-budget N` with `N>0` explicitly arms that cap even for a
+later model-generated block; `--think-budget 0` opts out. Requests can likewise
+arm or override the budget, gated behind `--request-think`:
 `thinking.budget_tokens` (Anthropic), `thinking_token_budget` (OpenAI/Qwen), or
 `chat_template_kwargs.thinking_budget` (llama.cpp). A trip is reported as
-`usage.reasoning_tokens` and `usage.reasoning_budget_exceeded` -- a budget that
-fired silently would be no better than the inert `budget_tokens` this replaced.
+`usage.reasoning_tokens` and `usage.reasoning_budget_exceeded`.
 
 Why it defaults on: an 11-pack / 240-scenario A/B (BUILDLOG 2026-07-28, rescored
 07-30) found unbudgeted block mode truncating **28 times against inline's 0**

--- a/docs/BUILDLOG.md
+++ b/docs/BUILDLOG.md
@@ -9999,9 +9999,48 @@ malformed-tool fallback; both were fixed and regression-pinned. The final Codex
 run returned no accepted/actionable findings (`patch is correct`, confidence
 0.91).
 
-CUDA gate: CUDA 12.8.93 on Yukon successfully rebuilt the corrected source with
+CUDA gate: CUDA 12.8.93 on our local RTX 3090 successfully rebuilt the corrected
+source with
 `make -B NVCC=/home/ddbb/.local/cuda-12.8/bin/nvcc build/q27-server-w8`.
-The compile emits only warnings in unchanged `prefill.cu` and `tokenizer.cpp`.
-No live-model result is claimed for this correction: the 3090 remained occupied
-by PID 2062415 (`evidence-wt/.venv/bin/python`, 21884 MiB), so taking the card
-would have disrupted another workload.
+The compile emitted only warnings in unchanged `prefill.cu` and `tokenizer.cpp`.
+No live-model result was claimed for this correction at the time because that
+GPU was occupied by another workload.
+
+## 2026-08-03 -- reasoning PR current-upstream stabilization and sampled pricing
+
+The five-commit reasoning candidate was rebased from `e2f150ca` onto current
+upstream `5ce983d0`. The `src/` tree is byte-identical to reviewed tip
+`1de550a7bf81`; the upstream change adds the corrected per-architecture sampling
+gate and BUILDLOG records. The PR documentation now states the intended default
+scope and sampled-budget price explicitly.
+
+Exact host gates on the rebased tree pass: conductor, think resolution and
+enforcement, stream splitting, OpenAI bridge, and chat integration. An
+independent concurrency pass found the changed queue-sink paths safe:
+`callback_forced` is written and read synchronously on the conductor thread,
+client disconnect drains to queue closure, cancellation is atomic, and every
+accepted-member normal/error path finishes decode before the final queue
+close/fail edge. It also noted a pre-existing, server-unreachable registration-
+refusal path that skips `finish_decode`; the sink is never installed there, so
+the new `DecodeTask` capture is not exposed. That bookkeeping cleanup remains
+outside this bug fix.
+
+CUDA 12.8.93 / `sm_86` on our local RTX 3090 rebuilt `q27`, `q27-server-w8`,
+`test_kernels`, and `fused_smoke`. `CANON_ARCH=sm86 tools/sampling_gate.sh`
+reports `6894254e3b1a184ee3802771ddd59c2b` EXACT and all five sampling gates
+pass. The full model-backed kernel battery ends `ALL PASS`. A live width-8,
+`Q27_BATCH=1` sampled Responses request with budget 4 reports exactly four
+reasoning tokens, `reasoning_budget_exceeded: true`, and continues into answer
+text. The two-engine fused binary cannot instantiate two full-model engines on
+the 24 GiB card, including its width-8/greedy-only profile; that is the expected
+24 GiB capacity boundary, not a candidate failure. Because the rebased `src/`
+tree is unchanged, the published A40 and maintainer-run RTX 5090 fused-smoke
+passes remain exact source evidence.
+
+Product decision: bounded sampled requests keep one-token acceptance for their
+full lifetime so every accepted token is a coherent budget boundary. The
+maintainer measured 56.9 t/s bounded versus 143.1 t/s unbounded on the reviewed
+RTX 5090 tip, a 2.51x reduction. Prompt-seeded reasoning remains covered by
+default; later model-generated reasoning is capped only when explicitly armed.
+Recovering sampled speculative width without weakening those semantics is a
+separate follow-up.

--- a/docs/BUILDLOG.md
+++ b/docs/BUILDLOG.md
@@ -9956,3 +9956,52 @@ master` still reverts the pin but would NOT remove the untracked packs.
 Artifacts in `q27/scratchpad/`: `gen_ext_packs.py` (generator + reproduction
 gate), `score_fallback.py` (classifier, imports the sandbox extractor),
 `run_blockarm.sh`.
+## 2026-08-02 -- reasoning pre-merge corrections: seeded defaults and byte-stable responses
+
+The pre-merge review found two reasoning-branch behaviors that were internally
+consistent but too expensive or too surprising to publish unchanged.
+
+**Default-budget scope.** The fractional `--think-budget` default now applies
+only when the rendered prompt actually starts inside the `<think>` channel. An
+ordinary sampled request therefore keeps its negotiated speculative width.
+Explicit request budgets and an explicit positive CLI budget still arm the
+later-block guard, so clients that intentionally permit spontaneous thinking
+retain decoder-visible force-close enforcement. `--think-budget 0` remains the
+unbounded opt-out.
+
+**Response byte parity.** Natural model whitespace is now preserved in every
+non-stream response instead of passing completed text through `strip_ws2()`.
+Only the exact whitespace belonging to a decoder-injected `</think>` control
+transition is suppressed. The OpenAI chat, Anthropic Messages, and Responses
+production paths apply that rule. The OpenAI integration harness pins
+concatenated stream deltas to non-stream text, including leading whitespace
+after a natural close and malformed-tool text interleaved between ordinary text;
+the Anthropic malformed-tool path uses the same flush-at-generation-position rule.
+
+Host gates on the corrected tree:
+
+- `tools/test_think_resolve.cpp`: all resolver/admission/enforcement assertions
+  pass, including default no-think speculative width and explicit spontaneous
+  budget coverage.
+- `tools/test_chat_completions_integration.cpp`: all integration tests pass,
+  including OpenAI stream/non-stream byte parity and malformed-tool fallback.
+- `tools/test_stream_split.cpp`, `tools/test_openai_bridge.cpp`, and
+  `tools/test_conductor.cpp`: all assertions pass.
+- `build/test_tokenizer` compiles; its file-independent UTF-8, GPU-gate, and
+  Anthropic-shape self-tests pass. The corpus leg was not run because this tree
+  contains neither `q27.tok` nor a tokenizer cases file.
+- `git diff --check`: clean.
+
+Structured closeout used
+`skill://autoreview/scripts/autoreview --mode local --stream-engine-output`.
+The first passes identified synthetic-newline and generation-order defects in
+malformed-tool fallback; both were fixed and regression-pinned. The final Codex
+run returned no accepted/actionable findings (`patch is correct`, confidence
+0.91).
+
+CUDA gate: CUDA 12.8.93 on Yukon successfully rebuilt the corrected source with
+`make -B NVCC=/home/ddbb/.local/cuda-12.8/bin/nvcc build/q27-server-w8`.
+The compile emits only warnings in unchanged `prefill.cu` and `tokenizer.cpp`.
+No live-model result is claimed for this correction: the 3090 remained occupied
+by PID 2062415 (`evidence-wt/.venv/bin/python`, 21884 MiB), so taking the card
+would have disrupted another workload.

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -418,18 +418,25 @@ inline bool resolve_think(const json& body, bool server_default, bool allow_requ
 // fraction ever exists, it should replace this.
 static constexpr double THINK_BUDGET_FRAC = 0.5;
 
-// Resolve the server's default budget for a request whose cap is `n_max`.
-// `flag` is --think-budget: <0 = use the fraction, 0 = unbounded, >0 = absolute.
+// Resolve the server budget for a request whose public cap is `n_max`.
+// `flag` is --think-budget: <0 = use the fractional default, 0 = unbounded,
+// >0 = an explicit absolute cap. The fractional default applies only when the
+// prompt already opened THINK. Otherwise every sampled no-think response would
+// be forced to one token per round merely to watch for a spontaneous opener.
+// An explicit request budget, or an explicit positive server flag, still arms
+// that later-block guard.
 inline int think_budget_default(int flag, int n_max) {
     if (flag == 0) return -1;
     if (flag > 0) return flag;
     return n_max > 0 ? (int)(THINK_BUDGET_FRAC * n_max) : -1;
 }
 
-inline int think_budget_for_request(bool /*prompt_starts_in_think*/, const ThinkCfg& cfg,
+inline int think_budget_for_request(bool prompt_starts_in_think, const ThinkCfg& cfg,
                                     int flag, int n_max) {
     if (cfg.enabled_set && !cfg.enabled) return -1;
-    return cfg.budget_set ? cfg.budget : think_budget_default(flag, n_max);
+    if (cfg.budget_set) return cfg.budget;
+    if (!prompt_starts_in_think && flag < 0) return -1;
+    return think_budget_default(flag, n_max);
 }
 
 struct ThinkDecodeLimits {

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <fstream>
+#include <limits>
 #include <mutex>
 #include <set>
 #include <string>
@@ -348,6 +349,8 @@ inline std::string tool_response_text(const std::string& out) {
 struct ThinkCfg {
     bool enabled = false;
     int budget = -1;  // -1 = unbounded; >=0 = max tokens inside the block
+    bool budget_set = false; // request supplied a budget, including negative opt-out
+    bool enabled_set = false; // request explicitly enabled/disabled thinking
 };
 
 inline ThinkCfg resolve_think_cfg(const json& body, bool server_default, bool allow_request,
@@ -355,24 +358,41 @@ inline ThinkCfg resolve_think_cfg(const json& body, bool server_default, bool al
     ThinkCfg c{server_default, server_budget};
     if (!allow_request) return c;
     auto take_budget = [&](const json& v) {
-        // 0 is a legitimate "no thinking budget at all"; negative means unbounded.
-        if (v.is_number_integer()) c.budget = v.get<int>();
+        // 0 is a legitimate "no thinking budget at all"; negative means
+        // unbounded. nlohmann classifies unsigned values as integer too, so
+        // validate the stored representation before narrowing to int.
+        if (!v.is_number_integer()) return;
+        if (v.is_number_unsigned()) {
+            const uint64_t value = v.get<uint64_t>();
+            if (value > (uint64_t)std::numeric_limits<int>::max()) return;
+            c.budget = (int)value;
+        } else {
+            const int64_t value = v.get<int64_t>();
+            if (value < (int64_t)std::numeric_limits<int>::min() ||
+                value > (int64_t)std::numeric_limits<int>::max()) return;
+            c.budget = (int)value;
+        }
+        c.budget_set = true;
     };
-    if (body.contains("enable_thinking") && body["enable_thinking"].is_boolean())
+    if (body.contains("enable_thinking") && body["enable_thinking"].is_boolean()) {
         c.enabled = body["enable_thinking"].get<bool>();
+        c.enabled_set = true;
+    }
     if (body.contains("thinking_token_budget")) take_budget(body["thinking_token_budget"]);
     if (body.contains("chat_template_kwargs") && body["chat_template_kwargs"].is_object()) {
         const auto& k = body["chat_template_kwargs"];
-        if (k.contains("enable_thinking") && k["enable_thinking"].is_boolean())
+        if (k.contains("enable_thinking") && k["enable_thinking"].is_boolean()) {
             c.enabled = k["enable_thinking"].get<bool>();
+            c.enabled_set = true;
+        }
         if (k.contains("thinking_budget")) take_budget(k["thinking_budget"]);
     }
     if (body.contains("thinking") && body["thinking"].is_object()) {
         const auto& t = body["thinking"];
         if (t.contains("type") && t["type"].is_string()) {
             const std::string ty = t["type"].get<std::string>();
-            if (ty == "enabled") c.enabled = true;
-            else if (ty == "disabled") c.enabled = false;
+            if (ty == "enabled") { c.enabled = true; c.enabled_set = true; }
+            else if (ty == "disabled") { c.enabled = false; c.enabled_set = true; }
         }
         if (t.contains("budget_tokens")) take_budget(t["budget_tokens"]);
     }
@@ -405,6 +425,123 @@ inline int think_budget_default(int flag, int n_max) {
     if (flag > 0) return flag;
     return n_max > 0 ? (int)(THINK_BUDGET_FRAC * n_max) : -1;
 }
+
+inline int think_budget_for_request(bool /*prompt_starts_in_think*/, const ThinkCfg& cfg,
+                                    int flag, int n_max) {
+    if (cfg.enabled_set && !cfg.enabled) return -1;
+    return cfg.budget_set ? cfg.budget : think_budget_default(flag, n_max);
+}
+
+struct ThinkDecodeLimits {
+    int n_max = 0;
+    int budget = -1;
+    bool context_ok = true;
+};
+
+inline ThinkDecodeLimits resolve_think_decode_limits(
+    int requested, int max_ctx, int prompt_tokens, int round_reserve,
+    int close_tokens, bool active, const ThinkCfg& cfg, int flag) {
+    const int raw_capacity = std::max(0, max_ctx - prompt_tokens - (round_reserve - 1));
+    const int raw_n_max = std::max(0, std::min(requested, raw_capacity));
+    const int raw_budget = think_budget_for_request(active, cfg, flag, raw_n_max);
+    if (raw_capacity == 0) return {0, raw_budget, false};
+
+    // Solve against the cap after reserving the close: fractional defaults
+    // shrink with n_max, and an absolute cap at/above n_max is inert. The
+    // candidate is valid only when the cap can fire before the public limit.
+    // A prompt already in THINK needs one remaining answer token; a prompt in
+    // TEXT also needs one public token for a model-generated <think> opener,
+    // which is a delimiter rather than budgeted reasoning content.
+    const int bounded_n_max = std::max(
+        0, std::min(requested, std::max(0, raw_capacity - close_tokens)));
+    const int bounded_budget =
+        think_budget_for_request(active, cfg, flag, bounded_n_max);
+    const int public_reserve = active ? 1 : 2;
+    if (bounded_budget >= 0 && bounded_budget <= bounded_n_max - public_reserve)
+        return {bounded_n_max, bounded_budget, true};
+
+    // If a prompt already in THINK would fire under the unreserved cap, the
+    // request cannot honor the close and still expose an answer token. A TEXT
+    // prompt is different: thinking is only a future model choice. When its
+    // public cap is too short for opener + budget + answer, preserve the
+    // ordinary request and disable enforcement instead of reporting a false
+    // context overflow; a spontaneous think then ends by the normal length cap.
+    if (raw_budget >= 0 && raw_budget < raw_n_max) {
+        if (!active) return {raw_n_max, -1, true};
+        return {0, raw_budget, false};
+    }
+
+    // Unbounded or unattainable caps require neither one-token acceptance nor
+    // close-token context. Report -1 to disable enforcement for this request.
+    return {raw_n_max, -1, true};
+}
+
+// Nearest admissible prompt below a rejected request. Admission can be
+// nonmonotonic near the boundary (an absolute cap can become inert), so a
+// larger admissible prompt is not a truthful compaction target for the current
+// rejection. Scan downward from the smaller of the ordinary ceiling and the
+// token count immediately below the rejected prompt.
+inline int max_prompt_for_think_decode(
+    int requested, int max_ctx, int round_reserve, int prompt_ceiling,
+    int rejected_prompt, int close_tokens, bool active, const ThinkCfg& cfg,
+    int flag) {
+    const int ceiling = std::max(0, std::min(prompt_ceiling, rejected_prompt - 1));
+    for (int prompt = ceiling; prompt >= 0; prompt--)
+        if (resolve_think_decode_limits(requested, max_ctx, prompt, round_reserve,
+                                        close_tokens, active, cfg, flag).context_ok)
+            return prompt;
+    return 0;
+}
+
+// Request-local controller for bounded <think> spans. The decoder task is the
+// owner of enforcement: parsing alone can hide </think> from the client but
+// cannot advance model state. The first forced close uses the context reserve
+// admitted above. A later exhausted span pays for its close by reducing the
+// remaining public token allowance, so repeated transitions cannot exceed the
+// admitted context.
+struct ThinkBudgetState {
+    int limit = -1;
+    int used = 0;
+    bool tripped = false;
+
+    explicit ThinkBudgetState(int cap = -1) : limit(cap) {}
+
+    template <typename Task>
+    void start(Task& task, const std::vector<int>& close_ids,
+               StreamSplitter::Chan initial = StreamSplitter::THINK) {
+        if (limit < 0) return;
+        task.accept_one = true;
+        if (limit == 0 && initial == StreamSplitter::THINK) trip(task, close_ids);
+    }
+
+    template <typename Task>
+    void observe(StreamSplitter::Chan before, StreamSplitter::Chan after, Task& task,
+                 const std::vector<int>& close_ids) {
+        if (!tripped && before == StreamSplitter::THINK) used++;
+        if (limit < 0) return;
+        if (after != StreamSplitter::THINK) {
+            if (task.sampling) task.accept_one = true;
+            else task.release_accept_one();
+            return;
+        }
+        if (before != StreamSplitter::THINK) {
+            task.accept_one = true;
+            if (used >= limit) {
+                if (tripped) task.force_from_public_budget(close_ids);
+                else trip(task, close_ids);
+            }
+            return;
+        }
+        if (!tripped && used >= limit) trip(task, close_ids);
+    }
+
+  private:
+    template <typename Task>
+    void trip(Task& task, const std::vector<int>& close_ids) {
+        tripped = true;
+        task.force(close_ids);
+    }
+};
 
 // Anthropic error envelope, exactly the real API's shape: the SDK inside
 // Claude Code reads error.message from it, and CC's compact-vs-retry
@@ -1512,6 +1649,21 @@ inline json openai_stream_chunk(const std::string& id, const std::string& obj, l
                    {"finish_reason", finish_reason ? json(finish_reason) : json(nullptr)}};
     return {{"id", id}, {"object", obj}, {"created", created}, {"model", model},
             {"choices", json::array({choice})}};
+}
+
+// Responses streaming has distinct terminal lifecycle events. One object owns
+// every terminal field so the SSE event and nested response status cannot
+// diverge when output reaches its public limit.
+struct ResponsesTerminalState {
+    bool incomplete;
+    const char* status;
+    const char* event;
+};
+inline ResponsesTerminalState responses_terminal_state(
+    int produced, int limit, bool budget_truncated) {
+    const bool incomplete = produced >= limit || budget_truncated;
+    return {incomplete, incomplete ? "incomplete" : "completed",
+            incomplete ? "response.incomplete" : "response.completed"};
 }
 
 // One streamed tool_calls[] delta entry. Whole-shot (id+name+full arguments

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -500,53 +500,57 @@ inline int max_prompt_for_think_decode(
     return 0;
 }
 
-// Request-local controller for bounded <think> spans. The decoder task is the
-// owner of enforcement: parsing alone can hide </think> from the client but
-// cannot advance model state. The first forced close uses the context reserve
-// admitted above. A later exhausted span pays for its close by reducing the
-// remaining public token allowance, so repeated transitions cannot exceed the
-// admitted context.
+// Request-local controller for bounded <think> spans. It observes semantic
+// channel transitions and decides WHEN a close is needed; the engine owns HOW
+// the tokenizer's close ids are committed through decoder state. Positive
+// budgets are checked after a whole decode round, so a trip may overshoot by
+// that round's accepted width. Request budget zero is the one pre-round case.
+enum class ThinkBudgetAction { NONE, FORCE_RESERVED, FORCE_PUBLIC };
+
 struct ThinkBudgetState {
     int limit = -1;
     int used = 0;
     bool tripped = false;
+    bool transition_pending = false;
+    bool reserved_close = true;
 
     explicit ThinkBudgetState(int cap = -1) : limit(cap) {}
 
-    template <typename Task>
-    void start(Task& task, const std::vector<int>& close_ids,
-               StreamSplitter::Chan initial = StreamSplitter::THINK) {
-        if (limit < 0) return;
-        task.accept_one = true;
-        if (limit == 0 && initial == StreamSplitter::THINK) trip(task, close_ids);
+    ThinkBudgetAction start(StreamSplitter::Chan initial = StreamSplitter::THINK) {
+        if (limit == 0 && initial == StreamSplitter::THINK) {
+            tripped = true;
+            transition_pending = true;
+            reserved_close = false;
+            return ThinkBudgetAction::FORCE_RESERVED;
+        }
+        return ThinkBudgetAction::NONE;
     }
 
-    template <typename Task>
-    void observe(StreamSplitter::Chan before, StreamSplitter::Chan after, Task& task,
-                 const std::vector<int>& close_ids) {
-        if (!tripped && before == StreamSplitter::THINK) used++;
-        if (limit < 0) return;
-        if (after != StreamSplitter::THINK) {
-            if (task.sampling) task.accept_one = true;
-            else task.release_accept_one();
-            return;
-        }
-        if (before != StreamSplitter::THINK) {
-            task.accept_one = true;
-            if (used >= limit) {
-                if (tripped) task.force_from_public_budget(close_ids);
-                else trip(task, close_ids);
-            }
-            return;
-        }
-        if (!tripped && used >= limit) trip(task, close_ids);
+    // Feed every semantically committed token in round order. Forced control
+    // ids change channel state but do not consume public reasoning usage.
+    void observe(StreamSplitter::Chan before, StreamSplitter::Chan after,
+                 bool forced = false) {
+        if (!forced && before == StreamSplitter::THINK) used++;
+        if (before == StreamSplitter::THINK && after != StreamSplitter::THINK)
+            transition_pending = false;
     }
 
-  private:
-    template <typename Task>
-    void trip(Task& task, const std::vector<int>& close_ids) {
+
+    // Call once after the complete retained round has been observed. A natural
+    // close later in the same speculative round wins: no duplicate close is
+    // queued. Once the reserved first close has tripped, any later re-entry
+    // borrows its close ids from the remaining public token allowance.
+    ThinkBudgetAction finish_round(StreamSplitter::Chan after) {
+        if (limit < 0 || transition_pending || after != StreamSplitter::THINK ||
+            used < limit)
+            return ThinkBudgetAction::NONE;
         tripped = true;
-        task.force(close_ids);
+        transition_pending = true;
+        if (reserved_close) {
+            reserved_close = false;
+            return ThinkBudgetAction::FORCE_RESERVED;
+        }
+        return ThinkBudgetAction::FORCE_PUBLIC;
     }
 };
 

--- a/src/conductor.h
+++ b/src/conductor.h
@@ -85,11 +85,14 @@ inline void trim_widths(int* want, const bool* is_suffix, int k, int cap) {
 // (gs.end="error" in the [req] line, 500 when nothing was emitted, an SSE
 // `error` event on the Anthropic stream). It rides the same close() wakeup.
 struct TokenQueue {
-    void push(const int* ids, int n) {
-        if (n <= 0) return;
+    struct Token {
+        int id = -1;
+        bool forced = false;
+    };
+    void push(int id, bool forced) {
         {
             std::lock_guard<std::mutex> lk(m);
-            buf.insert(buf.end(), ids, ids + n);
+            buf.push_back({id, forced});
         }
         cv.notify_one();
     }
@@ -126,13 +129,19 @@ struct TokenQueue {
     // token arrives or the queue closes. Returns false only when the queue is
     // closed AND nothing was delivered -- `while (q.pop(out)) {}` drains a
     // stream to completion.
-    bool pop(std::vector<int>& out) {
+    bool pop(std::vector<Token>& out) {
         std::unique_lock<std::mutex> lk(m);
         cv.wait(lk, [&] { return !buf.empty() || closed; });
         bool got = !buf.empty();
         out.insert(out.end(), buf.begin(), buf.end());
         buf.clear();
         return got || !closed;
+    }
+    bool pop(std::vector<int>& out) {
+        std::vector<Token> tokens;
+        const bool more = pop(tokens);
+        for (const auto& token : tokens) out.push_back(token.id);
+        return more;
     }
     const char* finish_reason() {
         std::lock_guard<std::mutex> lk(m);
@@ -146,7 +155,7 @@ struct TokenQueue {
 private:
     std::mutex m;
     std::condition_variable cv;
-    std::vector<int> buf;
+    std::vector<Token> buf;
     bool closed = false;
     const char* reason = "";
     const char* error = nullptr;
@@ -198,6 +207,13 @@ struct ConductorCore {
     std::vector<MemberT*> members; // live set; mutated at round boundaries only
     std::vector<MemberT*> joins;   // staged joins; drained at boundaries
     std::function<bool(MemberT&)> solo_round;
+    // Some rounds are intentionally ineligible for fusion (currently the
+    // host-forced token queue used for reasoning/tool close transitions).
+    // Run one such member through the exact solo decode_step path before
+    // drafting any other member; otherwise fused drafting overwrites the
+    // staged forced id and the transition never reaches decoder state.
+    std::function<bool(MemberT&)> needs_solo_round;
+
     std::function<void(MemberT**, const int*, const bool*, int, bool*)> fused_round;
     std::function<void(MemberT&)> on_leave;
     // P2a (optional): batch draft hook -- fills want[] and sfx[] for all k
@@ -225,6 +241,17 @@ struct ConductorCore {
                 on_leave(*gone);
             } else {
                 i++;
+            }
+        }
+        if (needs_solo_round) {
+            for (size_t i = 0; i < members.size(); i++) {
+                MemberT* mm = members[i];
+                if (!needs_solo_round(*mm)) continue;
+                if (solo_round(*mm)) {
+                    members.erase(members.begin() + i);
+                    on_leave(*mm);
+                }
+                return (int)members.size();
             }
         }
         const int k = (int)members.size();
@@ -890,6 +917,7 @@ public:
         // whose ctor throws never runs. Tear down + rethrow.
         try {
             core.solo_round = [this](Member& mm) { return this->solo_round(mm); };
+            core.needs_solo_round = [](Member& mm) { return mm.t->round_forced; };
             core.fused_round = [this](Member** ms, const int* granted, const bool* sfx,
                                       int k, bool* done) {
                 this->fused_round(ms, granted, sfx, k, done);
@@ -943,14 +971,14 @@ public:
         // dangling over the dead queue.
         std::function<bool(int)> sink;
         if (on_emit)
-            sink = [q, oe = std::move(on_emit)](int id) {
+            sink = [q, t, oe = std::move(on_emit)](int id) {
                 oe(id);
-                q->push(&id, 1);
+                q->push(id, t->callback_forced);
                 return true;
             };
         else
-            sink = [q](int id) {
-                q->push(&id, 1);
+            sink = [q, t](int id) {
+                q->push(id, t->callback_forced);
                 return true;
             };
         CUDA_CHECK(cudaEventCreateWithFlags(&mm->draft_done, cudaEventDisableTiming));

--- a/src/engine.cuh
+++ b/src/engine.cuh
@@ -3350,10 +3350,6 @@ struct Engine {
         // copies would alias anyway); conductor mode (Task 10) installs an
         // owning sink instead.
         std::function<bool(int)> on_token;
-        // Request-local semantic boundary limiter. Preview is side-effect free;
-        // commit advances only through the prefix retained after Engine::on_round.
-        std::function<int(const int*, int)> preview_round;
-        std::function<void(const int*, int)> commit_round;
         int emitted = 0; // tokens delivered to on_token so far (return value)
         int rounds = 0;  // decode rounds run -> gs.rounds at finish
         int Ph = 0;      // host mirror of the last written position (ctx guard)
@@ -3381,11 +3377,13 @@ struct Engine {
         // writes them, and the request thread reads them after the queue
         // closes (the close is the synchronization edge).
         long bat_members = 0, bat_r2 = 0;
-        // A bounded reasoning span must be observed one token at a time so the
-        // host can stop exactly at its cap. The same cap also makes injected
-        // close ids one committed token per round; unlike parser-only text,
-        // forced ids are written to d_token and therefore advance model state.
-        bool accept_one = false;
+        // Forced control ids are engine-owned decoder transitions. DecodeTask
+        // stores only request-local queue/accounting state so solo generate()
+        // and the conductor drive the identical round-boundary operation.
+        // Sampled rounds have no on_round hook; an explicitly bounded sampled
+        // request therefore keeps width one so its per-token observer still
+        // runs at a coherent round boundary. Greedy bounded requests do not.
+        bool sampled_budget_watch = false;
         bool public_budget_reduced = false;
         bool budget_cancelled = false;
         bool budget_truncated = false; // final stop actually came from either condition
@@ -3394,37 +3392,59 @@ struct Engine {
         int forced_id = -1;
         std::vector<int> forced_tokens;
         size_t forced_pos = 0;
-        void force(const std::vector<int>& ids) {
-            forced_tokens.insert(forced_tokens.end(), ids.begin(), ids.end());
-            accept_one = true;
-        }
-        // The first injected close is covered by admission's dedicated context
-        // reserve. Later closes borrow from the still-unemitted public budget;
-        // the current model token has not incremented `emitted` yet, hence the
-        // strict `>` requirement. If it cannot fit, stop before adding control
-        // tokens that would exceed the admitted context.
-        bool force_from_public_budget(const std::vector<int>& ids) {
-            const int cost = (int)ids.size();
-            public_budget_reduced = true;
-            if (n_max - emitted <= cost) {
-                budget_cancelled = true;
-                cancel.store(true);
-                return false;
-            }
-            n_max -= cost;
-            force(ids);
-            return true;
-        }
         bool has_forced() const { return forced_pos < forced_tokens.size(); }
-        void release_accept_one() {
-            if (!has_forced()) accept_one = false;
-        }
     };
 
-    // Install a forced id as the pending token the next decoder round consumes.
-    // DecodeTask owns the host source, and the sync is intentional: forced
-    // transitions are rare, while letting the next boundary overwrite
-    // forced_id before a deferred pageable H2D read would corrupt d_token.
+    bool reasoning_transition_active(const DecodeTask& t) const {
+        return t.round_forced || t.has_forced();
+    }
+
+    // Queue the tokenizer's exact close sequence as decoder input. This is the
+    // sole public reasoning-transition operation: callers decide only WHEN to
+    // close, while Engine owns pending-token replacement, acceptance capping,
+    // speculative-lane invalidation/rebuild, and conductor solo isolation.
+    // The first close uses admission's dedicated context reserve. A later
+    // re-entry borrows its control-token cost from the public allowance.
+    bool reasoning_close_fits(const DecodeTask& t, int current_public_tokens,
+                              int current_context_tokens, int close_tokens,
+                              bool from_public_budget) const {
+        if (current_public_tokens < 0 || current_context_tokens < 0 || close_tokens <= 0)
+            return false;
+        const int public_needed = from_public_budget ? close_tokens + 1 : 1;
+        if (t.n_max - t.emitted - current_public_tokens < public_needed) return false;
+        return (int64_t)t.Ph + current_context_tokens + close_tokens - 1 +
+                   ctx_round_reserve() <=
+               max_ctx;
+    }
+
+    bool force_reasoning_close(DecodeTask& t, const std::vector<int>& ids,
+                               bool from_public_budget = false,
+                               int current_public_tokens = 0,
+                               int current_context_tokens = -1) {
+        if (ids.empty()) return false;
+        if (reasoning_transition_active(t)) return true;
+        const int cost = (int)ids.size();
+        if (current_context_tokens < 0) current_context_tokens = current_public_tokens;
+        // start() queues a zero-budget close before make_decode_task() fills
+        // n_max/Ph/on_token; admission already proved that first close fits.
+        if (t.on_token &&
+            !reasoning_close_fits(t, current_public_tokens, current_context_tokens,
+                                  cost, from_public_budget)) {
+            t.budget_cancelled = true;
+            t.cancel.store(true);
+            return false;
+        }
+        if (from_public_budget) {
+            t.public_budget_reduced = true;
+            t.n_max -= cost;
+        }
+        t.forced_tokens.insert(t.forced_tokens.end(), ids.begin(), ids.end());
+        return true;
+    }
+
+    // Install one forced id as the pending token the next decoder round
+    // consumes. DecodeTask owns the persistent host source; the sync prevents a
+    // later boundary from changing it before the pageable H2D read completes.
     void install_forced_pending(DecodeTask& t) {
         CUDA_CHECK(cudaMemcpyAsync(d_token, &t.forced_id, 4, cudaMemcpyHostToDevice, stm));
         CUDA_CHECK(cudaMemcpyAsync(d_gen + t.Ph, &t.forced_id, 4,
@@ -3433,15 +3453,16 @@ struct Engine {
         last_pending = t.forced_id;
     }
 
-    // Replace the model-predicted pending token at a coherent round boundary.
-    // Plain sampling is different: d_token is the previously emitted token
-    // that still must be forwarded, so its forced id is installed only after
-    // sample_round commits that token below.
+    // Replace the model-predicted pending token only at a coherent boundary.
+    // The following capped round recomputes drafts from this forced token, so
+    // no speculative lane produced under the old pending token can commit.
+    // Plain sampling first forwards its outstanding emitted token below, then
+    // installs the close before drawing the next public token.
     void stage_forced_pending(DecodeTask& t) {
         t.forced_id = t.forced_tokens[t.forced_pos++];
         if (!(t.sampling && t.force_plain_sample)) {
             install_forced_pending(t);
-            if (t.sampling) samp_first = false; // zero-budget sampled spec starts from close
+            if (t.sampling) samp_first = false;
         }
         t.round_forced = true;
     }
@@ -3588,7 +3609,8 @@ struct Engine {
             finish_decode(t, "ctx-guard");
             return false;
         }
-        set_reasoning_accept_cap(t.accept_one);
+        set_reasoning_accept_cap(reasoning_transition_active(t) ||
+                                 (t.sampling && t.sampled_budget_watch));
         // ConductorCore pre-checks every member, then its solo fallback calls
         // decode_step(), which pre-checks again. Preserve an id staged by the
         // first call; resetting round_forced here silently discards the
@@ -3596,6 +3618,8 @@ struct Engine {
         if (!t.round_forced && t.has_forced()) stage_forced_pending(t);
         return true;
     }
+    // Post-round host bookkeeping (the tail of generate()'s old loop body):
+    // P15 grammar scan/truncate, suffix-index append, Ph advance, per-token
     // emission (EOS / client-stop / budget), on_pending, round_gap. Returns
     // false when generation is done, after running finish_decode(). Factored
     // out of decode_step (P1 Task 9): the conductor's fused round loop runs
@@ -3603,31 +3627,16 @@ struct Engine {
     // stop reasons and GenStats land exactly as the solo loop produces them.
     bool post_round(DecodeTask& t, const int* em, int n) {
         t.rounds++;
-        // Compute the semantic prefix first without mutating its parser. The
-        // tool scanner then sees only that prefix, so markers discarded by a
-        // reasoning boundary cannot engage grammar state. Refinish once at the
-        // earliest retained boundary, then commit the semantic parser through
-        // exactly the tokens that survived both scanners.
-        int committed = n;
-        bool refinish = false;
-        if (!t.sampling && t.preview_round) {
-            int m = t.preview_round(em, committed);
-            if (m >= 1 && m <= committed) {
-                committed = m;
-                refinish = true;
-            }
-        }
+        // on_round is still the sole greedy refinish contract. The server
+        // previews budget retention before its stateful tool scan, commits both
+        // observers to the same kept prefix, and returns that prefix here.
         if (!t.sampling && on_round) {
-            int m = on_round(em, committed);
-            if (m >= 1 && m <= committed) {
-                committed = m;
-                refinish = true;
+            int m = on_round(em, n);
+            if (m >= 1 && m <= n) {
+                last_pending = refinish_round(m, n, t.Ph + m);
+                n = m;
             }
         }
-        if (refinish)
-            last_pending = refinish_round(committed, n, t.Ph + committed);
-        if (!t.sampling && t.commit_round) t.commit_round(em, committed);
-        n = committed;
         // suffix index tracks the committed stream (post-truncation n);
         // the pending token rides along virtually in propose_with.
         if (suffix_on)

--- a/src/engine.cuh
+++ b/src/engine.cuh
@@ -181,7 +181,8 @@ struct Engine {
     int* d_mask_ids = nullptr;
     int* d_accept_cap = nullptr;
     int mask_words = 0, mask_pool_used = 0;
-    int h_mask_id0 = -1, h_cap0 = 0; // async-copy sources (must outlive copy)
+    int h_mask_id0 = -1, h_cap0 = 0; // tool-grammar cap (0 = none, 1 = one token)
+    int h_reason_cap = 0, h_accept_cap = 0; // reasoning cap + persistent async-copy source
     static constexpr int MASK_POOL_CAP = 512;
     // GDN state as W_MAX=12 physical buffers with a cyclic role permutation
     // (history: 6 at P12b, 8 at maxd7, 12 at width-12). role r (0=primary,
@@ -2680,6 +2681,20 @@ struct Engine {
     // (mask_id -1 = deactivate). Takes effect from the next spec round.
     // With on_drafts wired (P11) the round runs split and per-lane masks are
     // staged mid-round, so activate the split path instead of capping.
+    void upload_accept_cap() {
+        h_accept_cap = (h_cap0 > 0 || h_reason_cap > 0) ? 1 : 0;
+        CUDA_CHECK(cudaMemcpyAsync(d_accept_cap, &h_accept_cap, 4,
+                                   cudaMemcpyHostToDevice, stm));
+    }
+
+    void set_reasoning_accept_cap(bool active) {
+        const int next = active ? 1 : 0;
+        if (h_reason_cap == next) return;
+        h_reason_cap = next;
+        upload_accept_cap();
+    }
+
+
     void set_tool_constraint(int mask_id) {
         h_mask_id0 = mask_id;
         // P11 split path is OPT-IN (Q27_TOOL_SPLIT=1): it 4.2x's in-call decode
@@ -2701,7 +2716,7 @@ struct Engine {
         // cap only when constraining WITHOUT the split path (P7 v1 fallback)
         h_cap0 = (mask_id >= 0 && !tool_split_active) ? 1 : 0;
         CUDA_CHECK(cudaMemcpyAsync(d_mask_ids, &h_mask_id0, 4, cudaMemcpyHostToDevice, stm));
-        CUDA_CHECK(cudaMemcpyAsync(d_accept_cap, &h_cap0, 4, cudaMemcpyHostToDevice, stm));
+        upload_accept_cap();
     }
     // P11: stage all 5 lane mask ids at once (split path). cap stays 0.
     // W16: was a 12-entry {-1,...} brace list -- slots 12..15 would value-init
@@ -2714,7 +2729,7 @@ struct Engine {
         for (int i = 0; i < 5; i++) h_mask_ids5[i] = ids[i];
         h_cap0 = 0;
         CUDA_CHECK(cudaMemcpyAsync(d_mask_ids, h_mask_ids5, 5 * 4, cudaMemcpyHostToDevice, stm));
-        CUDA_CHECK(cudaMemcpyAsync(d_accept_cap, &h_cap0, 4, cudaMemcpyHostToDevice, stm));
+        upload_accept_cap();
     }
     // Full constraint reset: every lane mask id back to -1 + cap 0 (covers
     // stale split-path lanes that set_tool_constraint(-1) alone would miss).
@@ -2725,7 +2740,7 @@ struct Engine {
         for (int i = 0; i < W_PLUMB; i++) h_mask_ids5[i] = -1;
         CUDA_CHECK(cudaMemcpyAsync(d_mask_ids, h_mask_ids5, W_MAX * 4, cudaMemcpyHostToDevice,
                                    stm));
-        CUDA_CHECK(cudaMemcpyAsync(d_accept_cap, &h_cap0, 4, cudaMemcpyHostToDevice, stm));
+        upload_accept_cap();
     }
     // P15 engage-lag fix: rewind the JUST-FINISHED greedy spec round from n
     // accepted tokens to m (1 <= m <= n) and re-decide the pending token under
@@ -3335,6 +3350,10 @@ struct Engine {
         // copies would alias anyway); conductor mode (Task 10) installs an
         // owning sink instead.
         std::function<bool(int)> on_token;
+        // Request-local semantic boundary limiter. Preview is side-effect free;
+        // commit advances only through the prefix retained after Engine::on_round.
+        std::function<int(const int*, int)> preview_round;
+        std::function<void(const int*, int)> commit_round;
         int emitted = 0; // tokens delivered to on_token so far (return value)
         int rounds = 0;  // decode rounds run -> gs.rounds at finish
         int Ph = 0;      // host mirror of the last written position (ctx guard)
@@ -3362,7 +3381,70 @@ struct Engine {
         // writes them, and the request thread reads them after the queue
         // closes (the close is the synchronization edge).
         long bat_members = 0, bat_r2 = 0;
+        // A bounded reasoning span must be observed one token at a time so the
+        // host can stop exactly at its cap. The same cap also makes injected
+        // close ids one committed token per round; unlike parser-only text,
+        // forced ids are written to d_token and therefore advance model state.
+        bool accept_one = false;
+        bool public_budget_reduced = false;
+        bool budget_cancelled = false;
+        bool budget_truncated = false; // final stop actually came from either condition
+        bool round_forced = false;
+        bool callback_forced = false; // true only while on_token receives an injected id
+        int forced_id = -1;
+        std::vector<int> forced_tokens;
+        size_t forced_pos = 0;
+        void force(const std::vector<int>& ids) {
+            forced_tokens.insert(forced_tokens.end(), ids.begin(), ids.end());
+            accept_one = true;
+        }
+        // The first injected close is covered by admission's dedicated context
+        // reserve. Later closes borrow from the still-unemitted public budget;
+        // the current model token has not incremented `emitted` yet, hence the
+        // strict `>` requirement. If it cannot fit, stop before adding control
+        // tokens that would exceed the admitted context.
+        bool force_from_public_budget(const std::vector<int>& ids) {
+            const int cost = (int)ids.size();
+            public_budget_reduced = true;
+            if (n_max - emitted <= cost) {
+                budget_cancelled = true;
+                cancel.store(true);
+                return false;
+            }
+            n_max -= cost;
+            force(ids);
+            return true;
+        }
+        bool has_forced() const { return forced_pos < forced_tokens.size(); }
+        void release_accept_one() {
+            if (!has_forced()) accept_one = false;
+        }
     };
+
+    // Install a forced id as the pending token the next decoder round consumes.
+    // DecodeTask owns the host source, and the sync is intentional: forced
+    // transitions are rare, while letting the next boundary overwrite
+    // forced_id before a deferred pageable H2D read would corrupt d_token.
+    void install_forced_pending(DecodeTask& t) {
+        CUDA_CHECK(cudaMemcpyAsync(d_token, &t.forced_id, 4, cudaMemcpyHostToDevice, stm));
+        CUDA_CHECK(cudaMemcpyAsync(d_gen + t.Ph, &t.forced_id, 4,
+                                   cudaMemcpyHostToDevice, stm));
+        CUDA_CHECK(cudaStreamSynchronize(stm));
+        last_pending = t.forced_id;
+    }
+
+    // Replace the model-predicted pending token at a coherent round boundary.
+    // Plain sampling is different: d_token is the previously emitted token
+    // that still must be forwarded, so its forced id is installed only after
+    // sample_round commits that token below.
+    void stage_forced_pending(DecodeTask& t) {
+        t.forced_id = t.forced_tokens[t.forced_pos++];
+        if (!(t.sampling && t.force_plain_sample)) {
+            install_forced_pending(t);
+            if (t.sampling) samp_first = false; // zero-budget sampled spec starts from close
+        }
+        t.round_forced = true;
+    }
 
     // R1b preemption point (no-op when the hook is unset or nobody waits).
     // Shared by the prefill chunk loops and decode_step; park time goes to
@@ -3442,6 +3524,8 @@ struct Engine {
     // pre_round/post_round/decode_step is followed by a non-throwing
     // return, so a throwing round cannot have already finished).
     void finish_decode(DecodeTask& t, const char* why) {
+        t.budget_truncated = t.budget_cancelled ||
+                             (t.public_budget_reduced && !strcmp(why, "n_max"));
         if (t.prof_decode) {
             CUDA_CHECK(cudaStreamSynchronize(stm));
             (void)cudaProfilerStop();
@@ -3450,6 +3534,7 @@ struct Engine {
             std::chrono::duration<double>(std::chrono::steady_clock::now() - t.g0).count();
         gs.dec = t.emitted;
         gs.dec_ms = dt * 1000.0;
+        set_reasoning_accept_cap(false);
         gs.rounds = t.rounds;
         gs.end = why;
         // wall-inclusive of yield parks; the suffix keeps a contended
@@ -3487,7 +3572,10 @@ struct Engine {
             finish_decode(t, "cancelled");
             return false;
         }
-        if (t.emitted >= t.n_max) {
+        // Forced control ids are internal decoder transitions, not generated
+        // output. Let an already-queued close finish even when the last model
+        // token consumed n_max; the following round then takes this exit.
+        if (!t.round_forced && !t.has_forced() && t.emitted >= t.n_max) {
             finish_decode(t, "n_max");
             return false;
         }
@@ -3500,11 +3588,14 @@ struct Engine {
             finish_decode(t, "ctx-guard");
             return false;
         }
+        set_reasoning_accept_cap(t.accept_one);
+        // ConductorCore pre-checks every member, then its solo fallback calls
+        // decode_step(), which pre-checks again. Preserve an id staged by the
+        // first call; resetting round_forced here silently discards the
+        // decoder-state transition before the solo round can consume it.
+        if (!t.round_forced && t.has_forced()) stage_forced_pending(t);
         return true;
     }
-
-    // Post-round host bookkeeping (the tail of generate()'s old loop body):
-    // P15 grammar scan/truncate, suffix-index append, Ph advance, per-token
     // emission (EOS / client-stop / budget), on_pending, round_gap. Returns
     // false when generation is done, after running finish_decode(). Factored
     // out of decode_step (P1 Task 9): the conductor's fused round loop runs
@@ -3512,28 +3603,45 @@ struct Engine {
     // stop reasons and GenStats land exactly as the solo loop produces them.
     bool post_round(DecodeTask& t, const int* em, int n) {
         t.rounds++;
-        // P15 engage-lag fix: let the host grammar scan the whole round
-        // pre-emission; on a mid-round <tool_call> completion, truncate to
-        // the marker token and re-decide the pending under the staged mask.
-        if (!t.sampling && on_round) {
-            int m = on_round(em, n);
-            if (m >= 1 && m <= n) {
-                last_pending = refinish_round(m, n, t.Ph + m);
-                n = m;
+        // Compute the semantic prefix first without mutating its parser. The
+        // tool scanner then sees only that prefix, so markers discarded by a
+        // reasoning boundary cannot engage grammar state. Refinish once at the
+        // earliest retained boundary, then commit the semantic parser through
+        // exactly the tokens that survived both scanners.
+        int committed = n;
+        bool refinish = false;
+        if (!t.sampling && t.preview_round) {
+            int m = t.preview_round(em, committed);
+            if (m >= 1 && m <= committed) {
+                committed = m;
+                refinish = true;
             }
         }
+        if (!t.sampling && on_round) {
+            int m = on_round(em, committed);
+            if (m >= 1 && m <= committed) {
+                committed = m;
+                refinish = true;
+            }
+        }
+        if (refinish)
+            last_pending = refinish_round(committed, n, t.Ph + committed);
+        if (!t.sampling && t.commit_round) t.commit_round(em, committed);
+        n = committed;
         // suffix index tracks the committed stream (post-truncation n);
         // the pending token rides along virtually in propose_with.
         if (suffix_on)
             for (int k = 0; k < n; k++) sfx.append(em[k]);
         t.Ph += n;
-        for (int k = 0; k < n && t.emitted < t.n_max; k++) {
+        for (int k = 0; k < n && (t.round_forced || t.emitted < t.n_max); k++) {
             if (em[k] == t.eos) {
                 finish_decode(t, "eos");
                 return false;
             }
             auto c0 = std::chrono::steady_clock::now();
+            t.callback_forced = t.round_forced;
             bool cont = t.on_token(em[k]);
+            t.callback_forced = false;
             gs.cb_ms += std::chrono::duration<double, std::milli>(
                             std::chrono::steady_clock::now() - c0)
                             .count();
@@ -3541,8 +3649,9 @@ struct Engine {
                 finish_decode(t, "client-stop");
                 return false;
             }
-            t.emitted++;
+            if (!t.round_forced) t.emitted++;
         }
+        t.round_forced = false;
         if (!t.sampling && on_pending) on_pending(last_pending);
         round_gap();
         return true;
@@ -3560,9 +3669,19 @@ struct Engine {
     bool decode_step(DecodeTask& t) {
         if (!pre_round(t)) return false;
         int em[W_MAX]; // width-12: spec_round can emit up to 12 tokens
-        int n = t.sampling
-                    ? (t.force_plain_sample ? sample_round(em) : spec_sample_round(em))
-                    : spec_round(em);
+        int n;
+        if (t.round_forced && t.sampling && t.force_plain_sample) {
+            // First forward the last emitted reasoning token and sample its
+            // successor. The successor is deliberately discarded: install
+            // the forced close as the new pending token, so the following
+            // round forwards the close and samples the first answer token.
+            n = sample_round(em);
+            install_forced_pending(t);
+            em[0] = t.forced_id;
+        } else {
+            n = t.sampling ? (t.force_plain_sample ? sample_round(em) : spec_sample_round(em))
+                           : spec_round(em);
+        }
         return post_round(t, em, n);
     }
 
@@ -3837,14 +3956,15 @@ struct Engine {
     // only the per-turn suffix re-prefills. -1 = legacy tail snapshot.
     template <typename F>
     int generate(const std::vector<int>& prompt, int n_max, int eos, F&& on_token,
-                 int stable_len = -1) {
+                 int stable_len = -1, DecodeTask* external_task = nullptr) {
         int P = 0;
         if (!generate_prefill(prompt, stable_len, &P)) return 0;
         // Decode: pre-loop state lives in DecodeTask, one round per
         // decode_step (P1: the conductor drives the same step function for
         // several engines). finish_decode() runs inside the step that
         // returns false, so every exit path lands its GenStats/[gen-done].
-        DecodeTask t;
+        DecodeTask local_task;
+        DecodeTask& t = external_task ? *external_task : local_task;
         make_decode_task(t, n_max, eos, on_token, P);
         while (decode_step(t)) {}
         return t.emitted;

--- a/src/server.cu
+++ b/src/server.cu
@@ -103,58 +103,127 @@ struct HookGuard {
     }
 };
 
-// In batch mode the conductor must observe bounded-thinking transitions before
-// it starts the next round. The request thread drains TokenQueue asynchronously;
-// observing there races the next draft and can either miss the forced close or
-// enqueue it after a natural close, leaking a literal </think> into content.
-// Keep an independent parser on the conductor thread. The request parser still
-// owns output routing; this twin owns only ThinkBudgetState / DecodeTask control.
-struct BatchThinkBudgetObserver {
+// Greedy budgets are observed through Engine::on_round before host emission.
+// The whole retained round is parsed first, so a natural close later in that
+// round wins. When an overshooting round would consume reserved close/answer
+// capacity, only the prefix through the trip is retained and re-finished.
+// Sampled rounds intentionally keep on_round unset; bounded sampled requests
+// use the engine's one-token observation fallback instead.
+struct ReasoningBudgetObserver {
     q27::Tokenizer& tok;
     q27::ThinkBudgetState& state;
+    Engine& eng;
     Engine::DecodeTask& task;
     const std::vector<int>& close_ids;
     StreamSplitter split;
     q27::Utf8Gate gate;
-    StreamSplitter round_split;
-    q27::Utf8Gate round_gate;
 
-    BatchThinkBudgetObserver(q27::Tokenizer& tok_, q27::ThinkBudgetState& state_,
-                             Engine::DecodeTask& task_,
-                             const std::vector<int>& close_ids_,
-                             StreamSplitter::Chan initial)
-        : tok(tok_), state(state_), task(task_), close_ids(close_ids_) {
+    ReasoningBudgetObserver(q27::Tokenizer& tok_, q27::ThinkBudgetState& state_,
+                            Engine& eng_, Engine::DecodeTask& task_,
+                            const std::vector<int>& close_ids_,
+                            StreamSplitter::Chan initial)
+        : tok(tok_), state(state_), eng(eng_), task(task_), close_ids(close_ids_) {
         split.chan = initial;
-        round_split.chan = initial;
-        task.preview_round = [this](const int* ids, int n) { return preview_round(ids, n); };
-        task.commit_round = [this](const int* ids, int n) { commit_round(ids, n); };
+        task.sampled_budget_watch = state.limit >= 0;
     }
 
-    int preview_round(const int* ids, int n) const {
-        if (state.limit < 0) return -1;
-        StreamSplitter preview_split = round_split;
-        q27::Utf8Gate preview_gate = round_gate;
-        for (int i = 0; i < n; i++) {
-            const auto before = preview_split.chan;
-            (void)preview_split.feed(preview_gate.feed(tok.decode_one(ids[i])));
-            if (before != StreamSplitter::THINK &&
-                preview_split.chan == StreamSplitter::THINK)
-                return i + 1;
+    void apply(q27::ThinkBudgetAction action, int current_public_tokens = 0,
+               int current_context_tokens = -1) {
+        if (action == q27::ThinkBudgetAction::NONE ||
+            eng.reasoning_transition_active(task))
+            return;
+        eng.force_reasoning_close(
+            task, close_ids, action == q27::ThinkBudgetAction::FORCE_PUBLIC,
+            current_public_tokens, current_context_tokens);
+    }
+
+    void start() { apply(state.start(split.chan)); }
+
+    void observe_token(q27::ThinkBudgetState& target_state, StreamSplitter& target_split,
+                       q27::Utf8Gate& target_gate, int id, bool forced) {
+        const auto before = target_split.chan;
+        (void)target_split.feed(target_gate.feed(tok.decode_one(id)));
+        target_state.observe(before, target_split.chan, forced);
+    }
+
+    void observe_token(int id, bool forced) {
+        observe_token(state, split, gate, id, forced);
+    }
+
+    int visible_prefix(const int* ids, int n, bool forced, bool* hits_eos) const {
+        *hits_eos = false;
+        if (forced) return n;
+        int visible = std::min(n, std::max(0, task.n_max - task.emitted));
+        for (int i = 0; i < visible; i++)
+            if (ids[i] == task.eos) {
+                *hits_eos = true;
+                return i;
+            }
+        return visible;
+    }
+
+    // Pure planning pass. Tool scanning runs only over the prefix this returns,
+    // so a discarded suffix cannot engage or poison the stateful grammar hook.
+    int preview_round(const int* ids, int n) {
+        const bool forced = task.round_forced;
+        bool hits_eos = false;
+        const int visible = visible_prefix(ids, n, forced, &hits_eos);
+        q27::ThinkBudgetState trial_state = state;
+        StreamSplitter trial_split = split;
+        q27::Utf8Gate trial_gate = gate;
+        int trip_prefix = -1;
+        for (int i = 0; i < visible; i++) {
+            observe_token(trial_state, trial_split, trial_gate, ids[i], forced);
+            if (!forced && trip_prefix < 0 && trial_state.limit >= 0 &&
+                !trial_state.transition_pending &&
+                trial_split.chan == StreamSplitter::THINK &&
+                trial_state.used >= trial_state.limit)
+                trip_prefix = i + 1;
         }
-        return -1;
+        if (hits_eos) return -1;
+
+        const auto action = trial_state.finish_round(trial_split.chan);
+        const bool natural_close_after_trip =
+            trip_prefix > 0 && action == q27::ThinkBudgetAction::NONE &&
+            trial_split.chan != StreamSplitter::THINK;
+        const bool natural_close_keeps_answer =
+            task.n_max - task.emitted - visible >= 1;
+        const bool force_full_round_fits =
+            action != q27::ThinkBudgetAction::NONE &&
+            eng.reasoning_close_fits(
+                task, visible, visible, (int)close_ids.size(),
+                action == q27::ThinkBudgetAction::FORCE_PUBLIC);
+        if ((action == q27::ThinkBudgetAction::NONE &&
+             (!natural_close_after_trip || natural_close_keeps_answer)) ||
+            force_full_round_fits)
+            return -1;
+        return trip_prefix > 0 && trip_prefix < n ? trip_prefix : -1;
     }
 
     void commit_round(const int* ids, int n) {
-        if (state.limit < 0) return;
-        for (int i = 0; i < n; i++)
-            (void)round_split.feed(round_gate.feed(tok.decode_one(ids[i])));
+        const bool forced = task.round_forced;
+        bool hits_eos = false;
+        const int visible = visible_prefix(ids, n, forced, &hits_eos);
+        for (int i = 0; i < visible; i++) observe_token(ids[i], forced);
+        // EOS wins immediately. Count only tokens before it, but never queue a
+        // close that post_round cannot commit after taking the EOS exit.
+        if (hits_eos) return;
+        apply(state.finish_round(split.chan), visible, visible);
     }
 
+    int observe_round(const int* ids, int n) {
+        const int m = preview_round(ids, n);
+        const int kept = (m >= 1 && m < n) ? m : n;
+        commit_round(ids, kept);
+        return m;
+    }
 
-    void observe(int id) {
-        const auto before = split.chan;
-        (void)split.feed(gate.feed(tok.decode_one(id)));
-        state.observe(before, split.chan, task, close_ids);
+    void observe_sampled(int id, bool forced) {
+        if (!task.sampling) return;
+        observe_token(id, forced);
+        // post_round advanced Ph before invoking the callback, but emitted is
+        // incremented afterwards: account one public token and zero context rows.
+        apply(state.finish_round(split.chan), forced ? 0 : 1, 0);
     }
 };
 
@@ -1577,27 +1646,36 @@ int main(int argc, char** argv) {
             // generated token is already inside the block, and its </think> flips
             // back to text (same mechanism as the FORCED TOOL pre-seed above).
             else if (thinking) sp.chan = StreamSplitter::THINK;
-            tb.start(bt, think_close_ids, sp.chan);
+            ReasoningBudgetObserver budget{tok, tb, eng, bt, think_close_ids, sp.chan};
+            budget.start();
             eng.on_pending = [&](int id) { tc.on_pending(id); };
             eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
-            if (tc.enabled)
-                eng.on_round = [&](const int* em, int nr) { return tc.scan_round(em, nr); };
-            BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+            eng.on_round = [&](const int* em, int nr) {
+                int bm = budget.preview_round(em, nr);
+                int budget_kept = (bm >= 1 && bm < nr) ? bm : nr;
+                int m = tc.enabled ? tc.scan_round(em, budget_kept) : -1;
+                int kept = (m >= 1 && m <= budget_kept) ? m : budget_kept;
+                budget.commit_round(em, kept);
+                if (kept < nr) return kept;
+                return m;
+            };
             auto on_tok = [&](int id, bool forced) {
-                const auto before = sp.chan;
                 for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) {
                     if (forced && ch == StreamSplitter::TEXT && q27::strip_ws2(t).empty())
                         continue;
                     route(ch, t);
                 }
-                if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
+                if (!conductor) budget.observe_sampled(id, forced);
                 return true;
             };
             std::string berr;
             int n = conductor
                         ? batch_generate(eng, prompt, n_max,
                                          [&](int id, bool forced) { return on_tok(id, forced); },
-                                         [&](int id) { tc.on_id(id); batch_tb.observe(id); }, stable_len, qw,
+                                         [&](int id) {
+                                             tc.on_id(id);
+                                             budget.observe_sampled(id, bt.callback_forced);
+                                         }, stable_len, qw,
                                          rt, bt, &berr)
                         : eng.generate(prompt, n_max, EOS, [&](int id) {
                               tc.on_id(id);
@@ -1763,7 +1841,8 @@ int main(int argc, char** argv) {
                 Engine::DecodeTask bt;
                 if (tchoice.mode == q27::ToolChoice::FORCED) sp.chan = StreamSplitter::TOOL;
                 else if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
-                tb.start(bt, think_close_ids, sp.chan);
+                ReasoningBudgetObserver budget{tok, tb, eng, bt, think_close_ids, sp.chan};
+                budget.start();
                 q27::Utf8Gate ugate;
                 bool alive = true; // cleared when a write fails (client disconnected)
                 int tool_idx = 0;
@@ -1814,19 +1893,27 @@ int main(int argc, char** argv) {
                 };
                 eng.on_pending = [&](int id) { tc.on_pending(id); };
                 eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
-                if (tc.enabled)
-                    eng.on_round = [&](const int* em, int nr) { return tc.scan_round(em, nr); };
-                BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+                eng.on_round = [&](const int* em, int nr) {
+                    int bm = budget.preview_round(em, nr);
+                    int budget_kept = (bm >= 1 && bm < nr) ? bm : nr;
+                    int m = tc.enabled ? tc.scan_round(em, budget_kept) : -1;
+                    int kept = (m >= 1 && m <= budget_kept) ? m : budget_kept;
+                    budget.commit_round(em, kept);
+                    if (kept < nr) return kept;
+                    return m;
+                };
                 auto on_tok = [&](int id, bool forced) {
                     forced_control_token = forced;
-                    const auto before = sp.chan;
                     for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) emit_seg(ch, t);
-                    if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
+                    if (!conductor) budget.observe_sampled(id, forced);
                     return alive; // stop generating once the client has disconnected
                 };
                 int produced = conductor
                                    ? batch_generate(eng, prompt, nm, on_tok,
-                                                    [&](int id) { tc.on_id(id); batch_tb.observe(id); },
+                                                    [&](int id) {
+                                                        tc.on_id(id);
+                                                        budget.observe_sampled(id, bt.callback_forced);
+                                                    },
                                                     stable_len, qw, rt, bt, nullptr)
                                    : eng.generate(prompt, nm, EOS, [&](int id) {
                                          tc.on_id(id);
@@ -2020,7 +2107,8 @@ int main(int argc, char** argv) {
             q27::ThinkBudgetState tb{think_budget};
             Engine::DecodeTask bt;
             if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
-            tb.start(bt, think_close_ids, sp.chan);
+            ReasoningBudgetObserver budget{tok, tb, eng, bt, think_close_ids, sp.chan};
+            budget.start();
             q27::Utf8Gate ugate;
             std::string think, text, tool_buf;
             std::vector<q27::ToolCall> calls;
@@ -2042,17 +2130,22 @@ int main(int argc, char** argv) {
             tc.begin(tool_names_v);
             eng.on_pending = [&](int id) { tc.on_pending(id); };
             eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
-            if (tc.enabled)
-                eng.on_round = [&](const int* em, int nr) { return tc.scan_round(em, nr); };
-            BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+            eng.on_round = [&](const int* em, int nr) {
+                int bm = budget.preview_round(em, nr);
+                int budget_kept = (bm >= 1 && bm < nr) ? bm : nr;
+                int m = tc.enabled ? tc.scan_round(em, budget_kept) : -1;
+                int kept = (m >= 1 && m <= budget_kept) ? m : budget_kept;
+                budget.commit_round(em, kept);
+                if (kept < nr) return kept;
+                return m;
+            };
             auto on_tok = [&](int id, bool forced) {
-                const auto before = sp.chan;
                 for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) {
                     if (forced && ch == StreamSplitter::TEXT && q27::strip_ws2(t).empty())
                         continue;
                     route(ch, t);
                 }
-                if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
+                if (!conductor) budget.observe_sampled(id, forced);
                 return true;
             };
             std::string berr;
@@ -2061,7 +2154,10 @@ int main(int argc, char** argv) {
             int n = conductor
                         ? batch_generate(eng, prompt, n_max,
                                          [&](int id, bool forced) { return on_tok(id, forced); },
-                                         [&](int id) { tc.on_id(id); batch_tb.observe(id); }, stable_len, qw,
+                                         [&](int id) {
+                                             tc.on_id(id);
+                                             budget.observe_sampled(id, bt.callback_forced);
+                                         }, stable_len, qw,
                                          rt, bt, &berr)
                         : eng.generate(prompt, n_max, EOS, [&](int id) {
                               tc.on_id(id);
@@ -2180,7 +2276,8 @@ int main(int argc, char** argv) {
                 q27::ThinkBudgetState tb{think_budget};
                 Engine::DecodeTask bt;
                 if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
-                tb.start(bt, think_close_ids, sp.chan);
+                ReasoningBudgetObserver budget{tok, tb, eng, bt, think_close_ids, sp.chan};
+                budget.start();
                 std::string tool_buf, text_accum;
                 q27::Utf8Gate ugate;
                 int idx = -1;       // open think/text block index, -1 = none
@@ -2251,14 +2348,19 @@ int main(int argc, char** argv) {
                 };
                 eng.on_pending = [&](int id) { tc.on_pending(id); };
                 eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
-                if (tc.enabled)
-                    eng.on_round = [&](const int* em, int nr) { return tc.scan_round(em, nr); };
-                BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+                eng.on_round = [&](const int* em, int nr) {
+                    int bm = budget.preview_round(em, nr);
+                    int budget_kept = (bm >= 1 && bm < nr) ? bm : nr;
+                    int m = tc.enabled ? tc.scan_round(em, budget_kept) : -1;
+                    int kept = (m >= 1 && m <= budget_kept) ? m : budget_kept;
+                    budget.commit_round(em, kept);
+                    if (kept < nr) return kept;
+                    return m;
+                };
                 auto on_tok = [&](int id, bool forced) {
                     forced_control_token = forced;
-                    const auto before = sp.chan;
                     for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) emit_seg(ch, t);
-                    if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
+                    if (!conductor) budget.observe_sampled(id, forced);
                     return alive; // stop generating once the client has disconnected
                 };
                 std::string berr;
@@ -2266,7 +2368,10 @@ int main(int argc, char** argv) {
                 // a dead client flips `alive` -> the drain cancels (A3)
                 int produced = conductor
                                    ? batch_generate(eng, prompt, nm, on_tok,
-                                                    [&](int id) { tc.on_id(id); batch_tb.observe(id); },
+                                                    [&](int id) {
+                                                        tc.on_id(id);
+                                                        budget.observe_sampled(id, bt.callback_forced);
+                                                    },
                                                     stable_len, qw, rt, bt, &berr)
                                    : eng.generate(prompt, nm, EOS, [&](int id) {
                                          tc.on_id(id);
@@ -2544,6 +2649,7 @@ int main(int argc, char** argv) {
             Slot& sl = claim_slot(prompt, n_max, thinking, tcfg, true);
             auto sl_lease = slot_guard(sl);
             Engine& eng = *sl.eng;
+            HookGuard hooks{eng};
             eng.samp = parse_sample(body);
             eng.pfx_sys_len = sys_len; // P16b (0 on paths with no system boundary)
             std::optional<q27::GpuGate::Lease> lk; // solo whole-call hold; batch
@@ -2566,7 +2672,11 @@ int main(int argc, char** argv) {
             q27::ThinkBudgetState tb{think_budget};
             Engine::DecodeTask bt;
             if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
-            tb.start(bt, think_close_ids, sp.chan);
+            ReasoningBudgetObserver budget{tok, tb, eng, bt, think_close_ids, sp.chan};
+            budget.start();
+            eng.on_round = [&](const int* em, int nr) {
+                return budget.observe_round(em, nr);
+            };
             auto route = [&](StreamSplitter::Chan ch, const std::string& t) {
                 if (ch == StreamSplitter::TOOL) {
                     if (!ctx->think.empty()) flush_think();
@@ -2582,26 +2692,27 @@ int main(int argc, char** argv) {
                 }
             };
             q27::Utf8Gate ugate;
-            BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
             auto on_tok = [&](int id, bool forced) {
-                const auto before = sp.chan;
                 for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) {
                     if (forced && ch == StreamSplitter::TEXT && q27::strip_ws2(t).empty())
                         continue;
                     route(ch, t);
                 }
-                if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
+                if (!conductor) budget.observe_sampled(id, forced);
                 return true;
             };
             std::string berr;
             int produced = conductor
                                ? batch_generate(eng, prompt, n_max,
                                                 [&](int id, bool forced) { return on_tok(id, forced); },
-                                                [&](int id) { batch_tb.observe(id); }, -1,
+                                                [&](int id) {
+                                                    budget.observe_sampled(id, bt.callback_forced);
+                                                }, -1,
                                                 qw, rt, bt, &berr)
                                : eng.generate(prompt, n_max, EOS,
                                               [&](int id) { return on_tok(id, bt.callback_forced); },
                                               -1, &bt);
+            eng.on_round = nullptr;
             eng.on_round_gap = nullptr;
             req_log(rt, qw, eng, sl.id, bat_stats(bt));
             // batch error surfacing (review pass 2): nothing emitted = 500
@@ -2647,6 +2758,7 @@ int main(int argc, char** argv) {
                 Slot& sl = claim_slot(prompt, n_max, thinking, tcfg, true);
                 auto sl_lease = slot_guard(sl);
                 Engine& eng = *sl.eng;
+                HookGuard hooks{eng};
                 eng.samp = samp;
                 eng.pfx_sys_len = sys_len; // P16b
                 std::optional<q27::GpuGate::Lease> lk; // see the non-stream twin
@@ -2774,17 +2886,19 @@ int main(int argc, char** argv) {
                         {"output_index", msg_index}, {"content_index", 0}, {"delta", t}});
                 };
                 StreamSplitter sp;
+                q27::Utf8Gate ugate;
                 q27::ThinkBudgetState tb{think_budget};
                 Engine::DecodeTask bt;
                 if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
-                tb.start(bt, think_close_ids, sp.chan);
-                q27::Utf8Gate ugate;
-                BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+                ReasoningBudgetObserver budget{tok, tb, eng, bt, think_close_ids, sp.chan};
+                budget.start();
+                eng.on_round = [&](const int* em, int nr) {
+                    return budget.observe_round(em, nr);
+                };
                 auto on_tok = [&](int id, bool forced) {
                     forced_control_token = forced;
-                    const auto before = sp.chan;
                     for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) route(ch, t);
-                    if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
+                    if (!conductor) budget.observe_sampled(id, forced);
                     return alive; // stop generating once the client has disconnected
                 };
                 // TODO(batch error surfacing): no mid-stream error event is
@@ -2795,11 +2909,14 @@ int main(int argc, char** argv) {
                 // the what().
                 int produced = conductor
                                    ? batch_generate(eng, prompt, nm, on_tok,
-                                                    [&](int id) { batch_tb.observe(id); }, -1,
+                                                    [&](int id) {
+                                                        budget.observe_sampled(id, bt.callback_forced);
+                                                    }, -1,
                                                     qw, rt, bt, nullptr)
                                    : eng.generate(prompt, nm, EOS, [&](int id) {
                                          return on_tok(id, bt.callback_forced);
                                      }, -1, &bt);
+                eng.on_round = nullptr;
                 eng.on_round_gap = nullptr;
                 req_log(rt, qw, eng, sl.id, bat_stats(bt));
                 const auto terminal = q27::responses_terminal_state(

--- a/src/server.cu
+++ b/src/server.cu
@@ -172,16 +172,15 @@ int main(int argc, char** argv) {
                 "  --kv-fp16 --no-fast-head --think --request-think (honor per-\n"
                 "  request enable_thinking; off by default). The CLI keeps reference\n"
                 "  defaults (bitwise canonical).\n"
-                "  Reasoning budget: whenever a <think> block is served, tokens\n"
-                "  inside it are capped and the block is force-closed on trip --\n"
-                "  the answer still gets written. Default = half the request's\n"
-                "  max_tokens; --think-budget N sets an absolute cap, 0 disables.\n"
-                "  Requests may bound it too, symmetric with the enable\n"
-                "  conventions: thinking.budget_tokens (Anthropic),\n"
-                "  thinking_token_budget (OpenAI/Qwen), or\n"
-                "  chat_template_kwargs.thinking_budget -- honored only under\n"
-                "  --request-think. A trip is reported as usage.reasoning_tokens\n"
-                "  and usage.reasoning_budget_exceeded.\n"
+                "  Reasoning budget: prompt-seeded <think> blocks default to half\n"
+                "  the request's max_tokens and are force-closed on trip so the\n"
+                "  answer still gets written. A no-think request keeps ordinary\n"
+                "  speculative decode; --think-budget N (N>0) or an explicit\n"
+                "  request budget also arms a later model-generated block.\n"
+                "  --think-budget 0 disables. Request conventions: thinking.\n"
+                "  budget_tokens (Anthropic), thinking_token_budget (OpenAI/Qwen),\n"
+                "  or chat_template_kwargs.thinking_budget -- honored only under\n"
+                "  --request-think. A trip is reported in reasoning usage.\n"
                 "  Auth: no API key is required by default (loopback-only is the\n"
                 "  safety net). --api-key KEY may repeat; --api-key-file PATH loads\n"
                 "  one key per line (# comments ignored); Q27_API_KEY adds one more.\n"
@@ -219,9 +218,9 @@ int main(int argc, char** argv) {
     bool constrain_tools = false;
     bool req_think = false; // --request-think: honor per-request thinking fields (else ignored)
     // --think-budget: cap on tokens generated inside a <think> block. <0
-    // (default) = THINK_BUDGET_FRAC of the request max_tokens; 0 = unbounded
-    // (opt out); >0 = absolute. Applies whenever a block is served, by boot
-    // flag or by request. api_common.h documents why the default is ON.
+    // (default) = THINK_BUDGET_FRAC for prompt-seeded thinking only, preserving
+    // speculative width on ordinary no-think requests; 0 = unbounded; >0 = an
+    // explicit absolute cap that also arms a later model-generated block.
     int think_budget_flag = -1;
     std::vector<std::string> api_keys;
     q27::PrefixCacheCfg pfx_cfg; // P16: root empty = off
@@ -1547,12 +1546,15 @@ int main(int argc, char** argv) {
             q27::Utf8Gate ugate;
             std::string think, text, tool_buf;
             std::vector<q27::ToolCall> calls;
+            auto flush_tool = [&]() {
+                auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
+                tool_buf.clear();
+                if (c.ok) calls.push_back(std::move(c));
+                else text += c.raw; // stream parity: preserve generation order
+            };
             auto route = [&](StreamSplitter::Chan ch, const std::string& t) {
                 if (ch == StreamSplitter::TOOL) { tool_buf += t; return; }
-                if (!tool_buf.empty()) { // tool segment closed
-                    calls.push_back(q27::parse_tool_call(q27::strip_ws2(tool_buf)));
-                    tool_buf.clear();
-                }
+                if (!tool_buf.empty()) flush_tool();
                 (ch == StreamSplitter::THINK ? think : text) += t;
             };
             ToolConstrainer tc;
@@ -1616,12 +1618,9 @@ int main(int argc, char** argv) {
             }
             for (auto& [ch, t] : sp.feed(ugate.flush())) route(ch, t);
             for (auto& [ch, t] : sp.flush()) route(ch, t);
-            if (!tool_buf.empty())
-                calls.push_back(q27::parse_tool_call(q27::strip_ws2(tool_buf)));
+            if (!tool_buf.empty()) flush_tool();
 
-            std::string tx = q27::strip_ws2(text);
-            for (auto& c : calls)
-                if (!c.ok) tx += (tx.empty() ? "" : "\n") + c.raw;
+            std::string tx = text;
             if (tools.is_array() && !tools.empty()) {
                 // wrapper-less call recovery (see parse_bare_tool_calls)
                 std::string pre;
@@ -1637,7 +1636,7 @@ int main(int argc, char** argv) {
             bool any_call = false;
             for (auto& c : calls)
                 if (c.ok) any_call = true;
-            json msg = q27::openai_chat_message_json(tx, calls, rid, q27::strip_ws2(think));
+            json msg = q27::openai_chat_message_json(tx, calls, rid, think);
             json choice = {{"index", 0},
                           {"finish_reason", any_call ? "tool_calls" :
                               ((n >= n_max || bt.budget_truncated) ? "length" : "stop")},
@@ -2025,12 +2024,15 @@ int main(int argc, char** argv) {
             q27::Utf8Gate ugate;
             std::string think, text, tool_buf;
             std::vector<q27::ToolCall> calls;
+            auto flush_tool = [&]() {
+                auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
+                tool_buf.clear();
+                if (c.ok) calls.push_back(std::move(c));
+                else text += c.raw; // stream parity: preserve generation order
+            };
             auto route = [&](StreamSplitter::Chan ch, const std::string& t) {
                 if (ch == StreamSplitter::TOOL) { tool_buf += t; return; }
-                if (!tool_buf.empty()) { // tool segment closed
-                    calls.push_back(q27::parse_tool_call(q27::strip_ws2(tool_buf)));
-                    tool_buf.clear();
-                }
+                if (!tool_buf.empty()) flush_tool();
                 (ch == StreamSplitter::THINK ? think : text) += t;
             };
             ToolConstrainer tc;
@@ -2084,18 +2086,16 @@ int main(int argc, char** argv) {
             }
             for (auto& [ch, t] : sp.feed(ugate.flush())) route(ch, t);
             for (auto& [ch, t] : sp.flush()) route(ch, t);
-            if (!tool_buf.empty())
-                calls.push_back(q27::parse_tool_call(q27::strip_ws2(tool_buf)));
+            if (!tool_buf.empty()) flush_tool();
 
             json content = json::array();
-            std::string th = q27::strip_ws2(think), tx = q27::strip_ws2(text);
+            std::string th = think, tx = text;
             if (!th.empty())
                 content.push_back({{"type", "thinking"}, {"thinking", th},
                                    {"signature", "q27-local"}});
             bool any_call = false;
             int ci = 0;
             for (auto& c : calls) {
-                if (!c.ok) { tx += (tx.empty() ? "" : "\n") + c.raw; continue; }
                 any_call = true;
                 (void)ci;
             }
@@ -2491,7 +2491,7 @@ int main(int argc, char** argv) {
             };
             auto ctx = std::make_shared<Ctx>();
             auto flush_think = [&items, ctx, rid]() {
-                std::string th = q27::strip_ws2(ctx->think);
+                std::string th = ctx->think;
                 ctx->think.clear();
                 if (th.empty()) return json();
                 json r = {{"type", "reasoning"}, {"id", "rs_q27_" + std::to_string(rid)},
@@ -2501,7 +2501,7 @@ int main(int argc, char** argv) {
                 return r;
             };
             auto flush_text = [&items, ctx, rid](bool incomplete=false) {
-                std::string tx = q27::strip_ws2(ctx->text);
+                std::string tx = ctx->text;
                 ctx->text.clear();
                 if (tx.empty()) return json();
                 json m = {{"type", "message"}, {"id", "msg_q27_" + std::to_string(rid)},
@@ -2557,8 +2557,11 @@ int main(int argc, char** argv) {
             const int think_budget = limits.budget;
             json items = json::array();
             int tool_counter = 0;
-            auto [ctx, flush_think, flush_text, flush_tool] =
-                make_item_cbs(items, tool_counter, nullptr);
+            auto item_cbs = make_item_cbs(items, tool_counter, nullptr);
+            auto& ctx = std::get<0>(item_cbs);
+            auto& flush_think = std::get<1>(item_cbs);
+            auto& flush_text = std::get<2>(item_cbs);
+            auto& flush_tool = std::get<3>(item_cbs);
             StreamSplitter sp;
             q27::ThinkBudgetState tb{think_budget};
             Engine::DecodeTask bt;
@@ -2679,7 +2682,7 @@ int main(int argc, char** argv) {
                     items.push_back(it);
                 };
                 auto flush_think = [&]() {
-                    std::string th = q27::strip_ws2(think);
+                    std::string th = think;
                     think.clear();
                     if (th.empty()) return;
                     item_done({{"type", "reasoning"}, {"id", "rs_q27_" + std::to_string(rid)},
@@ -2709,7 +2712,7 @@ int main(int argc, char** argv) {
                 };
                 auto flush_text = [&](bool incomplete=false) {
                     if (msg_index < 0) { text.clear(); return; }
-                    std::string tx = q27::strip_ws2(text);
+                    std::string tx = text;
                     text.clear();
                     ev({{"type", "response.output_text.done"}, {"item_id", msg_id},
                         {"output_index", msg_index}, {"content_index", 0}, {"text", tx}});

--- a/src/server.cu
+++ b/src/server.cu
@@ -103,6 +103,61 @@ struct HookGuard {
     }
 };
 
+// In batch mode the conductor must observe bounded-thinking transitions before
+// it starts the next round. The request thread drains TokenQueue asynchronously;
+// observing there races the next draft and can either miss the forced close or
+// enqueue it after a natural close, leaking a literal </think> into content.
+// Keep an independent parser on the conductor thread. The request parser still
+// owns output routing; this twin owns only ThinkBudgetState / DecodeTask control.
+struct BatchThinkBudgetObserver {
+    q27::Tokenizer& tok;
+    q27::ThinkBudgetState& state;
+    Engine::DecodeTask& task;
+    const std::vector<int>& close_ids;
+    StreamSplitter split;
+    q27::Utf8Gate gate;
+    StreamSplitter round_split;
+    q27::Utf8Gate round_gate;
+
+    BatchThinkBudgetObserver(q27::Tokenizer& tok_, q27::ThinkBudgetState& state_,
+                             Engine::DecodeTask& task_,
+                             const std::vector<int>& close_ids_,
+                             StreamSplitter::Chan initial)
+        : tok(tok_), state(state_), task(task_), close_ids(close_ids_) {
+        split.chan = initial;
+        round_split.chan = initial;
+        task.preview_round = [this](const int* ids, int n) { return preview_round(ids, n); };
+        task.commit_round = [this](const int* ids, int n) { commit_round(ids, n); };
+    }
+
+    int preview_round(const int* ids, int n) const {
+        if (state.limit < 0) return -1;
+        StreamSplitter preview_split = round_split;
+        q27::Utf8Gate preview_gate = round_gate;
+        for (int i = 0; i < n; i++) {
+            const auto before = preview_split.chan;
+            (void)preview_split.feed(preview_gate.feed(tok.decode_one(ids[i])));
+            if (before != StreamSplitter::THINK &&
+                preview_split.chan == StreamSplitter::THINK)
+                return i + 1;
+        }
+        return -1;
+    }
+
+    void commit_round(const int* ids, int n) {
+        if (state.limit < 0) return;
+        for (int i = 0; i < n; i++)
+            (void)round_split.feed(round_gate.feed(tok.decode_one(ids[i])));
+    }
+
+
+    void observe(int id) {
+        const auto before = split.chan;
+        (void)split.feed(gate.feed(tok.decode_one(id)));
+        state.observe(before, split.chan, task, close_ids);
+    }
+};
+
 int main(int argc, char** argv) {
     if (argc < 3) {
         fprintf(stderr,
@@ -404,6 +459,7 @@ int main(int argc, char** argv) {
     // the post-upload block below; no legacy 8192 fallback.
     fprintf(stderr, "loading tokenizer...\n");
     q27::Tokenizer tok(tokpath);
+    const std::vector<int> think_close_ids = tok.encode("</think>\n\n");
     fprintf(stderr, "loading model...\n");
     // P10-A1: weights owned here and shared into the Engine(s) by reference.
     // Upload once; borrowing engines skip the 17.7 GB weight copy. (Multi-slot
@@ -850,14 +906,26 @@ int main(int argc, char** argv) {
     // bounded by <=4 slots and self-limiting clients -- the GPU gate is the
     // fair one.
     long slot_use_counter = 0;
-    auto claim_slot = [&](const std::vector<int>& prompt) -> Slot& {
+    auto claim_slot = [&](const std::vector<int>& prompt, int requested,
+                          bool thinking, const q27::ThinkCfg& cfg,
+                          bool budget_aware) -> Slot& {
         std::unique_lock<std::mutex> lk(route_m);
-        // eligibility requires a POSITIVE decode budget on the slot, not
-        // just prompt-fits (review follow-up 2026-07-09 #3): a slot whose
-        // clamp would floor n_max to 0 must not take the request. The route
-        // preflights guarantee at least the largest slot qualifies, so this
-        // never deadlocks.
-        const bool fits_any = (int)prompt.size() <= max_prompt;
+        const q27::ThinkCfg raw_cfg{false, -1, true};
+        const q27::ThinkCfg& limit_cfg = budget_aware ? cfg : raw_cfg;
+        const int limit_close = budget_aware ? (int)think_close_ids.size() : 0;
+        const int limit_flag = budget_aware ? think_budget_flag : 0;
+        // Eligibility includes the request's forced-close reserve. This keeps
+        // prefix reuse from routing a boundary request to a smaller slot that
+        // cannot honor the bounded-thinking transition.
+        auto can_fit = [&](Slot& s) {
+            return q27::resolve_think_decode_limits(
+                       requested, s.eng->max_ctx, (int)prompt.size(),
+                       s.eng->ctx_round_reserve(), limit_close, thinking,
+                       limit_cfg, limit_flag)
+                .context_ok;
+        };
+        bool fits_any = false;
+        for (auto& s : slots) fits_any = fits_any || can_fit(s);
         for (;;) {
             Slot* best = nullptr;
             int best_tier = -1, best_key = 0;
@@ -867,7 +935,7 @@ int main(int argc, char** argv) {
                     if (!best || s.eng->max_ctx > best->eng->max_ctx) best = &s;
                     continue;
                 }
-                if ((int)prompt.size() + s.eng->ctx_round_reserve() > s.eng->max_ctx) continue;
+                if (!can_fit(s)) continue;
                 int rl = s.eng->reuse_len(prompt);
                 int tier = rl > 0 ? 2 : s.eng->cache_empty() ? 1 : 0;
                 bool better;
@@ -1077,7 +1145,7 @@ int main(int argc, char** argv) {
     // stamped either way so the [req] line never reports a failed
     // generation as a normal finish.
     auto batch_generate = [&](Engine& eng, const std::vector<int>& prompt, int nm,
-                              std::function<bool(int)> on_token,
+                              std::function<bool(int, bool)> on_token,
                               std::function<void(int)> on_emit, int stable_len, double& qw,
                               const ReqTrace& rt, Engine::DecodeTask& t,
                               std::string* err_out) -> int {
@@ -1091,19 +1159,21 @@ int main(int argc, char** argv) {
                 return 0; // refused; gs.end already stamped for req_log
             }
             eng.on_round_gap = nullptr; // Task 9 invariant (contract above)
-            // sink is replaced by register_member; the queue carries tokens
-            eng.make_decode_task(t, nm, EOS, on_token, P);
+            // register_member replaces this placeholder with the queue sink.
+            auto placeholder = [](int) { return true; };
+            eng.make_decode_task(t, nm, EOS, placeholder, P);
         } // lease released: decode arbitration belongs to the conductor
         conductor->register_member(&eng, &t, &q, std::move(on_emit));
         bool client_gone = false;
-        std::vector<int> ids;
+        std::vector<q27::TokenQueue::Token> ids;
         try {
             while (q.pop(ids)) {
-                for (int id : ids)
-                    if (!client_gone && !on_token(id)) {
+                for (const auto& token : ids) {
+                    if (!client_gone && !on_token(token.id, token.forced)) {
                         client_gone = true;
                         t.cancel.store(true); // A3: takes effect at a round boundary
                     }
+                }
                 ids.clear();
             }
         } catch (...) {
@@ -1345,14 +1415,28 @@ int main(int argc, char** argv) {
                             "application/json");
             return;
         }
+        const bool think_aware=routed_chat && tchoice.mode!=q27::ToolChoice::FORCED;
         // context-limit preflight BEFORE slot claim / SSE commit (review
         // follow-up 2026-07-09 #3): past this bound the routed slot's
         // n_max clamp floors at 0 -> empty 200
-        if ((int)prompt.size() > max_prompt) {
+        const auto admission = think_aware
+            ? q27::resolve_think_decode_limits(
+                  n_max, max_slot_ctx, (int)prompt.size(), slots[0].eng->ctx_round_reserve(),
+                  (int)think_close_ids.size(), thinking, tcfg, think_budget_flag)
+            : q27::resolve_think_decode_limits(
+                  n_max, max_slot_ctx, (int)prompt.size(), slots[0].eng->ctx_round_reserve(),
+                  0, false, q27::ThinkCfg{false, -1, true}, 0);
+        const int request_max_prompt = !think_aware || admission.context_ok
+            ? max_prompt
+            : q27::max_prompt_for_think_decode(
+                  n_max, max_slot_ctx, slots[0].eng->ctx_round_reserve(), max_prompt,
+                  (int)prompt.size(), (int)think_close_ids.size(), thinking, tcfg,
+                  think_budget_flag);
+        if ((int)prompt.size() > max_prompt || !admission.context_ok) {
             res.status = 400;
             res.set_content(json{{"error",
                                   {{"message", q27::ctx_limit_error_message(
-                                                   (int)prompt.size(), max_prompt)},
+                                                   (int)prompt.size(), request_max_prompt)},
                                    {"type", "invalid_request_error"},
                                    {"code", "context_length_exceeded"}}}}
                                 .dump(),
@@ -1383,7 +1467,7 @@ int main(int argc, char** argv) {
         const char* objd = chat ? "chat.completion.chunk" : "text_completion";
 
         if (!stream) {
-            Slot& sl = claim_slot(prompt); // may wait for a free engine
+            Slot& sl = claim_slot(prompt,n_max,thinking,tcfg,think_aware); // may wait for a free engine
             auto sl_lease = slot_guard(sl);
             Engine& eng = *sl.eng;
             HookGuard hooks{eng}; // safe even when routed_chat is false: hooks
@@ -1399,7 +1483,15 @@ int main(int argc, char** argv) {
             eng.on_round_gap = make_yield(eng);
             // re-clamp to the routed slot (rows P+1..P+gate_maxd+1 must stay
             // in ctx; reserve derived from the engine's active max depth)
-            n_max = std::max(0, std::min(n_max, eng.max_ctx - (int)prompt.size() - (eng.ctx_round_reserve() - 1)));
+            auto limits = think_aware
+                ? q27::resolve_think_decode_limits(
+                      n_max, eng.max_ctx, (int)prompt.size(), eng.ctx_round_reserve(),
+                      (int)think_close_ids.size(), thinking, tcfg, think_budget_flag)
+                : q27::resolve_think_decode_limits(
+                      n_max, eng.max_ctx, (int)prompt.size(), eng.ctx_round_reserve(),
+                      0, false, q27::ThinkCfg{false, -1, true}, 0);
+            n_max = limits.n_max;
+            const int think_budget = limits.budget;
 
             if (!routed_chat) {
                 // ORIGINAL text-only behavior, byte-for-byte unchanged.
@@ -1411,9 +1503,11 @@ int main(int argc, char** argv) {
                 };
                 Engine::DecodeTask bt;
                 std::string berr;
-                int n = conductor ? batch_generate(eng, prompt, n_max, on_tok, nullptr, -1,
-                                                   qw, rt, bt, &berr)
-                                  : eng.generate(prompt, n_max, EOS, on_tok);
+                int n = conductor
+                            ? batch_generate(eng, prompt, n_max,
+                                             [&](int id, bool) { return on_tok(id); },
+                                             nullptr, -1, qw, rt, bt, &berr)
+                            : eng.generate(prompt, n_max, EOS, on_tok);
                 eng.on_round_gap = nullptr;
                 text += ugate.flush();
                 req_log(rt, qw, eng, sl.id, bat_stats(bt));
@@ -1448,8 +1542,8 @@ int main(int argc, char** argv) {
             // routed_chat: think/tool-aware path, an exact mechanical twin of
             // the /v1/messages non-stream handler above, OpenAI-shaped output.
             StreamSplitter sp;
-            q27::ThinkBudget tb{tcfg.budget >= 0 ? tcfg.budget
-                                : q27::think_budget_default(think_budget_flag, n_max)};
+            q27::ThinkBudgetState tb{think_budget};
+            Engine::DecodeTask bt;
             q27::Utf8Gate ugate;
             std::string think, text, tool_buf;
             std::vector<q27::ToolCall> calls;
@@ -1481,26 +1575,32 @@ int main(int argc, char** argv) {
             // generated token is already inside the block, and its </think> flips
             // back to text (same mechanism as the FORCED TOOL pre-seed above).
             else if (thinking) sp.chan = StreamSplitter::THINK;
+            tb.start(bt, think_close_ids, sp.chan);
             eng.on_pending = [&](int id) { tc.on_pending(id); };
             eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
             if (tc.enabled)
                 eng.on_round = [&](const int* em, int nr) { return tc.scan_round(em, nr); };
-            auto on_tok = [&](int id) {
-                for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) route(ch, t);
-                if (const char* bclose = tb.tick(sp))
-                    for (auto& [ch, t] : sp.feed(bclose)) route(ch, t);
+            BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+            auto on_tok = [&](int id, bool forced) {
+                const auto before = sp.chan;
+                for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) {
+                    if (forced && ch == StreamSplitter::TEXT && q27::strip_ws2(t).empty())
+                        continue;
+                    route(ch, t);
+                }
+                if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
                 return true;
             };
-            Engine::DecodeTask bt;
             std::string berr;
             int n = conductor
-                        ? batch_generate(eng, prompt, n_max, on_tok,
-                                         [&](int id) { tc.on_id(id); }, stable_len, qw,
+                        ? batch_generate(eng, prompt, n_max,
+                                         [&](int id, bool forced) { return on_tok(id, forced); },
+                                         [&](int id) { tc.on_id(id); batch_tb.observe(id); }, stable_len, qw,
                                          rt, bt, &berr)
                         : eng.generate(prompt, n_max, EOS, [&](int id) {
                               tc.on_id(id);
-                              return on_tok(id);
-                          }, stable_len);
+                              return on_tok(id, bt.callback_forced);
+                          }, stable_len, &bt);
             tc.end();
             eng.on_pending = nullptr;
             eng.on_drafts = nullptr;
@@ -1539,7 +1639,8 @@ int main(int argc, char** argv) {
                 if (c.ok) any_call = true;
             json msg = q27::openai_chat_message_json(tx, calls, rid, q27::strip_ws2(think));
             json choice = {{"index", 0},
-                          {"finish_reason", any_call ? "tool_calls" : (n >= n_max ? "length" : "stop")},
+                          {"finish_reason", any_call ? "tool_calls" :
+                              ((n >= n_max || bt.budget_truncated) ? "length" : "stop")},
                           {"message", msg}};
             json out = {{"id", "chatcmpl-q27-" + std::to_string(rid)}, {"object", obj},
                         {"created", created}, {"model", served_name},
@@ -1568,8 +1669,8 @@ int main(int argc, char** argv) {
             // 07-24 audit -- benign only by stack-layout luck.
             [&, samp, prompt, n_max, created, chat, obj, objd, rt, inc_usage, routed_chat,
              tools, tool_names_v, tchoice, stable_len, has_tools, rid,
-             thinking, sys_len](size_t, httplib::DataSink& sink) {
-                Slot& sl = claim_slot(prompt);
+             thinking, tcfg, sys_len, think_aware](size_t, httplib::DataSink& sink) {
+                Slot& sl = claim_slot(prompt,n_max,thinking,tcfg,think_aware);
                 auto sl_lease = slot_guard(sl);
                 Engine& eng = *sl.eng;
                 HookGuard hooks{eng}; // see the non-stream twin
@@ -1579,8 +1680,15 @@ int main(int argc, char** argv) {
                 if (!conductor) lk.emplace(gpu_gate);
                 double qw = ms_since(rt.t0);
                 eng.on_round_gap = make_yield(eng);
-                const int nm =
-                    std::max(0, std::min(n_max, eng.max_ctx - (int)prompt.size() - (eng.ctx_round_reserve() - 1)));
+                auto limits = think_aware
+                    ? q27::resolve_think_decode_limits(
+                          n_max, eng.max_ctx, (int)prompt.size(), eng.ctx_round_reserve(),
+                          (int)think_close_ids.size(), thinking, tcfg, think_budget_flag)
+                    : q27::resolve_think_decode_limits(
+                          n_max, eng.max_ctx, (int)prompt.size(), eng.ctx_round_reserve(),
+                          0, false, q27::ThinkCfg{false, -1, true}, 0);
+                const int nm = limits.n_max;
+                const int think_budget = limits.budget;
                 auto send = [&](const json& j) {
                     std::string s = "data: " + jdump(j) + "\n\n";
                     return sink.write(s.data(), s.size());
@@ -1608,9 +1716,11 @@ int main(int argc, char** argv) {
                     // SSE shape has no standard mid-stream error event, so none
                     // is invented; end=error lands in the [req] line and
                     // [req-error] carries the what().
-                    int produced = conductor ? batch_generate(eng, prompt, nm, on_tok, nullptr,
-                                                              -1, qw, rt, bt, nullptr)
-                                             : eng.generate(prompt, nm, EOS, on_tok);
+                    int produced = conductor
+                                       ? batch_generate(eng, prompt, nm,
+                                                        [&](int id, bool) { return on_tok(id); },
+                                                        nullptr, -1, qw, rt, bt, nullptr)
+                                       : eng.generate(prompt, nm, EOS, on_tok);
                     eng.on_round_gap = nullptr;
                     std::string tailp = ugate.flush();
                     if (!tailp.empty()) send(piece_chunk(tailp));
@@ -1650,15 +1760,17 @@ int main(int argc, char** argv) {
                             eng.samp.inv_temp <= 0.f; // constrained+sampled is Phase 3
                 tc.begin(tool_names_v);
                 StreamSplitter sp;
-                q27::ThinkBudget tb{tcfg.budget >= 0 ? tcfg.budget
-                                    : q27::think_budget_default(think_budget_flag, n_max)};
+                q27::ThinkBudgetState tb{think_budget};
+                Engine::DecodeTask bt;
                 if (tchoice.mode == q27::ToolChoice::FORCED) sp.chan = StreamSplitter::TOOL;
                 else if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
+                tb.start(bt, think_close_ids, sp.chan);
                 q27::Utf8Gate ugate;
                 bool alive = true; // cleared when a write fails (client disconnected)
                 int tool_idx = 0;
                 bool any_call = false;
                 std::string tool_buf, text_accum;
+                bool forced_control_token = false;
                 auto emit_tool = [&]() {
                     auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
                     tool_buf.clear();
@@ -1692,6 +1804,10 @@ int main(int argc, char** argv) {
                             alive = false;
                         return;
                     }
+                    // Only decoder-injected close whitespace is parser control.
+                    // Preserve ordinary leading whitespace, including when
+                    // thinking is disabled or the model closes naturally.
+                    if (forced_control_token && q27::strip_ws2(t).empty()) return;
                     text_accum += t;
                     if (!send(q27::openai_stream_chunk(cid, objd, created, served_name,
                                                        json{{"content", t}})))
@@ -1701,21 +1817,22 @@ int main(int argc, char** argv) {
                 eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
                 if (tc.enabled)
                     eng.on_round = [&](const int* em, int nr) { return tc.scan_round(em, nr); };
-                auto on_tok = [&](int id) {
+                BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+                auto on_tok = [&](int id, bool forced) {
+                    forced_control_token = forced;
+                    const auto before = sp.chan;
                     for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) emit_seg(ch, t);
-                    if (const char* bclose = tb.tick(sp))
-                        for (auto& [ch, t] : sp.feed(bclose)) emit_seg(ch, t);
+                    if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
                     return alive; // stop generating once the client has disconnected
                 };
-                Engine::DecodeTask bt;
                 int produced = conductor
                                    ? batch_generate(eng, prompt, nm, on_tok,
-                                                    [&](int id) { tc.on_id(id); },
+                                                    [&](int id) { tc.on_id(id); batch_tb.observe(id); },
                                                     stable_len, qw, rt, bt, nullptr)
                                    : eng.generate(prompt, nm, EOS, [&](int id) {
                                          tc.on_id(id);
-                                         return on_tok(id);
-                                     }, stable_len);
+                                         return on_tok(id, bt.callback_forced);
+                                     }, stable_len, &bt);
                 tc.end();
                 eng.on_pending = nullptr;
                 eng.on_drafts = nullptr;
@@ -1752,7 +1869,9 @@ int main(int argc, char** argv) {
                 // carries the what() (batch_generate logs it unconditionally
                 // when err_out is null, same as that leg's nullptr err_out).
                 {
-                    const char* fr = any_call ? "tool_calls" : (produced >= nm ? "length" : "stop");
+                    const char* fr = any_call ? "tool_calls"
+                                              : ((produced >= nm || bt.budget_truncated)
+                                                     ? "length" : "stop");
                     send(q27::openai_stream_chunk(cid, objd, created, served_name,
                                                   json::object(), fr));
                 }
@@ -1761,7 +1880,9 @@ int main(int argc, char** argv) {
                               {"model", served_name}, {"choices", json::array()},
                               {"usage", {{"prompt_tokens", (int)prompt.size()},
                                          {"completion_tokens", produced},
-                                         {"total_tokens", (int)prompt.size() + produced}}}});
+                                         {"total_tokens", (int)prompt.size() + produced},
+                                         {"reasoning_tokens", tb.used},
+                                         {"reasoning_budget_exceeded", tb.tripped}}}});
                 std::string done = "data: [DONE]\n\n";
                 sink.write(done.data(), done.size());
                 sink.done();
@@ -1850,10 +1971,20 @@ int main(int argc, char** argv) {
         // instead of compacting. "prompt is too long" is CC's compact-now
         // signal. Ceiling is the shared max_prompt (largest slot minus the
         // depth-derived spec-round reserve, keeping n_max >= 1).
-        if ((int)prompt.size() > max_prompt) {
+        const auto admission = q27::resolve_think_decode_limits(
+            n_max, max_slot_ctx, (int)prompt.size(), slots[0].eng->ctx_round_reserve(),
+            (int)think_close_ids.size(), thinking, tcfg, think_budget_flag);
+        const int request_max_prompt = admission.context_ok
+            ? max_prompt
+            : q27::max_prompt_for_think_decode(
+                  n_max, max_slot_ctx, slots[0].eng->ctx_round_reserve(), max_prompt,
+                  (int)prompt.size(), (int)think_close_ids.size(), thinking, tcfg,
+                  think_budget_flag);
+        if ((int)prompt.size() > max_prompt || !admission.context_ok) {
             fprintf(stderr, "[ctx-limit] prompt=%zu max=%d -> 400\n", prompt.size(),
-                    max_prompt);
-            anthropic_400(res, q27::ctx_limit_error_message((int)prompt.size(), max_prompt));
+                    request_max_prompt);
+            anthropic_400(
+                res, q27::ctx_limit_error_message((int)prompt.size(), request_max_prompt));
             return;
         }
         // Q27_SAMPLED=0 preflight (see the OpenAI handler's twin)
@@ -1871,7 +2002,7 @@ int main(int argc, char** argv) {
                     std::chrono::duration<double, std::milli>(tk2 - tk0).count()};
 
         if (!stream) {
-            Slot& sl = claim_slot(prompt);
+            Slot& sl = claim_slot(prompt, n_max, thinking, tcfg, true);
             auto sl_lease = slot_guard(sl);
             Engine& eng = *sl.eng;
             HookGuard hooks{eng}; // M1: clears tc hooks on unwind, pre slot-free
@@ -1881,11 +2012,16 @@ int main(int argc, char** argv) {
             if (!conductor) lk.emplace(gpu_gate);  // leases inside batch_generate
             double qw = ms_since(rt.t0);
             eng.on_round_gap = make_yield(eng);
-            n_max = std::max(0, std::min(n_max, eng.max_ctx - (int)prompt.size() - (eng.ctx_round_reserve() - 1)));
+            auto limits = q27::resolve_think_decode_limits(
+                n_max, eng.max_ctx, (int)prompt.size(), eng.ctx_round_reserve(),
+                (int)think_close_ids.size(), thinking, tcfg, think_budget_flag);
+            n_max = limits.n_max;
+            const int think_budget = limits.budget;
             StreamSplitter sp;
-            q27::ThinkBudget tb{tcfg.budget >= 0 ? tcfg.budget
-                                : q27::think_budget_default(think_budget_flag, n_max)};
+            q27::ThinkBudgetState tb{think_budget};
+            Engine::DecodeTask bt;
             if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
+            tb.start(bt, think_close_ids, sp.chan);
             q27::Utf8Gate ugate;
             std::string think, text, tool_buf;
             std::vector<q27::ToolCall> calls;
@@ -1906,24 +2042,29 @@ int main(int argc, char** argv) {
             eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
             if (tc.enabled)
                 eng.on_round = [&](const int* em, int nr) { return tc.scan_round(em, nr); };
-            auto on_tok = [&](int id) {
-                for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) route(ch, t);
-                if (const char* bclose = tb.tick(sp))
-                    for (auto& [ch, t] : sp.feed(bclose)) route(ch, t);
+            BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+            auto on_tok = [&](int id, bool forced) {
+                const auto before = sp.chan;
+                for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) {
+                    if (forced && ch == StreamSplitter::TEXT && q27::strip_ws2(t).empty())
+                        continue;
+                    route(ch, t);
+                }
+                if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
                 return true;
             };
-            Engine::DecodeTask bt;
             std::string berr;
             // batch: tc.on_id rides on_emit -- the CONDUCTOR thread, between
             // scan_round and on_pending, its exact solo slot (driver contract)
             int n = conductor
-                        ? batch_generate(eng, prompt, n_max, on_tok,
-                                         [&](int id) { tc.on_id(id); }, stable_len, qw,
+                        ? batch_generate(eng, prompt, n_max,
+                                         [&](int id, bool forced) { return on_tok(id, forced); },
+                                         [&](int id) { tc.on_id(id); batch_tb.observe(id); }, stable_len, qw,
                                          rt, bt, &berr)
                         : eng.generate(prompt, n_max, EOS, [&](int id) {
                               tc.on_id(id);
-                              return on_tok(id);
-                          }, stable_len);
+                              return on_tok(id, bt.callback_forced);
+                          }, stable_len, &bt);
             tc.end();
             eng.on_pending = nullptr;
             eng.on_drafts = nullptr;
@@ -1978,7 +2119,9 @@ int main(int argc, char** argv) {
                                        {"id", "toolu_q27_" + std::to_string(rid) + "_" +
                                                   std::to_string(ci++)},
                                        {"name", c.name}, {"input", c.arguments}});
-            const char* sr = any_call ? "tool_use" : (n >= n_max ? "max_tokens" : "end_turn");
+            const char* sr = any_call ? "tool_use"
+                                      : ((n >= n_max || bt.budget_truncated)
+                                             ? "max_tokens" : "end_turn");
             json out = {{"id", mid}, {"type", "message"}, {"role", "assistant"},
                         {"model", served_name}, {"content", content},
                         {"stop_reason", sr}, {"stop_sequence", nullptr},
@@ -1997,8 +2140,8 @@ int main(int argc, char** argv) {
             "text/event-stream",
             // by-value or dangling: see the /v1/chat/completions twin
             [&, samp, prompt, n_max, mid, rid, has_tools, tool_names_v, tools, stable_len, rt,
-             thinking, sys_len](size_t, httplib::DataSink& sink) {
-                Slot& sl = claim_slot(prompt);
+             thinking, tcfg, sys_len](size_t, httplib::DataSink& sink) {
+                Slot& sl = claim_slot(prompt, n_max, thinking, tcfg, true);
                 auto sl_lease = slot_guard(sl);
                 Engine& eng = *sl.eng;
                 HookGuard hooks{eng}; // M1: clears tc hooks on unwind, pre slot-free
@@ -2008,8 +2151,11 @@ int main(int argc, char** argv) {
                 if (!conductor) lk.emplace(gpu_gate);
                 double qw = ms_since(rt.t0);
                 eng.on_round_gap = make_yield(eng);
-                const int nm =
-                    std::max(0, std::min(n_max, eng.max_ctx - (int)prompt.size() - (eng.ctx_round_reserve() - 1)));
+                auto limits = q27::resolve_think_decode_limits(
+                    n_max, eng.max_ctx, (int)prompt.size(), eng.ctx_round_reserve(),
+                    (int)think_close_ids.size(), thinking, tcfg, think_budget_flag);
+                const int nm = limits.n_max;
+                const int think_budget = limits.budget;
                 ToolConstrainer tc;
                 tc.eng = &eng; tc.tok = &tok; tc.cache = &tool_mask_cache;
                 tc.host2dev = &sl.tool_mask_host2dev;
@@ -2031,9 +2177,10 @@ int main(int argc, char** argv) {
                 ev("message_start", {{"type", "message_start"}, {"message", msg}});
 
                 StreamSplitter sp;
-                q27::ThinkBudget tb{tcfg.budget >= 0 ? tcfg.budget
-                                    : q27::think_budget_default(think_budget_flag, n_max)};
+                q27::ThinkBudgetState tb{think_budget};
+                Engine::DecodeTask bt;
                 if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
+                tb.start(bt, think_close_ids, sp.chan);
                 std::string tool_buf, text_accum;
                 q27::Utf8Gate ugate;
                 int idx = -1;       // open think/text block index, -1 = none
@@ -2084,13 +2231,15 @@ int main(int argc, char** argv) {
                                    {"partial_json", jdump(c.arguments)}}}});
                     ev("content_block_stop", {{"type", "content_block_stop"}, {"index", ti}});
                 };
+                bool forced_control_token = false;
                 auto emit_seg = [&](StreamSplitter::Chan ch, const std::string& t) {
                     if (ch == StreamSplitter::TOOL) { tool_buf += t; return; }
                     if (!tool_buf.empty()) emit_tool();
                     if (t.empty()) return;
                     int chan = ch == StreamSplitter::THINK ? 1 : 0;
-                    // suppress pure-whitespace text before the first block or between blocks
-                    if (chan == 0 && idx < 0 && q27::strip_ws2(t).empty()) return;
+                    // Injected template whitespace is parser control; model
+                    // whitespace, including after a natural close, is content.
+                    if (chan == 0 && forced_control_token && q27::strip_ws2(t).empty()) return;
                     open_block(chan);
                     if (chan == 0) text_accum += t;
                     if (chan == 1)
@@ -2104,24 +2253,25 @@ int main(int argc, char** argv) {
                 eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
                 if (tc.enabled)
                     eng.on_round = [&](const int* em, int nr) { return tc.scan_round(em, nr); };
-                auto on_tok = [&](int id) {
+                BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+                auto on_tok = [&](int id, bool forced) {
+                    forced_control_token = forced;
+                    const auto before = sp.chan;
                     for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) emit_seg(ch, t);
-                    if (const char* bclose = tb.tick(sp))
-                        for (auto& [ch, t] : sp.feed(bclose)) emit_seg(ch, t);
+                    if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
                     return alive; // stop generating once the client has disconnected
                 };
-                Engine::DecodeTask bt;
                 std::string berr;
                 // batch: tc.on_id rides on_emit (conductor thread, solo slot);
                 // a dead client flips `alive` -> the drain cancels (A3)
                 int produced = conductor
                                    ? batch_generate(eng, prompt, nm, on_tok,
-                                                    [&](int id) { tc.on_id(id); },
+                                                    [&](int id) { tc.on_id(id); batch_tb.observe(id); },
                                                     stable_len, qw, rt, bt, &berr)
                                    : eng.generate(prompt, nm, EOS, [&](int id) {
                                          tc.on_id(id);
-                                         return on_tok(id);
-                                     }, stable_len);
+                                         return on_tok(id, bt.callback_forced);
+                                     }, stable_len, &bt);
                 tc.end();
                 eng.on_pending = nullptr;
                 eng.on_drafts = nullptr;
@@ -2178,10 +2328,13 @@ int main(int argc, char** argv) {
                     ev("error", {{"type", "error"},
                                  {"error", {{"type", "api_error"}, {"message", berr}}}});
                 const char* sr = any_call ? "tool_use"
-                                          : (produced >= nm ? "max_tokens" : "end_turn");
+                                          : ((produced >= nm || bt.budget_truncated)
+                                                 ? "max_tokens" : "end_turn");
                 ev("message_delta", {{"type", "message_delta"},
                                      {"delta", {{"stop_reason", sr}, {"stop_sequence", nullptr}}},
-                                     {"usage", {{"output_tokens", produced}}}});
+                                     {"usage", {{"output_tokens", produced},
+                                                {"reasoning_tokens", tb.used},
+                                                {"reasoning_budget_exceeded", tb.tripped}}}});
                 ev("message_stop", {{"type", "message_stop"}});
                 sink.done();
                 return true;
@@ -2191,9 +2344,10 @@ int main(int argc, char** argv) {
     // ---------------- OpenAI Responses API (Codex CLI) ----------------
     // Wire facts from codex-rs (v0.143): client keys off the JSON `type` field
     // in SSE data (event: lines ignored); the agent loop consumes only
-    // response.output_item.done items; response.completed{response:{id}} is the
-    // required terminator; function_call.arguments is a JSON-encoded STRING;
-    // tool results arrive as function_call_output with a bare-string output.
+    // response.output_item.done items; response.completed / response.incomplete
+    // terminate their matching lifecycle states; function_call.arguments is a
+    // JSON-encoded STRING; tool results arrive as function_call_output with a
+    // bare-string output.
     // 400 is fatal to Codex, 500 retries -- so tolerate quirks, 500 on bugs.
 
     srv.Post("/v1/responses", [&](const httplib::Request& req, httplib::Response& res) {
@@ -2306,7 +2460,10 @@ int main(int argc, char** argv) {
         // review follow-up 2026-07-09 #3: the bound includes the spec-round
         // reserve (max_prompt), so a prompt that passes can never have its
         // n_max floored to 0 by the routed slot's clamp (empty 200/stream)
-        if ((int)prompt.size() > max_prompt) {
+        const auto admission = q27::resolve_think_decode_limits(
+            n_max, max_slot_ctx, (int)prompt.size(), slots[0].eng->ctx_round_reserve(),
+            (int)think_close_ids.size(), thinking, tcfg, think_budget_flag);
+        if ((int)prompt.size() > max_prompt || !admission.context_ok) {
             res.status = 400; // context_length_exceeded is fatal-class for codex, correctly
             res.set_content("{\"error\":{\"code\":\"context_length_exceeded\"}}",
                             "application/json");
@@ -2343,26 +2500,27 @@ int main(int argc, char** argv) {
                 items.push_back(r);
                 return r;
             };
-            auto flush_text = [&items, ctx, rid]() {
+            auto flush_text = [&items, ctx, rid](bool incomplete=false) {
                 std::string tx = q27::strip_ws2(ctx->text);
                 ctx->text.clear();
                 if (tx.empty()) return json();
                 json m = {{"type", "message"}, {"id", "msg_q27_" + std::to_string(rid)},
-                          {"role", "assistant"}, {"status", "completed"},
+                          {"role", "assistant"}, {"status", incomplete ? "incomplete" : "completed"},
                           {"content",
                            json::array({{{"type", "output_text"}, {"text", tx},
                                          {"annotations", json::array()}}})}};
                 items.push_back(m);
                 return m;
             };
-            auto flush_tool = [&items, ctx, rid, &tool_counter, &custom_names]() {
+            auto flush_tool = [&items, ctx, rid, &tool_counter, &custom_names](bool incomplete=false) {
                 auto c = q27::parse_tool_call(q27::strip_ws2(ctx->tool_buf));
                 ctx->tool_buf.clear();
                 std::string cid = "call_q27_" + std::to_string(rid) + "_" +
                                   std::to_string(tool_counter++);
                 json it;
                 if (!c.ok) { // malformed call: surface as text so codex shows it
-                    it = {{"type", "message"}, {"role", "assistant"}, {"status", "completed"},
+                    it = {{"type", "message"}, {"role", "assistant"},
+                          {"status", incomplete ? "incomplete" : "completed"},
                           {"content", json::array({{{"type", "output_text"}, {"text", c.raw},
                                                     {"annotations", json::array()}}})}};
                 } else if (custom_names.count(c.name)) {
@@ -2383,7 +2541,7 @@ int main(int argc, char** argv) {
         };
 
         if (!stream) {
-            Slot& sl = claim_slot(prompt);
+            Slot& sl = claim_slot(prompt, n_max, thinking, tcfg, true);
             auto sl_lease = slot_guard(sl);
             Engine& eng = *sl.eng;
             eng.samp = parse_sample(body);
@@ -2392,15 +2550,20 @@ int main(int argc, char** argv) {
             if (!conductor) lk.emplace(gpu_gate);  // leases inside batch_generate
             double qw = ms_since(rt.t0);
             eng.on_round_gap = make_yield(eng);
-            n_max = std::max(0, std::min(n_max, eng.max_ctx - (int)prompt.size() - (eng.ctx_round_reserve() - 1)));
+            auto limits = q27::resolve_think_decode_limits(
+                n_max, eng.max_ctx, (int)prompt.size(), eng.ctx_round_reserve(),
+                (int)think_close_ids.size(), thinking, tcfg, think_budget_flag);
+            n_max = limits.n_max;
+            const int think_budget = limits.budget;
             json items = json::array();
             int tool_counter = 0;
             auto [ctx, flush_think, flush_text, flush_tool] =
                 make_item_cbs(items, tool_counter, nullptr);
             StreamSplitter sp;
-            q27::ThinkBudget tb{tcfg.budget >= 0 ? tcfg.budget
-                                : q27::think_budget_default(think_budget_flag, n_max)};
+            q27::ThinkBudgetState tb{think_budget};
+            Engine::DecodeTask bt;
             if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
+            tb.start(bt, think_close_ids, sp.chan);
             auto route = [&](StreamSplitter::Chan ch, const std::string& t) {
                 if (ch == StreamSplitter::TOOL) {
                     if (!ctx->think.empty()) flush_think();
@@ -2416,17 +2579,26 @@ int main(int argc, char** argv) {
                 }
             };
             q27::Utf8Gate ugate;
-            auto on_tok = [&](int id) {
-                for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) route(ch, t);
-                if (const char* bclose = tb.tick(sp))
-                    for (auto& [ch, t] : sp.feed(bclose)) route(ch, t);
+            BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+            auto on_tok = [&](int id, bool forced) {
+                const auto before = sp.chan;
+                for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) {
+                    if (forced && ch == StreamSplitter::TEXT && q27::strip_ws2(t).empty())
+                        continue;
+                    route(ch, t);
+                }
+                if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
                 return true;
             };
-            Engine::DecodeTask bt;
             std::string berr;
-            int produced = conductor ? batch_generate(eng, prompt, n_max, on_tok, nullptr,
-                                                      -1, qw, rt, bt, &berr)
-                                     : eng.generate(prompt, n_max, EOS, on_tok);
+            int produced = conductor
+                               ? batch_generate(eng, prompt, n_max,
+                                                [&](int id, bool forced) { return on_tok(id, forced); },
+                                                [&](int id) { batch_tb.observe(id); }, -1,
+                                                qw, rt, bt, &berr)
+                               : eng.generate(prompt, n_max, EOS,
+                                              [&](int id) { return on_tok(id, bt.callback_forced); },
+                                              -1, &bt);
             eng.on_round_gap = nullptr;
             req_log(rt, qw, eng, sl.id, bat_stats(bt));
             // batch error surfacing (review pass 2): nothing emitted = 500
@@ -2440,16 +2612,24 @@ int main(int argc, char** argv) {
                                 "application/json");
                 return;
             }
+            const auto terminal = q27::responses_terminal_state(
+                produced, n_max, bt.budget_truncated);
             for (auto& [ch, t] : sp.feed(ugate.flush())) route(ch, t);
             for (auto& [ch, t] : sp.flush()) route(ch, t);
-            if (!ctx->tool_buf.empty()) flush_tool();
+            if (!ctx->tool_buf.empty()) flush_tool(terminal.incomplete);
             flush_think();
-            flush_text();
-            json out = {{"id", resp_id}, {"object", "response"}, {"status", "completed"},
+            flush_text(terminal.incomplete);
+            const bool incomplete = terminal.incomplete;
+            json out = {{"id", resp_id}, {"object", "response"},
+                        {"status", incomplete ? "incomplete" : "completed"},
                         {"model", served_name}, {"output", items},
                         {"usage", {{"input_tokens", (int)prompt.size()},
                                    {"output_tokens", produced},
+                                   {"output_tokens_details", {{"reasoning_tokens", tb.used},
+                                                               {"reasoning_budget_exceeded", tb.tripped}}},
                                    {"total_tokens", (int)prompt.size() + produced}}}};
+            if (incomplete)
+                out["incomplete_details"] = {{"reason", "max_output_tokens"}};
             res.set_content(jdump(out), "application/json");
             return;
         }
@@ -2460,8 +2640,8 @@ int main(int argc, char** argv) {
             "text/event-stream",
             // by-value or dangling: see the /v1/chat/completions twin
             [&, samp, prompt, n_max, resp_id, rid, custom_names, tools, rt,
-             thinking, sys_len](size_t, httplib::DataSink& sink) {
-                Slot& sl = claim_slot(prompt);
+             thinking, tcfg, sys_len](size_t, httplib::DataSink& sink) {
+                Slot& sl = claim_slot(prompt, n_max, thinking, tcfg, true);
                 auto sl_lease = slot_guard(sl);
                 Engine& eng = *sl.eng;
                 eng.samp = samp;
@@ -2470,8 +2650,11 @@ int main(int argc, char** argv) {
                 if (!conductor) lk.emplace(gpu_gate);
                 double qw = ms_since(rt.t0);
                 eng.on_round_gap = make_yield(eng);
-                const int nm =
-                    std::max(0, std::min(n_max, eng.max_ctx - (int)prompt.size() - (eng.ctx_round_reserve() - 1)));
+                auto limits = q27::resolve_think_decode_limits(
+                    n_max, eng.max_ctx, (int)prompt.size(), eng.ctx_round_reserve(),
+                    (int)think_close_ids.size(), thinking, tcfg, think_budget_flag);
+                const int nm = limits.n_max;
+                const int think_budget = limits.budget;
                 bool alive = true; // cleared when a write fails (client disconnected)
                 auto ev = [&](const json& j) {
                     // codex keys off data.type; the event: line is decorative
@@ -2524,7 +2707,7 @@ int main(int argc, char** argv) {
                         {"part", {{"type", "output_text"}, {"text", ""},
                                   {"annotations", json::array()}}}});
                 };
-                auto flush_text = [&]() {
+                auto flush_text = [&](bool incomplete=false) {
                     if (msg_index < 0) { text.clear(); return; }
                     std::string tx = q27::strip_ws2(text);
                     text.clear();
@@ -2535,7 +2718,7 @@ int main(int argc, char** argv) {
                         {"part", {{"type", "output_text"}, {"text", tx},
                                   {"annotations", json::array()}}}});
                     json it = {{"type", "message"}, {"id", msg_id}, {"role", "assistant"},
-                               {"status", "completed"},
+                               {"status", incomplete ? "incomplete" : "completed"},
                                {"content", json::array({{{"type", "output_text"}, {"text", tx},
                                                          {"annotations", json::array()}}})}};
                     ev({{"type", "response.output_item.done"}, {"output_index", msg_index},
@@ -2544,14 +2727,14 @@ int main(int argc, char** argv) {
                     out_index = msg_index + 1;
                     msg_index = -1;
                 };
-                auto flush_tool = [&]() {
+                auto flush_tool = [&](bool incomplete=false) {
                     auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
                     tool_buf.clear();
                     std::string cid = "call_q27_" + std::to_string(rid) + "_" +
                                       std::to_string(tool_counter++);
                     if (!c.ok) {
                         item_done({{"type", "message"}, {"role", "assistant"},
-                                   {"status", "completed"},
+                                   {"status", incomplete ? "incomplete" : "completed"},
                                    {"content",
                                     json::array({{{"type", "output_text"}, {"text", c.raw},
                                                   {"annotations", json::array()}}})}});
@@ -2568,6 +2751,7 @@ int main(int argc, char** argv) {
                                    {"arguments", jdump(c.arguments)}});
                     }
                 };
+                bool forced_control_token = false;
                 auto route = [&](StreamSplitter::Chan ch, const std::string& t) {
                     if (ch == StreamSplitter::TOOL) {
                         if (!think.empty()) flush_think();
@@ -2576,9 +2760,10 @@ int main(int argc, char** argv) {
                         return;
                     }
                     if (!tool_buf.empty()) flush_tool();
+                    if (t.empty()) return;
                     if (ch == StreamSplitter::THINK) { think += t; return; }
                     if (!think.empty()) flush_think();
-                    if (text.empty() && q27::strip_ws2(t).empty()) return;
+                    if (forced_control_token && q27::strip_ws2(t).empty()) return;
                     open_text();
                     text += t;
                     text_accum += t; // survives flush_text for bare-call recovery
@@ -2586,33 +2771,41 @@ int main(int argc, char** argv) {
                         {"output_index", msg_index}, {"content_index", 0}, {"delta", t}});
                 };
                 StreamSplitter sp;
-                q27::ThinkBudget tb{tcfg.budget >= 0 ? tcfg.budget
-                                    : q27::think_budget_default(think_budget_flag, n_max)};
+                q27::ThinkBudgetState tb{think_budget};
+                Engine::DecodeTask bt;
                 if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
+                tb.start(bt, think_close_ids, sp.chan);
                 q27::Utf8Gate ugate;
-                auto on_tok = [&](int id) {
+                BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+                auto on_tok = [&](int id, bool forced) {
+                    forced_control_token = forced;
+                    const auto before = sp.chan;
                     for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) route(ch, t);
-                    if (const char* bclose = tb.tick(sp))
-                        for (auto& [ch, t] : sp.feed(bclose)) route(ch, t);
+                    if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
                     return alive; // stop generating once the client has disconnected
                 };
-                Engine::DecodeTask bt;
                 // TODO(batch error surfacing): no mid-stream error event is
                 // emitted here -- codex-rs (v0.143) keys only off the item /
                 // completed types this handler already sends and defines no
                 // error shape we could mirror without inventing protocol;
                 // end=error lands in the [req] line and [req-error] carries
                 // the what().
-                int produced = conductor ? batch_generate(eng, prompt, nm, on_tok, nullptr,
-                                                          -1, qw, rt, bt, nullptr)
-                                         : eng.generate(prompt, nm, EOS, on_tok);
+                int produced = conductor
+                                   ? batch_generate(eng, prompt, nm, on_tok,
+                                                    [&](int id) { batch_tb.observe(id); }, -1,
+                                                    qw, rt, bt, nullptr)
+                                   : eng.generate(prompt, nm, EOS, [&](int id) {
+                                         return on_tok(id, bt.callback_forced);
+                                     }, -1, &bt);
                 eng.on_round_gap = nullptr;
                 req_log(rt, qw, eng, sl.id, bat_stats(bt));
+                const auto terminal = q27::responses_terminal_state(
+                    produced, nm, bt.budget_truncated);
                 for (auto& [ch, t] : sp.feed(ugate.flush())) route(ch, t);
                 for (auto& [ch, t] : sp.flush()) route(ch, t);
-                if (!tool_buf.empty()) flush_tool();
+                if (!tool_buf.empty()) flush_tool(terminal.incomplete);
                 flush_think();
-                flush_text();
+                flush_text(terminal.incomplete);
                 // wrapper-less call recovery (parity with the Anthropic path):
                 // the model sometimes emits a bare {"name":...,"arguments":...}
                 // as text, no <tool_call> wrapper -- it already streamed as an
@@ -2649,14 +2842,19 @@ int main(int argc, char** argv) {
                         }
                     }
                 }
-                ev({{"type", "response.completed"},
-                    {"response", {{"id", resp_id}, {"object", "response"},
-                                  {"status", "completed"}, {"output", items},
-                                  {"usage", {{"input_tokens", (int)prompt.size()},
-                                             {"input_tokens_details", {{"cached_tokens", 0}}},
-                                             {"output_tokens", produced},
-                                             {"output_tokens_details", {{"reasoning_tokens", 0}}},
-                                             {"total_tokens", (int)prompt.size() + produced}}}}}});
+
+                json final_response = {{"id", resp_id}, {"object", "response"},
+                                       {"status", terminal.status},
+                                       {"output", items},
+                                       {"usage", {{"input_tokens", (int)prompt.size()},
+                                                  {"input_tokens_details", {{"cached_tokens", 0}}},
+                                                  {"output_tokens", produced},
+                                                  {"output_tokens_details", {{"reasoning_tokens", tb.used},
+                                                                               {"reasoning_budget_exceeded", tb.tripped}}},
+                                                  {"total_tokens", (int)prompt.size() + produced}}}};
+                if (terminal.incomplete)
+                    final_response["incomplete_details"] = {{"reason", "max_output_tokens"}};
+                ev({{"type", terminal.event}, {"response", final_response}});
                 sink.done();
                 return true;
             });

--- a/src/stream_split.h
+++ b/src/stream_split.h
@@ -96,37 +96,5 @@ struct StreamSplitter {
     }
 };
 
-// Reasoning-token budget (2026-07-28). Counts tokens generated INSIDE the THINK
-// channel and, on trip, hands back T_CLOSE for the caller to feed through the
-// splitter -- which flips the channel to TEXT exactly as a model-emitted
-// </think> would, so every downstream consumer (routing, tool scan, the
-// Anthropic thinking block, reasoning_content) sees an ordinary close.
-//
-// Call tick() once per generated token, AFTER feeding that token to the
-// splitter. It counts only while the splitter is actually in THINK, so a
-// prompt-injected opener, a natural close, and tool segments are all handled
-// without special cases. Trips at most once per request.
-//
-// Deliberately NOT a hard stop: closing the block lets the model answer with
-// what it has. Truncating the request instead would reproduce the failure this
-// exists to prevent.
-struct ThinkBudget {
-    int limit = -1;  // -1 = unbounded
-    int used = 0;
-    bool tripped = false;
-
-    const char* tick(const StreamSplitter& sp) {
-        if (sp.chan != StreamSplitter::THINK) return nullptr;
-        // Count ALWAYS, enforce only when bounded. `used` is reported as
-        // usage.reasoning_tokens, and a counter that reads 0 while the model
-        // reasoned for 2879 characters is the same accepted-and-inert failure
-        // this class exists to prevent -- just one level down.
-        ++used;
-        if (limit < 0 || tripped) return nullptr;
-        if (used < limit) return nullptr;
-        tripped = true;
-        return StreamSplitter::T_CLOSE;
-    }
-};
 
 } // namespace q27

--- a/src/test_kernels.cu
+++ b/src/test_kernels.cu
@@ -2707,6 +2707,21 @@ static void test_spec_sample() {
     printf("    [spec chi2=%.2f df=%d bound=%.1f]\n", chi2, df, bound);
     check("spec rejection-sampling vs served target", chi2 < bound ? 0.0 : 1.0, 0.5);
 
+    // Reasoning-boundary cap: sampled speculation commits exactly the pending
+    // token, matching greedy k_finish_round before a forced decoder transition.
+    {
+        int one = 1;
+        CUDA_CHECK(cudaMemcpy(d_cap, &one, 4, cudaMemcpyHostToDevice));
+        int bad = 0;
+        for (int t = 0; t < 64; t++) {
+            int n, nt;
+            round(9000000 + t, 4, n, nt);
+            bad += n != 1;
+        }
+        check("spec reasoning cap commits one token", (double)bad, 0.5);
+        CUDA_CHECK(cudaMemcpy(d_cap, &zero, 4, cudaMemcpyHostToDevice));
+    }
+
     // ---- P14 max_draft (accept-walk cap) tests ----
     // Per-lane served prob p_served(dr_k)=softmax_full_k(dr_k)/mass_k (0 if the
     // draft fell outside its nucleus) for the cap tests below.

--- a/tools/test_chat_completions_integration.cpp
+++ b/tools/test_chat_completions_integration.cpp
@@ -68,38 +68,24 @@ struct FakeTok {
 // ---- fake Engine --------------------------------------------------------
 struct FakeEngine {
     struct DecodeTask {
-        int rounds = 0, bat_members = 0; long bat_r2 = 0; int emitted = 0;
+        int rounds = 0, bat_members = 0;
+        long bat_r2 = 0;
+        int emitted = 0;
         int n_max = 100000;
+        int eos = -1;
+        int Ph = 0;
         std::atomic<bool> cancel{false};
-        bool accept_one = false;
         bool sampling = false;
+        bool sampled_budget_watch = false;
         bool public_budget_reduced = false;
         bool budget_cancelled = false;
         bool budget_truncated = false;
-        std::function<int(const int*, int)> preview_round;
-        std::function<void(const int*, int)> commit_round;
+        bool round_forced = false;
         bool callback_forced = false;
         std::vector<int> forced;
         size_t forced_pos = 0;
-        void force(const std::vector<int>& ids) {
-            forced.insert(forced.end(), ids.begin(), ids.end());
-            accept_one = true;
-        }
-        bool force_from_public_budget(const std::vector<int>& ids) {
-            const int cost = (int)ids.size();
-            public_budget_reduced = true;
-            if (n_max - emitted <= cost) {
-                budget_cancelled = true;
-                cancel.store(true);
-                return false;
-            }
-            n_max -= cost;
-            force(ids);
-            return true;
-        }
         bool has_forced() const { return forced_pos < forced.size(); }
         int pop_forced() { return forced[forced_pos++]; }
-        void release_accept_one() { accept_one = false; }
     };
     q27k::SampleParams samp;
     int max_ctx = 100000;
@@ -112,37 +98,118 @@ struct FakeEngine {
 
     int mask_pool_used = 0;
     int mask_pool_cap = 512;
+    int constraint_sets = 0;
+    int forced_commit_count = 0;
     int mask_pool_add(const void*) { return mask_pool_used >= mask_pool_cap ? -1 : mask_pool_used++; }
-    void set_tool_constraint(int) {}
+    void set_tool_constraint(int id) { if (id >= 0) constraint_sets++; }
     void set_tool_masks5(const int[5]) {}
 
-    std::vector<int> script; // token ids the test wants "generated"
+    bool reasoning_transition_active(const DecodeTask& task) const {
+        return task.round_forced || task.has_forced();
+    }
+    bool reasoning_close_fits(const DecodeTask& task, int current_public_tokens,
+                              int current_context_tokens, int close_tokens,
+                              bool from_public_budget) const {
+        if (current_public_tokens < 0 || current_context_tokens < 0 || close_tokens <= 0)
+            return false;
+        const int public_needed = from_public_budget ? close_tokens + 1 : 1;
+        if (task.n_max - task.emitted - current_public_tokens < public_needed) return false;
+        return task.Ph + current_context_tokens + close_tokens - 1 +
+                   ctx_round_reserve() <=
+               max_ctx;
+    }
+    bool force_reasoning_close(DecodeTask& task, const std::vector<int>& ids,
+                               bool from_public_budget = false,
+                               int current_public_tokens = 0,
+                               int current_context_tokens = -1) {
+        if (ids.empty()) return false;
+        if (reasoning_transition_active(task)) return true;
+        const int cost = (int)ids.size();
+        if (current_context_tokens < 0) current_context_tokens = current_public_tokens;
+        if (!reasoning_close_fits(task, current_public_tokens, current_context_tokens,
+                                  cost, from_public_budget)) {
+            task.budget_cancelled = true;
+            task.cancel.store(true);
+            return false;
+        }
+        if (from_public_budget) {
+            task.public_budget_reduced = true;
+            task.n_max -= cost;
+        }
+        task.forced.insert(task.forced.end(), ids.begin(), ids.end());
+        return true;
+    }
+
+    std::vector<int> script; // token ids the test wants generated
+    int round_width = 1;
+    int conditioned_token = -1;
+    int stale_token = -1;
+    bool forced_committed = false;
+
+    int resolve_token(int id) const {
+        return id == conditioned_token && !forced_committed ? stale_token : id;
+    }
+
     template <typename F>
-    int generate(const std::vector<int>&, int n_max, int /*eos*/, F&& on_token,
+    int generate(const std::vector<int>& prompt, int n_max, int eos, F&& on_token,
                  int = -1, DecodeTask* external_task = nullptr) {
         DecodeTask local;
         DecodeTask& task = external_task ? *external_task : local;
         task.n_max = n_max;
+        task.eos = eos;
+        task.Ph = (int)prompt.size() - 1;
         task.emitted = 0;
         task.sampling = samp.inv_temp > 0.f;
+        forced_committed = false;
+        forced_commit_count = 0;
         int n = 0;
         auto emit_forced = [&]() {
             while (task.has_forced()) {
+                int id = task.pop_forced();
+                task.round_forced = true;
+                if (!task.sampling && on_round) (void)on_round(&id, 1);
                 task.callback_forced = true;
-                const bool keep_going = on_token(task.pop_forced());
+                const bool keep_going = on_token(id);
                 task.callback_forced = false;
+                task.round_forced = false;
+                forced_committed = true;
+                forced_commit_count++;
+                task.Ph++;
                 if (!keep_going) return false;
             }
             return true;
         };
         if (!emit_forced()) return 0;
-        for (int id : script) {
-            if (n >= task.n_max) break;
-            task.callback_forced = false;
-            if (!on_token(id)) break;
-            n++;
-            task.emitted = n;
-            if (!emit_forced()) break;
+        for (size_t pos = 0; pos < script.size() && n < task.n_max;) {
+            const int width = task.sampling && task.sampled_budget_watch ? 1 : round_width;
+            const int available = (int)script.size() - (int)pos;
+            const int proposed = std::min(width, available);
+            std::vector<int> ids;
+            ids.reserve((size_t)proposed);
+            for (int i = 0; i < proposed; i++) ids.push_back(resolve_token(script[pos + i]));
+            int committed = proposed;
+            if (!task.sampling && on_round) {
+                int m = on_round(ids.data(), proposed);
+                if (m >= 1 && m <= proposed) committed = m;
+            }
+            task.Ph += committed;
+            bool stopped = false;
+            for (int i = 0; i < committed && n < task.n_max; i++) {
+                if (ids[(size_t)i] == task.eos) {
+                    stopped = true;
+                    break;
+                }
+                task.callback_forced = false;
+                if (!on_token(ids[(size_t)i])) {
+                    stopped = true;
+                    break;
+                }
+                n++;
+                task.emitted = n;
+            }
+            pos += (size_t)proposed;
+            if (stopped) break;
+            if (!emit_forced() || task.cancel.load()) break;
         }
         task.emitted = n;
         task.budget_truncated = task.budget_cancelled ||
@@ -167,26 +234,121 @@ struct HookGuard {
     ~HookGuard() { e.on_pending = nullptr; e.on_drafts = nullptr; e.on_round = nullptr; }
 };
 
-struct BatchThinkBudgetObserver {
+struct ReasoningBudgetObserver {
     FakeTok& tok;
     q27::ThinkBudgetState& state;
-    FakeEngine::DecodeTask& task;
+    Engine& eng;
+    Engine::DecodeTask& task;
     const std::vector<int>& close_ids;
     StreamSplitter split;
     q27::Utf8Gate gate;
 
-    BatchThinkBudgetObserver(FakeTok& tok_, q27::ThinkBudgetState& state_,
-                             FakeEngine::DecodeTask& task_,
-                             const std::vector<int>& close_ids_,
-                             StreamSplitter::Chan initial)
-        : tok(tok_), state(state_), task(task_), close_ids(close_ids_) {
+    ReasoningBudgetObserver(FakeTok& tok_, q27::ThinkBudgetState& state_,
+                            Engine& eng_, Engine::DecodeTask& task_,
+                            const std::vector<int>& close_ids_,
+                            StreamSplitter::Chan initial)
+        : tok(tok_), state(state_), eng(eng_), task(task_), close_ids(close_ids_) {
         split.chan = initial;
+        task.sampled_budget_watch = state.limit >= 0;
     }
 
-    void observe(int id) {
-        const auto before = split.chan;
-        (void)split.feed(gate.feed(tok.decode_one(id)));
-        state.observe(before, split.chan, task, close_ids);
+    void apply(q27::ThinkBudgetAction action, int current_public_tokens = 0,
+               int current_context_tokens = -1) {
+        if (action == q27::ThinkBudgetAction::NONE ||
+            eng.reasoning_transition_active(task))
+            return;
+        eng.force_reasoning_close(
+            task, close_ids, action == q27::ThinkBudgetAction::FORCE_PUBLIC,
+            current_public_tokens, current_context_tokens);
+    }
+
+    void start() { apply(state.start(split.chan)); }
+
+    void observe_token(q27::ThinkBudgetState& target_state, StreamSplitter& target_split,
+                       q27::Utf8Gate& target_gate, int id, bool forced) {
+        const auto before = target_split.chan;
+        (void)target_split.feed(target_gate.feed(tok.decode_one(id)));
+        target_state.observe(before, target_split.chan, forced);
+    }
+
+    void observe_token(int id, bool forced) {
+        observe_token(state, split, gate, id, forced);
+    }
+
+    int visible_prefix(const int* ids, int n, bool forced, bool* hits_eos) const {
+        *hits_eos = false;
+        if (forced) return n;
+        int visible = std::min(n, std::max(0, task.n_max - task.emitted));
+        for (int i = 0; i < visible; i++)
+            if (ids[i] == task.eos) {
+                *hits_eos = true;
+                return i;
+            }
+        return visible;
+    }
+
+    // Pure planning pass. Tool scanning runs only over the prefix this returns,
+    // so a discarded suffix cannot engage or poison the stateful grammar hook.
+    int preview_round(const int* ids, int n) {
+        const bool forced = task.round_forced;
+        bool hits_eos = false;
+        const int visible = visible_prefix(ids, n, forced, &hits_eos);
+        q27::ThinkBudgetState trial_state = state;
+        StreamSplitter trial_split = split;
+        q27::Utf8Gate trial_gate = gate;
+        int trip_prefix = -1;
+        for (int i = 0; i < visible; i++) {
+            observe_token(trial_state, trial_split, trial_gate, ids[i], forced);
+            if (!forced && trip_prefix < 0 && trial_state.limit >= 0 &&
+                !trial_state.transition_pending &&
+                trial_split.chan == StreamSplitter::THINK &&
+                trial_state.used >= trial_state.limit)
+                trip_prefix = i + 1;
+        }
+        if (hits_eos) return -1;
+
+        const auto action = trial_state.finish_round(trial_split.chan);
+        const bool natural_close_after_trip =
+            trip_prefix > 0 && action == q27::ThinkBudgetAction::NONE &&
+            trial_split.chan != StreamSplitter::THINK;
+        const bool natural_close_keeps_answer =
+            task.n_max - task.emitted - visible >= 1;
+        const bool force_full_round_fits =
+            action != q27::ThinkBudgetAction::NONE &&
+            eng.reasoning_close_fits(
+                task, visible, visible, (int)close_ids.size(),
+                action == q27::ThinkBudgetAction::FORCE_PUBLIC);
+        if ((action == q27::ThinkBudgetAction::NONE &&
+             (!natural_close_after_trip || natural_close_keeps_answer)) ||
+            force_full_round_fits)
+            return -1;
+        return trip_prefix > 0 && trip_prefix < n ? trip_prefix : -1;
+    }
+
+    void commit_round(const int* ids, int n) {
+        const bool forced = task.round_forced;
+        bool hits_eos = false;
+        const int visible = visible_prefix(ids, n, forced, &hits_eos);
+        for (int i = 0; i < visible; i++) observe_token(ids[i], forced);
+        // EOS wins immediately. Count only tokens before it, but never queue a
+        // close that post_round cannot commit after taking the EOS exit.
+        if (hits_eos) return;
+        apply(state.finish_round(split.chan), visible, visible);
+    }
+
+    int observe_round(const int* ids, int n) {
+        const int m = preview_round(ids, n);
+        const int kept = (m >= 1 && m < n) ? m : n;
+        commit_round(ids, kept);
+        return m;
+    }
+
+    void observe_sampled(int id, bool forced) {
+        if (!task.sampling) return;
+        observe_token(id, forced);
+        // post_round advanced Ph before invoking the callback, but emitted is
+        // incremented afterwards: account one public token and zero context rows.
+        apply(state.finish_round(split.chan), forced ? 0 : 1, 0);
     }
 };
 
@@ -269,25 +431,47 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
         t.n_max = nm;
         t.emitted = 0;
         t.sampling = eng.samp.inv_temp > 0.f;
+        eng.forced_committed = false;
         auto emit_forced = [&]() {
             while (t.has_forced()) {
                 int id = t.pop_forced();
+                t.round_forced = true;
+                if (!t.sampling && eng.on_round) (void)eng.on_round(&id, 1);
                 t.callback_forced = true;
                 if (on_emit) on_emit(id);
                 const bool keep_going = on_token(id, true);
                 t.callback_forced = false;
+                t.round_forced = false;
+                eng.forced_committed = true;
                 if (!keep_going) return false;
             }
             return true;
         };
         if (!emit_forced()) return 0;
-        for (int id : eng.script) {
-            if (n >= t.n_max) break;
-            if (on_emit) on_emit(id);
-            t.callback_forced = false;
-            if (!on_token(id, false)) break;
-            n++;
-            t.emitted = n;
+        for (size_t pos = 0; pos < eng.script.size() && n < t.n_max;) {
+            const int width = t.sampling && t.sampled_budget_watch ? 1 : eng.round_width;
+            const int available = (int)eng.script.size() - (int)pos;
+            const int proposed = std::min(width, available);
+            std::vector<int> ids;
+            ids.reserve((size_t)proposed);
+            for (int i = 0; i < proposed; i++)
+                ids.push_back(eng.resolve_token(eng.script[pos + (size_t)i]));
+            int committed = proposed;
+            if (!t.sampling && eng.on_round) {
+                int m = eng.on_round(ids.data(), proposed);
+                if (m >= 1 && m <= proposed) committed = m;
+            }
+            for (int i = 0; i < committed && n < t.n_max; i++) {
+                t.callback_forced = false;
+                if (on_emit) on_emit(ids[(size_t)i]);
+                if (!on_token(ids[(size_t)i], false)) {
+                    pos = eng.script.size();
+                    break;
+                }
+                n++;
+                t.emitted = n;
+            }
+            pos += (size_t)proposed;
             if (!emit_forced()) break;
         }
         t.emitted = n;
@@ -332,7 +516,7 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
         return tok.encode(q27::jstr(body, "prompt"));
     };
 
-    auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat) {
+auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat) {
         json body;
         try { body = json::parse(req.body); }
         catch (...) { res.status = 400; res.set_content("{\"error\":\"bad json\"}", "application/json"); return; }
@@ -564,7 +748,7 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                 auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
                 tool_buf.clear();
                 if (c.ok) calls.push_back(std::move(c));
-                else text += c.raw;
+                else text += c.raw; // stream parity: preserve generation order
             };
             auto route = [&](StreamSplitter::Chan ch, const std::string& t) {
                 if (ch == StreamSplitter::TOOL) { tool_buf += t; return; }
@@ -591,27 +775,36 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
             // generated token is already inside the block, and its </think> flips
             // back to text (same mechanism as the FORCED TOOL pre-seed above).
             else if (thinking) sp.chan = StreamSplitter::THINK;
-            tb.start(bt, think_close_ids, sp.chan);
+            ReasoningBudgetObserver budget{tok, tb, eng, bt, think_close_ids, sp.chan};
+            budget.start();
             eng.on_pending = [&](int id) { tc.on_pending(id); };
             eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
-            if (tc.enabled)
-                eng.on_round = [&](const int* em, int nr) { return tc.scan_round(em, nr); };
-            BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+            eng.on_round = [&](const int* em, int nr) {
+                int bm = budget.preview_round(em, nr);
+                int budget_kept = (bm >= 1 && bm < nr) ? bm : nr;
+                int m = tc.enabled ? tc.scan_round(em, budget_kept) : -1;
+                int kept = (m >= 1 && m <= budget_kept) ? m : budget_kept;
+                budget.commit_round(em, kept);
+                if (kept < nr) return kept;
+                return m;
+            };
             auto on_tok = [&](int id, bool forced) {
-                const auto before = sp.chan;
                 for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) {
                     if (forced && ch == StreamSplitter::TEXT && q27::strip_ws2(t).empty())
                         continue;
                     route(ch, t);
                 }
-                if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
+                if (!conductor) budget.observe_sampled(id, forced);
                 return true;
             };
             std::string berr;
             int n = conductor
                         ? batch_generate(eng, prompt, n_max,
                                          [&](int id, bool forced) { return on_tok(id, forced); },
-                                         [&](int id) { tc.on_id(id); batch_tb.observe(id); }, stable_len, qw,
+                                         [&](int id) {
+                                             tc.on_id(id);
+                                             budget.observe_sampled(id, bt.callback_forced);
+                                         }, stable_len, qw,
                                          rt, bt, &berr)
                         : eng.generate(prompt, n_max, EOS, [&](int id) {
                               tc.on_id(id);
@@ -777,7 +970,8 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                 Engine::DecodeTask bt;
                 if (tchoice.mode == q27::ToolChoice::FORCED) sp.chan = StreamSplitter::TOOL;
                 else if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
-                tb.start(bt, think_close_ids, sp.chan);
+                ReasoningBudgetObserver budget{tok, tb, eng, bt, think_close_ids, sp.chan};
+                budget.start();
                 q27::Utf8Gate ugate;
                 bool alive = true; // cleared when a write fails (client disconnected)
                 int tool_idx = 0;
@@ -828,19 +1022,27 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                 };
                 eng.on_pending = [&](int id) { tc.on_pending(id); };
                 eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
-                if (tc.enabled)
-                    eng.on_round = [&](const int* em, int nr) { return tc.scan_round(em, nr); };
-                BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+                eng.on_round = [&](const int* em, int nr) {
+                    int bm = budget.preview_round(em, nr);
+                    int budget_kept = (bm >= 1 && bm < nr) ? bm : nr;
+                    int m = tc.enabled ? tc.scan_round(em, budget_kept) : -1;
+                    int kept = (m >= 1 && m <= budget_kept) ? m : budget_kept;
+                    budget.commit_round(em, kept);
+                    if (kept < nr) return kept;
+                    return m;
+                };
                 auto on_tok = [&](int id, bool forced) {
                     forced_control_token = forced;
-                    const auto before = sp.chan;
                     for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) emit_seg(ch, t);
-                    if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
+                    if (!conductor) budget.observe_sampled(id, forced);
                     return alive; // stop generating once the client has disconnected
                 };
                 int produced = conductor
                                    ? batch_generate(eng, prompt, nm, on_tok,
-                                                    [&](int id) { tc.on_id(id); batch_tb.observe(id); },
+                                                    [&](int id) {
+                                                        tc.on_id(id);
+                                                        budget.observe_sampled(id, bt.callback_forced);
+                                                    },
                                                     stable_len, qw, rt, bt, nullptr)
                                    : eng.generate(prompt, nm, EOS, [&](int id) {
                                          tc.on_id(id);
@@ -1343,16 +1545,19 @@ int main() {
         CHECK(g_last_response["choices"][0]["finish_reason"] == "stop");
     }
 
-    // ---- Test 10: cap trip is decoder-visible. The model never emits a
-    // close, yet the forced template id transitions the real splitter to TEXT;
-    // answer generation continues and forced ids do not consume max_tokens. ----
+    // ---- Test 10: a cap trip is a decoder-state transition. The second
+    // model token is deliberately conditioned on whether the forced close was
+    // committed; host-only queueing would expose the stale reasoning successor. ----
     {
         FakeTok tok;
-        tok.pieces = {/*0*/ "<eos>", /*1*/ "still reasoning", /*2*/ "Process complete."};
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "still reasoning",
+                      /*2*/ "Conditioned answer.", /*3*/ "STALE successor"};
         std::vector<std::string> vb = tok.pieces;
         auto cache = fresh_cache(vb);
         auto slots = fresh_slots();
         slots[0].eng->script = {1, 2};
+        slots[0].eng->conditioned_token = 2;
+        slots[0].eng->stale_token = 3;
         std::atomic<long> rc{0};
         json body = {{"messages", json::array({{{"role", "user"}, {"content", "finish"}}})},
                      {"enable_thinking", true}, {"thinking_token_budget", 1},
@@ -1361,7 +1566,8 @@ int main() {
                     body, true);
         const auto& msg = g_last_response["choices"][0]["message"];
         CHECK(msg["reasoning_content"] == "still reasoning");
-        CHECK(msg["content"] == "Process complete.");
+        CHECK(msg["content"] == "Conditioned answer.");
+        CHECK(msg["content"].get<std::string>().find("STALE") == std::string::npos);
         CHECK(g_last_response["usage"]["completion_tokens"] == 2);
         CHECK(g_last_response["usage"]["reasoning_tokens"] == 1);
         CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == true);
@@ -1389,8 +1595,8 @@ int main() {
         CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == true);
     }
 
-    // ---- Test 12: natural close before the cap releases enforcement and is
-    // not followed by a duplicate injected close. ----
+    // ---- Test 12: a natural close later in the same fused round wins over a
+    // crossed cap and is not followed by a duplicate injected close. ----
     {
         FakeTok tok;
         tok.pieces = {/*0*/ "<eos>", /*1*/ "short thought", /*2*/ "</think>",
@@ -1399,9 +1605,10 @@ int main() {
         auto cache = fresh_cache(vb);
         auto slots = fresh_slots();
         slots[0].eng->script = {1, 2, 3};
+        slots[0].eng->round_width = 2;
         std::atomic<long> rc{0};
         json body = {{"messages", json::array({{{"role", "user"}, {"content", "answer"}}})},
-                     {"enable_thinking", true}, {"thinking_token_budget", 4},
+                     {"enable_thinking", true}, {"thinking_token_budget", 1},
                      {"max_tokens", 3}};
         run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
                     body, true);
@@ -1413,29 +1620,171 @@ int main() {
         CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == false);
     }
 
-    // ---- Test 13: batch mode observes the trip on the conductor thread
-    // before the next draft; the injected close stays parser control, never
-    // literal response content. ----
+    // ---- Test 13: greedy fused decode may overshoot by the retained round,
+    // then the conductor commits the forced close before the next proposal. ----
     {
         FakeTok tok;
-        tok.pieces = {/*0*/ "<eos>", /*1*/ "still reasoning", /*2*/ "Process complete."};
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "reason A", /*2*/ "reason B",
+                      /*3*/ "Process complete."};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 2, 3};
+        slots[0].eng->round_width = 2;
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "finish"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", 1},
+                     {"max_tokens", 3}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true, /*batch=*/true);
+        const auto& msg = g_last_response["choices"][0]["message"];
+        CHECK(msg["reasoning_content"] == "reason Areason B");
+        CHECK(msg["content"] == "Process complete.");
+        CHECK(msg["content"].get<std::string>().find("</think>") == std::string::npos);
+        CHECK(g_last_response["usage"]["completion_tokens"] == 3);
+        CHECK(g_last_response["usage"]["reasoning_tokens"] == 2);
+        CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == true);
+    }
+
+    // ---- Test 13a: an overshooting greedy round is rewound only when keeping
+    // it would consume the public answer reserved behind the forced close. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "reason A", /*2*/ "discarded tail",
+                      /*3*/ "Capacity-safe answer."};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 2, 3};
+        slots[0].eng->round_width = 2;
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "finish"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", 1},
+                     {"max_tokens", 2}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true);
+        const auto& msg = g_last_response["choices"][0]["message"];
+        CHECK(msg["reasoning_content"] == "reason A");
+        CHECK(msg["content"] == "Capacity-safe answer.");
+        CHECK(g_last_response["usage"]["completion_tokens"] == 2);
+        CHECK(g_last_response["usage"]["reasoning_tokens"] == 1);
+        CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == true);
+    }
+
+    // ---- Test 13b: EOS wins over a same-round cap crossing. Tokens at and
+    // after EOS are neither observed as reasoning nor allowed to queue a close. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "final thought", /*2*/ "unreachable"};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 0, 2};
+        slots[0].eng->round_width = 3;
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "finish"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", 1},
+                     {"max_tokens", 3}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true);
+        CHECK(g_last_response["usage"]["completion_tokens"] == 1);
+        CHECK(g_last_response["usage"]["reasoning_tokens"] == 1);
+        CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == false);
+    }
+
+    // ---- Test 13c: a later think re-entry accounts for the current retained
+    // round before borrowing close capacity from the public allowance. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "<think>", /*2*/ "stale reason A",
+                      /*3*/ "stale reason B", /*4*/ "Re-entry answer."};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 2, 3, 4};
+        slots[0].eng->round_width = 3;
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "finish"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", 0},
+                     {"max_tokens", 3}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true);
+        const auto& msg = g_last_response["choices"][0]["message"];
+        CHECK(msg["content"] == "Re-entry answer.");
+        CHECK(msg["content"].get<std::string>().find("stale") == std::string::npos);
+        CHECK(g_last_response["usage"]["completion_tokens"] == 2);
+        CHECK(g_last_response["usage"]["reasoning_tokens"] == 0);
+        CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == true);
+    }
+
+    // ---- Test 13d: a budget rewind is planned before the stateful tool scan,
+    // so a discarded same-round <tool_call> marker cannot stage a phantom mask. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "reason A",
+                      /*2*/ "</think><tool_call>", /*3*/ "Tool-safe answer."};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 2, 3};
+        slots[0].eng->round_width = 2;
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "finish"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", 1},
+                     {"max_tokens", 2},
+                     {"tools", json::array({{{"type", "function"},
+                         {"function", {{"name", "get_weather"}, {"description", "w"},
+                                       {"parameters", json::object()}}}}})}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true);
+        const auto& msg = g_last_response["choices"][0]["message"];
+        CHECK(msg["content"] == "Tool-safe answer.");
+        CHECK(slots[0].eng->constraint_sets == 0);
+    }
+
+    // ---- Test 13e: sampled observation runs after Ph advances but before
+    // emitted increments; the current token is charged only to public capacity. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "<think>", /*2*/ "unreachable answer"};
         std::vector<std::string> vb = tok.pieces;
         auto cache = fresh_cache(vb);
         auto slots = fresh_slots();
         slots[0].eng->script = {1, 2};
         std::atomic<long> rc{0};
         json body = {{"messages", json::array({{{"role", "user"}, {"content", "finish"}}})},
-                     {"enable_thinking", true}, {"thinking_token_budget", 1},
-                     {"max_tokens", 2}};
+                     {"enable_thinking", true}, {"thinking_token_budget", 0},
+                     {"temperature", 0.7}, {"max_tokens", 2}};
         run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
-                    body, true, /*batch=*/true);
-        const auto& msg = g_last_response["choices"][0]["message"];
-        CHECK(msg["reasoning_content"] == "still reasoning");
-        CHECK(msg["content"] == "Process complete.");
-        CHECK(msg["content"].get<std::string>().find("</think>") == std::string::npos);
-        CHECK(g_last_response["usage"]["completion_tokens"] == 2);
-        CHECK(g_last_response["usage"]["reasoning_tokens"] == 1);
+                    body, true);
+        CHECK(slots[0].eng->forced_commit_count == 1);
+        CHECK(g_last_response["usage"]["completion_tokens"] == 1);
         CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == true);
+    }
+    // ---- Test 13b: sampled bounded decode keeps one-token rounds so the
+    // forced close conditions the next draw in both solo and conductor modes. ----
+    for (bool batch : {false, true}) {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "sampled reasoning",
+                      /*2*/ "Sampled answer.", /*3*/ "STALE sampled successor"};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 2};
+        slots[0].eng->round_width = 4;
+        slots[0].eng->conditioned_token = 2;
+        slots[0].eng->stale_token = 3;
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "finish"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", 1},
+                     {"temperature", 0.7}, {"max_tokens", 2}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true, batch);
+        const auto& msg = g_last_response["choices"][0]["message"];
+        CHECK(msg["reasoning_content"] == "sampled reasoning");
+        CHECK(msg["content"] == "Sampled answer.");
+        CHECK(msg["content"].get<std::string>().find("STALE") == std::string::npos);
+        CHECK(g_last_response["usage"]["reasoning_tokens"] == 1);
     }
 
     // ---- Test 14: injected template newlines never surface as an OpenAI

--- a/tools/test_chat_completions_integration.cpp
+++ b/tools/test_chat_completions_integration.cpp
@@ -35,9 +35,9 @@ struct SampleParams { float inv_temp = 0.f; float top_p = 1.f; unsigned long lon
 }
 
 // ---- fake Tokenizer ---------------------------------------------------
-// decode_one() replays a pre-scripted piece-table; encode() hands back one
-// synthetic id per call (only the resulting vector SIZE matters to the code
-// under test -- ids are never decoded back).
+// decode_one() replays a pre-scripted piece-table. encode() normally hands
+// back one synthetic id per call; the decoder-control close is also installed
+// in the table so forced ids traverse the real StreamSplitter path.
 struct FakeTok {
     std::vector<std::string> pieces;
     int eos_id = 0;
@@ -45,7 +45,14 @@ struct FakeTok {
     std::string decode_one(int id) const {
         return (id >= 0 && (size_t)id < pieces.size()) ? pieces[(size_t)id] : std::string();
     }
-    std::vector<int> encode(const std::string&) { return {next_encode_id++}; }
+    std::vector<int> encode(const std::string& text) {
+        const int id = next_encode_id++;
+        if (text == "</think>\n\n") {
+            if (pieces.size() <= (size_t)id) pieces.resize((size_t)id + 1);
+            pieces[(size_t)id] = text;
+        }
+        return {id};
+    }
     int eos() const { return eos_id; }
     int token_id(const std::string&) const { return -1; }
     std::vector<std::string> vocab_bytes() const { return pieces; }
@@ -62,10 +69,41 @@ struct FakeTok {
 struct FakeEngine {
     struct DecodeTask {
         int rounds = 0, bat_members = 0; long bat_r2 = 0; int emitted = 0;
+        int n_max = 100000;
         std::atomic<bool> cancel{false};
+        bool accept_one = false;
+        bool sampling = false;
+        bool public_budget_reduced = false;
+        bool budget_cancelled = false;
+        bool budget_truncated = false;
+        std::function<int(const int*, int)> preview_round;
+        std::function<void(const int*, int)> commit_round;
+        bool callback_forced = false;
+        std::vector<int> forced;
+        size_t forced_pos = 0;
+        void force(const std::vector<int>& ids) {
+            forced.insert(forced.end(), ids.begin(), ids.end());
+            accept_one = true;
+        }
+        bool force_from_public_budget(const std::vector<int>& ids) {
+            const int cost = (int)ids.size();
+            public_budget_reduced = true;
+            if (n_max - emitted <= cost) {
+                budget_cancelled = true;
+                cancel.store(true);
+                return false;
+            }
+            n_max -= cost;
+            force(ids);
+            return true;
+        }
+        bool has_forced() const { return forced_pos < forced.size(); }
+        int pop_forced() { return forced[forced_pos++]; }
+        void release_accept_one() { accept_one = false; }
     };
     q27k::SampleParams samp;
     int max_ctx = 100000;
+    int pfx_sys_len = 0;
     int ctx_round_reserve() const { return 8; }
     std::function<bool()> on_round_gap;
     std::function<void(int)> on_pending;
@@ -80,13 +118,35 @@ struct FakeEngine {
 
     std::vector<int> script; // token ids the test wants "generated"
     template <typename F>
-    int generate(const std::vector<int>&, int n_max, int /*eos*/, F&& on_token, int = -1) {
+    int generate(const std::vector<int>&, int n_max, int /*eos*/, F&& on_token,
+                 int = -1, DecodeTask* external_task = nullptr) {
+        DecodeTask local;
+        DecodeTask& task = external_task ? *external_task : local;
+        task.n_max = n_max;
+        task.emitted = 0;
+        task.sampling = samp.inv_temp > 0.f;
         int n = 0;
+        auto emit_forced = [&]() {
+            while (task.has_forced()) {
+                task.callback_forced = true;
+                const bool keep_going = on_token(task.pop_forced());
+                task.callback_forced = false;
+                if (!keep_going) return false;
+            }
+            return true;
+        };
+        if (!emit_forced()) return 0;
         for (int id : script) {
-            if (n >= n_max) break;
+            if (n >= task.n_max) break;
+            task.callback_forced = false;
             if (!on_token(id)) break;
             n++;
+            task.emitted = n;
+            if (!emit_forced()) break;
         }
+        task.emitted = n;
+        task.budget_truncated = task.budget_cancelled ||
+                                (task.public_budget_reduced && n >= task.n_max);
         return n;
     }
 };
@@ -105,6 +165,29 @@ using ToolConstrainer = q27::BasicToolConstrainer<Engine, FakeTok>;
 struct HookGuard {
     Engine& e;
     ~HookGuard() { e.on_pending = nullptr; e.on_drafts = nullptr; e.on_round = nullptr; }
+};
+
+struct BatchThinkBudgetObserver {
+    FakeTok& tok;
+    q27::ThinkBudgetState& state;
+    FakeEngine::DecodeTask& task;
+    const std::vector<int>& close_ids;
+    StreamSplitter split;
+    q27::Utf8Gate gate;
+
+    BatchThinkBudgetObserver(FakeTok& tok_, q27::ThinkBudgetState& state_,
+                             FakeEngine::DecodeTask& task_,
+                             const std::vector<int>& close_ids_,
+                             StreamSplitter::Chan initial)
+        : tok(tok_), state(state_), task(task_), close_ids(close_ids_) {
+        split.chan = initial;
+    }
+
+    void observe(int id) {
+        const auto before = split.chan;
+        (void)split.feed(gate.feed(tok.decode_one(id)));
+        state.observe(before, split.chan, task, close_ids);
+    }
 };
 
 // ---- fake httplib -------------------------------------------------------
@@ -139,11 +222,16 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                         bool constrain_tools, bool sampled_on, int max_prompt,
                         int max_slot_ctx, std::atomic<long>& req_counter,
                         q27::ToolMaskCache& tool_mask_cache, std::vector<Slot>& slots,
-                        const json& body, bool chat) {
+                        const json& body, bool chat, bool batch = false,
+                        int budget_flag = 0) {
     const int EOS = tok.eos();
     std::mutex route_m;
-    void* conductor = nullptr; // always null: only the non-conductor branches execute
+    void* conductor = batch ? reinterpret_cast<void*>(1) : nullptr;
     q27::GpuGate gpu_gate; // real type (api_common.h, CUDA-free) -- Lease is RAII-only here
+    const bool req_think = true;
+    const int think_budget_flag = budget_flag;
+    const std::vector<int> think_close_ids = tok.encode("</think>\n\n");
+    struct FakePfxCache { bool enabled() const { return false; } } pfx_cache;
 
     auto ms_since = [](std::chrono::steady_clock::time_point t) {
         return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t)
@@ -154,7 +242,10 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
         long rid; const char* api; unsigned long long conv;
         std::chrono::steady_clock::time_point t0; double tok_ms;
     };
-    auto claim_slot = [&](const std::vector<int>&) -> Slot& { slots[0].busy = true; return slots[0]; };
+    auto claim_slot = [&](const std::vector<int>&, int, bool, const q27::ThinkCfg&, bool) -> Slot& {
+        slots[0].busy = true;
+        return slots[0];
+    };
     auto slot_guard = [&](Slot& s) {
         return std::shared_ptr<Slot>(&s, [](Slot* p) { p->busy = false; });
     };
@@ -170,18 +261,38 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
         return s;
     };
     auto batch_generate = [&](Engine& eng, const std::vector<int>&, int nm,
-                              std::function<bool(int)> on_token,
+                              std::function<bool(int, bool)> on_token,
                               std::function<void(int)> on_emit, int /*stable_len*/, double&,
                               const ReqTrace&, FakeEngine::DecodeTask& t,
                               std::string*) -> int {
         int n = 0;
+        t.n_max = nm;
+        t.emitted = 0;
+        t.sampling = eng.samp.inv_temp > 0.f;
+        auto emit_forced = [&]() {
+            while (t.has_forced()) {
+                int id = t.pop_forced();
+                t.callback_forced = true;
+                if (on_emit) on_emit(id);
+                const bool keep_going = on_token(id, true);
+                t.callback_forced = false;
+                if (!keep_going) return false;
+            }
+            return true;
+        };
+        if (!emit_forced()) return 0;
         for (int id : eng.script) {
-            if (n >= nm) break;
+            if (n >= t.n_max) break;
             if (on_emit) on_emit(id);
-            if (!on_token(id)) break;
+            t.callback_forced = false;
+            if (!on_token(id, false)) break;
             n++;
+            t.emitted = n;
+            if (!emit_forced()) break;
         }
         t.emitted = n;
+        t.budget_truncated = t.budget_cancelled ||
+                             (t.public_budget_reduced && n >= t.n_max);
         return n;
     };
 
@@ -193,37 +304,46 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
         if (body.contains("messages")) {
             std::vector<std::pair<std::string, std::string>> msgs;
             for (auto& m : body["messages"]) {
+                // is_object() BEFORE any value() call: value() on a non-object
+                // element throws 306 -> httplib 500 (same ordering fix as
+                // anthropic_msgs).
+                if (!m.is_object()) continue;
                 std::string role = m.value("role", "user");
                 std::string content;
                 // const operator[] on a missing key aborts (json.hpp assertion) --
                 // a content-less message must not kill the server (Security #1;
                 // mirrors the Anthropic-path guard in api_common.h).
-                if (m.is_object() && m.contains("content")) {
+                if (m.contains("content")) {
                     if (m["content"].is_string()) content = m["content"];
                     else if (m["content"].is_array())
                         for (auto& part : m["content"])
-                            if (part.value("type", "") == "text")
+                            if (part.is_object() && part.value("type", "") == "text")
                                 content += part.value("text", "");
                 }
                 msgs.push_back({role, content});
             }
-            // enable_thinking=false: top-level (Qwen-style clients) or nested
-            // chat_template_kwargs (llama.cpp/GLM-style) -> empty-think prefill
-            bool think = body.value("enable_thinking", true);
-            if (body.contains("chat_template_kwargs"))
-                think = body["chat_template_kwargs"].value("enable_thinking", think);
-            if (no_think_srv) think = false;
+            // Per-request thinking: the server profile is the default, an
+            // explicit enable_thinking / chat_template_kwargs / Anthropic
+            // thinking field overrides it either way (resolve_think in
+            // api_common.h). Silent request on a no-think server -> no-think.
+            bool think = q27::resolve_think(body, !no_think_srv, req_think);
             return tok.apply_chat_template(msgs, think);
         }
-        return tok.encode(body.value("prompt", std::string()));
+        return tok.encode(q27::jstr(body, "prompt"));
     };
 
     auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat) {
         json body;
         try { body = json::parse(req.body); }
         catch (...) { res.status = 400; res.set_content("{\"error\":\"bad json\"}", "application/json"); return; }
-        int n_max = body.value("max_tokens", 256);
-        bool stream = body.value("stream", false);
+        // Default when the client omits max_tokens: a generous floor, unified
+        // across all three API shapes. Clamped to the context window below, so a
+        // big default can't over-reserve; 8192 covers a real answer plus a short
+        // think trace. A long *thinking* request should still set max_tokens
+        // explicitly (a grad-level trace wants 16K+). jint/jbool: a
+        // present-but-null field reads as absent (see parse_sample).
+        int n_max = (int)q27::jint(body, "max_tokens", 8192);
+        bool stream = q27::jbool(body, "stream", false);
         // stream_options.include_usage (OpenAI streaming spec, both API
         // shapes): when true, one extra SSE chunk -- empty choices + the
         // usage totals -- goes out after the finish_reason chunk, before
@@ -260,14 +380,25 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
         auto tk0 = std::chrono::steady_clock::now();
         std::vector<int> prompt;
         int stable_len = -1; // -1 = legacy tail snapshot (build_prompt's fallback path)
+        int sys_len = 0;     // P16b: system-block tokens (0 = none/feature off)
+        bool thinking = false; // request wants a real <think> block; seeds the splitter below
+        q27::ThinkCfg tcfg;    // .budget resolved against the final n_max at each loop
         if (routed_chat) {
-            bool think = body.value("enable_thinking", true);
-            if (body.contains("chat_template_kwargs"))
-                think = body["chat_template_kwargs"].value("enable_thinking", think);
-            if (no_think_srv) think = false;
-            size_t stable_off = 0;
+            tcfg = q27::resolve_think_cfg(body, !no_think_srv, req_think, -1);
+            thinking = tcfg.enabled;
+            // thinking and a FORCED tool call are mutually exclusive: FORCED
+            // injects <tool_call>\n into the tail (below), leaving no room for a
+            // think block, so suppress the opener when a tool is forced.
+            if (tchoice.mode == q27::ToolChoice::FORCED) thinking = false;
+            size_t stable_off = 0, sys_off = 0;
             std::string rendered =
-                q27::chatml_prompt(q27::openai_msgs(body), tools, think, &stable_off);
+                q27::chatml_prompt(q27::openai_msgs(body), tools, thinking, &stable_off, &sys_off);
+            // P16b: token length of the system+tools block. Measured with a
+            // THIRD encode used only for its length -- the prompt itself is
+            // still built from the same two pieces, so no request's bytes
+            // change when the cache is on.
+            if (pfx_cache.enabled() && sys_off > 0)
+                sys_len = (int)tok.encode(rendered.substr(0, sys_off)).size();
             // FORCED tool_choice: inject the opener into the volatile tail
             // (past stable_off, alongside the assistant-open/think-prefill --
             // P8 prefix-cache reuse is unaffected). The stream router below
@@ -297,14 +428,28 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                             "application/json");
             return;
         }
+        const bool think_aware=routed_chat && tchoice.mode!=q27::ToolChoice::FORCED;
         // context-limit preflight BEFORE slot claim / SSE commit (review
         // follow-up 2026-07-09 #3): past this bound the routed slot's
         // n_max clamp floors at 0 -> empty 200
-        if ((int)prompt.size() > max_prompt) {
+        const auto admission = think_aware
+            ? q27::resolve_think_decode_limits(
+                  n_max, max_slot_ctx, (int)prompt.size(), slots[0].eng->ctx_round_reserve(),
+                  (int)think_close_ids.size(), thinking, tcfg, think_budget_flag)
+            : q27::resolve_think_decode_limits(
+                  n_max, max_slot_ctx, (int)prompt.size(), slots[0].eng->ctx_round_reserve(),
+                  0, false, q27::ThinkCfg{false, -1, true}, 0);
+        const int request_max_prompt = !think_aware || admission.context_ok
+            ? max_prompt
+            : q27::max_prompt_for_think_decode(
+                  n_max, max_slot_ctx, slots[0].eng->ctx_round_reserve(), max_prompt,
+                  (int)prompt.size(), (int)think_close_ids.size(), thinking, tcfg,
+                  think_budget_flag);
+        if ((int)prompt.size() > max_prompt || !admission.context_ok) {
             res.status = 400;
             res.set_content(json{{"error",
                                   {{"message", q27::ctx_limit_error_message(
-                                                   (int)prompt.size(), max_prompt)},
+                                                   (int)prompt.size(), request_max_prompt)},
                                    {"type", "invalid_request_error"},
                                    {"code", "context_length_exceeded"}}}}
                                 .dump(),
@@ -316,7 +461,7 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
         // Q27_SAMPLED=0 preflight: the sampled graphs were never captured.
         // (Q27_FORCE_TEMP>0 is a boot-time FATAL on such boots, so the
         // request-absent default here is genuinely greedy.)
-        if (!sampled_on && body.value("temperature", 0.0) > 0.0) {
+        if (!sampled_on && q27::jnum(body, "temperature", 0.0) > 0.0) {
             res.status = 400;
             res.set_content(json{{"error",
                                   {{"message", "sampling disabled: server booted with "
@@ -335,13 +480,14 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
         const char* objd = chat ? "chat.completion.chunk" : "text_completion";
 
         if (!stream) {
-            Slot& sl = claim_slot(prompt); // may wait for a free engine
+            Slot& sl = claim_slot(prompt,n_max,thinking,tcfg,think_aware); // may wait for a free engine
             auto sl_lease = slot_guard(sl);
             Engine& eng = *sl.eng;
             HookGuard hooks{eng}; // safe even when routed_chat is false: hooks
                                   // are never set on that path, so the clear
                                   // on scope-exit is a no-op (P15 M1 pattern)
             eng.samp = parse_sample(body);
+            eng.pfx_sys_len = sys_len; // P16b (0 on paths with no system boundary)
             // Q27_BATCH: solo keeps the whole-call lease; batch mode scopes
             // its prefill lease inside batch_generate (A7) and re-stamps qw.
             std::optional<q27::GpuGate::Lease> lk;
@@ -350,7 +496,15 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
             eng.on_round_gap = make_yield(eng);
             // re-clamp to the routed slot (rows P+1..P+gate_maxd+1 must stay
             // in ctx; reserve derived from the engine's active max depth)
-            n_max = std::max(0, std::min(n_max, eng.max_ctx - (int)prompt.size() - (eng.ctx_round_reserve() - 1)));
+            auto limits = think_aware
+                ? q27::resolve_think_decode_limits(
+                      n_max, eng.max_ctx, (int)prompt.size(), eng.ctx_round_reserve(),
+                      (int)think_close_ids.size(), thinking, tcfg, think_budget_flag)
+                : q27::resolve_think_decode_limits(
+                      n_max, eng.max_ctx, (int)prompt.size(), eng.ctx_round_reserve(),
+                      0, false, q27::ThinkCfg{false, -1, true}, 0);
+            n_max = limits.n_max;
+            const int think_budget = limits.budget;
 
             if (!routed_chat) {
                 // ORIGINAL text-only behavior, byte-for-byte unchanged.
@@ -362,9 +516,11 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                 };
                 Engine::DecodeTask bt;
                 std::string berr;
-                int n = conductor ? batch_generate(eng, prompt, n_max, on_tok, nullptr, -1,
-                                                   qw, rt, bt, &berr)
-                                  : eng.generate(prompt, n_max, EOS, on_tok);
+                int n = conductor
+                            ? batch_generate(eng, prompt, n_max,
+                                             [&](int id, bool) { return on_tok(id); },
+                                             nullptr, -1, qw, rt, bt, &berr)
+                            : eng.generate(prompt, n_max, EOS, on_tok);
                 eng.on_round_gap = nullptr;
                 text += ugate.flush();
                 req_log(rt, qw, eng, sl.id, bat_stats(bt));
@@ -399,6 +555,8 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
             // routed_chat: think/tool-aware path, an exact mechanical twin of
             // the /v1/messages non-stream handler above, OpenAI-shaped output.
             StreamSplitter sp;
+            q27::ThinkBudgetState tb{think_budget};
+            Engine::DecodeTask bt;
             q27::Utf8Gate ugate;
             std::string think, text, tool_buf;
             std::vector<q27::ToolCall> calls;
@@ -425,24 +583,37 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
             // so the splitter must start already inside the TOOL channel or
             // the call body would be read back as ordinary text.
             if (tchoice.mode == q27::ToolChoice::FORCED) sp.chan = StreamSplitter::TOOL;
+            // thinking: the <think> opener was prompt-injected (not generated), so
+            // start the splitter INSIDE the THINK channel -- the model's first
+            // generated token is already inside the block, and its </think> flips
+            // back to text (same mechanism as the FORCED TOOL pre-seed above).
+            else if (thinking) sp.chan = StreamSplitter::THINK;
+            tb.start(bt, think_close_ids, sp.chan);
             eng.on_pending = [&](int id) { tc.on_pending(id); };
             eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
             if (tc.enabled)
                 eng.on_round = [&](const int* em, int nr) { return tc.scan_round(em, nr); };
-            auto on_tok = [&](int id) {
-                for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) route(ch, t);
+            BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+            auto on_tok = [&](int id, bool forced) {
+                const auto before = sp.chan;
+                for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) {
+                    if (forced && ch == StreamSplitter::TEXT && q27::strip_ws2(t).empty())
+                        continue;
+                    route(ch, t);
+                }
+                if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
                 return true;
             };
-            Engine::DecodeTask bt;
             std::string berr;
             int n = conductor
-                        ? batch_generate(eng, prompt, n_max, on_tok,
-                                         [&](int id) { tc.on_id(id); }, stable_len, qw,
+                        ? batch_generate(eng, prompt, n_max,
+                                         [&](int id, bool forced) { return on_tok(id, forced); },
+                                         [&](int id) { tc.on_id(id); batch_tb.observe(id); }, stable_len, qw,
                                          rt, bt, &berr)
                         : eng.generate(prompt, n_max, EOS, [&](int id) {
                               tc.on_id(id);
-                              return on_tok(id);
-                          }, stable_len);
+                              return on_tok(id, bt.callback_forced);
+                          }, stable_len, &bt);
             tc.end();
             eng.on_pending = nullptr;
             eng.on_drafts = nullptr;
@@ -481,14 +652,19 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                 if (c.ok) any_call = true;
             json msg = q27::openai_chat_message_json(tx, calls, rid, q27::strip_ws2(think));
             json choice = {{"index", 0},
-                          {"finish_reason", any_call ? "tool_calls" : (n >= n_max ? "length" : "stop")},
+                          {"finish_reason", any_call ? "tool_calls" :
+                              ((n >= n_max || bt.budget_truncated) ? "length" : "stop")},
                           {"message", msg}};
             json out = {{"id", "chatcmpl-q27-" + std::to_string(rid)}, {"object", obj},
                         {"created", created}, {"model", served_name},
                         {"choices", json::array({choice})},
                         {"usage", {{"prompt_tokens", (int)prompt.size()},
                                    {"completion_tokens", n},
-                                   {"total_tokens", (int)prompt.size() + n}}}};
+                                   {"total_tokens", (int)prompt.size() + n},
+                                   // an accepted-and-inert budget field is worse
+                                   // than none: say when it fired.
+                                   {"reasoning_tokens", tb.used},
+                                   {"reasoning_budget_exceeded", tb.tripped}}}};
             res.set_content(jdump(out), "application/json");
             return;
         }
@@ -498,19 +674,34 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
         q27k::SampleParams samp = parse_sample(body);
         res.set_chunked_content_provider(
             "text/event-stream",
+            // EVERY handler local this lambda reads must be captured BY VALUE:
+            // httplib runs the provider from write_response(), long after this
+            // handler's frame is dead (routing() and write_response() are
+            // sibling calls in Server::process_request). `thinking` shipped as
+            // a by-reference read of that dead frame from 2026-07-20 until the
+            // 07-24 audit -- benign only by stack-layout luck.
             [&, samp, prompt, n_max, created, chat, obj, objd, rt, inc_usage, routed_chat,
-             tools, tool_names_v, tchoice, stable_len, has_tools, rid](size_t, httplib::DataSink& sink) {
-                Slot& sl = claim_slot(prompt);
+             tools, tool_names_v, tchoice, stable_len, has_tools, rid,
+             thinking, tcfg, sys_len, think_aware](size_t, httplib::DataSink& sink) {
+                Slot& sl = claim_slot(prompt,n_max,thinking,tcfg,think_aware);
                 auto sl_lease = slot_guard(sl);
                 Engine& eng = *sl.eng;
                 HookGuard hooks{eng}; // see the non-stream twin
                 eng.samp = samp;
+                eng.pfx_sys_len = sys_len; // P16b
                 std::optional<q27::GpuGate::Lease> lk; // see the non-stream twin
                 if (!conductor) lk.emplace(gpu_gate);
                 double qw = ms_since(rt.t0);
                 eng.on_round_gap = make_yield(eng);
-                const int nm =
-                    std::max(0, std::min(n_max, eng.max_ctx - (int)prompt.size() - (eng.ctx_round_reserve() - 1)));
+                auto limits = think_aware
+                    ? q27::resolve_think_decode_limits(
+                          n_max, eng.max_ctx, (int)prompt.size(), eng.ctx_round_reserve(),
+                          (int)think_close_ids.size(), thinking, tcfg, think_budget_flag)
+                    : q27::resolve_think_decode_limits(
+                          n_max, eng.max_ctx, (int)prompt.size(), eng.ctx_round_reserve(),
+                          0, false, q27::ThinkCfg{false, -1, true}, 0);
+                const int nm = limits.n_max;
+                const int think_budget = limits.budget;
                 auto send = [&](const json& j) {
                     std::string s = "data: " + jdump(j) + "\n\n";
                     return sink.write(s.data(), s.size());
@@ -538,9 +729,11 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                     // SSE shape has no standard mid-stream error event, so none
                     // is invented; end=error lands in the [req] line and
                     // [req-error] carries the what().
-                    int produced = conductor ? batch_generate(eng, prompt, nm, on_tok, nullptr,
-                                                              -1, qw, rt, bt, nullptr)
-                                             : eng.generate(prompt, nm, EOS, on_tok);
+                    int produced = conductor
+                                       ? batch_generate(eng, prompt, nm,
+                                                        [&](int id, bool) { return on_tok(id); },
+                                                        nullptr, -1, qw, rt, bt, nullptr)
+                                       : eng.generate(prompt, nm, EOS, on_tok);
                     eng.on_round_gap = nullptr;
                     std::string tailp = ugate.flush();
                     if (!tailp.empty()) send(piece_chunk(tailp));
@@ -580,12 +773,17 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                             eng.samp.inv_temp <= 0.f; // constrained+sampled is Phase 3
                 tc.begin(tool_names_v);
                 StreamSplitter sp;
+                q27::ThinkBudgetState tb{think_budget};
+                Engine::DecodeTask bt;
                 if (tchoice.mode == q27::ToolChoice::FORCED) sp.chan = StreamSplitter::TOOL;
+                else if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
+                tb.start(bt, think_close_ids, sp.chan);
                 q27::Utf8Gate ugate;
                 bool alive = true; // cleared when a write fails (client disconnected)
                 int tool_idx = 0;
                 bool any_call = false;
                 std::string tool_buf, text_accum;
+                bool forced_control_token = false;
                 auto emit_tool = [&]() {
                     auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
                     tool_buf.clear();
@@ -619,6 +817,10 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                             alive = false;
                         return;
                     }
+                    // Only decoder-injected close whitespace is parser control.
+                    // Preserve ordinary leading whitespace, including when
+                    // thinking is disabled or the model closes naturally.
+                    if (forced_control_token && q27::strip_ws2(t).empty()) return;
                     text_accum += t;
                     if (!send(q27::openai_stream_chunk(cid, objd, created, served_name,
                                                        json{{"content", t}})))
@@ -628,19 +830,22 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                 eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
                 if (tc.enabled)
                     eng.on_round = [&](const int* em, int nr) { return tc.scan_round(em, nr); };
-                auto on_tok = [&](int id) {
+                BatchThinkBudgetObserver batch_tb{tok, tb, bt, think_close_ids, sp.chan};
+                auto on_tok = [&](int id, bool forced) {
+                    forced_control_token = forced;
+                    const auto before = sp.chan;
                     for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) emit_seg(ch, t);
+                    if (!conductor) tb.observe(before, sp.chan, bt, think_close_ids);
                     return alive; // stop generating once the client has disconnected
                 };
-                Engine::DecodeTask bt;
                 int produced = conductor
                                    ? batch_generate(eng, prompt, nm, on_tok,
-                                                    [&](int id) { tc.on_id(id); },
+                                                    [&](int id) { tc.on_id(id); batch_tb.observe(id); },
                                                     stable_len, qw, rt, bt, nullptr)
                                    : eng.generate(prompt, nm, EOS, [&](int id) {
                                          tc.on_id(id);
-                                         return on_tok(id);
-                                     }, stable_len);
+                                         return on_tok(id, bt.callback_forced);
+                                     }, stable_len, &bt);
                 tc.end();
                 eng.on_pending = nullptr;
                 eng.on_drafts = nullptr;
@@ -677,7 +882,9 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                 // carries the what() (batch_generate logs it unconditionally
                 // when err_out is null, same as that leg's nullptr err_out).
                 {
-                    const char* fr = any_call ? "tool_calls" : (produced >= nm ? "length" : "stop");
+                    const char* fr = any_call ? "tool_calls"
+                                              : ((produced >= nm || bt.budget_truncated)
+                                                     ? "length" : "stop");
                     send(q27::openai_stream_chunk(cid, objd, created, served_name,
                                                   json::object(), fr));
                 }
@@ -686,7 +893,9 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                               {"model", served_name}, {"choices", json::array()},
                               {"usage", {{"prompt_tokens", (int)prompt.size()},
                                          {"completion_tokens", produced},
-                                         {"total_tokens", (int)prompt.size() + produced}}}});
+                                         {"total_tokens", (int)prompt.size() + produced},
+                                         {"reasoning_tokens", tb.used},
+                                         {"reasoning_budget_exceeded", tb.tripped}}}});
                 std::string done = "data: [DONE]\n\n";
                 sink.write(done.data(), done.size());
                 sink.done();
@@ -738,6 +947,19 @@ static q27::ToolMaskCache fresh_cache(std::vector<std::string>& vocab_bytes) {
 }
 
 int main() {
+    const auto responses_completed=q27::responses_terminal_state(1,2,false);
+    CHECK(!responses_completed.incomplete &&
+          std::string(responses_completed.status)=="completed" &&
+          std::string(responses_completed.event)=="response.completed");
+    const auto responses_limited=q27::responses_terminal_state(2,2,false);
+    CHECK(responses_limited.incomplete &&
+          std::string(responses_limited.status)=="incomplete" &&
+          std::string(responses_limited.event)=="response.incomplete");
+    const auto responses_budget_limited=q27::responses_terminal_state(1,2,true);
+    CHECK(responses_budget_limited.incomplete &&
+          std::string(responses_budget_limited.status)=="incomplete" &&
+          std::string(responses_budget_limited.event)=="response.incomplete");
+
     // ---- Test 1: plain chat, no tools -> plain content, no tool_calls ----
     {
         FakeTok tok;
@@ -809,7 +1031,7 @@ int main() {
         std::vector<std::string> vb = tok.pieces;
         auto cache = fresh_cache(vb);
         auto slots = fresh_slots();
-        slots[0].eng->script = {1, 2, 3, 4};
+        slots[0].eng->script = {2, 3, 4}; // prompt already contains <think>
         std::atomic<long> rc{0};
         json body = {
             {"tools", json::array({
@@ -900,7 +1122,8 @@ int main() {
     // is injected into the PROMPT (invisible to this harness's FakeTok, which
     // discards prompt text) and the stream splitter is pre-seeded into TOOL
     // channel, so generated text -- with NO literal opening marker this time
-    // -- must still parse as a tool call. ----
+    // and a zero think budget -- must still parse as a tool call without an
+    // injected </think>. ----
     {
         FakeTok tok;
         tok.pieces = {
@@ -915,6 +1138,7 @@ int main() {
         std::atomic<long> rc{0};
         json body = {
             {"tool_choice", {{"type","function"},{"function",{{"name","get_weather"}}}}},
+            {"thinking_token_budget", 0},
             {"tools", json::array({
                 {{"type","function"},{"function",{{"name","get_weather"},{"description","w"},
                     {"parameters", json::object()}}}}
@@ -931,7 +1155,42 @@ int main() {
         CHECK(args["location"] == "Paris");
     }
 
-    // ---- Test 7: /v1/completions (chat=false) with a raw "prompt" field
+    // ---- Test 6b: forced-tool requests start in TOOL, so they must not lose
+    // output capacity to a reasoning close that cannot occur. Exercise both
+    // handler twins at the exact four-token boundary. ----
+    for(bool stream:{false,true}) {
+        FakeTok tok;
+        tok.pieces = {"<eos>", "{\"name\":\"get_", "weather\",\"arguments\":",
+                      "{}}", "</tool_call>"};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->max_ctx = 13; // P=2, round reserve=8, four public tokens fit
+        slots[0].eng->script = {1,2,3,4};
+        std::atomic<long> rc{0};
+        json body = {
+            {"tool_choice", {{"type","function"},{"function",{{"name","get_weather"}}}}},
+            {"tools", json::array({
+                {{"type","function"},{"function",{{"name","get_weather"},
+                    {"parameters",json::object()}}}}
+            })},
+            {"messages", json::array({{{"role","user"},{"content","weather?"}}})},
+            {"max_tokens",4}, {"stream",stream},
+        };
+        run_request(tok,"q27-test",false,false,true,100,13,rc,cache,slots,
+                    body,true,false,-1);
+        if(stream) {
+            bool saw_call=false;
+            for(const auto& event:g_sse_events)
+                if(event.contains("choices") && !event["choices"].empty() &&
+                   event["choices"][0]["delta"].contains("tool_calls")) saw_call=true;
+            CHECK(saw_call);
+        } else {
+            CHECK(g_last_response["choices"][0]["message"]["tool_calls"].size()==1);
+        }
+    }
+
+    // ---- Test 8: /v1/completions (chat=false) with a raw "prompt" field
     // must take the ORIGINAL text-only path untouched (no routed_chat). ----
     {
         FakeTok tok;
@@ -949,11 +1208,30 @@ int main() {
         CHECK(!g_last_response["choices"][0].contains("message"));
     }
 
+    // ---- Test 8: text-only completion admission does not reserve think-close
+    // capacity even when the server default budget is enabled. ----
+    {
+        FakeTok tok;
+        tok.pieces = {"<eos>", "x"};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->max_ctx = 9; // P=1, round reserve=7, one output token fits
+        slots[0].eng->script = {1};
+        std::atomic<long> rc{0};
+        json body = {{"prompt", "raw"}, {"max_tokens", 1}};
+        run_request(tok, "q27-test", true, false, true, 100000, 9, rc, cache, slots,
+                    body, false, false, -1);
+        CHECK(g_last_response["__status"] == 200);
+        CHECK(g_last_response["choices"][0]["text"] == "x");
+    }
+
     // ---- Test 8: streaming, tool call -- verify SSE delta shapes ----
     {
         FakeTok tok;
         tok.pieces = {
             /*0*/ "<eos>",
+
             /*1*/ "Checking now.",
             /*2*/ "<tool_call>\n",
             /*3*/ "{\"name\": \"get_weather\", \"arguments\": {\"location\": \"Rome\"}}\n",
@@ -1008,7 +1286,7 @@ int main() {
         std::vector<std::string> vb = tok.pieces;
         auto cache = fresh_cache(vb);
         auto slots = fresh_slots();
-        slots[0].eng->script = {1, 2, 3, 4};
+        slots[0].eng->script = {2, 3, 4}; // prompt already contains <think>
         std::atomic<long> rc{0};
         json body = {
             {"stream", true},
@@ -1063,6 +1341,255 @@ int main() {
         CHECK(!msg.contains("tool_calls"));
         CHECK(msg["content"].get<std::string>().find("not valid json at all") != std::string::npos);
         CHECK(g_last_response["choices"][0]["finish_reason"] == "stop");
+    }
+
+    // ---- Test 10: cap trip is decoder-visible. The model never emits a
+    // close, yet the forced template id transitions the real splitter to TEXT;
+    // answer generation continues and forced ids do not consume max_tokens. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "still reasoning", /*2*/ "Process complete."};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 2};
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "finish"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", 1},
+                     {"max_tokens", 2}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true);
+        const auto& msg = g_last_response["choices"][0]["message"];
+        CHECK(msg["reasoning_content"] == "still reasoning");
+        CHECK(msg["content"] == "Process complete.");
+        CHECK(g_last_response["usage"]["completion_tokens"] == 2);
+        CHECK(g_last_response["usage"]["reasoning_tokens"] == 1);
+        CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == true);
+    }
+
+    // ---- Test 11: zero budget closes before the first model token. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "Immediate answer."};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1};
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "answer"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", 0},
+                     {"max_tokens", 1}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true);
+        const auto& msg = g_last_response["choices"][0]["message"];
+        CHECK(msg["content"] == "Immediate answer.");
+        CHECK(!msg.contains("reasoning_content"));
+        CHECK(g_last_response["usage"]["completion_tokens"] == 1);
+        CHECK(g_last_response["usage"]["reasoning_tokens"] == 0);
+        CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == true);
+    }
+
+    // ---- Test 12: natural close before the cap releases enforcement and is
+    // not followed by a duplicate injected close. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "short thought", /*2*/ "</think>",
+                      /*3*/ "Natural answer."};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 2, 3};
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "answer"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", 4},
+                     {"max_tokens", 3}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true);
+        const auto& msg = g_last_response["choices"][0]["message"];
+        CHECK(msg["reasoning_content"] == "short thought");
+        CHECK(msg["content"] == "Natural answer.");
+        CHECK(g_last_response["usage"]["completion_tokens"] == 3);
+        CHECK(g_last_response["usage"]["reasoning_tokens"] == 2);
+        CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == false);
+    }
+
+    // ---- Test 13: batch mode observes the trip on the conductor thread
+    // before the next draft; the injected close stays parser control, never
+    // literal response content. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "still reasoning", /*2*/ "Process complete."};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 2};
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "finish"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", 1},
+                     {"max_tokens", 2}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true, /*batch=*/true);
+        const auto& msg = g_last_response["choices"][0]["message"];
+        CHECK(msg["reasoning_content"] == "still reasoning");
+        CHECK(msg["content"] == "Process complete.");
+        CHECK(msg["content"].get<std::string>().find("</think>") == std::string::npos);
+        CHECK(g_last_response["usage"]["completion_tokens"] == 2);
+        CHECK(g_last_response["usage"]["reasoning_tokens"] == 1);
+        CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == true);
+    }
+
+    // ---- Test 14: injected template newlines never surface as an OpenAI
+    // content delta; only the model-generated answer is public. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "Immediate answer."};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1};
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "answer"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", 0},
+                     {"max_tokens", 1}, {"stream", true}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true);
+        bool saw_answer = false, saw_control_ws = false;
+        for (const auto& ev : g_sse_events) {
+            if (!ev.contains("choices") || ev["choices"].empty()) continue;
+            const auto& delta = ev["choices"][0]["delta"];
+            if (!delta.contains("content") || !delta["content"].is_string()) continue;
+            const std::string content = delta["content"].get<std::string>();
+            if (!content.empty() && q27::strip_ws2(content).empty()) saw_control_ws = true;
+            if (content == "Immediate answer.") saw_answer = true;
+        }
+        CHECK(saw_answer);
+        CHECK(!saw_control_ws);
+    }
+
+    // ---- Test 15: bounded thinking near the context boundary is rejected
+    // before generation instead of returning an empty successful response. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "unused"};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1};
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "answer"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", 0},
+                     {"max_tokens", 8}};
+        run_request(tok, "q27-test", false, false, true, 2, 10, rc, cache, slots,
+                    body, true);
+        CHECK(g_last_response["__status"] == 400);
+        CHECK(g_last_response["error"]["code"] == "context_length_exceeded");
+    }
+
+    // ---- Test 16: ordinary overflow reports the real prompt ceiling; the
+    // think-close reserve applies only to bounded-thinking rejection. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "unused"};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "answer"}}})},
+                     {"enable_thinking", false}, {"max_tokens", 8}};
+        run_request(tok, "q27-test", false, false, true, 1, 9, rc, cache, slots,
+                    body, true);
+        CHECK(g_last_response["__status"] == 400);
+        CHECK(g_last_response["error"]["message"].get<std::string>().find(
+                  "1 maximum") != std::string::npos);
+    }
+
+    // ---- Test 17: a non-thinking stream preserves model-generated leading
+    // whitespace; only exact injected close-token whitespace is suppressed. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "\n", /*2*/ "answer"};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 2};
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "answer"}}})},
+                     {"enable_thinking", false}, {"max_tokens", 2}, {"stream", true}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true);
+        std::string content;
+        for (const auto& ev : g_sse_events) {
+            if (!ev.contains("choices") || ev["choices"].empty()) continue;
+            const auto& delta = ev["choices"][0]["delta"];
+            if (delta.contains("content") && delta["content"].is_string())
+                content += delta["content"].get<std::string>();
+        }
+        CHECK(content == "\nanswer");
+    }
+
+    // ---- Test 18: a model-generated natural close is not mislabeled as an
+    // injected close even when its token bytes match the template exactly. ----
+    {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "</think>\n\n", /*2*/ "answer"};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 2};
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "answer"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", -1},
+                     {"max_tokens", 2}, {"stream", true}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true);
+        std::string content;
+        for (const auto& ev : g_sse_events) {
+            if (!ev.contains("choices") || ev["choices"].empty()) continue;
+            const auto& delta = ev["choices"][0]["delta"];
+            if (delta.contains("content") && delta["content"].is_string())
+                content += delta["content"].get<std::string>();
+        }
+        CHECK(content == "\n\nanswer");
+    }
+
+    // ---- Test 19: a later exhausted think span suppresses its injected
+    // whitespace and reports length only when the reduced cap is reached. ----
+    for (bool batch : {false, true}) {
+        for (bool stream : {false, true}) {
+            for (int cap : {4, 8}) {
+                FakeTok tok;
+                tok.pieces = {/*0*/ "<eos>", /*1*/ "prefix", /*2*/ "<think>",
+                              /*3*/ "suffix"};
+                std::vector<std::string> vb = tok.pieces;
+                auto cache = fresh_cache(vb);
+                auto slots = fresh_slots();
+                slots[0].eng->script = {1, 2, 3};
+                std::atomic<long> rc{0};
+                json body = {{"messages", json::array({{{"role", "user"}, {"content", "answer"}}})},
+                             {"enable_thinking", true}, {"thinking_token_budget", 0},
+                             {"max_tokens", cap}, {"stream", stream}};
+                run_request(tok, "q27-test", false, false, true, 100000, 100000, rc,
+                            cache, slots, body, true, batch);
+                std::string content, finish;
+                if (stream) {
+                    for (const auto& ev : g_sse_events) {
+                        if (!ev.contains("choices") || ev["choices"].empty()) continue;
+                        const auto& choice = ev["choices"][0];
+                        const auto& delta = choice["delta"];
+                        if (delta.contains("content") && delta["content"].is_string())
+                            content += delta["content"].get<std::string>();
+                        if (choice.contains("finish_reason") && choice["finish_reason"].is_string())
+                            finish = choice["finish_reason"].get<std::string>();
+                    }
+                } else {
+                    const auto& choice = g_last_response["choices"][0];
+                    content = choice["message"]["content"].get<std::string>();
+                    finish = choice["finish_reason"].get<std::string>();
+                }
+                CHECK(content == "prefixsuffix");
+                CHECK(finish == (cap == 4 ? "length" : "stop"));
+            }
+        }
     }
 
     fprintf(stderr, failures ? "%d FAILURE(S)\n" : "all integration tests passed\n", failures);

--- a/tools/test_chat_completions_integration.cpp
+++ b/tools/test_chat_completions_integration.cpp
@@ -560,12 +560,15 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
             q27::Utf8Gate ugate;
             std::string think, text, tool_buf;
             std::vector<q27::ToolCall> calls;
+            auto flush_tool = [&]() {
+                auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
+                tool_buf.clear();
+                if (c.ok) calls.push_back(std::move(c));
+                else text += c.raw;
+            };
             auto route = [&](StreamSplitter::Chan ch, const std::string& t) {
                 if (ch == StreamSplitter::TOOL) { tool_buf += t; return; }
-                if (!tool_buf.empty()) { // tool segment closed
-                    calls.push_back(q27::parse_tool_call(q27::strip_ws2(tool_buf)));
-                    tool_buf.clear();
-                }
+                if (!tool_buf.empty()) flush_tool();
                 (ch == StreamSplitter::THINK ? think : text) += t;
             };
             ToolConstrainer tc;
@@ -629,12 +632,9 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
             }
             for (auto& [ch, t] : sp.feed(ugate.flush())) route(ch, t);
             for (auto& [ch, t] : sp.flush()) route(ch, t);
-            if (!tool_buf.empty())
-                calls.push_back(q27::parse_tool_call(q27::strip_ws2(tool_buf)));
+            if (!tool_buf.empty()) flush_tool();
 
-            std::string tx = q27::strip_ws2(text);
-            for (auto& c : calls)
-                if (!c.ok) tx += (tx.empty() ? "" : "\n") + c.raw;
+            std::string tx = text;
             if (tools.is_array() && !tools.empty()) {
                 // wrapper-less call recovery (see parse_bare_tool_calls)
                 std::string pre;
@@ -650,7 +650,7 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
             bool any_call = false;
             for (auto& c : calls)
                 if (c.ok) any_call = true;
-            json msg = q27::openai_chat_message_json(tx, calls, rid, q27::strip_ws2(think));
+            json msg = q27::openai_chat_message_json(tx, calls, rid, think);
             json choice = {{"index", 0},
                           {"finish_reason", any_call ? "tool_calls" :
                               ((n >= n_max || bt.budget_truncated) ? "length" : "stop")},
@@ -1503,9 +1503,9 @@ int main() {
                   "1 maximum") != std::string::npos);
     }
 
-    // ---- Test 17: a non-thinking stream preserves model-generated leading
+    // ---- Test 17: stream and non-stream both preserve model-generated leading
     // whitespace; only exact injected close-token whitespace is suppressed. ----
-    {
+    for (bool stream : {false, true}) {
         FakeTok tok;
         tok.pieces = {/*0*/ "<eos>", /*1*/ "\n", /*2*/ "answer"};
         std::vector<std::string> vb = tok.pieces;
@@ -1514,22 +1514,26 @@ int main() {
         slots[0].eng->script = {1, 2};
         std::atomic<long> rc{0};
         json body = {{"messages", json::array({{{"role", "user"}, {"content", "answer"}}})},
-                     {"enable_thinking", false}, {"max_tokens", 2}, {"stream", true}};
+                     {"enable_thinking", false}, {"max_tokens", 2}, {"stream", stream}};
         run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
                     body, true);
         std::string content;
-        for (const auto& ev : g_sse_events) {
-            if (!ev.contains("choices") || ev["choices"].empty()) continue;
-            const auto& delta = ev["choices"][0]["delta"];
-            if (delta.contains("content") && delta["content"].is_string())
-                content += delta["content"].get<std::string>();
+        if (stream) {
+            for (const auto& ev : g_sse_events) {
+                if (!ev.contains("choices") || ev["choices"].empty()) continue;
+                const auto& delta = ev["choices"][0]["delta"];
+                if (delta.contains("content") && delta["content"].is_string())
+                    content += delta["content"].get<std::string>();
+            }
+        } else {
+            content = g_last_response["choices"][0]["message"]["content"].get<std::string>();
         }
         CHECK(content == "\nanswer");
     }
 
-    // ---- Test 18: a model-generated natural close is not mislabeled as an
-    // injected close even when its token bytes match the template exactly. ----
-    {
+    // ---- Test 18: a model-generated natural close keeps the same answer bytes
+    // in stream and non-stream, even when it matches the template close. ----
+    for (bool stream : {false, true}) {
         FakeTok tok;
         tok.pieces = {/*0*/ "<eos>", /*1*/ "</think>\n\n", /*2*/ "answer"};
         std::vector<std::string> vb = tok.pieces;
@@ -1539,15 +1543,19 @@ int main() {
         std::atomic<long> rc{0};
         json body = {{"messages", json::array({{{"role", "user"}, {"content", "answer"}}})},
                      {"enable_thinking", true}, {"thinking_token_budget", -1},
-                     {"max_tokens", 2}, {"stream", true}};
+                     {"max_tokens", 2}, {"stream", stream}};
         run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
                     body, true);
         std::string content;
-        for (const auto& ev : g_sse_events) {
-            if (!ev.contains("choices") || ev["choices"].empty()) continue;
-            const auto& delta = ev["choices"][0]["delta"];
-            if (delta.contains("content") && delta["content"].is_string())
-                content += delta["content"].get<std::string>();
+        if (stream) {
+            for (const auto& ev : g_sse_events) {
+                if (!ev.contains("choices") || ev["choices"].empty()) continue;
+                const auto& delta = ev["choices"][0]["delta"];
+                if (delta.contains("content") && delta["content"].is_string())
+                    content += delta["content"].get<std::string>();
+            }
+        } else {
+            content = g_last_response["choices"][0]["message"]["content"].get<std::string>();
         }
         CHECK(content == "\n\nanswer");
     }
@@ -1590,6 +1598,42 @@ int main() {
                 CHECK(finish == (cap == 4 ? "length" : "stop"));
             }
         }
+    }
+
+    // ---- Test 20: malformed tool text stays adjacent to preceding model
+    // whitespace in both stream and non-stream responses. ----
+    for (bool stream : {false, true}) {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ " before", /*2*/ "<tool_call>",
+                      /*3*/ "not valid json", /*4*/ "</tool_call>", /*5*/ " after"};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 2, 3, 4, 5};
+        std::atomic<long> rc{0};
+        json body = {
+            {"tools", json::array({
+                {{"type", "function"}, {"function", {{"name", "get_weather"},
+                    {"description", "w"}, {"parameters", json::object()}}}}
+            })},
+            {"messages", json::array({{{"role", "user"}, {"content", "weather?"}}})},
+            {"enable_thinking", false}, {"max_tokens", 5}, {"stream", stream},
+        };
+        run_request(tok, "q27-test", true, false, true, 100000, 100000, rc, cache,
+                    slots, body, true);
+        std::string content;
+        if (stream) {
+            for (const auto& ev : g_sse_events) {
+                if (!ev.contains("choices") || ev["choices"].empty()) continue;
+                const auto& delta = ev["choices"][0]["delta"];
+                if (delta.contains("content") && delta["content"].is_string())
+                    content += delta["content"].get<std::string>();
+            }
+        } else {
+            content = g_last_response["choices"][0]["message"]["content"]
+                          .get<std::string>();
+        }
+        CHECK(content == " beforenot valid json after");
     }
 
     fprintf(stderr, failures ? "%d FAILURE(S)\n" : "all integration tests passed\n", failures);

--- a/tools/test_conductor.cpp
+++ b/tools/test_conductor.cpp
@@ -18,6 +18,7 @@
 #include "../src/conductor.h"
 
 #include <cstdio>
+#include <thread>
 #include <vector>
 
 static int fails = 0;
@@ -149,6 +150,7 @@ int main() {
         int id = 0;
         int budget = 0;
         bool cancel = false;
+        bool forced = false;
         int want = 4;
         bool suffix = false;
         int granted = -1;
@@ -262,6 +264,40 @@ int main() {
             {1}, {1, 2, 3}, {1, 2, 3, 4}, {1, 4}, {1}, {1}};
         CHECK(round_ids == expect, "core: full round-membership trace matches");
     }
+    { // staged control ids must run through the solo decoder path: fused
+      // drafting would overwrite the forced pending token before commit.
+        q27::ConductorCore<FakeMember> core(12);
+        FakeMember A{}, B{};
+        A.id = 1; A.budget = 3;
+        B.id = 2; B.budget = 3; B.forced = true;
+        int solo_calls = 0, fused_calls = 0;
+        core.needs_solo_round = [](FakeMember& mm) { return mm.forced; };
+        core.solo_round = [&](FakeMember& mm) {
+            solo_calls++;
+            mm.rounds++;
+            mm.forced = false;
+            return false;
+        };
+        core.fused_round = [&](FakeMember** ms, const int*, const bool*, int k,
+                               bool* done) {
+            fused_calls++;
+            for (int i = 0; i < k; i++) {
+                ms[i]->rounds++;
+                done[i] = false;
+            }
+        };
+        core.on_leave = [](FakeMember&) {};
+        core.join(&A);
+        core.join(&B);
+        int live = core.round();
+        CHECK(live == 2 && solo_calls == 1 && fused_calls == 0 &&
+                  A.rounds == 0 && B.rounds == 1,
+              "core: forced member runs solo before any fused draft");
+        live = core.round();
+        CHECK(live == 2 && solo_calls == 1 && fused_calls == 1 &&
+                  A.rounds == 1 && B.rounds == 2,
+              "core: member rejoins fused rounds after forced transition");
+    }
     { // solo member cancelled at the boundary: no solo hook, done-path only
         q27::ConductorCore<FakeMember> core(12);
         FakeMember A{};
@@ -275,6 +311,27 @@ int main() {
         int live = core.round();
         CHECK(live == 0 && solo_calls == 0 && A.finished && left,
               "core: pre-check cancel beats the solo hook");
+    }
+    { // Producer-side provenance must remain attached to its token while the
+      // request thread drains concurrently; no shared DecodeTask flag is read.
+        q27::TokenQueue q;
+        std::thread producer([&]() {
+            for (int i = 0; i < 512; i++) q.push(i, (i % 7) == 0);
+            q.close("test complete");
+        });
+        std::vector<q27::TokenQueue::Token> chunk;
+        int next = 0;
+        bool ordered = true;
+        while (q.pop(chunk)) {
+            for (const auto& token : chunk) {
+                ordered = ordered && token.id == next && token.forced == ((next % 7) == 0);
+                next++;
+            }
+            chunk.clear();
+        }
+        producer.join();
+        CHECK(ordered && next == 512,
+              "queue: forced provenance stays ordered across threads");
     }
     printf(fails ? "test_conductor: %d FAILED\n" : "test_conductor: ALL PASS\n", fails);
     return fails ? 1 : 0;

--- a/tools/test_think_resolve.cpp
+++ b/tools/test_think_resolve.cpp
@@ -15,29 +15,6 @@ static void ok(bool c, const char* n) {
     if (!c) failures++;
 }
 
-struct FakeTask {
-    bool accept_one = false;
-    int n_max = 8;
-    int emitted = 0;
-    bool cancel = false;
-    bool sampling = false;
-    std::vector<int> forced;
-    void force(const std::vector<int>& ids) {
-        forced.insert(forced.end(), ids.begin(), ids.end());
-        accept_one = true;
-    }
-    bool force_from_public_budget(const std::vector<int>& ids) {
-        const int cost = (int)ids.size();
-        if (n_max - emitted <= cost) {
-            cancel = true;
-            return false;
-        }
-        n_max -= cost;
-        force(ids);
-        return true;
-    }
-    void release_accept_one() { accept_one = false; }
-};
 
 int main() {
     // existing cases exercise the honoring path (allow_request=true, i.e. the
@@ -230,96 +207,59 @@ int main() {
     ok(q27::think_budget_default(1234, 8192) == 1234, "default: flag >0 -> absolute");
     ok(q27::think_budget_default(-1, 0) == -1, "default: no max_tokens -> unbounded");
 
-    // --- decoder-visible enforcement: exact trip, zero budget, and release ---
-    const std::vector<int> close_ids{70, 71};
+    // --- round-boundary enforcement: overshoot, natural close, and re-entry ---
+    using Action = q27::ThinkBudgetAction;
     {
-        FakeTask task;
         q27::ThinkBudgetState state(-1);
-        state.start(task, close_ids);
-        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::THINK, task,
-                      close_ids);
-        ok(!task.accept_one && task.forced.empty() && state.used == 1 && !state.tripped,
-           "enforce: unbounded counts usage without constraining speculation");
+        ok(state.start() == Action::NONE, "enforce: unbounded start is inert");
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::THINK);
+        ok(state.finish_round(q27::StreamSplitter::THINK) == Action::NONE &&
+               state.used == 1 && !state.tripped,
+           "enforce: unbounded counts usage without forcing a close");
     }
     {
-        FakeTask task;
         q27::ThinkBudgetState state(0);
-        state.start(task, close_ids);
-        ok(task.accept_one && task.forced == close_ids && state.used == 0 && state.tripped,
-           "enforce: zero budget queues close before any model token");
+        ok(state.start() == Action::FORCE_RESERVED && state.used == 0 &&
+               state.tripped && state.transition_pending && !state.reserved_close,
+           "enforce: zero budget requests the reserved close before decoding");
     }
     {
-        FakeTask task;
         q27::ThinkBudgetState state(0);
-        state.start(task, close_ids, q27::StreamSplitter::TEXT);
-        ok(task.accept_one && task.forced.empty() && !state.tripped,
+        ok(state.start(q27::StreamSplitter::TEXT) == Action::NONE && !state.tripped,
            "enforce: zero budget stays armed outside a think span");
-        state.observe(q27::StreamSplitter::TEXT, q27::StreamSplitter::THINK, task,
-                      close_ids);
-        ok(task.forced == close_ids && state.tripped,
+        state.observe(q27::StreamSplitter::TEXT, q27::StreamSplitter::THINK);
+        ok(state.finish_round(q27::StreamSplitter::THINK) == Action::FORCE_RESERVED &&
+               state.tripped,
            "enforce: zero budget closes a later spontaneous think span");
     }
     {
-        FakeTask task;
         q27::ThinkBudgetState state(2);
-        state.start(task, close_ids);
-        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::THINK, task,
-                      close_ids);
-        ok(task.accept_one && task.forced.empty() && state.used == 1 && !state.tripped,
-           "enforce: bounded span observes one token per round before cap");
-        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::THINK, task,
-                      close_ids);
-        ok(task.forced == close_ids && state.used == 2 && state.tripped,
-           "enforce: exact cap queues template close ids once");
-        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::THINK, task,
-                      close_ids);
-        ok(task.forced == close_ids && state.used == 2,
-           "enforce: injected close ids are not counted or queued twice");
-        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::TEXT, task,
-                      close_ids);
-        ok(!task.accept_one, "enforce: completed close releases one-token acceptance cap");
-        task.emitted = 2;
-        state.observe(q27::StreamSplitter::TEXT, q27::StreamSplitter::THINK, task,
-                      close_ids);
-        ok(task.accept_one && task.forced.size() == 4 && task.n_max == 6 &&
-               state.used == 2 && !task.cancel,
-           "enforce: later forced close consumes remaining public capacity");
+        ok(state.start() == Action::NONE, "enforce: positive budget starts normally");
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::THINK);
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::THINK);
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::THINK);
+        ok(state.finish_round(q27::StreamSplitter::THINK) == Action::FORCE_RESERVED &&
+               state.used == 3 && state.tripped && state.transition_pending,
+           "enforce: fused round may overshoot but uses its retained token count");
+        ok(state.finish_round(q27::StreamSplitter::THINK) == Action::NONE,
+           "enforce: a pending transition is requested only once");
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::TEXT, true);
+        ok(state.tripped && !state.transition_pending && state.used == 3,
+           "enforce: forced close exits think without adding reasoning usage");
+        state.observe(q27::StreamSplitter::TEXT, q27::StreamSplitter::THINK);
+        ok(state.finish_round(q27::StreamSplitter::THINK) == Action::FORCE_PUBLIC,
+           "enforce: later re-entry borrows close capacity from public tokens");
     }
     {
-        FakeTask task;
-        q27::ThinkBudgetState state(4);
-        state.start(task, close_ids);
-        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::TEXT, task,
-                      close_ids);
-        ok(!task.accept_one && task.forced.empty() && state.used == 1 && !state.tripped,
-           "enforce: natural close before cap needs no forced transition");
-        state.observe(q27::StreamSplitter::TEXT, q27::StreamSplitter::THINK, task,
-                      close_ids);
-        ok(task.accept_one && task.forced.empty() && state.used == 1 && !state.tripped,
-           "enforce: later think span re-arms one-token acceptance");
-    }
-    {
-        FakeTask task;
-        task.sampling = true;
-        q27::ThinkBudgetState state(4);
-        state.start(task, close_ids);
-        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::TEXT, task,
-                      close_ids);
-        ok(task.accept_one && !state.tripped,
-           "enforce: sampled decode stays one-token outside think for safe reentry");
-    }
-    {
-        FakeTask task;
-        task.n_max = 4;
-        task.emitted = 2;
-        q27::ThinkBudgetState state(0);
-        state.start(task, close_ids);
-        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::TEXT, task,
-                      close_ids);
-        state.observe(q27::StreamSplitter::TEXT, q27::StreamSplitter::THINK, task,
-                      close_ids);
-        ok(task.cancel && task.forced.size() == 2 && task.n_max == 4,
-           "enforce: later close stops when public capacity cannot pay for it");
+        q27::ThinkBudgetState state(1);
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::THINK);
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::TEXT);
+        ok(state.finish_round(q27::StreamSplitter::TEXT) == Action::NONE &&
+               state.used == 2 && !state.tripped && state.reserved_close,
+           "enforce: natural close later in the same round suppresses forcing");
+        state.observe(q27::StreamSplitter::TEXT, q27::StreamSplitter::THINK);
+        ok(state.finish_round(q27::StreamSplitter::THINK) == Action::FORCE_RESERVED,
+           "enforce: unused reserved close remains available for later re-entry");
     }
 
     printf(failures ? "\nTHINK-RESOLVE: %d FAIL\n" : "\nTHINK-RESOLVE: all pass\n", failures);

--- a/tools/test_think_resolve.cpp
+++ b/tools/test_think_resolve.cpp
@@ -187,10 +187,12 @@ int main() {
     ok(disabled_limits.context_ok && disabled_limits.n_max == 8 &&
            disabled_limits.budget == -1,
        "budget: explicit thinking disable reserves no close tokens and enforces no cap");
-    ok(q27::think_budget_for_request(false, q27::ThinkCfg{}, -1, 8) == 4,
-       "default: spontaneous think blocks retain the server budget");
+    ok(q27::think_budget_for_request(false, q27::ThinkCfg{}, -1, 8) == -1,
+       "default: no-think request preserves sampled speculation");
     ok(q27::think_budget_for_request(false, q27::ThinkCfg{false, 3, true}, 0, 8) == 3,
-       "default: explicit budget applies without prompt-seeded thinking");
+       "default: explicit request budget applies without prompt-seeded thinking");
+    ok(q27::think_budget_for_request(false, q27::ThinkCfg{}, 3, 8) == 3,
+       "default: explicit server budget applies without prompt-seeded thinking");
 
     const auto active_two_token_limits = q27::resolve_think_decode_limits(
         2, 20, 8, 5, 2, true, q27::ThinkCfg{}, -1);
@@ -213,14 +215,14 @@ int main() {
         3, 20, 8, 5, 2, false, q27::ThinkCfg{}, -1);
     ok(spontaneous_three_token_limits.context_ok &&
            spontaneous_three_token_limits.n_max == 3 &&
-           spontaneous_three_token_limits.budget == 1,
-       "budget: spontaneous think keeps opener reasoning and answer capacity");
+           spontaneous_three_token_limits.budget == -1,
+       "budget: default no-think request keeps ordinary decode width");
     const auto spontaneous_zero_budget_limits = q27::resolve_think_decode_limits(
         2, 20, 8, 5, 2, false, q27::ThinkCfg{true, 0, true}, -1);
     ok(spontaneous_zero_budget_limits.context_ok &&
            spontaneous_zero_budget_limits.n_max == 2 &&
            spontaneous_zero_budget_limits.budget == 0,
-       "budget: zero spontaneous budget keeps opener and answer capacity");
+       "budget: explicit zero spontaneous budget keeps opener and answer capacity");
 
     // --- server default: fraction of max_tokens, absolute, or opt-out ---
     ok(q27::think_budget_default(-1, 8192) == 4096, "default: <0 flag -> half of max_tokens");

--- a/tools/test_think_resolve.cpp
+++ b/tools/test_think_resolve.cpp
@@ -15,6 +15,30 @@ static void ok(bool c, const char* n) {
     if (!c) failures++;
 }
 
+struct FakeTask {
+    bool accept_one = false;
+    int n_max = 8;
+    int emitted = 0;
+    bool cancel = false;
+    bool sampling = false;
+    std::vector<int> forced;
+    void force(const std::vector<int>& ids) {
+        forced.insert(forced.end(), ids.begin(), ids.end());
+        accept_one = true;
+    }
+    bool force_from_public_budget(const std::vector<int>& ids) {
+        const int cost = (int)ids.size();
+        if (n_max - emitted <= cost) {
+            cancel = true;
+            return false;
+        }
+        n_max -= cost;
+        force(ids);
+        return true;
+    }
+    void release_accept_one() { accept_one = false; }
+};
+
 int main() {
     // existing cases exercise the honoring path (allow_request=true, i.e. the
     // server booted with --request-think); a local wrapper supplies that arg.
@@ -92,6 +116,62 @@ int main() {
        "budget: non-integer budget ignored -> server budget");
     ok(bud(json{{"thinking", {{"budget_tokens", -1}}}}, 4096) == -1,
        "budget: negative request budget means unbounded, overriding server");
+    ok(bud(json{{"thinking_token_budget", 2147483648ULL}}, 4096) == 4096,
+       "budget: unsigned value above INT_MAX ignored -> server budget");
+    ok(bud(json{{"thinking", {{"budget_tokens", -2147483649LL}}}}, 4096) == 4096,
+       "budget: signed value below INT_MIN ignored -> server budget");
+    auto explicit_unbounded = q27::resolve_think_cfg(
+        json{{"thinking", {{"budget_tokens", -1}}}}, true, true, 4096);
+    ok(explicit_unbounded.budget_set,
+       "budget: explicit negative override remains distinguishable from default");
+    ok(q27::think_budget_for_request(true, explicit_unbounded, 64, 128) == -1,
+       "budget: explicit unbounded request overrides absolute server flag");
+    auto silent_budget = q27::resolve_think_cfg(json::object(), true, true, -1);
+    ok(!silent_budget.budget_set,
+       "budget: absent request budget keeps server default eligible");
+    auto bounded_limits = q27::resolve_think_decode_limits(
+        8, 20, 8, 5, 2, true, q27::ThinkCfg{true, 0, true}, -1);
+    ok(bounded_limits.n_max == 6,
+       "budget: bounded close ids reserve decoder context outside public cap");
+    auto unbounded_limits = q27::resolve_think_decode_limits(
+        8, 20, 8, 5, 2, true, q27::ThinkCfg{true, -1, true}, -1);
+    ok(unbounded_limits.n_max == 8,
+       "budget: explicit unbounded span needs no forced-close reserve");
+    auto default_limits = q27::resolve_think_decode_limits(
+        8, 20, 8, 5, 2, true, q27::ThinkCfg{true, -1, false}, -1);
+    ok(default_limits.n_max == 6 && default_limits.budget == 3,
+       "budget: fractional default recomputes against context-clamped public cap");
+    auto unattainable_limits = q27::resolve_think_decode_limits(
+        8, 20, 8, 5, 2, true, q27::ThinkCfg{true, 64, true}, -1);
+    ok(unattainable_limits.context_ok && unattainable_limits.n_max == 8 &&
+           unattainable_limits.budget == -1,
+       "budget: unattainable absolute cap reserves nothing and disables enforcement");
+    auto impossible_limits = q27::resolve_think_decode_limits(
+        8, 14, 8, 5, 2, true, q27::ThinkCfg{true, 0, true}, -1);
+    ok(!impossible_limits.context_ok,
+       "budget: context unable to fit close plus answer is rejected");
+    auto fixed_point_limits = q27::resolve_think_decode_limits(
+        8, 16, 8, 5, 2, true, q27::ThinkCfg{true, -1, false}, -1);
+    ok(fixed_point_limits.context_ok && fixed_point_limits.n_max == 2 &&
+           fixed_point_limits.budget == 1,
+       "budget: fractional cap is solved after reserving close tokens");
+    ok(q27::max_prompt_for_think_decode(
+           8, 16, 5, 11, 10, 2, true, q27::ThinkCfg{true, -1, false}, -1) == 9,
+       "budget: reported fractional prompt ceiling matches fixed-point admission");
+    ok(q27::max_prompt_for_think_decode(
+           8, 16, 5, 11, 12, 2, true, q27::ThinkCfg{true, -1, false}, 0) == 11,
+       "budget: unbounded prompt ceiling keeps the ordinary context limit");
+    ok(q27::max_prompt_for_think_decode(
+           8, 16, 5, 11, 7, 2, true, q27::ThinkCfg{true, 4, true}, -1) == 5,
+       "budget: nonmonotonic admission reports a lower compaction target");
+    auto zero_output_too_large = q27::resolve_think_decode_limits(
+        0, 12, 8, 5, 2, false, q27::ThinkCfg{}, -1);
+    ok(!zero_output_too_large.context_ok,
+       "budget: zero-output request still rejects a prompt with no decode reserve");
+    auto zero_output_fits = q27::resolve_think_decode_limits(
+        0, 13, 8, 5, 2, false, q27::ThinkCfg{}, -1);
+    ok(zero_output_fits.context_ok && zero_output_fits.n_max == 0,
+       "budget: zero-output request may route when the prompt reserve fits");
     // enabling and bounding are independent: a request may bound a block it
     // did not itself turn on.
     ok(q27::resolve_think_cfg(json{{"thinking_token_budget", 64}}, true, true, -1).enabled == true,
@@ -99,12 +179,146 @@ int main() {
     ok(q27::resolve_think_cfg(json{{"enable_thinking", false}, {"thinking_token_budget", 64}},
                               true, true, -1).enabled == false,
        "budget: bounding alone does not re-enable a disabled block");
+    const auto disabled_bounded = q27::resolve_think_cfg(
+        json{{"enable_thinking", false}, {"thinking_token_budget", 32}},
+        true, true, -1);
+    const auto disabled_limits = q27::resolve_think_decode_limits(
+        8, 20, 8, 5, 2, false, disabled_bounded, -1);
+    ok(disabled_limits.context_ok && disabled_limits.n_max == 8 &&
+           disabled_limits.budget == -1,
+       "budget: explicit thinking disable reserves no close tokens and enforces no cap");
+    ok(q27::think_budget_for_request(false, q27::ThinkCfg{}, -1, 8) == 4,
+       "default: spontaneous think blocks retain the server budget");
+    ok(q27::think_budget_for_request(false, q27::ThinkCfg{false, 3, true}, 0, 8) == 3,
+       "default: explicit budget applies without prompt-seeded thinking");
+
+    const auto active_two_token_limits = q27::resolve_think_decode_limits(
+        2, 20, 8, 5, 2, true, q27::ThinkCfg{}, -1);
+    ok(active_two_token_limits.context_ok && active_two_token_limits.n_max == 2 &&
+           active_two_token_limits.budget == 1,
+       "budget: prompt-seeded think reserves one answer token");
+    const auto spontaneous_two_token_limits = q27::resolve_think_decode_limits(
+        2, 20, 8, 5, 2, false, q27::ThinkCfg{}, -1);
+    ok(spontaneous_two_token_limits.context_ok &&
+           spontaneous_two_token_limits.n_max == 2 &&
+           spontaneous_two_token_limits.budget == -1,
+       "budget: short spontaneous request falls back to ordinary length stop");
+    const auto spontaneous_one_token_limits = q27::resolve_think_decode_limits(
+        1, 20, 8, 5, 2, false, q27::ThinkCfg{}, -1);
+    ok(spontaneous_one_token_limits.context_ok &&
+           spontaneous_one_token_limits.n_max == 1 &&
+           spontaneous_one_token_limits.budget == -1,
+       "budget: one-token non-thinking request is not a context overflow");
+    const auto spontaneous_three_token_limits = q27::resolve_think_decode_limits(
+        3, 20, 8, 5, 2, false, q27::ThinkCfg{}, -1);
+    ok(spontaneous_three_token_limits.context_ok &&
+           spontaneous_three_token_limits.n_max == 3 &&
+           spontaneous_three_token_limits.budget == 1,
+       "budget: spontaneous think keeps opener reasoning and answer capacity");
+    const auto spontaneous_zero_budget_limits = q27::resolve_think_decode_limits(
+        2, 20, 8, 5, 2, false, q27::ThinkCfg{true, 0, true}, -1);
+    ok(spontaneous_zero_budget_limits.context_ok &&
+           spontaneous_zero_budget_limits.n_max == 2 &&
+           spontaneous_zero_budget_limits.budget == 0,
+       "budget: zero spontaneous budget keeps opener and answer capacity");
 
     // --- server default: fraction of max_tokens, absolute, or opt-out ---
     ok(q27::think_budget_default(-1, 8192) == 4096, "default: <0 flag -> half of max_tokens");
     ok(q27::think_budget_default(0, 8192) == -1, "default: flag 0 -> unbounded (opt out)");
     ok(q27::think_budget_default(1234, 8192) == 1234, "default: flag >0 -> absolute");
     ok(q27::think_budget_default(-1, 0) == -1, "default: no max_tokens -> unbounded");
+
+    // --- decoder-visible enforcement: exact trip, zero budget, and release ---
+    const std::vector<int> close_ids{70, 71};
+    {
+        FakeTask task;
+        q27::ThinkBudgetState state(-1);
+        state.start(task, close_ids);
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::THINK, task,
+                      close_ids);
+        ok(!task.accept_one && task.forced.empty() && state.used == 1 && !state.tripped,
+           "enforce: unbounded counts usage without constraining speculation");
+    }
+    {
+        FakeTask task;
+        q27::ThinkBudgetState state(0);
+        state.start(task, close_ids);
+        ok(task.accept_one && task.forced == close_ids && state.used == 0 && state.tripped,
+           "enforce: zero budget queues close before any model token");
+    }
+    {
+        FakeTask task;
+        q27::ThinkBudgetState state(0);
+        state.start(task, close_ids, q27::StreamSplitter::TEXT);
+        ok(task.accept_one && task.forced.empty() && !state.tripped,
+           "enforce: zero budget stays armed outside a think span");
+        state.observe(q27::StreamSplitter::TEXT, q27::StreamSplitter::THINK, task,
+                      close_ids);
+        ok(task.forced == close_ids && state.tripped,
+           "enforce: zero budget closes a later spontaneous think span");
+    }
+    {
+        FakeTask task;
+        q27::ThinkBudgetState state(2);
+        state.start(task, close_ids);
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::THINK, task,
+                      close_ids);
+        ok(task.accept_one && task.forced.empty() && state.used == 1 && !state.tripped,
+           "enforce: bounded span observes one token per round before cap");
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::THINK, task,
+                      close_ids);
+        ok(task.forced == close_ids && state.used == 2 && state.tripped,
+           "enforce: exact cap queues template close ids once");
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::THINK, task,
+                      close_ids);
+        ok(task.forced == close_ids && state.used == 2,
+           "enforce: injected close ids are not counted or queued twice");
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::TEXT, task,
+                      close_ids);
+        ok(!task.accept_one, "enforce: completed close releases one-token acceptance cap");
+        task.emitted = 2;
+        state.observe(q27::StreamSplitter::TEXT, q27::StreamSplitter::THINK, task,
+                      close_ids);
+        ok(task.accept_one && task.forced.size() == 4 && task.n_max == 6 &&
+               state.used == 2 && !task.cancel,
+           "enforce: later forced close consumes remaining public capacity");
+    }
+    {
+        FakeTask task;
+        q27::ThinkBudgetState state(4);
+        state.start(task, close_ids);
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::TEXT, task,
+                      close_ids);
+        ok(!task.accept_one && task.forced.empty() && state.used == 1 && !state.tripped,
+           "enforce: natural close before cap needs no forced transition");
+        state.observe(q27::StreamSplitter::TEXT, q27::StreamSplitter::THINK, task,
+                      close_ids);
+        ok(task.accept_one && task.forced.empty() && state.used == 1 && !state.tripped,
+           "enforce: later think span re-arms one-token acceptance");
+    }
+    {
+        FakeTask task;
+        task.sampling = true;
+        q27::ThinkBudgetState state(4);
+        state.start(task, close_ids);
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::TEXT, task,
+                      close_ids);
+        ok(task.accept_one && !state.tripped,
+           "enforce: sampled decode stays one-token outside think for safe reentry");
+    }
+    {
+        FakeTask task;
+        task.n_max = 4;
+        task.emitted = 2;
+        q27::ThinkBudgetState state(0);
+        state.start(task, close_ids);
+        state.observe(q27::StreamSplitter::THINK, q27::StreamSplitter::TEXT, task,
+                      close_ids);
+        state.observe(q27::StreamSplitter::TEXT, q27::StreamSplitter::THINK, task,
+                      close_ids);
+        ok(task.cancel && task.forced.size() == 2 && task.n_max == 4,
+           "enforce: later close stops when public capacity cannot pay for it");
+    }
 
     printf(failures ? "\nTHINK-RESOLVE: %d FAIL\n" : "\nTHINK-RESOLVE: all pass\n", failures);
     return failures ? 1 : 0;


### PR DESCRIPTION
Fixes #7.

## Problem

The server enforced a reasoning budget by feeding `</think>` only to `StreamSplitter`. That changed the public channel without committing the close through decoder/KV state, so generation continued from the unclosed reasoning trajectory and the next visible answer token could still be reasoning.

## Change

- Make one `Engine` operation own forced close-token commitment, pending-token replacement, speculative-lane invalidation, and identical solo/conductor behavior.
- Check positive greedy budgets after the accepted speculative round, allowing bounded round-width overshoot rather than rewinding for exact cap precision.
- Close a per-request zero budget before the first model-generated reasoning token; preserve CLI `--think-budget 0` as the unbounded opt-out.
- Use the existing refinish path only when retaining the whole round would consume reserved close/answer capacity.
- Select any capacity-limited retained prefix before the stateful tool scanner runs, then commit the same prefix to both observers.
- Keep nested Responses status, `incomplete_details`, `response.incomplete`, and reasoning usage truthful in streaming and non-streaming paths.

## Product decisions

The default scope is intentionally prompt-seeded reasoning. Standard thinking-enabled serving starts inside the template-provided reasoning block and remains covered. A later model-generated block is capped only when explicitly armed through a positive CLI budget or request-level budget.

Bounded sampled requests intentionally use one-token acceptance rounds so every accepted token is a coherent budget-observation point. This disables speculative acceptance for the bounded request. The maintainer's reviewed RTX 5090 measurement was 56.9 t/s bounded versus 143.1 t/s unbounded, a 2.51x reduction. Unbounded sampled requests retain normal speculative width. Restoring sampled speculative width without weakening transition semantics is separate follow-up work.

Greedy checks occur after an accepted speculative round, so the reasoning count may exceed the configured limit by that round's accepted width. A natural close later in that round ends normally rather than reporting a budget trip.

## Verification

Current-upstream stabilized tip: `e7fde25a2e6f92239b67e187f804c34a1b6d6b62`, rebased onto upstream `5ce983d059b7ba78dfef365a9b141d313ae33b46`. Its `src/` tree is byte-identical to the previously reviewed `1de550a7bf81`; the upstream refresh adds the corrected per-architecture sampling gate and BUILDLOG records.

Host gates on the stabilized tip:

- conductor forced-member and queue-provenance behavior
- think resolution, admission, and enforcement
- stream splitting
- OpenAI bridge behavior
- chat-handler integration and stream/non-stream parity
- `git diff --check`

Ampere / `sm_86`, CUDA 12.8.93, our local RTX 3090:

- built `q27`, `q27-server-w8`, `test_kernels`, and `fused_smoke`
- corrected `CANON_ARCH=sm86` sampling gate: canonical `6894254e3b1a184ee3802771ddd59c2b` EXACT; all five sampling gates PASS
- full model-backed `test_kernels`: `ALL PASS`
- live width-8 `Q27_BATCH=1` sampled Responses request: budget 4 reported exactly four reasoning tokens, `reasoning_budget_exceeded: true`, and continued into answer text
- the full two-engine fused binary cannot instantiate two full-model engines on the 24 GiB card, including the width-8/greedy-only profile; this is the documented capacity boundary, not a candidate failure

Published exact-source fused evidence remains applicable because `src/` is unchanged by the refresh:

- dedicated A40: full model-backed kernels, fused/conductor identity, injected-error isolation, graph-cache identity, and live Responses matrix PASS
- maintainer RTX 5090: canonical `a2982c5197c627551b27d76a0a94b220` EXACT, sampling gates PASS, 352/352 model-backed kernels PASS, `ninv_test` PASS, and every `fused_smoke` leg byte-identical

## Independent concurrency pass

The new `callback_forced` write/read is synchronous on the conductor thread and is copied into the queue during that call. Cancellation is atomic. SSE/client disconnect continues draining until queue closure, so the handler frame cannot unwind while the conductor still owns the member. Accepted-member normal completion, cancellation, shutdown, and caught solo/fused host exceptions finish decode before the final queue close/fail edge. No callback can fire after that edge.

The pass also noted a pre-existing, production-unreachable registration-refusal bookkeeping path that skips `finish_decode`; the queue sink is never installed there, so the new `DecodeTask` capture is not exposed. That cleanup is outside this correctness fix.

## Follow-up

Add a sampled round-boundary observer that preserves coherent reasoning-budget transitions without pinning speculative acceptance to one token for the full bounded request.