### PR TITLE
fix: make tokenizer ownership explicit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build/inspect: src/inspect.cpp src/loader.cpp src/loader.h | build
 	$(CXX) $(CXXFLAGS) src/inspect.cpp src/loader.cpp -o $@
 
 build/test_tokenizer: src/test_tokenizer.cpp src/tokenizer.cpp src/tokenizer.h src/api_common.h src/stream_split.h src/toolgram.h | build
-	$(CXX) $(CXXFLAGS) src/test_tokenizer.cpp src/tokenizer.cpp -o $@
+	$(CXX) $(CXXFLAGS) -DQ27_TOKENIZER_TESTING src/test_tokenizer.cpp src/tokenizer.cpp -o $@
 
 build/test_depthctl: tools/test_depthctl.cpp src/depthctl.h | build
 	$(CXX) $(CXXFLAGS) tools/test_depthctl.cpp -o $@

--- a/src/test_tokenizer.cpp
+++ b/src/test_tokenizer.cpp
@@ -3,11 +3,14 @@
 // cases.txt: alternating lines — text line, then space-separated reference ids.
 #include <algorithm>
 #include <atomic>
+#include <dirent.h>
+#include <unistd.h>
 #include <cstdio>
 #include <fstream>
 #include <chrono>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <thread>
 #include <vector>
 
@@ -247,11 +250,130 @@ static int anthropic_api_selftest() {
     printf("anthropic api shapes: %s\n", fail ? "FAIL" : "PASS");
     return fail;
 }
+static int count_open_fds() {
+    for (const char* root : {"/proc/self/fd", "/dev/fd"}) {
+        DIR* dir = opendir(root);
+        if (!dir) continue;
+        int count = 0;
+        while (dirent* ent = readdir(dir))
+            if (ent->d_name[0] != '.') count++;
+        closedir(dir);
+        return count;
+    }
+    return -1;
+}
+
+static int tokenizer_failure_selftest() {
+    char path[] = "/tmp/q27-tokenizer-failure-XXXXXX";
+    int raw_fd = mkstemp(path);
+    if (raw_fd < 0) {
+        perror("mkstemp");
+        return 1;
+    }
+    close(raw_fd);
+
+    auto append_u32 = [](std::string& out, uint32_t value) {
+        out.append(reinterpret_cast<const char*>(&value), sizeof(value));
+    };
+    auto append_u16 = [](std::string& out, uint16_t value) {
+        out.append(reinterpret_cast<const char*>(&value), sizeof(value));
+    };
+    auto expect_fail = [&](const std::string& bytes, const char* name) {
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        out.write(bytes.data(), (std::streamsize)bytes.size());
+        out.close();
+        try {
+            q27::Tokenizer tokenizer(path);
+        } catch (const std::runtime_error&) {
+            return true;
+        }
+        printf("tokenizer lifetime FAIL %s: construction succeeded\n", name);
+        return false;
+    };
+
+    std::string bad_magic;
+    for (int i = 0; i < 5; i++) append_u32(bad_magic, 0);
+    std::string short_header("Q27", 3);
+    std::string short_token;
+    append_u32(short_token, 0x54373251);
+    append_u32(short_token, 1);
+    append_u32(short_token, 1);
+    append_u32(short_token, 0);
+    append_u32(short_token, 0);
+    const uint16_t token_len = 4;
+    short_token.append(reinterpret_cast<const char*>(&token_len), sizeof(token_len));
+    short_token.push_back('x');
+
+    std::string valid;
+    append_u32(valid, 0x54373251);
+    append_u32(valid, 1);
+    append_u32(valid, 1);
+    append_u32(valid, 0);
+    append_u32(valid, 0);
+    append_u16(valid, 1);
+    valid.push_back('x');
+    valid.push_back(0);
+    append_u32(valid, 0);
+
+    const int before = count_open_fds();
+    const int before_impls = q27::tokenizer_live_impls_for_test();
+    bool ok = true;
+    for (int i = 0; i < 100; i++) {
+        ok = expect_fail(bad_magic, "bad magic") && ok;
+        ok = expect_fail(short_header, "short header") && ok;
+        ok = expect_fail(short_token, "short token") && ok;
+        try {
+            q27::Tokenizer tokenizer(std::string(path) + ".missing");
+            printf("tokenizer lifetime FAIL nonexistent: construction succeeded\n");
+            ok = false;
+        } catch (const std::runtime_error&) {
+        }
+    }
+    {
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        out.write(valid.data(), (std::streamsize)valid.size());
+    }
+    for (int i = 0; i < 100; i++) {
+        q27::Tokenizer tokenizer(path);
+        if (tokenizer.token_id("x") != 0) {
+            printf("tokenizer lifetime FAIL valid lookup\n");
+            ok = false;
+        }
+        q27::Tokenizer moved(std::move(tokenizer));
+        if (moved.token_id("x") != 0) {
+            printf("tokenizer lifetime FAIL move construction\n");
+            ok = false;
+        }
+        q27::Tokenizer assigned(path);
+        assigned = std::move(moved);
+        if (assigned.token_id("x") != 0) {
+            printf("tokenizer lifetime FAIL move assignment\n");
+            ok = false;
+        }
+    }
+    const int after = count_open_fds();
+    if (before >= 0 && after != before) {
+        printf("tokenizer lifetime FAIL descriptors: before=%d after=%d\n", before, after);
+        ok = false;
+    }
+    const int after_impls = q27::tokenizer_live_impls_for_test();
+    if (after_impls != before_impls) {
+        printf("tokenizer lifetime FAIL impls: before=%d after=%d\n",
+               before_impls, after_impls);
+        ok = false;
+    }
+    std::remove(path);
+    printf("tokenizer failure lifetime: %s\n", ok ? "PASS" : "FAIL");
+    return ok ? 0 : 1;
+}
+
 
 int main(int argc, char** argv) {
     if (utf8gate_selftest()) return 2;
     if (gpu_gate_selftest()) return 3;
     if (anthropic_api_selftest()) return 4;
+    if (tokenizer_failure_selftest()) return 5;
+    if (argc == 2 && std::string(argv[1]) == "--selftest") return 0;
     if (argc != 3) { fprintf(stderr, "usage: %s q27.tok cases.txt\n", argv[0]); return 1; }
     q27::Tokenizer tok(argv[1]);
     std::ifstream in(argv[2]);

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -1,5 +1,9 @@
 #include "tokenizer.h"
 
+#ifdef Q27_TOKENIZER_TESTING
+#include <atomic>
+#endif
+
 #include <cstdio>
 #include <cstring>
 #include <stdexcept>
@@ -7,6 +11,7 @@
 #include <cctype>
 #include <cstdint>
 #include <unordered_map>
+#include <memory>
 
 namespace q27 {
 
@@ -36,7 +41,15 @@ static void build_byte_maps(std::string b2u[256], std::unordered_map<std::string
     }
 }
 
+#ifdef Q27_TOKENIZER_TESTING
+static std::atomic<int> tokenizer_live_impls{0};
+#endif
+
 struct Tokenizer::Impl {
+#ifdef Q27_TOKENIZER_TESTING
+    Impl() { tokenizer_live_impls.fetch_add(1, std::memory_order_relaxed); }
+    ~Impl() { tokenizer_live_impls.fetch_sub(1, std::memory_order_relaxed); }
+#endif
     std::unordered_map<std::string, int> tok2id;
     std::unordered_map<std::string, int> merge_rank; // "left right" -> rank
     std::string b2u[256];
@@ -44,30 +57,48 @@ struct Tokenizer::Impl {
     std::vector<std::pair<std::string, int>> specials; // control tokens, longest first
 };
 
+#ifdef Q27_TOKENIZER_TESTING
+int tokenizer_live_impls_for_test() {
+    return tokenizer_live_impls.load(std::memory_order_relaxed);
+}
+#endif
+
+struct FileCloser {
+    void operator()(FILE* f) const { if (f) fclose(f); }
+};
+
+template <typename T>
+static void read_exact(FILE* f, T* out, size_t count) {
+    if (count && fread(out, sizeof(T), count, f) != count)
+        throw std::runtime_error("tok: truncated");
+}
+
 static std::string read_lp(FILE* f) {
-    uint16_t n;
-    if (fread(&n, 2, 1, f) != 1) throw std::runtime_error("tok: truncated");
+    uint16_t n = 0;
+    read_exact(f, &n, 1);
     std::string s(n, 0);
-    if (n && fread(s.data(), 1, n, f) != n) throw std::runtime_error("tok: truncated");
+    read_exact(f, s.data(), n);
     return s;
 }
 
-Tokenizer::Tokenizer(const std::string& path) : impl_(new Impl) {
-    FILE* f = fopen(path.c_str(), "rb");
+Tokenizer::Tokenizer(const std::string& path) : impl_(std::make_unique<Impl>()) {
+    std::unique_ptr<FILE, FileCloser> f(fopen(path.c_str(), "rb"));
     if (!f) throw std::runtime_error("tok: cannot open " + path);
-    uint32_t magic, ver, n, bos, eos;
-    fread(&magic, 4, 1, f); fread(&ver, 4, 1, f); fread(&n, 4, 1, f);
-    fread(&bos, 4, 1, f); fread(&eos, 4, 1, f);
+    uint32_t magic = 0, ver = 0, n = 0, bos = 0, eos = 0;
+    read_exact(f.get(), &magic, 1);
+    read_exact(f.get(), &ver, 1);
+    read_exact(f.get(), &n, 1);
+    read_exact(f.get(), &bos, 1);
+    read_exact(f.get(), &eos, 1);
     if (magic != 0x54373251) throw std::runtime_error("tok: bad magic");
     bos_ = (int)bos; eos_ = (int)eos;
     tokens_.reserve(n);
-    for (uint32_t i = 0; i < n; i++) tokens_.push_back(read_lp(f));
+    for (uint32_t i = 0; i < n; i++) tokens_.push_back(read_lp(f.get()));
     types_.resize(n);
-    fread(types_.data(), 1, n, f);
-    uint32_t nm;
-    fread(&nm, 4, 1, f);
-    for (uint32_t i = 0; i < nm; i++) impl_->merge_rank.emplace(read_lp(f), (int)i);
-    fclose(f);
+    read_exact(f.get(), types_.data(), n);
+    uint32_t nm = 0;
+    read_exact(f.get(), &nm, 1);
+    for (uint32_t i = 0; i < nm; i++) impl_->merge_rank.emplace(read_lp(f.get()), (int)i);
 
     for (uint32_t i = 0; i < n; i++) impl_->tok2id.emplace(tokens_[i], (int)i);
     build_byte_maps(impl_->b2u, impl_->u2b);
@@ -230,6 +261,11 @@ std::vector<std::string> Tokenizer::pretokenize(const std::string& t) const {
     }
     return out;
 }
+
+
+Tokenizer::~Tokenizer() = default;
+Tokenizer::Tokenizer(Tokenizer&&) noexcept = default;
+Tokenizer& Tokenizer::operator=(Tokenizer&&) noexcept = default;
 
 std::vector<int> Tokenizer::encode(const std::string& text) const {
     std::vector<int> out;

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -4,6 +4,7 @@
 // against llama-tokenize on an English/code corpus (see test_tokenizer).
 #pragma once
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -12,6 +13,11 @@ namespace q27 {
 class Tokenizer {
   public:
     explicit Tokenizer(const std::string& tok_path);
+    ~Tokenizer();
+    Tokenizer(const Tokenizer&) = delete;
+    Tokenizer& operator=(const Tokenizer&) = delete;
+    Tokenizer(Tokenizer&&) noexcept;
+    Tokenizer& operator=(Tokenizer&&) noexcept;
 
     std::vector<int> encode(const std::string& text) const; // handles special tokens
     std::string decode(const std::vector<int>& ids) const;
@@ -44,10 +50,15 @@ class Tokenizer {
     int bos_ = 0, eos_ = 0;
     // lookup structures built at load
     struct Impl;
-    Impl* impl_;
+    std::unique_ptr<Impl> impl_;
 
     std::vector<int> bpe_word(const std::string& word) const;
+
     std::vector<std::string> pretokenize(const std::string& text) const;
 };
+
+#ifdef Q27_TOKENIZER_TESTING
+int tokenizer_live_impls_for_test();
+#endif
 
 } // namespace q27


### PR DESCRIPTION
## Problem

`Tokenizer` owns a heap-allocated PImpl but had no explicit ownership contract. A defaulted destructor leaked the implementation, implicit copying would duplicate the raw owner, and constructor failures could leave the tokenizer file open.

## Change

- make the PImpl a `std::unique_ptr` and define destruction where `Impl` is complete;
- delete copy construction/assignment and add `noexcept` moves;
- use RAII for the tokenizer file and checked reads for truncated artifacts;
- add a deterministic lifetime regression covering malformed construction, valid construction, moves, descriptor balance, and live implementation balance.

## Verification

- `make build/test_tokenizer && ./build/test_tokenizer --selftest`
- ASan build and `ASAN_OPTIONS=detect_leaks=0 ./build/test_tokenizer_asan --selftest`
- `leaks --atExit -- ./build/test_tokenizer --selftest`: 0 leaks
- final Codex branch review against `upstream/master`: no findings, correctness 0.98

Independent standalone fix in the issue #8 approved sequence. It contains no Metal implementation.