### PR TITLE
perf: restore sampled reasoning budget width

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,11 +634,14 @@ Bounded sampled requests now retain normal speculative acceptance. The accepted
 round is observed before host emission; if committing it would consume reserved
 close/answer capacity, the engine retains only the prefix through the budget
 trip, re-finishes that sampled state, and installs the forced close before the
-next model decision. On one local RTX 3090 / width-8 / `Q27_BATCH=1` gate, the
-same 256-token bounded request improved from 32.4 t/s and 0.985 tokens/round to
-89.7 t/s and 2.639 tokens/round (2.77x); the unbounded control was 100.2 t/s and
-2.943 tokens/round. This is a single-prompt regression gate, not a universal
-throughput claim.
+next model decision. On the maintainer's matched RTX 5090 A/B
+(`temperature=0.7`, `top_p=0.95`, `max_tokens=700`, n=2 per arm), bounded
+throughput moved from 56.9 t/s on master to 147.9 t/s on this PR, while the
+unbounded control held at 143.1 -> 143.5 t/s (inside noise). Both bounded PR
+reps were exactly 147.9 t/s. The bounded arm used 275 rounds against 284
+unbounded, so its slight lead reflects the budget closing the trajectory early,
+not a faster kernel. This is a single-prompt gate, not a universal throughput
+claim.
 
 
 Why it defaults on: an 11-pack / 240-scenario A/B (BUILDLOG 2026-07-28, rescored

--- a/README.md
+++ b/README.md
@@ -625,16 +625,20 @@ Messages report a trip as `usage.reasoning_tokens` and
 `usage.reasoning_budget_exceeded`; Responses reports the same fields under
 `usage.output_tokens_details`.
 
-Greedy checks land after the accepted speculative round, so the reasoning count
-may exceed the configured limit by that round's accepted width. A natural close
-later in the same round ends normally rather than reporting a budget trip.
+Positive budget checks land after the accepted speculative round, so the
+reasoning count may exceed the configured limit by that round's accepted width.
+A natural close later in the same round ends normally rather than reporting a
+budget trip.
 
-Bounded sampled requests intentionally use one-token acceptance rounds so every
-accepted token is a coherent budget-observation point. This disables
-speculative acceptance for the bounded request: on the reviewed RTX 5090 run,
-the exact tip measured 56.9 t/s bounded versus 143.1 t/s unbounded, a 2.51x
-reduction. Unbounded sampled requests retain normal speculative width. Restoring
-speculative width without weakening transition semantics is follow-up work.
+Bounded sampled requests now retain normal speculative acceptance. The accepted
+round is observed before host emission; if committing it would consume reserved
+close/answer capacity, the engine retains only the prefix through the budget
+trip, re-finishes that sampled state, and installs the forced close before the
+next model decision. On one local RTX 3090 / width-8 / `Q27_BATCH=1` gate, the
+same 256-token bounded request improved from 32.4 t/s and 0.985 tokens/round to
+89.7 t/s and 2.639 tokens/round (2.77x); the unbounded control was 100.2 t/s and
+2.943 tokens/round. This is a single-prompt regression gate, not a universal
+throughput claim.
 
 
 Why it defaults on: an 11-pack / 240-scenario A/B (BUILDLOG 2026-07-28, rescored

--- a/docs/BUILDLOG.md
+++ b/docs/BUILDLOG.md
@@ -10037,10 +10037,69 @@ the 24 GiB card, including its width-8/greedy-only profile; that is the expected
 tree is unchanged, the published A40 and maintainer-run RTX 5090 fused-smoke
 passes remain exact source evidence.
 
-Product decision: bounded sampled requests keep one-token acceptance for their
-full lifetime so every accepted token is a coherent budget boundary. The
-maintainer measured 56.9 t/s bounded versus 143.1 t/s unbounded on the reviewed
-RTX 5090 tip, a 2.51x reduction. Prompt-seeded reasoning remains covered by
-default; later model-generated reasoning is capped only when explicitly armed.
-Recovering sampled speculative width without weakening those semantics is a
-separate follow-up.
+Stabilization baseline: until a coherent round observer existed, bounded sampled
+requests kept one-token acceptance for their full lifetime. The maintainer
+measured 56.9 t/s bounded versus 143.1 t/s unbounded on the reviewed RTX 5090
+tip, a 2.51x reduction. Prompt-seeded reasoning remained covered by default;
+later model-generated reasoning was capped only when explicitly armed. That
+baseline made sampled-width recovery, without weakening either semantic, the
+separate follow-up recorded below.
+
+## 2026-08-03 -- sampled reasoning-budget round observer
+
+The follow-up removes the full-lifetime one-token acceptance cap from bounded
+sampled requests. `Engine::post_round` now runs the existing pre-emission round
+observer for sampled as well as greedy rounds. Ordinary accepted sampled rounds
+commit at their natural width. If a crossing round would consume the reserved
+close/answer capacity, the observer returns only the prefix through the budget
+trip and `refinish_round` restores that retained hidden/KV position. The normal
+case already queued a forced close, which replaces the provisional argmax
+pending before any next model decision. If a later public-budget close cannot
+fit, `force_reasoning_close` cancels the task instead; the next-boundary cancel
+check likewise prevents that provisional pending from being consumed. Forced-
+close rounds still cap acceptance to one, so no speculative lane produced from
+the superseded pending token can commit.
+
+The obsolete sampled per-token observer and `sampled_budget_watch` state were
+deleted. The fake integration engine now drives `on_round` for sampled traffic,
+and its regression matrix covers both solo and conductor paths: a sampled
+boundary-crossing round discards its stale suffix, the forced close conditions
+the answer, a budget-4 request commits a three-token sampled round before
+truncating only the later crossing round, and a capacity-starved re-entry
+retains its opener then cancels without exposing the discarded suffix.
+
+Two independent final-review passes then found three boundary defects. A
+capacity-starved sampled refinish could hit an assertion after cancellation; a
+natural close plus public answer in the same exact-cap round could be rewound
+solely because no *later* answer slot remained; and the conductor fake emitted
+EOS plus its scripted suffix instead of stopping before callbacks. The fixes
+treat cancellation as a valid terminal refinish outcome, recognize ordinary,
+marker-buffered, and incomplete-UTF-8 public tails after a natural close, and
+make the fake's EOS contract match solo and production generation. Focused
+solo/conductor regressions cover all three cases. A final Luna review reported
+no actionable findings with 0.94 confidence.
+
+Fresh host gates on the final one-commit tree pass: extracted server/fake parity,
+chat integration, think resolver/enforcement, depth control, and conductor.
+CUDA 12.8.93 / `sm_86` rebuilt `q27`, `q27-server-w8`, `test_kernels`, and the
+fused-smoke binary on the local RTX 3090. The corrected `CANON_ARCH=sm86`
+sampling gate remains canonical `6894254e3b1a184ee3802771ddd59c2b` EXACT with
+all five gates PASS, and the full model-backed kernel battery ends `ALL PASS`.
+
+Live width-8 validation covered both `Q27_BATCH=1` and `Q27_BATCH=0` at
+temperature 0.7. Budget-1/max-2 requests expose one reasoning token plus one
+answer token in both modes; concurrent conductor requests remain isolated; a
+zero-budget request exposes no reasoning; and streaming reports the same public
+bytes and terminal usage as non-streaming. This exercises the sampled refinish
+path rather than merely a naturally one-token sampled round.
+
+Direct same-machine performance gate (`Q27_BATCH=1`, temperature 0.7, top-p
+0.95, seed 42, width-8, 256-token request): the pre-follow-up build delivered
+32.4 t/s and 0.985 public tokens/round. The follow-up delivered 89.7 t/s and
+2.639 tokens/round on the first run, 95.4 t/s and 2.813 tokens/round on repeat.
+The unbounded control delivered 100.2 t/s and 2.943 tokens/round. Conservatively,
+the bounded path recovered 2.77x over the old cap and reached 89.5% of the
+unbounded control in this single-prompt regression gate. The final boundary-
+hardening tip was not rebenchmarked; these numbers document the immediately
+preceding follow-up tree and remain directional feature evidence, not an exact-
+tip throughput measurement.

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -421,10 +421,9 @@ static constexpr double THINK_BUDGET_FRAC = 0.5;
 // Resolve the server budget for a request whose public cap is `n_max`.
 // `flag` is --think-budget: <0 = use the fractional default, 0 = unbounded,
 // >0 = an explicit absolute cap. The fractional default applies only when the
-// prompt already opened THINK. Otherwise every sampled no-think response would
-// be forced to one token per round merely to watch for a spontaneous opener.
-// An explicit request budget, or an explicit positive server flag, still arms
-// that later-block guard.
+// prompt already opened THINK: standard thinking-enabled serving starts there,
+// while a later model-generated block is intentionally unbounded unless the
+// client or an explicit positive server flag arms that guard.
 inline int think_budget_default(int flag, int n_max) {
     if (flag == 0) return -1;
     if (flag > 0) return flag;

--- a/src/engine.cuh
+++ b/src/engine.cuh
@@ -2653,12 +2653,13 @@ struct Engine {
     // host grammar can stage next round's slot-0 mask (state must include
     // the pending token -- masks lag one token otherwise).
     std::function<void(int)> on_pending;
-    // P15: called after each greedy spec round with the round's emitted
-    // tokens BEFORE anything is emitted or committed host-side. Returns -1
-    // for no action, or m in [1..n] when the <tool_call> marker completed at
-    // em[m-1]: generate() truncates the round to m tokens and refinishes so
-    // the first post-marker decision onward is grammar-masked (the engage-lag
-    // fix). Server-only, greedy-only; CLI never sets it.
+    // P15: called after each speculative round with the round's emitted tokens
+    // BEFORE anything is emitted or committed host-side. Returns -1 for no
+    // action, or m in [1..n] to retain only that prefix. Greedy tool constraints
+    // use it to re-decide the pending token under a newly engaged mask. A sampled
+    // callback may truncate only when it queues a forced pending token or marks
+    // the task cancelled; either way the provisional refinish argmax is never
+    // consumed by another model decision. Server-only; CLI never sets it.
     std::function<int(const int*, int)> on_round;
     // R1b: optional preemption hook, called between decode rounds and
     // between prefill chunks -- the two boundaries where this engine's
@@ -2742,16 +2743,17 @@ struct Engine {
                                    stm));
         upload_accept_cap();
     }
-    // P15 engage-lag fix: rewind the JUST-FINISHED greedy spec round from n
-    // accepted tokens to m (1 <= m <= n) and re-decide the pending token under
-    // the freshly staged slot-0 mask. Everything needed is still resident:
-    // per-lane GDN states / conv rings sit in the rotating role buffers (the
-    // round "commits" by advancing perm, never by copying -- state-after-lane-
-    // (m-1) is old role m-1), lane hiddens in x1..x1_L[5], lane logits in
-    // logits2. KV/MTP rows past the kept position are rewritten by the next
-    // round. Must be called BETWEEN rounds (server on_round hook), with the
-    // engage mask already staged on this stream so the re-argmax orders after
-    // it. Returns the new pending token. The CLI/canonical path never sets
+    // Rewind the JUST-FINISHED speculative round from n accepted tokens to m
+    // (1 <= m <= n). Everything needed is still resident: per-lane GDN states /
+    // conv rings sit in the rotating role buffers (the round "commits" by
+    // advancing perm, never by copying -- state-after-lane-(m-1) is old role
+    // m-1), lane hiddens in x1_L, and lane logits in logits2. KV/MTP rows past
+    // the kept position are rewritten by the next round. Greedy tool engagement
+    // uses the freshly staged slot-0 mask for the replacement pending token.
+    // Sampled budget truncation immediately overwrites that provisional argmax
+    // with the queued forced close, preserving the accepted sampled prefix
+    // without needing a second random draw. Must be called BETWEEN rounds.
+    // Returns the provisional pending token. The CLI/canonical path never sets
     // on_round, so this code is unreachable there.
     int refinish_round(int m, int n, int P_target) {
         perm = (perm + (m - n) + W_MAX) % W_MAX;
@@ -3380,10 +3382,6 @@ struct Engine {
         // Forced control ids are engine-owned decoder transitions. DecodeTask
         // stores only request-local queue/accounting state so solo generate()
         // and the conductor drive the identical round-boundary operation.
-        // Sampled rounds have no on_round hook; an explicitly bounded sampled
-        // request therefore keeps width one so its per-token observer still
-        // runs at a coherent round boundary. Greedy bounded requests do not.
-        bool sampled_budget_watch = false;
         bool public_budget_reduced = false;
         bool budget_cancelled = false;
         bool budget_truncated = false; // final stop actually came from either condition
@@ -3609,8 +3607,7 @@ struct Engine {
             finish_decode(t, "ctx-guard");
             return false;
         }
-        set_reasoning_accept_cap(reasoning_transition_active(t) ||
-                                 (t.sampling && t.sampled_budget_watch));
+        set_reasoning_accept_cap(reasoning_transition_active(t));
         // ConductorCore pre-checks every member, then its solo fallback calls
         // decode_step(), which pre-checks again. Preserve an id staged by the
         // first call; resetting round_forced here silently discards the
@@ -3627,12 +3624,24 @@ struct Engine {
     // stop reasons and GenStats land exactly as the solo loop produces them.
     bool post_round(DecodeTask& t, const int* em, int n) {
         t.rounds++;
-        // on_round is still the sole greedy refinish contract. The server
-        // previews budget retention before its stateful tool scan, commits both
-        // observers to the same kept prefix, and returns that prefix here.
-        if (!t.sampling && on_round) {
+        // on_round previews the accepted speculative round before host emission.
+        // Greedy callbacks may truncate for grammar or budget transitions.
+        // Sampled callbacks normally queue a forced decoder transition, whose
+        // pending token replaces refinish_round's provisional argmax at the next
+        // boundary. If the close cannot fit, force_reasoning_close cancels the
+        // task instead; the retained hidden/KV prefix is still coherent and the
+        // cancel pre-check guarantees that provisional pending is never consumed.
+        if (on_round) {
             int m = on_round(em, n);
             if (m >= 1 && m <= n) {
+                if (t.sampling && m < n && !reasoning_transition_active(t) &&
+                    !t.cancel.load()) {
+                    // Defensive containment for future sampled observers that
+                    // violate the callback contract: retain their prefix, but
+                    // never make a model decision from the provisional argmax.
+                    t.budget_cancelled = true;
+                    t.cancel.store(true);
+                }
                 last_pending = refinish_round(m, n, t.Ph + m);
                 n = m;
             }

--- a/src/server.cu
+++ b/src/server.cu
@@ -103,12 +103,12 @@ struct HookGuard {
     }
 };
 
-// Greedy budgets are observed through Engine::on_round before host emission.
-// The whole retained round is parsed first, so a natural close later in that
+// Reasoning budgets are observed through Engine::on_round before host emission.
+// The whole accepted round is parsed first, so a natural close later in that
 // round wins. When an overshooting round would consume reserved close/answer
-// capacity, only the prefix through the trip is retained and re-finished.
-// Sampled rounds intentionally keep on_round unset; bounded sampled requests
-// use the engine's one-token observation fallback instead.
+// capacity, only the prefix through the trip is retained and re-finished. On
+// sampled paths that refinish immediately precedes the forced close, so the
+// provisional argmax pending is replaced before any next-token decision.
 struct ReasoningBudgetObserver {
     q27::Tokenizer& tok;
     q27::ThinkBudgetState& state;
@@ -124,7 +124,6 @@ struct ReasoningBudgetObserver {
                             StreamSplitter::Chan initial)
         : tok(tok_), state(state_), eng(eng_), task(task_), close_ids(close_ids_) {
         split.chan = initial;
-        task.sampled_budget_watch = state.limit >= 0;
     }
 
     void apply(q27::ThinkBudgetAction action, int current_public_tokens = 0,
@@ -139,15 +138,21 @@ struct ReasoningBudgetObserver {
 
     void start() { apply(state.start(split.chan)); }
 
-    void observe_token(q27::ThinkBudgetState& target_state, StreamSplitter& target_split,
-                       q27::Utf8Gate& target_gate, int id, bool forced) {
+    bool observe_token(q27::ThinkBudgetState& target_state,
+                       StreamSplitter& target_split, q27::Utf8Gate& target_gate,
+                       int id, bool forced) {
         const auto before = target_split.chan;
-        (void)target_split.feed(target_gate.feed(tok.decode_one(id)));
+        const auto segments = target_split.feed(target_gate.feed(tok.decode_one(id)));
         target_state.observe(before, target_split.chan, forced);
+        for (const auto& [ch, text] : segments)
+            if (ch != StreamSplitter::THINK &&
+                text.find_first_not_of(" \t\r\n") != std::string::npos)
+                return true;
+        return false;
     }
 
-    void observe_token(int id, bool forced) {
-        observe_token(state, split, gate, id, forced);
+    bool observe_token(int id, bool forced) {
+        return observe_token(state, split, gate, id, forced);
     }
 
     int visible_prefix(const int* ids, int n, bool forced, bool* hits_eos) const {
@@ -172,8 +177,11 @@ struct ReasoningBudgetObserver {
         StreamSplitter trial_split = split;
         q27::Utf8Gate trial_gate = gate;
         int trip_prefix = -1;
+        bool public_answer_after_trip = false;
         for (int i = 0; i < visible; i++) {
-            observe_token(trial_state, trial_split, trial_gate, ids[i], forced);
+            const bool emitted_public =
+                observe_token(trial_state, trial_split, trial_gate, ids[i], forced);
+            if (trip_prefix > 0 && emitted_public) public_answer_after_trip = true;
             if (!forced && trip_prefix < 0 && trial_state.limit >= 0 &&
                 !trial_state.transition_pending &&
                 trial_split.chan == StreamSplitter::THINK &&
@@ -186,8 +194,12 @@ struct ReasoningBudgetObserver {
         const bool natural_close_after_trip =
             trip_prefix > 0 && action == q27::ThinkBudgetAction::NONE &&
             trial_split.chan != StreamSplitter::THINK;
-        const bool natural_close_keeps_answer =
-            task.n_max - task.emitted - visible >= 1;
+        const bool buffered_public_answer =
+            trial_split.chan != StreamSplitter::THINK &&
+            (!trial_gate.pend.empty() ||
+             trial_split.hold.find_first_not_of(" \t\r\n") != std::string::npos);
+        const bool natural_close_keeps_answer = public_answer_after_trip ||
+            buffered_public_answer || task.n_max - task.emitted - visible >= 1;
         const bool force_full_round_fits =
             action != q27::ThinkBudgetAction::NONE &&
             eng.reasoning_close_fits(
@@ -218,13 +230,6 @@ struct ReasoningBudgetObserver {
         return m;
     }
 
-    void observe_sampled(int id, bool forced) {
-        if (!task.sampling) return;
-        observe_token(id, forced);
-        // post_round advanced Ph before invoking the callback, but emitted is
-        // incremented afterwards: account one public token and zero context rows.
-        apply(state.finish_round(split.chan), forced ? 0 : 1, 0);
-    }
 };
 
 int main(int argc, char** argv) {
@@ -1665,17 +1670,13 @@ int main(int argc, char** argv) {
                         continue;
                     route(ch, t);
                 }
-                if (!conductor) budget.observe_sampled(id, forced);
                 return true;
             };
             std::string berr;
             int n = conductor
                         ? batch_generate(eng, prompt, n_max,
                                          [&](int id, bool forced) { return on_tok(id, forced); },
-                                         [&](int id) {
-                                             tc.on_id(id);
-                                             budget.observe_sampled(id, bt.callback_forced);
-                                         }, stable_len, qw,
+                                         [&](int id) { tc.on_id(id); }, stable_len, qw,
                                          rt, bt, &berr)
                         : eng.generate(prompt, n_max, EOS, [&](int id) {
                               tc.on_id(id);
@@ -1905,15 +1906,11 @@ int main(int argc, char** argv) {
                 auto on_tok = [&](int id, bool forced) {
                     forced_control_token = forced;
                     for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) emit_seg(ch, t);
-                    if (!conductor) budget.observe_sampled(id, forced);
                     return alive; // stop generating once the client has disconnected
                 };
                 int produced = conductor
                                    ? batch_generate(eng, prompt, nm, on_tok,
-                                                    [&](int id) {
-                                                        tc.on_id(id);
-                                                        budget.observe_sampled(id, bt.callback_forced);
-                                                    },
+                                                    [&](int id) { tc.on_id(id); },
                                                     stable_len, qw, rt, bt, nullptr)
                                    : eng.generate(prompt, nm, EOS, [&](int id) {
                                          tc.on_id(id);
@@ -2145,7 +2142,6 @@ int main(int argc, char** argv) {
                         continue;
                     route(ch, t);
                 }
-                if (!conductor) budget.observe_sampled(id, forced);
                 return true;
             };
             std::string berr;
@@ -2154,10 +2150,7 @@ int main(int argc, char** argv) {
             int n = conductor
                         ? batch_generate(eng, prompt, n_max,
                                          [&](int id, bool forced) { return on_tok(id, forced); },
-                                         [&](int id) {
-                                             tc.on_id(id);
-                                             budget.observe_sampled(id, bt.callback_forced);
-                                         }, stable_len, qw,
+                                         [&](int id) { tc.on_id(id); }, stable_len, qw,
                                          rt, bt, &berr)
                         : eng.generate(prompt, n_max, EOS, [&](int id) {
                               tc.on_id(id);
@@ -2360,7 +2353,6 @@ int main(int argc, char** argv) {
                 auto on_tok = [&](int id, bool forced) {
                     forced_control_token = forced;
                     for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) emit_seg(ch, t);
-                    if (!conductor) budget.observe_sampled(id, forced);
                     return alive; // stop generating once the client has disconnected
                 };
                 std::string berr;
@@ -2368,10 +2360,7 @@ int main(int argc, char** argv) {
                 // a dead client flips `alive` -> the drain cancels (A3)
                 int produced = conductor
                                    ? batch_generate(eng, prompt, nm, on_tok,
-                                                    [&](int id) {
-                                                        tc.on_id(id);
-                                                        budget.observe_sampled(id, bt.callback_forced);
-                                                    },
+                                                    [&](int id) { tc.on_id(id); },
                                                     stable_len, qw, rt, bt, &berr)
                                    : eng.generate(prompt, nm, EOS, [&](int id) {
                                          tc.on_id(id);
@@ -2698,16 +2687,13 @@ int main(int argc, char** argv) {
                         continue;
                     route(ch, t);
                 }
-                if (!conductor) budget.observe_sampled(id, forced);
                 return true;
             };
             std::string berr;
             int produced = conductor
                                ? batch_generate(eng, prompt, n_max,
                                                 [&](int id, bool forced) { return on_tok(id, forced); },
-                                                [&](int id) {
-                                                    budget.observe_sampled(id, bt.callback_forced);
-                                                }, -1,
+                                                nullptr, -1,
                                                 qw, rt, bt, &berr)
                                : eng.generate(prompt, n_max, EOS,
                                               [&](int id) { return on_tok(id, bt.callback_forced); },
@@ -2898,7 +2884,6 @@ int main(int argc, char** argv) {
                 auto on_tok = [&](int id, bool forced) {
                     forced_control_token = forced;
                     for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) route(ch, t);
-                    if (!conductor) budget.observe_sampled(id, forced);
                     return alive; // stop generating once the client has disconnected
                 };
                 // TODO(batch error surfacing): no mid-stream error event is
@@ -2909,9 +2894,7 @@ int main(int argc, char** argv) {
                 // the what().
                 int produced = conductor
                                    ? batch_generate(eng, prompt, nm, on_tok,
-                                                    [&](int id) {
-                                                        budget.observe_sampled(id, bt.callback_forced);
-                                                    }, -1,
+                                                    nullptr, -1,
                                                     qw, rt, bt, nullptr)
                                    : eng.generate(prompt, nm, EOS, [&](int id) {
                                          return on_tok(id, bt.callback_forced);

--- a/tools/test_chat_completions_integration.cpp
+++ b/tools/test_chat_completions_integration.cpp
@@ -76,7 +76,6 @@ struct FakeEngine {
         int Ph = 0;
         std::atomic<bool> cancel{false};
         bool sampling = false;
-        bool sampled_budget_watch = false;
         bool public_budget_reduced = false;
         bool budget_cancelled = false;
         bool budget_truncated = false;
@@ -145,6 +144,7 @@ struct FakeEngine {
     int conditioned_token = -1;
     int stale_token = -1;
     bool forced_committed = false;
+    int max_sampled_round = 0;
 
     int resolve_token(int id) const {
         return id == conditioned_token && !forced_committed ? stale_token : id;
@@ -162,12 +162,13 @@ struct FakeEngine {
         task.sampling = samp.inv_temp > 0.f;
         forced_committed = false;
         forced_commit_count = 0;
+        max_sampled_round = 0;
         int n = 0;
         auto emit_forced = [&]() {
             while (task.has_forced()) {
                 int id = task.pop_forced();
                 task.round_forced = true;
-                if (!task.sampling && on_round) (void)on_round(&id, 1);
+                if (on_round) (void)on_round(&id, 1);
                 task.callback_forced = true;
                 const bool keep_going = on_token(id);
                 task.callback_forced = false;
@@ -181,17 +182,18 @@ struct FakeEngine {
         };
         if (!emit_forced()) return 0;
         for (size_t pos = 0; pos < script.size() && n < task.n_max;) {
-            const int width = task.sampling && task.sampled_budget_watch ? 1 : round_width;
+            const int width = round_width;
             const int available = (int)script.size() - (int)pos;
             const int proposed = std::min(width, available);
             std::vector<int> ids;
             ids.reserve((size_t)proposed);
             for (int i = 0; i < proposed; i++) ids.push_back(resolve_token(script[pos + i]));
             int committed = proposed;
-            if (!task.sampling && on_round) {
+            if (on_round) {
                 int m = on_round(ids.data(), proposed);
                 if (m >= 1 && m <= proposed) committed = m;
             }
+            if (task.sampling) max_sampled_round = std::max(max_sampled_round, committed);
             task.Ph += committed;
             bool stopped = false;
             for (int i = 0; i < committed && n < task.n_max; i++) {
@@ -207,7 +209,7 @@ struct FakeEngine {
                 n++;
                 task.emitted = n;
             }
-            pos += (size_t)proposed;
+            pos += (size_t)(task.sampling ? committed : proposed);
             if (stopped) break;
             if (!emit_forced() || task.cancel.load()) break;
         }
@@ -249,7 +251,6 @@ struct ReasoningBudgetObserver {
                             StreamSplitter::Chan initial)
         : tok(tok_), state(state_), eng(eng_), task(task_), close_ids(close_ids_) {
         split.chan = initial;
-        task.sampled_budget_watch = state.limit >= 0;
     }
 
     void apply(q27::ThinkBudgetAction action, int current_public_tokens = 0,
@@ -264,15 +265,21 @@ struct ReasoningBudgetObserver {
 
     void start() { apply(state.start(split.chan)); }
 
-    void observe_token(q27::ThinkBudgetState& target_state, StreamSplitter& target_split,
-                       q27::Utf8Gate& target_gate, int id, bool forced) {
+    bool observe_token(q27::ThinkBudgetState& target_state,
+                       StreamSplitter& target_split, q27::Utf8Gate& target_gate,
+                       int id, bool forced) {
         const auto before = target_split.chan;
-        (void)target_split.feed(target_gate.feed(tok.decode_one(id)));
+        const auto segments = target_split.feed(target_gate.feed(tok.decode_one(id)));
         target_state.observe(before, target_split.chan, forced);
+        for (const auto& [ch, text] : segments)
+            if (ch != StreamSplitter::THINK &&
+                text.find_first_not_of(" \t\r\n") != std::string::npos)
+                return true;
+        return false;
     }
 
-    void observe_token(int id, bool forced) {
-        observe_token(state, split, gate, id, forced);
+    bool observe_token(int id, bool forced) {
+        return observe_token(state, split, gate, id, forced);
     }
 
     int visible_prefix(const int* ids, int n, bool forced, bool* hits_eos) const {
@@ -297,8 +304,11 @@ struct ReasoningBudgetObserver {
         StreamSplitter trial_split = split;
         q27::Utf8Gate trial_gate = gate;
         int trip_prefix = -1;
+        bool public_answer_after_trip = false;
         for (int i = 0; i < visible; i++) {
-            observe_token(trial_state, trial_split, trial_gate, ids[i], forced);
+            const bool emitted_public =
+                observe_token(trial_state, trial_split, trial_gate, ids[i], forced);
+            if (trip_prefix > 0 && emitted_public) public_answer_after_trip = true;
             if (!forced && trip_prefix < 0 && trial_state.limit >= 0 &&
                 !trial_state.transition_pending &&
                 trial_split.chan == StreamSplitter::THINK &&
@@ -311,8 +321,12 @@ struct ReasoningBudgetObserver {
         const bool natural_close_after_trip =
             trip_prefix > 0 && action == q27::ThinkBudgetAction::NONE &&
             trial_split.chan != StreamSplitter::THINK;
-        const bool natural_close_keeps_answer =
-            task.n_max - task.emitted - visible >= 1;
+        const bool buffered_public_answer =
+            trial_split.chan != StreamSplitter::THINK &&
+            (!trial_gate.pend.empty() ||
+             trial_split.hold.find_first_not_of(" \t\r\n") != std::string::npos);
+        const bool natural_close_keeps_answer = public_answer_after_trip ||
+            buffered_public_answer || task.n_max - task.emitted - visible >= 1;
         const bool force_full_round_fits =
             action != q27::ThinkBudgetAction::NONE &&
             eng.reasoning_close_fits(
@@ -343,13 +357,6 @@ struct ReasoningBudgetObserver {
         return m;
     }
 
-    void observe_sampled(int id, bool forced) {
-        if (!task.sampling) return;
-        observe_token(id, forced);
-        // post_round advanced Ph before invoking the callback, but emitted is
-        // incremented afterwards: account one public token and zero context rows.
-        apply(state.finish_round(split.chan), forced ? 0 : 1, 0);
-    }
 };
 
 // ---- fake httplib -------------------------------------------------------
@@ -429,27 +436,31 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                               std::string*) -> int {
         int n = 0;
         t.n_max = nm;
+        t.eos = tok.eos();
         t.emitted = 0;
         t.sampling = eng.samp.inv_temp > 0.f;
         eng.forced_committed = false;
+        eng.forced_commit_count = 0;
+        eng.max_sampled_round = 0;
         auto emit_forced = [&]() {
             while (t.has_forced()) {
                 int id = t.pop_forced();
                 t.round_forced = true;
-                if (!t.sampling && eng.on_round) (void)eng.on_round(&id, 1);
+                if (eng.on_round) (void)eng.on_round(&id, 1);
                 t.callback_forced = true;
                 if (on_emit) on_emit(id);
                 const bool keep_going = on_token(id, true);
                 t.callback_forced = false;
                 t.round_forced = false;
                 eng.forced_committed = true;
+                eng.forced_commit_count++;
                 if (!keep_going) return false;
             }
             return true;
         };
         if (!emit_forced()) return 0;
         for (size_t pos = 0; pos < eng.script.size() && n < t.n_max;) {
-            const int width = t.sampling && t.sampled_budget_watch ? 1 : eng.round_width;
+            const int width = eng.round_width;
             const int available = (int)eng.script.size() - (int)pos;
             const int proposed = std::min(width, available);
             std::vector<int> ids;
@@ -457,11 +468,17 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
             for (int i = 0; i < proposed; i++)
                 ids.push_back(eng.resolve_token(eng.script[pos + (size_t)i]));
             int committed = proposed;
-            if (!t.sampling && eng.on_round) {
+            if (eng.on_round) {
                 int m = eng.on_round(ids.data(), proposed);
                 if (m >= 1 && m <= proposed) committed = m;
             }
+            if (t.sampling)
+                eng.max_sampled_round = std::max(eng.max_sampled_round, committed);
             for (int i = 0; i < committed && n < t.n_max; i++) {
+                if (ids[(size_t)i] == t.eos) {
+                    pos = eng.script.size();
+                    break;
+                }
                 t.callback_forced = false;
                 if (on_emit) on_emit(ids[(size_t)i]);
                 if (!on_token(ids[(size_t)i], false)) {
@@ -471,8 +488,8 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
                 n++;
                 t.emitted = n;
             }
-            pos += (size_t)proposed;
-            if (!emit_forced()) break;
+            pos += (size_t)(t.sampling ? committed : proposed);
+            if (!emit_forced() || t.cancel.load()) break;
         }
         t.emitted = n;
         t.budget_truncated = t.budget_cancelled ||
@@ -794,17 +811,13 @@ auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat
                         continue;
                     route(ch, t);
                 }
-                if (!conductor) budget.observe_sampled(id, forced);
                 return true;
             };
             std::string berr;
             int n = conductor
                         ? batch_generate(eng, prompt, n_max,
                                          [&](int id, bool forced) { return on_tok(id, forced); },
-                                         [&](int id) {
-                                             tc.on_id(id);
-                                             budget.observe_sampled(id, bt.callback_forced);
-                                         }, stable_len, qw,
+                                         [&](int id) { tc.on_id(id); }, stable_len, qw,
                                          rt, bt, &berr)
                         : eng.generate(prompt, n_max, EOS, [&](int id) {
                               tc.on_id(id);
@@ -1034,15 +1047,11 @@ auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat
                 auto on_tok = [&](int id, bool forced) {
                     forced_control_token = forced;
                     for (auto& [ch, t] : sp.feed(ugate.feed(tok.decode_one(id)))) emit_seg(ch, t);
-                    if (!conductor) budget.observe_sampled(id, forced);
                     return alive; // stop generating once the client has disconnected
                 };
                 int produced = conductor
                                    ? batch_generate(eng, prompt, nm, on_tok,
-                                                    [&](int id) {
-                                                        tc.on_id(id);
-                                                        budget.observe_sampled(id, bt.callback_forced);
-                                                    },
+                                                    [&](int id) { tc.on_id(id); },
                                                     stable_len, qw, rt, bt, nullptr)
                                    : eng.generate(prompt, nm, EOS, [&](int id) {
                                          tc.on_id(id);
@@ -1620,6 +1629,41 @@ int main() {
         CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == false);
     }
 
+    // ---- Test 12s: a sampled natural close plus answer may fill the accepted
+    // round and public cap exactly. Preserve ordinary output and tails buffered
+    // by the marker/UTF-8 gates instead of replacing them with a forced close. ----
+    const std::vector<std::pair<std::string, std::string>> sampled_answers = {
+        {"Natural sampled answer.", "Natural sampled answer."},
+        {"<", "<"},
+        {std::string("\xE2"), std::string("\xEF\xBF\xBD")},
+    };
+    for (bool batch : {false, true}) {
+        for (const auto& [answer_piece, expected_answer] : sampled_answers) {
+            FakeTok tok;
+            tok.pieces = {/*0*/ "<eos>", /*1*/ "short thought",
+                          /*2*/ "</think>\n\n", /*3*/ answer_piece};
+            std::vector<std::string> vb = tok.pieces;
+            auto cache = fresh_cache(vb);
+            auto slots = fresh_slots();
+            slots[0].eng->script = {1, 2, 3};
+            slots[0].eng->round_width = 3;
+            std::atomic<long> rc{0};
+            json body = {{"messages", json::array({{{"role", "user"}, {"content", "answer"}}})},
+                         {"enable_thinking", true}, {"thinking_token_budget", 1},
+                         {"temperature", 0.7}, {"max_tokens", 3}};
+            run_request(tok, "q27-test", false, false, true, 100000, 100000, rc,
+                        cache, slots, body, true, batch);
+            const auto& msg = g_last_response["choices"][0]["message"];
+            CHECK(msg["reasoning_content"] == "short thought");
+            CHECK(msg["content"] == "\n\n" + expected_answer);
+            CHECK(slots[0].eng->forced_commit_count == 0);
+            CHECK(slots[0].eng->max_sampled_round == 3);
+            CHECK(g_last_response["usage"]["completion_tokens"] == 3);
+            CHECK(g_last_response["usage"]["reasoning_tokens"] == 2);
+            CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == false);
+        }
+    }
+
     // ---- Test 13: greedy fused decode may overshoot by the retained round,
     // then the conductor commits the forced close before the next proposal. ----
     {
@@ -1672,8 +1716,9 @@ int main() {
     }
 
     // ---- Test 13b: EOS wins over a same-round cap crossing. Tokens at and
-    // after EOS are neither observed as reasoning nor allowed to queue a close. ----
-    {
+    // after EOS are neither emitted nor observed as reasoning, in solo or the
+    // widened sampled conductor fake, and no close is queued. ----
+    for (bool batch : {false, true}) {
         FakeTok tok;
         tok.pieces = {/*0*/ "<eos>", /*1*/ "final thought", /*2*/ "unreachable"};
         std::vector<std::string> vb = tok.pieces;
@@ -1684,9 +1729,10 @@ int main() {
         std::atomic<long> rc{0};
         json body = {{"messages", json::array({{{"role", "user"}, {"content", "finish"}}})},
                      {"enable_thinking", true}, {"thinking_token_budget", 1},
-                     {"max_tokens", 3}};
+                     {"temperature", 0.7}, {"max_tokens", 3}};
         run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
-                    body, true);
+                    body, true, batch);
+        CHECK(slots[0].eng->forced_commit_count == 0);
         CHECK(g_last_response["usage"]["completion_tokens"] == 1);
         CHECK(g_last_response["usage"]["reasoning_tokens"] == 1);
         CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == false);
@@ -1742,27 +1788,31 @@ int main() {
         CHECK(slots[0].eng->constraint_sets == 0);
     }
 
-    // ---- Test 13e: sampled observation runs after Ph advances but before
-    // emitted increments; the current token is charged only to public capacity. ----
-    {
+    // ---- Test 13e: sampled zero-budget close commits before any public
+    // reasoning token. A later two-token re-entry round has no public capacity
+    // for another close plus answer, so it retains only the opener and cancels
+    // without exposing or consuming the discarded sampled pending. ----
+    for (bool batch : {false, true}) {
         FakeTok tok;
         tok.pieces = {/*0*/ "<eos>", /*1*/ "<think>", /*2*/ "unreachable answer"};
         std::vector<std::string> vb = tok.pieces;
         auto cache = fresh_cache(vb);
         auto slots = fresh_slots();
         slots[0].eng->script = {1, 2};
+        slots[0].eng->round_width = 2;
         std::atomic<long> rc{0};
         json body = {{"messages", json::array({{{"role", "user"}, {"content", "finish"}}})},
                      {"enable_thinking", true}, {"thinking_token_budget", 0},
                      {"temperature", 0.7}, {"max_tokens", 2}};
         run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
-                    body, true);
+                    body, true, batch);
         CHECK(slots[0].eng->forced_commit_count == 1);
+        CHECK(slots[0].eng->max_sampled_round == 1);
         CHECK(g_last_response["usage"]["completion_tokens"] == 1);
         CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == true);
     }
-    // ---- Test 13b: sampled bounded decode keeps one-token rounds so the
-    // forced close conditions the next draw in both solo and conductor modes. ----
+    // ---- Test 13b: a sampled boundary-crossing round retains only the budget
+    // prefix, then the forced close conditions the next draw in solo and batch. ----
     for (bool batch : {false, true}) {
         FakeTok tok;
         tok.pieces = {/*0*/ "<eos>", /*1*/ "sampled reasoning",
@@ -1785,6 +1835,35 @@ int main() {
         CHECK(msg["content"] == "Sampled answer.");
         CHECK(msg["content"].get<std::string>().find("STALE") == std::string::npos);
         CHECK(g_last_response["usage"]["reasoning_tokens"] == 1);
+    }
+
+    // ---- Test 13c: bounded sampling keeps speculative width until the round
+    // that crosses the budget, then truncates only that round's stale suffix. ----
+    for (bool batch : {false, true}) {
+        FakeTok tok;
+        tok.pieces = {/*0*/ "<eos>", /*1*/ "r1 ", /*2*/ "r2 ", /*3*/ "r3 ",
+                      /*4*/ "r4 ", /*5*/ "Sampled answer.",
+                      /*6*/ "STALE sampled successor"};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 2, 3, 4, 5};
+        slots[0].eng->round_width = 3;
+        slots[0].eng->conditioned_token = 5;
+        slots[0].eng->stale_token = 6;
+        std::atomic<long> rc{0};
+        json body = {{"messages", json::array({{{"role", "user"}, {"content", "finish"}}})},
+                     {"enable_thinking", true}, {"thinking_token_budget", 4},
+                     {"temperature", 0.7}, {"max_tokens", 5}};
+        run_request(tok, "q27-test", false, false, true, 100000, 100000, rc, cache, slots,
+                    body, true, batch);
+        const auto& msg = g_last_response["choices"][0]["message"];
+        CHECK(msg["reasoning_content"] == "r1 r2 r3 r4 ");
+        CHECK(msg["content"] == "Sampled answer.");
+        CHECK(msg["content"].get<std::string>().find("STALE") == std::string::npos);
+        CHECK(g_last_response["usage"]["reasoning_tokens"] == 4);
+        CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == true);
+        CHECK(slots[0].eng->max_sampled_round == 3);
     }
 
     // ---- Test 14: injected template newlines never surface as an OpenAI


### PR DESCRIPTION
## Relationship to #9

Focused single-commit follow-up to merged PR #9. Current review commit: `6ad7ee10`.

## Problem

#9 intentionally gives every bounded sampled request one-token acceptance rounds so reasoning-budget transitions are coherent. The maintainer measured the cost on RTX 5090: 56.9 t/s bounded versus 143.1 t/s unbounded (2.51x slower).

## Change

- Run the request-local pre-emission `Engine::on_round` observer for sampled as well as greedy accepted rounds.
- Keep ordinary sampled speculative acceptance at its natural width.
- When a crossing round would consume reserved close/answer capacity, retain only the prefix through the budget trip and restore its hidden/KV/position state with the existing `refinish_round` path.
- Keep forced-transition rounds capped to one token so no speculative lane derived from the superseded pending token can commit.
- Treat a capacity-starved close as terminal cancellation: the retained sampled prefix remains coherent and the cancellation boundary prevents the provisional refinish argmax from driving another model decision.
- Preserve a natural close plus public answer/tool bytes that already fit in the same exact-cap round, including marker-buffered and incomplete-UTF-8 tails.
- Delete the obsolete full-request sampled acceptance cap and per-token sampled budget observer.

The budget remains round-granular: a naturally accepted round may overshoot the configured reasoning count, and a natural close later in that same round still wins. This PR changes throughput, not those semantics.

## Verification

Fresh host gates on the final commit:

- extracted `server.cu` / integration-fake parity: PASS
- `test_chat_completions_integration`: PASS, including solo/conductor sampled-boundary, exact-cap natural-close, marker/UTF-8 buffered-tail, EOS, stale-suffix, forced-conditioning, multi-token-width, and capacity-starved cancellation regressions
- `test_think_resolve`: PASS
- `test_depthctl`: PASS
- `test_conductor`: PASS

RTX 3090, CUDA 12.8.93, `sm_86`, rebuilt from `6ad7ee10`:

- `q27`, `q27-server-w8`, `test_kernels`, and the fused-smoke binary: BUILD PASS
- canonical greedy md5: `6894254e3b1a184ee3802771ddd59c2b` EXACT
- sampling gates 1-5: ALL PASS
- freshly rebuilt model-backed `test_kernels`: ALL PASS
- live `Q27_BATCH=1` and `Q27_BATCH=0` budget-1/max-2 sampled requests expose one reasoning token plus one answer token
- concurrent conductor requests remain isolated; zero budget exposes no reasoning; streaming and non-streaming report coherent public bytes and terminal usage

The two-full-engine `fused_smoke` runtime still exceeds the 24 GiB RTX 3090 capacity; this is recorded as a capacity boundary, not a runtime pass.

## Performance

The maintainer will run the final tip against #9 on RTX 5090 using the same prompt, sampling parameters, and protocol, so the README carries one matched before/after comparison. The earlier local 256-token run predates the final boundary hardening and is retained only as diagnostic history, not as the release throughput claim.

## Review

Review was deliberately adversarial and iterative:

- an initial independent review found the capacity-starved refinish assertion/cancellation defect
- Luna found an exact-cap natural-close rewind and fake-conductor EOS divergence
- after those fixes, Luna found the remaining marker/UTF-8 buffered-tail classification gap
- focused regressions were added for every defect
- final Luna code review: no actionable findings, confidence 0.94
- final Luna evidence review: no actionable findings, confidence 0.99
- final independent Sol review of `6ad7ee10`: no actionable findings, confidence 0.94
