### PR TITLE
backend: add validated compute seam

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,13 @@ build:
 
 build/inspect: src/inspect.cpp src/loader.cpp src/loader.h | build
 	$(CXX) $(CXXFLAGS) src/inspect.cpp src/loader.cpp -o $@
+build/test_loader_contracts: src/test_loader_contracts.cpp src/loader.cpp src/loader.h | build
+	$(CXX) $(CXXFLAGS) src/test_loader_contracts.cpp src/loader.cpp -o $@
 
-test-inspect: build/inspect
+
+test-inspect: build/inspect build/test_loader_contracts
 	python3 tools/test_inspect.py ./build/inspect
+	./build/test_loader_contracts
 
 build/test_sampling: src/test_sampling.cpp src/sampling.h | build
 	$(CXX) $(CXXFLAGS) src/test_sampling.cpp -o $@

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build/mma16_bench: tools/mma16_bench.cu src/kernels.cu src/device_model.cu src/l
 	$(NVCC) $(NVCCFLAGS) tools/mma16_bench.cu src/kernels.cu src/device_model.cu src/loader.cpp -o $@
 
 build/test_kernels: src/test_kernels.cu src/kernels.cu src/prefill.cu src/blocks.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp \
-                    src/kernels.cuh src/prefill.cuh src/blocks.cuh src/spec3.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/device_model.h src/loader.h src/cuda_common.h | build
+                    src/kernels.cuh src/prefill.cuh src/blocks.cuh src/spec3.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/device_model.h src/loader.h src/cuda_common.h src/sampling.h | build
 	$(NVCC) $(NVCCFLAGS) src/test_kernels.cu src/kernels.cu src/prefill.cu src/blocks.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp -o $@
 
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ NVCCFLAGS ?= -O2 -std=c++17 -gencode arch=compute_86,code=sm_86 \
              -gencode arch=compute_89,code=sm_89 \
              -gencode arch=compute_120,code=sm_120 -Xcompiler -Wall
 
-.PHONY: all clean
-all: build/inspect build/test_kernels build/q27 build/q27-server build/test_tokenizer build/test_depthctl build/test_toolconstrain
+.PHONY: all clean test-inspect
+all: build/inspect build/test_sampling build/test_kernels build/q27 build/q27-server build/test_tokenizer build/test_depthctl build/test_toolconstrain
 
 build/q27: src/engine.cu src/engine.cuh src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp \
            src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/device_model.h src/loader.h src/cuda_common.h src/depthctl.h src/prefix_cache.h src/prefix_ram.h | build
@@ -19,6 +19,12 @@ build:
 
 build/inspect: src/inspect.cpp src/loader.cpp src/loader.h | build
 	$(CXX) $(CXXFLAGS) src/inspect.cpp src/loader.cpp -o $@
+
+test-inspect: build/inspect
+	python3 tools/test_inspect.py ./build/inspect
+
+build/test_sampling: src/test_sampling.cpp src/sampling.h | build
+	$(CXX) $(CXXFLAGS) src/test_sampling.cpp -o $@
 
 build/test_tokenizer: src/test_tokenizer.cpp src/tokenizer.cpp src/tokenizer.h src/api_common.h src/stream_split.h src/toolgram.h | build
 	$(CXX) $(CXXFLAGS) src/test_tokenizer.cpp src/tokenizer.cpp -o $@

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -14,7 +14,7 @@ Offline-repacked weights for the q27 engine. Produced by `tools/repack.py` from 
 [tensor table]  n_tensors entries:
   name_len   u16
   name       u8[name_len]   GGUF tensor name, unchanged
-  dtype      u8             0=F32  1=F16  2=Q8_G128  3=Q4_G64
+  dtype      u8             0=F32  1=F16  2=Q8_G128  3=Q4_G64  4=T2_G128  5=T3_G128  6=B1_G128
   n_dims     u8
   shape      u64[n_dims]    numpy row-major shape (outer first; innermost/contiguous LAST)
   data_off   u64            relative to data section start, 256-byte aligned
@@ -26,8 +26,8 @@ Offline-repacked weights for the q27 engine. Produced by `tools/repack.py` from 
 
 ## Quantized types
 
-Both types quantize along the **contiguous (innermost) axis**, which is the GEMV
-reduction axis for every matmul weight in this model.
+All quantized types quantize along the **contiguous (innermost) axis**, which
+is the GEMV reduction axis for every matmul weight in this model.
 
 ### Q4_G64 (bulk weights)
 - symmetric, group size 64: `scale = max(|wـgroup|) / 7`, `q = clip(round(w/scale), -8, 7) + 8` stored as unsigned nibble
@@ -40,6 +40,29 @@ reduction axis for every matmul weight in this model.
 - symmetric, group size 128: `scale = max(|w_group|) / 127`, int8
 - scales: fp16, `[rows, cols/128]`
 - effective 8.125 bpw
+
+### T2_G128 (ternary weights, dtype 4)
+- group size 128; element `i` of a row uses the 2-bit field at
+  `(i % 4) * 2` in byte `i / 4` (sequential, LSB-first)
+- code `c` must be in `{0,1,2}` and decodes to `(c-1) * scale`; code 3 is invalid
+- row data is `cols/4` bytes; scales are fp16 `[rows, cols/128]`
+- effective 2.125 bits per weight
+
+### B1_G128 (binary weights, dtype 6)
+- group size 128; element `i` of a row uses bit `i % 8` in byte `i / 8`
+  (sequential, LSB-first)
+- bit `b` decodes to `(2b-1) * scale`; every bit pattern is valid
+- row data is `cols/8` bytes; scales are fp16 `[rows, cols/128]`
+- effective 1.125 bits per weight
+
+### T3_G128 (experimental ternary packing, dtype 5)
+- group size 128; five ternary codes are stored per byte in base 3:
+  `c0 + 3*c1 + 9*c2 + 27*c3 + 81*c4`, with every byte in `[0,242]`
+- each group uses 26 bytes; byte 25 carries columns 125..127 and its unused
+  slots 3 and 4 must contain code 1 (zero)
+- row data is `(cols/128)*26` bytes; scales are fp16 `[rows, cols/128]`
+- effective 1.75 bits per weight; dtype 5 is reserved and no production
+  artifacts currently use it
 
 ## Quant policy (v1)
 

--- a/src/backend.h
+++ b/src/backend.h
@@ -1,0 +1,314 @@
+// Backend-neutral device ownership and primitive execution boundary.
+#pragma once
+
+#include "loader.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace q27 {
+
+class BackendBuffer {
+  public:
+    virtual ~BackendBuffer() = default;
+    virtual uint64_t size() const = 0;
+};
+
+struct BackendQuantized {
+    uint32_t count = 0;
+    std::shared_ptr<BackendBuffer> values;
+    std::shared_ptr<BackendBuffer> scales;
+};
+
+struct BackendTensor {
+    DType dtype = DType::F32;
+    uint64_t rows = 0;
+    uint64_t cols = 0;
+    std::shared_ptr<BackendBuffer> data;
+    std::shared_ptr<BackendBuffer> scales;
+    uint64_t data_offset = 0;
+    uint64_t scales_offset = 0;
+    // Logical tensor extents within the buffers. Buffers may be shared views
+    // of a whole model mapping, so buffer size alone cannot bound a tensor;
+    // 0 means unknown and falls back to the buffer size.
+    uint64_t data_size = 0;
+    uint64_t scales_size = 0;
+};
+
+// This intentionally starts small. New primitives should describe model
+// operations, not CUDA/Metal launch mechanics. The CUDA engine remains the
+// reference while its call sites are moved behind this interface incrementally.
+class ComputeBackend {
+  public:
+    virtual ~ComputeBackend() = default;
+
+    virtual std::string name() const = 0;
+    virtual std::shared_ptr<BackendBuffer> allocate(uint64_t bytes) = 0;
+    virtual void write(BackendBuffer& dst, uint64_t offset, const void* src,
+                       uint64_t bytes) = 0;
+    virtual void read(const BackendBuffer& src, uint64_t offset, void* dst,
+                      uint64_t bytes) = 0;
+    virtual void zero(BackendBuffer& dst) = 0;
+    virtual void copy(const BackendBuffer& src, uint64_t src_offset,
+                      BackendBuffer& dst, uint64_t dst_offset, uint64_t bytes) = 0;
+    virtual BackendTensor upload(const Tensor& tensor) = 0;
+    // Default may copy. Unified-memory backends can return mmap-backed views;
+    // the Model must then outlive the returned tensor.
+    virtual BackendTensor upload(const Model& model, const Tensor& tensor) {
+        (void)model;
+        return upload(tensor);
+    }
+
+    virtual void begin_commands() = 0;
+    virtual void end_commands() = 0;
+    virtual void abort_commands() noexcept = 0;
+
+    // y[rows] = weight[rows, cols] * x[cols], accumulating into F32.
+    virtual void matvec(const BackendTensor& weight, const BackendBuffer& x,
+                        BackendBuffer& y) = 0;
+    // Shared-input projection pair. Backends may fuse dispatch; the default
+    // preserves semantics for reference implementations.
+    virtual void matvec_pair(const BackendTensor& a, BackendBuffer& a_out,
+                             const BackendTensor& b, BackendBuffer& b_out,
+                             const BackendBuffer& x) {
+        matvec(a, x, a_out); matvec(b, x, b_out);
+    }
+    virtual BackendQuantized allocate_quantized(uint32_t count) = 0;
+    virtual void quantize(const BackendBuffer& x, BackendQuantized& out) = 0;
+    virtual void matvec_quantized(const BackendTensor& weight,
+                                  const BackendQuantized& x, BackendBuffer& y) = 0;
+    virtual void matvec_quantized_pair(const BackendTensor& a, BackendBuffer& a_out,
+                                       const BackendTensor& b, BackendBuffer& b_out,
+                                       const BackendQuantized& x) {
+        matvec_quantized(a, x, a_out); matvec_quantized(b, x, b_out);
+    }
+    virtual void matmul_quantized(const BackendTensor& weight,const BackendQuantized& x,
+                                  uint32_t x_rows,BackendBuffer& y) {
+        if(x_rows!=1) throw std::runtime_error("q27: backend has no quantized matmul");
+        matvec_quantized(weight,x,y);
+    }
+    virtual void embedding_q8(const BackendTensor& weight, uint32_t token,
+                              BackendBuffer& out) = 0;
+    virtual void rmsnorm(const BackendBuffer& x, const BackendTensor& weight,
+                         BackendBuffer& out, uint32_t n, float eps) = 0;
+    virtual void rmsnorm_quantized(const BackendBuffer& x, const BackendTensor& weight,
+                                   BackendBuffer& out, uint32_t n, float eps,
+                                   BackendQuantized& quantized) {
+        rmsnorm(x,weight,out,n,eps); quantize(out,quantized);
+    }
+    virtual void rmsnorm_heads(BackendBuffer& x, const BackendTensor& weight,
+                               uint32_t heads, uint32_t head_dim, uint32_t stride,
+                               float eps) = 0;
+    virtual void l2norm_heads(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
+                              float eps) = 0;
+    virtual void silu_mul(const BackendBuffer& gate, const BackendBuffer& up,
+                          BackendBuffer& out, uint32_t n) = 0;
+    virtual void add_inplace(BackendBuffer& x, const BackendBuffer& y, uint32_t n) = 0;
+    virtual void concat(const BackendBuffer& a, uint32_t a_count,
+                        const BackendBuffer& b, uint32_t b_count,
+                        BackendBuffer& out) = 0;
+    virtual void sigmoid_gate_mul(BackendBuffer& out, const BackendBuffer& qg,
+                                  uint32_t heads, uint32_t head_dim) = 0;
+    virtual void rope_neox(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
+                           uint32_t n_rot, uint32_t stride, uint32_t position,
+                           float freq_base) = 0;
+    virtual void argmax(const BackendBuffer& x, uint32_t n, BackendBuffer& out_index) = 0;
+    // Top-k candidate extraction for GPU-assisted sampling. `values` is an
+    // array of float elements and `indices` an array of uint32 elements;
+    // their candidate capacity is min(values.size()/4, indices.size()/4).
+    // Implementations may require capacity >= 2*k for tie headroom. `count`
+    // must hold one uint32 and receives the number of candidates produced.
+    // A count above capacity means degenerate ties; the caller must fall back
+    // to a full logits readback. Candidates are unordered; the caller sorts.
+    // Must run outside a command batch: the count buffer may be CPU-cleared
+    // immediately before dispatch.
+    // x_offset_bytes: byte offset into x for multi-row logits (e.g. clogits_
+    // lane * VOCAB * 4). Indices in the output are relative to that row
+    // (0..n-1), not absolute buffer indices.
+    virtual void topk(const BackendBuffer& x, uint32_t n, uint32_t k,
+                      BackendBuffer& values, BackendBuffer& indices, BackendBuffer& count,
+                      uint64_t x_offset_bytes = 0) {
+        (void)x; (void)n; (void)k; (void)values; (void)indices; (void)count;
+        (void)x_offset_bytes;
+        throw std::runtime_error("q27: backend has no top-k primitive");
+    }
+    virtual void kv_store_f16(const BackendBuffer& k, const BackendBuffer& v,
+                              BackendBuffer& k_cache, BackendBuffer& v_cache,
+                              uint32_t position, uint32_t row_length) = 0;
+    virtual void turbo_wht(BackendBuffer& x, uint32_t heads, uint32_t stride,
+                           bool inverse) = 0;
+    virtual void kv_store_turbo3(const BackendBuffer& k, const BackendBuffer& v,
+                                 BackendBuffer& k_cache, BackendBuffer& v_cache,
+                                 uint32_t position, uint32_t kv_heads) = 0;
+    // partials: caller-owned scratch for the blocked-GQA softmax partials;
+    // may be null only when the call cannot route to the blocked kernels
+    // (see attention_f16_causal below).
+    virtual void attention_turbo3(const BackendBuffer& q, uint32_t q_stride,
+                                  const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                                  BackendBuffer& out,
+                                  uint32_t seq_len, uint32_t q_heads, uint32_t kv_heads,
+                                  uint32_t head_dim, float scale,
+                                  BackendBuffer* partials) = 0;
+    virtual void attention_f16(const BackendBuffer& q, uint32_t q_stride,
+                               const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                               BackendBuffer& out, uint32_t seq_len,
+                               uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
+                               float scale, BackendBuffer* partials) = 0;
+    virtual void gdn_gates(const BackendBuffer& alpha, const BackendBuffer& beta_raw,
+                           const BackendTensor& ssm_a, const BackendTensor& ssm_dt,
+                           BackendBuffer& g, BackendBuffer& beta, uint32_t heads) = 0;
+    virtual void conv_step(const BackendBuffer& ring_src, BackendBuffer& ring_dst,
+                           const BackendBuffer& qkv, const BackendTensor& conv_weight,
+                           BackendBuffer& out, uint32_t channels) = 0;
+    virtual void delta_step(const BackendBuffer& state_src, BackendBuffer& state_dst,
+                            const BackendBuffer& conv, const BackendBuffer& g,
+                            const BackendBuffer& beta, BackendBuffer& out,
+                            uint32_t value_heads, uint32_t qk_heads,
+                            uint32_t head_dim) = 0;
+    virtual void gated_norm_gdn(const BackendBuffer& x, const BackendTensor& weight,
+                                const BackendBuffer& gate, BackendBuffer& out,
+                                uint32_t heads, uint32_t head_dim, float eps) = 0;
+
+    // Chunked layer-major execution: each call advances `tokens` consecutive
+    // positions in one dispatch. The caller must respect the concrete
+    // backend's supported chunk width. Recurrent operators commit their
+    // carried state exactly once, at the chunk boundary. Backends without
+    // chunked support keep the token-serial path.
+    virtual void embedding_q8_rows(const BackendTensor& weight, const uint32_t* tokens,
+                                   uint32_t count, BackendBuffer& out) {
+        (void)weight; (void)tokens; (void)count; (void)out;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    virtual void rmsnorm_rows_quantized(const BackendBuffer& x, const BackendTensor& weight,
+                                        BackendBuffer& out, uint32_t n, uint32_t rows,
+                                        float eps, BackendQuantized& quantized) {
+        (void)x; (void)weight; (void)out; (void)n; (void)rows; (void)eps; (void)quantized;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    virtual void matvec_f16_pair_rows(const BackendTensor& a, BackendBuffer& a_out,
+                                      const BackendTensor& b, BackendBuffer& b_out,
+                                      const BackendBuffer& x, uint32_t rows) {
+        (void)a; (void)a_out; (void)b; (void)b_out; (void)x; (void)rows;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    virtual void gdn_gates_rows(const BackendBuffer& alpha, const BackendBuffer& beta_raw,
+                                const BackendTensor& ssm_a, const BackendTensor& ssm_dt,
+                                BackendBuffer& g, BackendBuffer& beta,
+                                uint32_t heads, uint32_t tokens) {
+        (void)alpha; (void)beta_raw; (void)ssm_a; (void)ssm_dt; (void)g; (void)beta;
+        (void)heads; (void)tokens;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    // Chunk state kernels take separate src/dst state bindings (in-place when
+    // equal): speculative verification writes dst to a discard slot so the
+    // chunk never commits, and acceptance replay commits from parked inputs.
+    virtual void conv_chunk(const BackendBuffer& ring_src, BackendBuffer& ring_dst,
+                            const BackendBuffer& qkv,
+                            const BackendTensor& conv_weight, BackendBuffer& out,
+                            uint32_t channels, uint32_t tokens) {
+        (void)ring_src; (void)ring_dst; (void)qkv; (void)conv_weight; (void)out;
+        (void)channels; (void)tokens;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    virtual void delta_chunk(const BackendBuffer& state_src, BackendBuffer& state_dst,
+                             const BackendBuffer& conv,
+                             const BackendBuffer& g, const BackendBuffer& beta,
+                             BackendBuffer& out, uint32_t value_heads, uint32_t qk_heads,
+                             uint32_t head_dim, uint32_t tokens) {
+        (void)state_src; (void)state_dst; (void)conv; (void)g; (void)beta; (void)out;
+        (void)value_heads; (void)qk_heads; (void)head_dim; (void)tokens;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    virtual void l2norm_rows(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
+                             uint32_t row_stride, uint32_t tokens, float eps) {
+        (void)x; (void)heads; (void)head_dim; (void)row_stride; (void)tokens; (void)eps;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    virtual void rope_neox_rows(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
+                                uint32_t n_rot, uint32_t stride, uint32_t row_stride,
+                                uint32_t position, uint32_t tokens, float freq_base) {
+        (void)x; (void)heads; (void)head_dim; (void)n_rot; (void)stride; (void)row_stride;
+        (void)position; (void)tokens; (void)freq_base;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    virtual void kv_store_f16_rows(const BackendBuffer& k, const BackendBuffer& v,
+                                   BackendBuffer& k_cache, BackendBuffer& v_cache,
+                                   uint32_t position, uint32_t row_length, uint32_t tokens) {
+        (void)k; (void)v; (void)k_cache; (void)v_cache; (void)position; (void)row_length;
+        (void)tokens;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    virtual void kv_store_turbo3_rows(const BackendBuffer& k, const BackendBuffer& v,
+                                      BackendBuffer& k_cache, BackendBuffer& v_cache,
+                                      uint32_t position, uint32_t kv_heads, uint32_t tokens) {
+        (void)k; (void)v; (void)k_cache; (void)v_cache; (void)position; (void)kv_heads;
+        (void)tokens;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    // KV-codec attribution store (kl-kv instrument): fp16 cache write with
+    // one side (mode 1 = K, mode 2 = V) round-tripped through the turbo3
+    // quantizer, so the side's quantization error can be measured alone.
+    // head = UINT32_MAX round-trips every head of the selected side; a
+    // specific head narrows attribution to one (layer is the caller's cut).
+    // flags/scale_off/aux: step-2 scaling arms and the per-feature stats
+    // pass (docs/metal/plans/2026-07-16-kv-codec-step2.md). aux may be null when
+    // flags need no buffer.
+    virtual void kv_store_f16_attrib_rows(const BackendBuffer& k, const BackendBuffer& v,
+                                          BackendBuffer& k_cache, BackendBuffer& v_cache,
+                                          uint32_t position, uint32_t kv_heads, uint32_t tokens,
+                                          uint32_t mode, uint32_t head, uint32_t flags,
+                                          uint32_t scale_off, BackendBuffer* aux) {
+        (void)k; (void)v; (void)k_cache; (void)v_cache; (void)position; (void)kv_heads;
+        (void)tokens; (void)mode; (void)head; (void)flags; (void)scale_off; (void)aux;
+        throw std::runtime_error("q27: backend has no KV attribution store");
+    }
+    // partials: caller-owned scratch for the blocked-GQA softmax partials
+    // (engines allocate it once at construction, sized for their own
+    // max context — docs/metal/plans/2026-07-17-metal-review-triage.md E2). May
+    // be null only when the call cannot route to the blocked kernels.
+    virtual void attention_f16_causal(const BackendBuffer& q, uint32_t q_stride,
+                                      uint32_t q_row_stride, const BackendBuffer& k_cache,
+                                      const BackendBuffer& v_cache,
+                                      BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
+                                      uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
+                                      float scale, BackendBuffer* partials) {
+        (void)q; (void)q_stride; (void)q_row_stride; (void)k_cache; (void)v_cache;
+        (void)out; (void)base_len; (void)q_heads; (void)kv_heads;
+        (void)head_dim; (void)tokens; (void)scale; (void)partials;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    virtual void attention_turbo3_causal(const BackendBuffer& q, uint32_t q_stride,
+                                         uint32_t q_row_stride, const BackendBuffer& k_cache,
+                                         const BackendBuffer& v_cache,
+                                         BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
+                                         uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
+                                         float scale, BackendBuffer* partials) {
+        (void)q; (void)q_stride; (void)q_row_stride; (void)k_cache; (void)v_cache;
+        (void)out; (void)base_len; (void)q_heads; (void)kv_heads;
+        (void)head_dim; (void)tokens; (void)scale; (void)partials;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    virtual void sigmoid_gate_mul_rows(BackendBuffer& out, const BackendBuffer& qg,
+                                       uint32_t heads, uint32_t head_dim, uint32_t tokens) {
+        (void)out; (void)qg; (void)heads; (void)head_dim; (void)tokens;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    virtual void argmax_rows(const BackendBuffer& x, uint32_t n, uint32_t rows,
+                             BackendBuffer& out_indices) {
+        (void)x; (void)n; (void)rows; (void)out_indices;
+        throw std::runtime_error("q27: backend has no chunked execution");
+    }
+    // nll[r] = logsumexp(logits[r,:]) - logits[r, targets[r]] over a row-major
+    // [rows, n] logit matrix. Targets are uint32 token ids in [0, n).
+    virtual void nll_rows(const BackendBuffer& logits, const BackendBuffer& targets,
+                          BackendBuffer& nll, uint32_t n, uint32_t rows) {
+        (void)logits; (void)targets; (void)nll; (void)n; (void)rows;
+        throw std::runtime_error("q27: backend has no NLL primitive");
+    }
+    virtual void synchronize() = 0;
+};
+
+} // namespace q27

--- a/src/backend.h
+++ b/src/backend.h
@@ -38,6 +38,17 @@ struct BackendTensor {
     uint64_t scales_size = 0;
 };
 
+// Cache layout is an execution contract, not a backend name. Keeping the
+// format as data lets new layouts use the same vtable entry. A backend must
+// reject unsupported formats rather than silently reinterpret their buffers.
+enum class KvFormat : uint8_t {
+    F16 = 0,
+    FP8_E4M3 = 1,
+    TURBO3 = 2,
+    TURBO3V = 3,
+    TURBO5K = 4,
+};
+
 // This intentionally starts small. New primitives should describe model
 // operations, not CUDA/Metal launch mechanics. The CUDA engine remains the
 // reference while its call sites are moved behind this interface incrementally.
@@ -74,7 +85,8 @@ class ComputeBackend {
     virtual void matvec_pair(const BackendTensor& a, BackendBuffer& a_out,
                              const BackendTensor& b, BackendBuffer& b_out,
                              const BackendBuffer& x) {
-        matvec(a, x, a_out); matvec(b, x, b_out);
+        matvec(a, x, a_out);
+        matvec(b, x, b_out);
     }
     virtual BackendQuantized allocate_quantized(uint32_t count) = 0;
     virtual void quantize(const BackendBuffer& x, BackendQuantized& out) = 0;
@@ -83,12 +95,15 @@ class ComputeBackend {
     virtual void matvec_quantized_pair(const BackendTensor& a, BackendBuffer& a_out,
                                        const BackendTensor& b, BackendBuffer& b_out,
                                        const BackendQuantized& x) {
-        matvec_quantized(a, x, a_out); matvec_quantized(b, x, b_out);
+        matvec_quantized(a, x, a_out);
+        matvec_quantized(b, x, b_out);
     }
-    virtual void matmul_quantized(const BackendTensor& weight,const BackendQuantized& x,
-                                  uint32_t x_rows,BackendBuffer& y) {
-        if(x_rows!=1) throw std::runtime_error("q27: backend has no quantized matmul");
-        matvec_quantized(weight,x,y);
+    virtual void matmul_quantized(const BackendTensor& weight,
+                                  const BackendQuantized& x,
+                                  uint32_t x_rows, BackendBuffer& y) {
+        if (x_rows != 1)
+            throw std::runtime_error("q27: backend has no quantized matmul");
+        matvec_quantized(weight, x, y);
     }
     virtual void embedding_q8(const BackendTensor& weight, uint32_t token,
                               BackendBuffer& out) = 0;
@@ -97,7 +112,8 @@ class ComputeBackend {
     virtual void rmsnorm_quantized(const BackendBuffer& x, const BackendTensor& weight,
                                    BackendBuffer& out, uint32_t n, float eps,
                                    BackendQuantized& quantized) {
-        rmsnorm(x,weight,out,n,eps); quantize(out,quantized);
+        rmsnorm(x, weight, out, n, eps);
+        quantize(out, quantized);
     }
     virtual void rmsnorm_heads(BackendBuffer& x, const BackendTensor& weight,
                                uint32_t heads, uint32_t head_dim, uint32_t stride,
@@ -135,28 +151,19 @@ class ComputeBackend {
         (void)x_offset_bytes;
         throw std::runtime_error("q27: backend has no top-k primitive");
     }
-    virtual void kv_store_f16(const BackendBuffer& k, const BackendBuffer& v,
-                              BackendBuffer& k_cache, BackendBuffer& v_cache,
-                              uint32_t position, uint32_t row_length) = 0;
+    virtual void kv_store(const BackendBuffer& k, const BackendBuffer& v,
+                          BackendBuffer& k_cache, BackendBuffer& v_cache,
+                          uint32_t position, uint32_t kv_heads, uint32_t head_dim,
+                          KvFormat format) = 0;
     virtual void turbo_wht(BackendBuffer& x, uint32_t heads, uint32_t stride,
                            bool inverse) = 0;
-    virtual void kv_store_turbo3(const BackendBuffer& k, const BackendBuffer& v,
-                                 BackendBuffer& k_cache, BackendBuffer& v_cache,
-                                 uint32_t position, uint32_t kv_heads) = 0;
-    // partials: caller-owned scratch for the blocked-GQA softmax partials;
-    // may be null only when the call cannot route to the blocked kernels
-    // (see attention_f16_causal below).
-    virtual void attention_turbo3(const BackendBuffer& q, uint32_t q_stride,
-                                  const BackendBuffer& k_cache, const BackendBuffer& v_cache,
-                                  BackendBuffer& out,
-                                  uint32_t seq_len, uint32_t q_heads, uint32_t kv_heads,
-                                  uint32_t head_dim, float scale,
-                                  BackendBuffer* partials) = 0;
-    virtual void attention_f16(const BackendBuffer& q, uint32_t q_stride,
-                               const BackendBuffer& k_cache, const BackendBuffer& v_cache,
-                               BackendBuffer& out, uint32_t seq_len,
-                               uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
-                               float scale, BackendBuffer* partials) = 0;
+    // partials: caller-owned scratch for blocked-GQA softmax partials; may be
+    // null only when the selected format cannot route to blocked kernels.
+    virtual void attention(const BackendBuffer& q, uint32_t q_stride,
+                           const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                           BackendBuffer& out, uint32_t seq_len, uint32_t q_heads,
+                           uint32_t kv_heads, uint32_t head_dim, float scale,
+                           KvFormat format, BackendBuffer* partials) = 0;
     virtual void gdn_gates(const BackendBuffer& alpha, const BackendBuffer& beta_raw,
                            const BackendTensor& ssm_a, const BackendTensor& ssm_dt,
                            BackendBuffer& g, BackendBuffer& beta, uint32_t heads) = 0;
@@ -234,44 +241,29 @@ class ComputeBackend {
         (void)position; (void)tokens; (void)freq_base;
         throw std::runtime_error("q27: backend has no chunked execution");
     }
-    virtual void kv_store_f16_rows(const BackendBuffer& k, const BackendBuffer& v,
-                                   BackendBuffer& k_cache, BackendBuffer& v_cache,
-                                   uint32_t position, uint32_t row_length, uint32_t tokens) {
-        (void)k; (void)v; (void)k_cache; (void)v_cache; (void)position; (void)row_length;
-        (void)tokens;
-        throw std::runtime_error("q27: backend has no chunked execution");
-    }
-    virtual void kv_store_turbo3_rows(const BackendBuffer& k, const BackendBuffer& v,
-                                      BackendBuffer& k_cache, BackendBuffer& v_cache,
-                                      uint32_t position, uint32_t kv_heads, uint32_t tokens) {
-        (void)k; (void)v; (void)k_cache; (void)v_cache; (void)position; (void)kv_heads;
-        (void)tokens;
-        throw std::runtime_error("q27: backend has no chunked execution");
+    virtual void kv_store_rows(const BackendBuffer& k, const BackendBuffer& v,
+                               BackendBuffer& k_cache, BackendBuffer& v_cache,
+                               uint32_t position, uint32_t kv_heads, uint32_t head_dim,
+                               uint32_t tokens, KvFormat format) {
+        (void)k; (void)v; (void)k_cache; (void)v_cache; (void)position;
+        (void)kv_heads; (void)head_dim; (void)tokens; (void)format;
+        throw std::runtime_error("q27: backend has no chunked KV store");
     }
     // partials: caller-owned scratch for blocked-GQA softmax partials, sized
     // once by the engine for its maximum context. May be null only when the
-    // call cannot route to the blocked kernels.
-    virtual void attention_f16_causal(const BackendBuffer& q, uint32_t q_stride,
-                                      uint32_t q_row_stride, const BackendBuffer& k_cache,
-                                      const BackendBuffer& v_cache,
-                                      BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
-                                      uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
-                                      float scale, BackendBuffer* partials) {
+    // selected format cannot route to blocked kernels.
+    virtual void attention_causal(const BackendBuffer& q, uint32_t q_stride,
+                                  uint32_t q_row_stride,
+                                  const BackendBuffer& k_cache,
+                                  const BackendBuffer& v_cache,
+                                  BackendBuffer& out, uint32_t base_len,
+                                  uint32_t q_heads, uint32_t kv_heads,
+                                  uint32_t head_dim, uint32_t tokens, float scale,
+                                  KvFormat format, BackendBuffer* partials) {
         (void)q; (void)q_stride; (void)q_row_stride; (void)k_cache; (void)v_cache;
-        (void)out; (void)base_len; (void)q_heads; (void)kv_heads;
-        (void)head_dim; (void)tokens; (void)scale; (void)partials;
-        throw std::runtime_error("q27: backend has no chunked execution");
-    }
-    virtual void attention_turbo3_causal(const BackendBuffer& q, uint32_t q_stride,
-                                         uint32_t q_row_stride, const BackendBuffer& k_cache,
-                                         const BackendBuffer& v_cache,
-                                         BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
-                                         uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
-                                         float scale, BackendBuffer* partials) {
-        (void)q; (void)q_stride; (void)q_row_stride; (void)k_cache; (void)v_cache;
-        (void)out; (void)base_len; (void)q_heads; (void)kv_heads;
-        (void)head_dim; (void)tokens; (void)scale; (void)partials;
-        throw std::runtime_error("q27: backend has no chunked execution");
+        (void)out; (void)base_len; (void)q_heads; (void)kv_heads; (void)head_dim;
+        (void)tokens; (void)scale; (void)format; (void)partials;
+        throw std::runtime_error("q27: backend has no chunked attention");
     }
     virtual void sigmoid_gate_mul_rows(BackendBuffer& out, const BackendBuffer& qg,
                                        uint32_t heads, uint32_t head_dim, uint32_t tokens) {

--- a/src/backend.h
+++ b/src/backend.h
@@ -248,27 +248,9 @@ class ComputeBackend {
         (void)tokens;
         throw std::runtime_error("q27: backend has no chunked execution");
     }
-    // KV-codec attribution store (kl-kv instrument): fp16 cache write with
-    // one side (mode 1 = K, mode 2 = V) round-tripped through the turbo3
-    // quantizer, so the side's quantization error can be measured alone.
-    // head = UINT32_MAX round-trips every head of the selected side; a
-    // specific head narrows attribution to one (layer is the caller's cut).
-    // flags/scale_off/aux: step-2 scaling arms and the per-feature stats
-    // pass (docs/metal/plans/2026-07-16-kv-codec-step2.md). aux may be null when
-    // flags need no buffer.
-    virtual void kv_store_f16_attrib_rows(const BackendBuffer& k, const BackendBuffer& v,
-                                          BackendBuffer& k_cache, BackendBuffer& v_cache,
-                                          uint32_t position, uint32_t kv_heads, uint32_t tokens,
-                                          uint32_t mode, uint32_t head, uint32_t flags,
-                                          uint32_t scale_off, BackendBuffer* aux) {
-        (void)k; (void)v; (void)k_cache; (void)v_cache; (void)position; (void)kv_heads;
-        (void)tokens; (void)mode; (void)head; (void)flags; (void)scale_off; (void)aux;
-        throw std::runtime_error("q27: backend has no KV attribution store");
-    }
-    // partials: caller-owned scratch for the blocked-GQA softmax partials
-    // (engines allocate it once at construction, sized for their own
-    // max context — docs/metal/plans/2026-07-17-metal-review-triage.md E2). May
-    // be null only when the call cannot route to the blocked kernels.
+    // partials: caller-owned scratch for blocked-GQA softmax partials, sized
+    // once by the engine for its maximum context. May be null only when the
+    // call cannot route to the blocked kernels.
     virtual void attention_f16_causal(const BackendBuffer& q, uint32_t q_stride,
                                       uint32_t q_row_stride, const BackendBuffer& k_cache,
                                       const BackendBuffer& v_cache,

--- a/src/device_model.cu
+++ b/src/device_model.cu
@@ -19,6 +19,8 @@ const DevTensor& DeviceModel::upload(const std::string& name) {
     if (it != dev_.end()) return it->second;
 
     const Tensor& src = model_.get(name);
+    validate_cuda_tensor(src);
+
     DevTensor d;
     d.dtype = src.dtype;
     d.rows = src.rows();
@@ -105,6 +107,8 @@ int DeviceModel::checksum_verify(bool print) const {
 }
 
 void DeviceModel::upload_all() {
+    validate_cuda_model(model_);
+
     for (const auto& t : model_.tensors) upload(t.name);
 }
 

--- a/src/device_model.h
+++ b/src/device_model.h
@@ -20,7 +20,7 @@ struct DevTensor {
 
 class DeviceModel {
   public:
-    explicit DeviceModel(const Model& m) : model_(m) { validate_cuda_model(model_); }
+    explicit DeviceModel(const Model& m) : model_(m) {}
     ~DeviceModel();
     // owns raw CUDA pointers in dev_; a copy would double-free on destruction.
     DeviceModel(const DeviceModel&) = delete;

--- a/src/device_model.h
+++ b/src/device_model.h
@@ -20,7 +20,7 @@ struct DevTensor {
 
 class DeviceModel {
   public:
-    explicit DeviceModel(const Model& m) : model_(m) {}
+    explicit DeviceModel(const Model& m) : model_(m) { validate_cuda_model(model_); }
     ~DeviceModel();
     // owns raw CUDA pointers in dev_; a copy would double-free on destruction.
     DeviceModel(const DeviceModel&) = delete;

--- a/src/engine.cuh
+++ b/src/engine.cuh
@@ -539,6 +539,13 @@ struct Engine {
         const q27::Tensor& embedding = model.get("token_embd.weight");
         if (embedding.dtype != q27::DType::Q8_G128)
             throw std::runtime_error("q27 CUDA: token_embd.weight must be Q8_G128");
+        for (const q27::Tensor& tensor : model.tensors) {
+            if (!q27::cuda_weight_dtype_supported(tensor.dtype))
+                throw std::runtime_error("q27 CUDA: unsupported weight dtype " +
+                                         std::string(q27::dtype_name(tensor.dtype)) +
+                                         " in " + tensor.name);
+        }
+
 
         CUDA_CHECK(cudaStreamCreate(&stm));
         const char* kve = getenv("Q27_KV");

--- a/src/engine.cuh
+++ b/src/engine.cuh
@@ -536,16 +536,7 @@ struct Engine {
 
   private:
     void init(int ctx, bool own_weights) {
-        const q27::Tensor& embedding = model.get("token_embd.weight");
-        if (embedding.dtype != q27::DType::Q8_G128)
-            throw std::runtime_error("q27 CUDA: token_embd.weight must be Q8_G128");
-        for (const q27::Tensor& tensor : model.tensors) {
-            if (!q27::cuda_weight_dtype_supported(tensor.dtype))
-                throw std::runtime_error("q27 CUDA: unsupported weight dtype " +
-                                         std::string(q27::dtype_name(tensor.dtype)) +
-                                         " in " + tensor.name);
-        }
-
+        q27::validate_cuda_model(model);
 
         CUDA_CHECK(cudaStreamCreate(&stm));
         const char* kve = getenv("Q27_KV");

--- a/src/engine.cuh
+++ b/src/engine.cuh
@@ -536,6 +536,10 @@ struct Engine {
 
   private:
     void init(int ctx, bool own_weights) {
+        const q27::Tensor& embedding = model.get("token_embd.weight");
+        if (embedding.dtype != q27::DType::Q8_G128)
+            throw std::runtime_error("q27 CUDA: token_embd.weight must be Q8_G128");
+
         CUDA_CHECK(cudaStreamCreate(&stm));
         const char* kve = getenv("Q27_KV");
         kv_fp8 = kve && !strcmp(kve, "fp8");

--- a/src/engine.cuh
+++ b/src/engine.cuh
@@ -536,7 +536,6 @@ struct Engine {
 
   private:
     void init(int ctx, bool own_weights) {
-        q27::validate_cuda_model(model);
 
         CUDA_CHECK(cudaStreamCreate(&stm));
         const char* kve = getenv("Q27_KV");

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -30,10 +30,6 @@ int main(int argc, char** argv) {
         e.first++;
         e.second += t.data_size + t.scales_size;
         total += t.data_size + t.scales_size;
-        if (t.name == "token_embd.weight" && t.dtype != q27::DType::Q8_G128) {
-            printf("INVARIANT FAIL token_embd.weight: CUDA row lookup requires Q8_G128\n");
-            bad++;
-        }
 
     }
 

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -41,6 +41,11 @@ int main(int argc, char** argv) {
         e.first++;
         e.second += t.data_size + t.scales_size;
         total += t.data_size + t.scales_size;
+        if (t.name == "token_embd.weight" && t.dtype != q27::DType::Q8_G128) {
+            printf("INVARIANT FAIL token_embd.weight: CUDA row lookup requires Q8_G128\n");
+            bad++;
+        }
+
 
         // size invariants per dtype
         uint64_t r = t.rows(), c = t.cols();

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -4,6 +4,8 @@
 #include <cinttypes>
 #include <cstdio>
 #include <map>
+#include <initializer_list>
+#include <limits>
 #include <string>
 
 int main(int argc, char** argv) {
@@ -11,7 +13,13 @@ int main(int argc, char** argv) {
         fprintf(stderr, "usage: %s model.q27\n", argv[0]);
         return 1;
     }
-    q27::Model m = q27::Model::open(argv[1]);
+    q27::Model m;
+    try {
+        m = q27::Model::open(argv[1]);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "INVARIANT FAIL container: %s\n", e.what());
+        return 1;
+    }
 
     printf("meta (%zu bytes): %.300s%s\n\n", m.meta_json.size(), m.meta_json.c_str(),
            m.meta_json.size() > 300 ? "..." : "");
@@ -19,6 +27,15 @@ int main(int argc, char** argv) {
     std::map<std::string, std::pair<int, uint64_t>> by_type; // name -> {count, bytes}
     uint64_t total = 0;
     int bad = 0;
+    auto checked_product = [](std::initializer_list<uint64_t> factors, uint64_t& out) {
+        out = 1;
+        for (uint64_t factor : factors) {
+            if (factor && out > std::numeric_limits<uint64_t>::max() / factor)
+                return false;
+            out *= factor;
+        }
+        return true;
+    };
     for (const auto& t : m.tensors) {
         auto& e = by_type[q27::dtype_name(t.dtype)];
         e.first++;
@@ -39,20 +56,63 @@ int main(int argc, char** argv) {
             continue;
         }
         uint64_t want_data = 0, want_scales = 0;
+        bool sizes_representable = true;
         switch (t.dtype) {
-            case q27::DType::F32:     want_data = r * c * 4; break;
-            case q27::DType::F16:     want_data = r * c * 2; break;
-            case q27::DType::Q8_G128: want_data = r * c;     want_scales = r * (c / 128) * 2; break;
-            case q27::DType::Q4_G64:  want_data = r * c / 2; want_scales = r * (c / 64) * 2;  break;
-            case q27::DType::T2_G128: want_data = r * c / 4; want_scales = r * (c / 128) * 2; break;
-            case q27::DType::T3_G128: want_data = r * (c / 128) * 26; want_scales = r * (c / 128) * 2; break;
-            case q27::DType::B1_G128: want_data = r * c / 8; want_scales = r * (c / 128) * 2; break;
+            case q27::DType::F32:     sizes_representable = checked_product({r, c, 4}, want_data); break;
+            case q27::DType::F16:     sizes_representable = checked_product({r, c, 2}, want_data); break;
+            case q27::DType::Q8_G128: sizes_representable = checked_product({r, c}, want_data) &&
+                checked_product({r, c / 128, 2}, want_scales); break;
+            case q27::DType::Q4_G64:  sizes_representable = checked_product({r, c / 2}, want_data) &&
+                checked_product({r, c / 64, 2}, want_scales); break;
+            case q27::DType::T2_G128: sizes_representable = checked_product({r, c / 4}, want_data) &&
+                checked_product({r, c / 128, 2}, want_scales); break;
+            case q27::DType::T3_G128: sizes_representable = checked_product({r, c / 128, 26}, want_data) &&
+                checked_product({r, c / 128, 2}, want_scales); break;
+            case q27::DType::B1_G128: sizes_representable = checked_product({r, c / 8}, want_data) &&
+                checked_product({r, c / 128, 2}, want_scales); break;
+        }
+        if (!sizes_representable) {
+            printf("INVARIANT FAIL %s: packed payload size overflows uint64\n", t.name.c_str());
+            bad++;
+            continue;
         }
         if (t.data_size != want_data || t.scales_size != want_scales) {
             printf("INVARIANT FAIL %s: data %" PRIu64 " (want %" PRIu64 "), scales %" PRIu64
                    " (want %" PRIu64 ")\n",
                    t.name.c_str(), t.data_size, want_data, t.scales_size, want_scales);
             bad++;
+        } else if (t.dtype == q27::DType::T2_G128) {
+            bool invalid = false;
+            for (uint64_t i = 0; i < t.data_size && !invalid; i++) {
+                const uint8_t byte = t.data[i];
+                for (int shift = 0; shift < 8; shift += 2)
+                    if (((byte >> shift) & 3u) == 3u) { invalid = true; break; }
+            }
+            if (invalid) {
+                printf("INVARIANT FAIL %s: T2 payload contains reserved code 3\n",
+                       t.name.c_str());
+                bad++;
+            }
+        } else if (t.dtype == q27::DType::T3_G128) {
+            bool invalid_byte = false, invalid_padding = false;
+            const uint64_t groups = r * (c / 128);
+            for (uint64_t g = 0; g < groups; g++) {
+                const uint8_t* packed = t.data + g * 26;
+                for (int i = 0; i < 26; i++)
+                    if (packed[i] > 242) { invalid_byte = true; break; }
+                const uint8_t tail = packed[25];
+                if ((tail / 27) % 3 != 1 || (tail / 81) % 3 != 1)
+                    invalid_padding = true;
+            }
+            if (invalid_byte) {
+                printf("INVARIANT FAIL %s: T3 payload byte exceeds 242\n", t.name.c_str());
+                bad++;
+            }
+            if (invalid_padding) {
+                printf("INVARIANT FAIL %s: T3 final-byte padding is noncanonical\n",
+                       t.name.c_str());
+                bad++;
+            }
         }
     }
 

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -27,12 +27,26 @@ int main(int argc, char** argv) {
 
         // size invariants per dtype
         uint64_t r = t.rows(), c = t.cols();
+        uint64_t group = 0;
+        if (t.dtype == q27::DType::Q4_G64) group = 64;
+        else if (t.dtype == q27::DType::Q8_G128 || t.dtype == q27::DType::T2_G128 ||
+                 t.dtype == q27::DType::T3_G128 || t.dtype == q27::DType::B1_G128)
+            group = 128;
+        if (group && c % group) {
+            printf("INVARIANT FAIL %s: cols %" PRIu64 " not divisible by group %" PRIu64 "\n",
+                   t.name.c_str(), c, group);
+            bad++;
+            continue;
+        }
         uint64_t want_data = 0, want_scales = 0;
         switch (t.dtype) {
             case q27::DType::F32:     want_data = r * c * 4; break;
             case q27::DType::F16:     want_data = r * c * 2; break;
             case q27::DType::Q8_G128: want_data = r * c;     want_scales = r * (c / 128) * 2; break;
             case q27::DType::Q4_G64:  want_data = r * c / 2; want_scales = r * (c / 64) * 2;  break;
+            case q27::DType::T2_G128: want_data = r * c / 4; want_scales = r * (c / 128) * 2; break;
+            case q27::DType::T3_G128: want_data = r * (c / 128) * 26; want_scales = r * (c / 128) * 2; break;
+            case q27::DType::B1_G128: want_data = r * c / 8; want_scales = r * (c / 128) * 2; break;
         }
         if (t.data_size != want_data || t.scales_size != want_scales) {
             printf("INVARIANT FAIL %s: data %" PRIu64 " (want %" PRIu64 "), scales %" PRIu64

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -35,10 +35,6 @@ int main(int argc, char** argv) {
             bad++;
         }
 
-        for (const std::string& error : q27::validate_tensor_payload(t)) {
-            printf("INVARIANT FAIL %s: %s\n", t.name.c_str(), error.c_str());
-            bad++;
-        }
     }
 
     printf("%zu tensors, %.2f GB payload\n", m.tensors.size(), total / 1e9);

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -4,8 +4,6 @@
 #include <cinttypes>
 #include <cstdio>
 #include <map>
-#include <initializer_list>
-#include <limits>
 #include <string>
 
 int main(int argc, char** argv) {
@@ -27,15 +25,6 @@ int main(int argc, char** argv) {
     std::map<std::string, std::pair<int, uint64_t>> by_type; // name -> {count, bytes}
     uint64_t total = 0;
     int bad = 0;
-    auto checked_product = [](std::initializer_list<uint64_t> factors, uint64_t& out) {
-        out = 1;
-        for (uint64_t factor : factors) {
-            if (factor && out > std::numeric_limits<uint64_t>::max() / factor)
-                return false;
-            out *= factor;
-        }
-        return true;
-    };
     for (const auto& t : m.tensors) {
         auto& e = by_type[q27::dtype_name(t.dtype)];
         e.first++;
@@ -46,78 +35,9 @@ int main(int argc, char** argv) {
             bad++;
         }
 
-
-        // size invariants per dtype
-        uint64_t r = t.rows(), c = t.cols();
-        uint64_t group = 0;
-        if (t.dtype == q27::DType::Q4_G64) group = 64;
-        else if (t.dtype == q27::DType::Q8_G128 || t.dtype == q27::DType::T2_G128 ||
-                 t.dtype == q27::DType::T3_G128 || t.dtype == q27::DType::B1_G128)
-            group = 128;
-        if (group && c % group) {
-            printf("INVARIANT FAIL %s: cols %" PRIu64 " not divisible by group %" PRIu64 "\n",
-                   t.name.c_str(), c, group);
+        for (const std::string& error : q27::validate_tensor_payload(t)) {
+            printf("INVARIANT FAIL %s: %s\n", t.name.c_str(), error.c_str());
             bad++;
-            continue;
-        }
-        uint64_t want_data = 0, want_scales = 0;
-        bool sizes_representable = true;
-        switch (t.dtype) {
-            case q27::DType::F32:     sizes_representable = checked_product({r, c, 4}, want_data); break;
-            case q27::DType::F16:     sizes_representable = checked_product({r, c, 2}, want_data); break;
-            case q27::DType::Q8_G128: sizes_representable = checked_product({r, c}, want_data) &&
-                checked_product({r, c / 128, 2}, want_scales); break;
-            case q27::DType::Q4_G64:  sizes_representable = checked_product({r, c / 2}, want_data) &&
-                checked_product({r, c / 64, 2}, want_scales); break;
-            case q27::DType::T2_G128: sizes_representable = checked_product({r, c / 4}, want_data) &&
-                checked_product({r, c / 128, 2}, want_scales); break;
-            case q27::DType::T3_G128: sizes_representable = checked_product({r, c / 128, 26}, want_data) &&
-                checked_product({r, c / 128, 2}, want_scales); break;
-            case q27::DType::B1_G128: sizes_representable = checked_product({r, c / 8}, want_data) &&
-                checked_product({r, c / 128, 2}, want_scales); break;
-        }
-        if (!sizes_representable) {
-            printf("INVARIANT FAIL %s: packed payload size overflows uint64\n", t.name.c_str());
-            bad++;
-            continue;
-        }
-        if (t.data_size != want_data || t.scales_size != want_scales) {
-            printf("INVARIANT FAIL %s: data %" PRIu64 " (want %" PRIu64 "), scales %" PRIu64
-                   " (want %" PRIu64 ")\n",
-                   t.name.c_str(), t.data_size, want_data, t.scales_size, want_scales);
-            bad++;
-        } else if (t.dtype == q27::DType::T2_G128) {
-            bool invalid = false;
-            for (uint64_t i = 0; i < t.data_size && !invalid; i++) {
-                const uint8_t byte = t.data[i];
-                for (int shift = 0; shift < 8; shift += 2)
-                    if (((byte >> shift) & 3u) == 3u) { invalid = true; break; }
-            }
-            if (invalid) {
-                printf("INVARIANT FAIL %s: T2 payload contains reserved code 3\n",
-                       t.name.c_str());
-                bad++;
-            }
-        } else if (t.dtype == q27::DType::T3_G128) {
-            bool invalid_byte = false, invalid_padding = false;
-            const uint64_t groups = r * (c / 128);
-            for (uint64_t g = 0; g < groups; g++) {
-                const uint8_t* packed = t.data + g * 26;
-                for (int i = 0; i < 26; i++)
-                    if (packed[i] > 242) { invalid_byte = true; break; }
-                const uint8_t tail = packed[25];
-                if ((tail / 27) % 3 != 1 || (tail / 81) % 3 != 1)
-                    invalid_padding = true;
-            }
-            if (invalid_byte) {
-                printf("INVARIANT FAIL %s: T3 payload byte exceeds 242\n", t.name.c_str());
-                bad++;
-            }
-            if (invalid_padding) {
-                printf("INVARIANT FAIL %s: T3 final-byte padding is noncanonical\n",
-                       t.name.c_str());
-                bad++;
-            }
         }
     }
 

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -20,6 +20,9 @@ const char* dtype_name(DType t) {
         case DType::F16:     return "F16";
         case DType::Q8_G128: return "Q8_G128";
         case DType::Q4_G64:  return "Q4_G64";
+        case DType::T2_G128: return "T2_G128";
+        case DType::T3_G128: return "T3_G128";
+        case DType::B1_G128: return "B1_G128";
     }
     return "?";
 }

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -67,6 +67,11 @@ std::vector<std::string> validate_tensor_payload(const Tensor& tensor) {
             checked_product({rows, cols / 128, 2}, want_scales); break;
         case DType::B1_G128: sizes_representable = checked_product({rows, cols / 8}, want_data) &&
             checked_product({rows, cols / 128, 2}, want_scales); break;
+        default:
+            errors.push_back("unsupported dtype " +
+                             std::to_string(static_cast<unsigned>(tensor.dtype)));
+            return errors;
+
     }
     if (!sizes_representable) {
         errors.push_back("packed payload size overflows uint64");

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include <cstring>
+#include <initializer_list>
 #include <limits>
 #include <stdexcept>
 
@@ -26,6 +27,82 @@ const char* dtype_name(DType t) {
         case DType::B1_G128: return "B1_G128";
     }
     return "?";
+}
+
+std::vector<std::string> validate_tensor_payload(const Tensor& tensor) {
+    std::vector<std::string> errors;
+    const uint64_t rows = tensor.rows(), cols = tensor.cols();
+    uint64_t group = 0;
+    if (tensor.dtype == DType::Q4_G64) group = 64;
+    else if (tensor.dtype == DType::Q8_G128 || tensor.dtype == DType::T2_G128 ||
+             tensor.dtype == DType::T3_G128 || tensor.dtype == DType::B1_G128)
+        group = 128;
+    if (group && cols % group) {
+        errors.push_back("cols " + std::to_string(cols) +
+                         " not divisible by group " + std::to_string(group));
+        return errors;
+    }
+
+    auto checked_product = [](std::initializer_list<uint64_t> factors, uint64_t& out) {
+        out = 1;
+        for (uint64_t factor : factors) {
+            if (factor && out > std::numeric_limits<uint64_t>::max() / factor)
+                return false;
+            out *= factor;
+        }
+        return true;
+    };
+    uint64_t want_data = 0, want_scales = 0;
+    bool sizes_representable = true;
+    switch (tensor.dtype) {
+        case DType::F32:     sizes_representable = checked_product({rows, cols, 4}, want_data); break;
+        case DType::F16:     sizes_representable = checked_product({rows, cols, 2}, want_data); break;
+        case DType::Q8_G128: sizes_representable = checked_product({rows, cols}, want_data) &&
+            checked_product({rows, cols / 128, 2}, want_scales); break;
+        case DType::Q4_G64:  sizes_representable = checked_product({rows, cols / 2}, want_data) &&
+            checked_product({rows, cols / 64, 2}, want_scales); break;
+        case DType::T2_G128: sizes_representable = checked_product({rows, cols / 4}, want_data) &&
+            checked_product({rows, cols / 128, 2}, want_scales); break;
+        case DType::T3_G128: sizes_representable = checked_product({rows, cols / 128, 26}, want_data) &&
+            checked_product({rows, cols / 128, 2}, want_scales); break;
+        case DType::B1_G128: sizes_representable = checked_product({rows, cols / 8}, want_data) &&
+            checked_product({rows, cols / 128, 2}, want_scales); break;
+    }
+    if (!sizes_representable) {
+        errors.push_back("packed payload size overflows uint64");
+        return errors;
+    }
+    if (tensor.data_size != want_data || tensor.scales_size != want_scales) {
+        errors.push_back("data " + std::to_string(tensor.data_size) +
+                         " (want " + std::to_string(want_data) + "), scales " +
+                         std::to_string(tensor.scales_size) + " (want " +
+                         std::to_string(want_scales) + ")");
+        return errors;
+    }
+    if (tensor.dtype == DType::T2_G128) {
+        for (uint64_t i = 0; i < tensor.data_size; i++) {
+            const uint8_t byte = tensor.data[i];
+            for (int shift = 0; shift < 8; shift += 2)
+                if (((byte >> shift) & 3u) == 3u) {
+                    errors.push_back("T2 payload contains reserved code 3");
+                    return errors;
+                }
+        }
+    } else if (tensor.dtype == DType::T3_G128) {
+        bool invalid_byte = false, invalid_padding = false;
+        const uint64_t groups = rows * (cols / 128);
+        for (uint64_t group_index = 0; group_index < groups; group_index++) {
+            const uint8_t* packed = tensor.data + group_index * 26;
+            for (int i = 0; i < 26; i++)
+                if (packed[i] > 242) { invalid_byte = true; break; }
+            const uint8_t tail = packed[25];
+            if ((tail / 27) % 3 != 1 || (tail / 81) % 3 != 1)
+                invalid_padding = true;
+        }
+        if (invalid_byte) errors.push_back("T3 payload byte exceeds 242");
+        if (invalid_padding) errors.push_back("T3 final-byte padding is noncanonical");
+    }
+    return errors;
 }
 
 uint64_t Tensor::rows() const {

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -74,6 +74,9 @@ std::string validate_tensor_payload(const Tensor& tensor) {
                " (want " + std::to_string(want_data) + "), scales " +
                std::to_string(tensor.scales_size) + " (want " +
                std::to_string(want_scales) + ")";
+    if (want_data && !tensor.data) return "data payload is missing";
+    if (want_scales && !tensor.scales) return "scale payload is missing";
+
 
     if (tensor.dtype == DType::T2_G128) {
         for (uint64_t i = 0; i < tensor.data_size; i++) {
@@ -95,6 +98,21 @@ std::string validate_tensor_payload(const Tensor& tensor) {
     }
     return {};
 }
+bool cuda_weight_dtype_supported(DType dtype) {
+    switch (dtype) {
+        case DType::F32:
+        case DType::F16:
+        case DType::Q8_G128:
+        case DType::Q4_G64:
+            return true;
+        case DType::T2_G128:
+        case DType::T3_G128:
+        case DType::B1_G128:
+            return false;
+    }
+    return false;
+}
+
 
 uint64_t Tensor::rows() const {
     if (shape.size() <= 1) return 1;
@@ -218,8 +236,10 @@ Model Model::open(const std::string& path) {
         if (!in_file(doff, t.data_size))
             throw std::runtime_error("q27: tensor data out of range: " + t.name);
         t.data = b + data_base + doff;
-        if (t.scales) {
+        if (t.scales_size) {
             uint64_t soff = (uint64_t)(uintptr_t)t.scales;
+            if (!soff)
+                throw std::runtime_error("q27: tensor scale offset is zero: " + t.name);
             if (!in_file(soff, t.scales_size))
                 throw std::runtime_error("q27: tensor scales out of range: " + t.name);
             t.scales = b + data_base + soff;

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -112,16 +112,17 @@ bool cuda_weight_dtype_supported(DType dtype) {
     }
     return false;
 }
-void validate_cuda_model(const Model& model) {
-    const Tensor& embedding=model.get("token_embd.weight");
-    if(embedding.dtype!=DType::Q8_G128)
+void validate_cuda_tensor(const Tensor& tensor) {
+    if(tensor.name=="token_embd.weight" && tensor.dtype!=DType::Q8_G128)
         throw std::runtime_error("q27 CUDA: token_embd.weight must be Q8_G128");
-    for(const Tensor& tensor:model.tensors) {
-        if(!cuda_weight_dtype_supported(tensor.dtype))
-            throw std::runtime_error("q27 CUDA: unsupported weight dtype " +
-                                     std::string(dtype_name(tensor.dtype)) +
-                                     " in " + tensor.name);
-    }
+    if(!cuda_weight_dtype_supported(tensor.dtype))
+        throw std::runtime_error("q27 CUDA: unsupported weight dtype " +
+                                 std::string(dtype_name(tensor.dtype)) +
+                                 " in " + tensor.name);
+}
+void validate_cuda_model(const Model& model) {
+    validate_cuda_tensor(model.get("token_embd.weight"));
+    for(const Tensor& tensor:model.tensors) validate_cuda_tensor(tensor);
 }
 
 uint64_t Tensor::rows() const {

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -29,19 +29,16 @@ const char* dtype_name(DType t) {
     return "?";
 }
 
-std::vector<std::string> validate_tensor_payload(const Tensor& tensor) {
-    std::vector<std::string> errors;
+std::string validate_tensor_payload(const Tensor& tensor) {
     const uint64_t rows = tensor.rows(), cols = tensor.cols();
     uint64_t group = 0;
     if (tensor.dtype == DType::Q4_G64) group = 64;
     else if (tensor.dtype == DType::Q8_G128 || tensor.dtype == DType::T2_G128 ||
              tensor.dtype == DType::T3_G128 || tensor.dtype == DType::B1_G128)
         group = 128;
-    if (group && cols % group) {
-        errors.push_back("cols " + std::to_string(cols) +
-                         " not divisible by group " + std::to_string(group));
-        return errors;
-    }
+    if (group && cols % group)
+        return "cols " + std::to_string(cols) +
+               " not divisible by group " + std::to_string(group);
 
     auto checked_product = [](std::initializer_list<uint64_t> factors, uint64_t& out) {
         out = 1;
@@ -68,46 +65,35 @@ std::vector<std::string> validate_tensor_payload(const Tensor& tensor) {
         case DType::B1_G128: sizes_representable = checked_product({rows, cols / 8}, want_data) &&
             checked_product({rows, cols / 128, 2}, want_scales); break;
         default:
-            errors.push_back("unsupported dtype " +
-                             std::to_string(static_cast<unsigned>(tensor.dtype)));
-            return errors;
+            return "unsupported dtype " +
+                   std::to_string(static_cast<unsigned>(tensor.dtype));
+    }
+    if (!sizes_representable) return "packed payload size overflows uint64";
+    if (tensor.data_size != want_data || tensor.scales_size != want_scales)
+        return "data " + std::to_string(tensor.data_size) +
+               " (want " + std::to_string(want_data) + "), scales " +
+               std::to_string(tensor.scales_size) + " (want " +
+               std::to_string(want_scales) + ")";
 
-    }
-    if (!sizes_representable) {
-        errors.push_back("packed payload size overflows uint64");
-        return errors;
-    }
-    if (tensor.data_size != want_data || tensor.scales_size != want_scales) {
-        errors.push_back("data " + std::to_string(tensor.data_size) +
-                         " (want " + std::to_string(want_data) + "), scales " +
-                         std::to_string(tensor.scales_size) + " (want " +
-                         std::to_string(want_scales) + ")");
-        return errors;
-    }
     if (tensor.dtype == DType::T2_G128) {
         for (uint64_t i = 0; i < tensor.data_size; i++) {
             const uint8_t byte = tensor.data[i];
             for (int shift = 0; shift < 8; shift += 2)
-                if (((byte >> shift) & 3u) == 3u) {
-                    errors.push_back("T2 payload contains reserved code 3");
-                    return errors;
-                }
+                if (((byte >> shift) & 3u) == 3u)
+                    return "T2 payload contains reserved code 3";
         }
     } else if (tensor.dtype == DType::T3_G128) {
-        bool invalid_byte = false, invalid_padding = false;
         const uint64_t groups = rows * (cols / 128);
         for (uint64_t group_index = 0; group_index < groups; group_index++) {
             const uint8_t* packed = tensor.data + group_index * 26;
             for (int i = 0; i < 26; i++)
-                if (packed[i] > 242) { invalid_byte = true; break; }
+                if (packed[i] > 242) return "T3 payload byte exceeds 242";
             const uint8_t tail = packed[25];
             if ((tail / 27) % 3 != 1 || (tail / 81) % 3 != 1)
-                invalid_padding = true;
+                return "T3 final-byte padding is noncanonical";
         }
-        if (invalid_byte) errors.push_back("T3 payload byte exceeds 242");
-        if (invalid_padding) errors.push_back("T3 final-byte padding is noncanonical");
     }
-    return errors;
+    return {};
 }
 
 uint64_t Tensor::rows() const {
@@ -238,6 +224,10 @@ Model Model::open(const std::string& path) {
                 throw std::runtime_error("q27: tensor scales out of range: " + t.name);
             t.scales = b + data_base + soff;
         }
+        const std::string payload_error = validate_tensor_payload(t);
+        if (!payload_error.empty())
+            throw std::runtime_error("q27: invalid tensor payload " + t.name + ": " +
+                                     payload_error);
         m.index.emplace(t.name, i);
     }
     return m;

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -228,7 +228,7 @@ Model Model::open(const std::string& path) {
         t.scales_size = c.read<uint64_t>();
         // stash offsets in pointers temporarily; fixed up after base is known
         t.data   = (const uint8_t*)(uintptr_t)doff;
-        t.scales = t.scales_size ? (const uint8_t*)(uintptr_t)soff : nullptr;
+        t.scales = (const uint8_t*)(uintptr_t)soff;
         m.tensors.push_back(std::move(t));
     }
     uint64_t table_end = (uint64_t)(c.p - b);
@@ -244,16 +244,28 @@ Model Model::open(const std::string& path) {
     for (size_t i = 0; i < m.tensors.size(); i++) {
         Tensor& t = m.tensors[i];
         uint64_t doff = (uint64_t)(uintptr_t)t.data;
+        if (doff % ALIGN)
+            throw std::runtime_error("q27: tensor data offset is not 256-byte aligned: " +
+                                     t.name);
         if (!in_file(doff, t.data_size))
             throw std::runtime_error("q27: tensor data out of range: " + t.name);
         t.data = b + data_base + doff;
+
+        uint64_t soff = (uint64_t)(uintptr_t)t.scales;
         if (t.scales_size) {
-            uint64_t soff = (uint64_t)(uintptr_t)t.scales;
             if (!soff)
                 throw std::runtime_error("q27: tensor scale offset is zero: " + t.name);
+            if (soff % ALIGN)
+                throw std::runtime_error("q27: tensor scale offset is not 256-byte aligned: " +
+                                         t.name);
             if (!in_file(soff, t.scales_size))
                 throw std::runtime_error("q27: tensor scales out of range: " + t.name);
             t.scales = b + data_base + soff;
+        } else {
+            if (soff)
+                throw std::runtime_error("q27: tensor scale offset must be zero without scales: " +
+                                         t.name);
+            t.scales = nullptr;
         }
         const std::string payload_error = validate_tensor_payload(t);
         if (!payload_error.empty())

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -112,7 +112,17 @@ bool cuda_weight_dtype_supported(DType dtype) {
     }
     return false;
 }
-
+void validate_cuda_model(const Model& model) {
+    const Tensor& embedding=model.get("token_embd.weight");
+    if(embedding.dtype!=DType::Q8_G128)
+        throw std::runtime_error("q27 CUDA: token_embd.weight must be Q8_G128");
+    for(const Tensor& tensor:model.tensors) {
+        if(!cuda_weight_dtype_supported(tensor.dtype))
+            throw std::runtime_error("q27 CUDA: unsupported weight dtype " +
+                                     std::string(dtype_name(tensor.dtype)) +
+                                     " in " + tensor.name);
+    }
+}
 
 uint64_t Tensor::rows() const {
     if (shape.size() <= 1) return 1;

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include <cstring>
+#include <limits>
 #include <stdexcept>
 
 namespace q27 {
@@ -29,12 +30,21 @@ const char* dtype_name(DType t) {
 
 uint64_t Tensor::rows() const {
     if (shape.size() <= 1) return 1;
-    uint64_t r = 1;
-    for (size_t i = 0; i + 1 < shape.size(); i++) r *= shape[i];
-    return r;
+    uint64_t rows = 1;
+    for (size_t i = 0; i + 1 < shape.size(); i++) {
+        if (shape[i] && rows > std::numeric_limits<uint64_t>::max() / shape[i])
+            throw std::runtime_error("q27: tensor row count overflows uint64: " + name);
+        rows *= shape[i];
+    }
+    return rows;
 }
 uint64_t Tensor::cols() const { return shape.empty() ? 0 : shape.back(); }
-uint64_t Tensor::n_elements() const { return rows() * cols(); }
+uint64_t Tensor::n_elements() const {
+    const uint64_t row_count = rows(), column_count = cols();
+    if (column_count && row_count > std::numeric_limits<uint64_t>::max() / column_count)
+        throw std::runtime_error("q27: tensor element count overflows uint64: " + name);
+    return row_count * column_count;
+}
 
 const Tensor* Model::find(const std::string& name) const {
     auto it = index.find(name);
@@ -70,12 +80,12 @@ struct Cursor {
     const uint8_t* p;
     const uint8_t* end;
     template <typename T> T read() {
-        if (p + sizeof(T) > end) throw std::runtime_error("q27: truncated file");
+        if ((size_t)(end - p) < sizeof(T)) throw std::runtime_error("q27: truncated file");
         T v; std::memcpy(&v, p, sizeof(T)); p += sizeof(T);
         return v;
     }
     void bytes(void* dst, size_t n) {
-        if (p + n > end) throw std::runtime_error("q27: truncated file");
+        if (n > (size_t)(end - p)) throw std::runtime_error("q27: truncated file");
         std::memcpy(dst, p, n); p += n;
     }
 };
@@ -114,6 +124,7 @@ Model Model::open(const std::string& path) {
         uint8_t nd = c.read<uint8_t>();
         t.shape.resize(nd);
         for (uint8_t d = 0; d < nd; d++) t.shape[d] = c.read<uint64_t>();
+        (void)t.n_elements(); // reject overflowing shapes before any backend sees them
         uint64_t doff = c.read<uint64_t>();
         t.data_size   = c.read<uint64_t>();
         uint64_t soff = c.read<uint64_t>();
@@ -124,17 +135,24 @@ Model Model::open(const std::string& path) {
         m.tensors.push_back(std::move(t));
     }
     uint64_t table_end = (uint64_t)(c.p - b);
+    if (table_end > std::numeric_limits<uint64_t>::max() - (ALIGN - 1))
+        throw std::runtime_error("q27: tensor table size overflow");
     uint64_t data_base = (table_end + ALIGN - 1) / ALIGN * ALIGN;
+    const uint64_t file_size = (uint64_t)sz;
+    auto in_file = [&](uint64_t offset, uint64_t length) {
+        return data_base <= file_size && offset <= file_size - data_base &&
+               length <= file_size - data_base - offset;
+    };
 
     for (size_t i = 0; i < m.tensors.size(); i++) {
         Tensor& t = m.tensors[i];
         uint64_t doff = (uint64_t)(uintptr_t)t.data;
-        if (data_base + doff + t.data_size > sz)
+        if (!in_file(doff, t.data_size))
             throw std::runtime_error("q27: tensor data out of range: " + t.name);
         t.data = b + data_base + doff;
         if (t.scales) {
             uint64_t soff = (uint64_t)(uintptr_t)t.scales;
-            if (data_base + soff + t.scales_size > sz)
+            if (!in_file(soff, t.scales_size))
                 throw std::runtime_error("q27: tensor scales out of range: " + t.name);
             t.scales = b + data_base + soff;
         }

--- a/src/loader.h
+++ b/src/loader.h
@@ -58,8 +58,11 @@ struct Model {
     size_t map_size_ = 0;
 };
 
-// Reject model-wide dtype combinations the CUDA kernels cannot consume.
-// Call before constructing or populating a DeviceModel.
+// Reject one tensor whose dtype or CUDA-specific role is unsupported.
+// Selective upload paths validate only the tensor they request.
+void validate_cuda_tensor(const Tensor& tensor);
+// Reject model-wide CUDA incompatibilities and require the full engine schema.
 void validate_cuda_model(const Model& model);
+
 
 } // namespace q27

--- a/src/loader.h
+++ b/src/loader.h
@@ -28,6 +28,8 @@ struct Tensor {
 // Structural payload invariants shared by inspection and runtime loading.
 // Empty means valid; otherwise returns the first tensor-local failure.
 std::string validate_tensor_payload(const Tensor& tensor);
+bool cuda_weight_dtype_supported(DType dtype);
+
 
 struct Model {
     std::string meta_json;                        // raw JSON metadata blob

--- a/src/loader.h
+++ b/src/loader.h
@@ -58,4 +58,8 @@ struct Model {
     size_t map_size_ = 0;
 };
 
+// Reject model-wide dtype combinations the CUDA kernels cannot consume.
+// Call before constructing or populating a DeviceModel.
+void validate_cuda_model(const Model& model);
+
 } // namespace q27

--- a/src/loader.h
+++ b/src/loader.h
@@ -25,6 +25,10 @@ struct Tensor {
     uint64_t n_elements() const;
 };
 
+// Structural payload invariants shared by inspect and runtime validation.
+// Empty means valid; each string is a tensor-local failure description.
+std::vector<std::string> validate_tensor_payload(const Tensor& tensor);
+
 struct Model {
     std::string meta_json;                        // raw JSON metadata blob
     std::vector<Tensor> tensors;                  // file order

--- a/src/loader.h
+++ b/src/loader.h
@@ -7,7 +7,7 @@
 
 namespace q27 {
 
-enum class DType : uint8_t { F32 = 0, F16 = 1, Q8_G128 = 2, Q4_G64 = 3 };
+enum class DType : uint8_t { F32 = 0, F16 = 1, Q8_G128 = 2, Q4_G64 = 3, T2_G128 = 4, T3_G128 = 5, B1_G128 = 6 };
 
 const char* dtype_name(DType t);
 
@@ -41,6 +41,11 @@ struct Model {
     ~Model();
 
     static Model open(const std::string& path); // throws std::runtime_error
+
+    // Read-only mapped file range. Backends may wrap page-aligned subranges
+    // without copying; the Model must outlive every such device view.
+    const void* mapping_base() const { return map_base_; }
+    size_t mapping_size() const { return map_size_; }
 
   private:
     void* map_base_ = nullptr;

--- a/src/loader.h
+++ b/src/loader.h
@@ -25,9 +25,9 @@ struct Tensor {
     uint64_t n_elements() const;
 };
 
-// Structural payload invariants shared by inspect and runtime validation.
-// Empty means valid; each string is a tensor-local failure description.
-std::vector<std::string> validate_tensor_payload(const Tensor& tensor);
+// Structural payload invariants shared by inspection and runtime loading.
+// Empty means valid; otherwise returns the first tensor-local failure.
+std::string validate_tensor_payload(const Tensor& tensor);
 
 struct Model {
     std::string meta_json;                        // raw JSON metadata blob

--- a/src/sampling.h
+++ b/src/sampling.h
@@ -24,9 +24,16 @@ inline void validate_sampling(const SamplingParams& p) {
 }
 
 inline void validate_logits(const float* values,size_t count) {
-    for(size_t i=0;i<count;i++)
+    bool any_finite=false;
+    for(size_t i=0;i<count;i++) {
         if(std::isnan(values[i]))
             throw std::runtime_error("q27: logits contain NaN");
+        if(values[i]==std::numeric_limits<float>::infinity())
+            throw std::runtime_error("q27: logits contain positive infinity");
+        any_finite=any_finite || std::isfinite(values[i]);
+    }
+    if(!any_finite)
+        throw std::runtime_error("q27: logits contain no finite values");
 }
 
 inline uint32_t sample_logits_cpu(const std::vector<float>& logits,const SamplingParams& p,

--- a/src/sampling.h
+++ b/src/sampling.h
@@ -1,0 +1,370 @@
+#pragma once
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <stdexcept>
+#include <vector>
+
+namespace q27 {
+
+struct SamplingParams {
+    float temperature = 0.0f;
+    float top_p = 1.0f;
+    uint32_t top_k = 0;
+    uint64_t seed = 0;
+};
+
+inline void validate_sampling(const SamplingParams& p) {
+    if(!std::isfinite(p.temperature) || p.temperature<0.0f)
+        throw std::runtime_error("q27: temperature must be finite and non-negative");
+    if(!std::isfinite(p.top_p) || p.top_p<=0.0f || p.top_p>1.0f)
+        throw std::runtime_error("q27: top_p must be in (0,1]");
+}
+
+inline uint32_t sample_logits_cpu(const std::vector<float>& logits,const SamplingParams& p,
+                                  std::mt19937_64& random) {
+    validate_sampling(p);
+    if(logits.empty()) throw std::runtime_error("q27: logits are empty");
+    auto argmax=[&] {
+        return (uint32_t)std::distance(logits.begin(),std::max_element(logits.begin(),logits.end()));
+    };
+    if(p.temperature==0.0f || p.top_k==1) return argmax();
+
+    std::vector<uint32_t> order(logits.size());
+    for(uint32_t i=0;i<order.size();i++) order[i]=i;
+    // Ties break index-ascending (codex P2 on the boundary-tie fix): the
+    // candidates path already orders ties by index, and with boundary ties
+    // now inside the nucleus the two paths must map the same draw to the
+    // same token — unspecified sort order here would break that.
+    auto before=[&](uint32_t a,uint32_t b){return logits[a]!=logits[b]?logits[a]>logits[b]:a<b;};
+    const size_t keep=p.top_k?std::min<size_t>(p.top_k,order.size()):order.size();
+    if(keep<order.size()) {
+        std::partial_sort(order.begin(),order.begin()+keep,order.end(),before);
+        order.resize(keep);
+    } else std::sort(order.begin(),order.end(),before);
+
+    const double maximum=logits[order.front()]/(double)p.temperature;
+    std::vector<double> weights; weights.reserve(order.size()); double total=0.0;
+    for(uint32_t token:order) {
+        double weight=std::exp(logits[token]/(double)p.temperature-maximum);
+        if(!std::isfinite(weight)) weight=0.0;
+        weights.push_back(weight); total+=weight;
+    }
+    if(!(total>0.0)) return argmax();
+    if(p.top_p<1.0f) {
+        const double cutoff=total*p.top_p; double cumulative=0.0; size_t retained=0;
+        do { cumulative+=weights[retained++]; } while(retained<weights.size() && cumulative<cutoff);
+        // Boundary ties stay in the nucleus (parity audit 2026-07-17): the
+        // CUDA sampler keeps every token at or above its threshold value, so
+        // exact ties at the truncation boundary must not be dropped by sort
+        // order here. Extends through logits exactly equal to the boundary.
+        while(retained<weights.size() && logits[order[retained]]==logits[order[retained-1]])
+            cumulative+=weights[retained++];
+        order.resize(retained); weights.resize(retained); total=cumulative;
+    }
+    std::uniform_real_distribution<double> distribution(0.0,total);
+    double draw=distribution(random);
+    for(size_t i=0;i<order.size();i++) { draw-=weights[i]; if(draw<=0.0) return order[i]; }
+    return order.back();
+}
+
+// GPU-assisted sampling: sample from a candidate over-set — (value, index)
+// pairs guaranteed to contain the exact top-k — instead of the full logits
+// vector. Arithmetic mirrors sample_logits_cpu exactly (same descending
+// order over distinct values, same double-precision weight accumulation,
+// same single uniform draw), so same-seed token sequences match the
+// full-logits path whenever no exact-float tie crosses the top-k boundary.
+// Ties inside the candidate list use the same index-ascending order as the
+// full-logits path.
+inline uint32_t sample_candidates_cpu(const std::vector<float>& values,
+                                      const std::vector<uint32_t>& indices,
+                                      uint32_t count,const SamplingParams& p,
+                                      std::mt19937_64& random) {
+    validate_sampling(p);
+    if(!count) throw std::runtime_error("q27: candidate list is empty");
+    if(values.size()<count || indices.size()<count)
+        throw std::runtime_error("q27: candidate list shorter than count");
+    std::vector<uint32_t> order(count);
+    for(uint32_t i=0;i<count;i++) order[i]=i;
+    auto before=[&](uint32_t a,uint32_t b) {
+        return values[a]!=values[b] ? values[a]>values[b] : indices[a]<indices[b];
+    };
+    auto argmax=[&] {
+        return indices[*std::min_element(order.begin(),order.end(),before)];
+    };
+    if(p.temperature==0.0f || p.top_k==1) return argmax();
+
+    std::sort(order.begin(),order.end(),before);
+    const size_t keep=p.top_k?std::min<size_t>(p.top_k,count):count;
+    order.resize(keep);
+    const double maximum=values[order.front()]/(double)p.temperature;
+    std::vector<double> weights; weights.reserve(order.size()); double total=0.0;
+    for(uint32_t slot:order) {
+        double weight=std::exp(values[slot]/(double)p.temperature-maximum);
+        if(!std::isfinite(weight)) weight=0.0;
+        weights.push_back(weight); total+=weight;
+    }
+    if(!(total>0.0)) return argmax();
+    if(p.top_p<1.0f) {
+        const double cutoff=total*p.top_p; double cumulative=0.0; size_t retained=0;
+        do { cumulative+=weights[retained++]; } while(retained<weights.size() && cumulative<cutoff);
+        // Boundary ties stay in the nucleus — same rule as sample_logits_cpu
+        // (parity audit 2026-07-17), keyed on the exact candidate values.
+        while(retained<weights.size() && values[order[retained]]==values[order[retained-1]])
+            cumulative+=weights[retained++];
+        order.resize(retained); weights.resize(retained); total=cumulative;
+    }
+    std::uniform_real_distribution<double> distribution(0.0,total);
+    double draw=distribution(random);
+    for(size_t i=0;i<order.size();i++) { draw-=weights[i]; if(draw<=0.0) return indices[order[i]]; }
+    return indices[order.back()];
+}
+
+// ---- Spec rejection sampling (Metal sampled-MTP Phase 0) --------------------
+// Host-side Leviathan/Chen accept walk with greedy drafts (q = delta at draft).
+// Served p matches sample_logits_cpu (temp / top_p / top_k, boundary ties).
+// Used by Metal mtp_sample_round; CUDA already has device kernels for this.
+// See docs/metal/plans/2026-07-21-metal-sampled-mtp.md.
+
+// Unnormalized nucleus weights for one lane's logits under SamplingParams.
+// tokens[i] is a vocab id; weights[i] > 0; total = sum(weights). Empty when
+// the nucleus collapses (caller falls back to argmax).
+struct ServedDistribution {
+    std::vector<uint32_t> tokens;
+    std::vector<double> weights;
+    double total = 0.0;
+    uint32_t argmax_token = 0;
+};
+
+// Build the served nucleus from a contiguous logits row (length vocab).
+// temperature==0 or top_k==1 → delta at argmax (total=1, single token).
+inline ServedDistribution build_served_distribution(const float* logits,uint32_t vocab,
+                                                    const SamplingParams& p) {
+    validate_sampling(p);
+    if(!logits || !vocab) throw std::runtime_error("q27: logits/vocab empty for served dist");
+    ServedDistribution d;
+    uint32_t argmax = 0;
+    float best = logits[0];
+    for(uint32_t i=1;i<vocab;i++) {
+        if(logits[i]>best) { best=logits[i]; argmax=i; }
+    }
+    d.argmax_token = argmax;
+    if(p.temperature==0.0f || p.top_k==1) {
+        d.tokens.push_back(argmax);
+        d.weights.push_back(1.0);
+        d.total = 1.0;
+        return d;
+    }
+    std::vector<uint32_t> order(vocab);
+    for(uint32_t i=0;i<vocab;i++) order[i]=i;
+    auto before=[&](uint32_t a,uint32_t b){
+        return logits[a]!=logits[b]?logits[a]>logits[b]:a<b;
+    };
+    const size_t keep=p.top_k?std::min<size_t>(p.top_k,order.size()):order.size();
+    if(keep<order.size()) {
+        std::partial_sort(order.begin(),order.begin()+keep,order.end(),before);
+        order.resize(keep);
+    } else std::sort(order.begin(),order.end(),before);
+
+    const double maximum=logits[order.front()]/(double)p.temperature;
+    d.weights.reserve(order.size());
+    d.tokens.reserve(order.size());
+    for(uint32_t token:order) {
+        double weight=std::exp(logits[token]/(double)p.temperature-maximum);
+        if(!std::isfinite(weight)) weight=0.0;
+        d.tokens.push_back(token);
+        d.weights.push_back(weight);
+        d.total+=weight;
+    }
+    if(!(d.total>0.0)) {
+        d.tokens={argmax}; d.weights={1.0}; d.total=1.0;
+        return d;
+    }
+    if(p.top_p<1.0f) {
+        const double cutoff=d.total*p.top_p; double cumulative=0.0; size_t retained=0;
+        do { cumulative+=d.weights[retained++]; }
+        while(retained<d.weights.size() && cumulative<cutoff);
+        while(retained<d.weights.size() &&
+              logits[d.tokens[retained]]==logits[d.tokens[retained-1]])
+            cumulative+=d.weights[retained++];
+        d.tokens.resize(retained); d.weights.resize(retained); d.total=cumulative;
+    }
+    return d;
+}
+
+inline ServedDistribution build_served_distribution(const std::vector<float>& logits,
+                                                    const SamplingParams& p) {
+    return build_served_distribution(logits.data(),(uint32_t)logits.size(),p);
+}
+
+// Served nucleus from a GPU top-k over-set (value, index pairs containing the
+// true top-k). Arithmetic mirrors sample_candidates_cpu so accept probs match
+// plain sampling under the same top_k. Used by Metal mtp_sample_round to avoid
+// full-vocab readback when top_k is in 1..256.
+inline ServedDistribution build_served_from_candidates(const float* values,
+                                                       const uint32_t* indices,
+                                                       uint32_t count,
+                                                       const SamplingParams& p) {
+    validate_sampling(p);
+    if(!values || !indices || !count)
+        throw std::runtime_error("q27: empty candidates for served dist");
+    ServedDistribution d;
+    std::vector<uint32_t> order(count);
+    for(uint32_t i=0;i<count;i++) order[i]=i;
+    auto before=[&](uint32_t a,uint32_t b) {
+        return values[a]!=values[b] ? values[a]>values[b] : indices[a]<indices[b];
+    };
+    d.argmax_token = indices[*std::min_element(order.begin(),order.end(),before)];
+    if(p.temperature==0.0f || p.top_k==1) {
+        d.tokens.push_back(d.argmax_token);
+        d.weights.push_back(1.0);
+        d.total = 1.0;
+        return d;
+    }
+    std::sort(order.begin(),order.end(),before);
+    const size_t keep=p.top_k?std::min<size_t>(p.top_k,count):count;
+    order.resize(keep);
+    const double maximum=values[order.front()]/(double)p.temperature;
+    d.tokens.reserve(keep); d.weights.reserve(keep);
+    for(uint32_t slot:order) {
+        double weight=std::exp(values[slot]/(double)p.temperature-maximum);
+        if(!std::isfinite(weight)) weight=0.0;
+        d.tokens.push_back(indices[slot]);
+        d.weights.push_back(weight);
+        d.total+=weight;
+    }
+    if(!(d.total>0.0)) {
+        d.tokens={d.argmax_token}; d.weights={1.0}; d.total=1.0;
+        return d;
+    }
+    if(p.top_p<1.0f) {
+        const double cutoff=d.total*p.top_p; double cumulative=0.0; size_t retained=0;
+        do { cumulative+=d.weights[retained++]; }
+        while(retained<d.weights.size() && cumulative<cutoff);
+        while(retained<d.weights.size() &&
+              values[order[retained]]==values[order[retained-1]])
+            cumulative+=d.weights[retained++];
+        d.tokens.resize(retained); d.weights.resize(retained); d.total=cumulative;
+    }
+    return d;
+}
+
+// p_served(token) under the nucleus; 0 if outside. Uses mass renormalization
+// (weight/total) — required for top_p<1 accept tests (CUDA mass fix).
+inline double served_probability(const ServedDistribution& d,uint32_t token) {
+    if(!(d.total>0.0)) return 0.0;
+    for(size_t i=0;i<d.tokens.size();i++)
+        if(d.tokens[i]==token) return d.weights[i]/d.total;
+    return 0.0;
+}
+
+// Sample from the served nucleus, optionally excluding one token (residual
+// resample after a rejected draft). Never returns `exclude`. If exclude
+// removes all mass (singleton nucleus on the rejected draft), throws —
+// re-emitting the excluded token would violate the residual distribution
+// (codex P2 on Phase 0). Callers that need a soft fallback must widen the
+// nucleus (e.g. drop top_k) before sampling; the Metal sample round keeps
+// vocab-wide logits and only hits this when p(draft) was already ~1.
+inline uint32_t sample_served(const ServedDistribution& d,std::mt19937_64& random,
+                              int32_t exclude=-1) {
+    if(d.tokens.empty()) throw std::runtime_error("q27: empty served distribution");
+    double total=0.0;
+    for(size_t i=0;i<d.tokens.size();i++) {
+        if(exclude>=0 && (int32_t)d.tokens[i]==exclude) continue;
+        total+=d.weights[i];
+    }
+    if(!(total>0.0)) {
+        if(exclude>=0)
+            throw std::runtime_error("q27: empty residual after excluding draft from nucleus");
+        return d.argmax_token;
+    }
+    std::uniform_real_distribution<double> distribution(0.0,total);
+    double draw=distribution(random);
+    for(size_t i=0;i<d.tokens.size();i++) {
+        if(exclude>=0 && (int32_t)d.tokens[i]==exclude) continue;
+        draw-=d.weights[i];
+        if(draw<=0.0) return d.tokens[i];
+    }
+    // Numeric tail: last non-excluded (total>0 guarantees one exists).
+    for(size_t i=d.tokens.size();i-- > 0;) {
+        if(exclude<0 || (int32_t)d.tokens[i]!=exclude) return d.tokens[i];
+    }
+    throw std::runtime_error("q27: sample_served internal: no non-excluded token");
+}
+
+// Result of one speculative verify-tail rejection walk.
+// n = committed count (pending + accepted drafts), in 1..live.
+// stop_lane = lane whose logits produce the next pending (0..live-1).
+// exclude = rejected draft token, or -1 on all-accept (bonus sample).
+// pending = newly sampled next-round pending token.
+struct SpecRejectResult {
+    uint32_t n = 1;
+    uint32_t stop_lane = 0;
+    int32_t exclude = -1;
+    uint32_t pending = 0;
+};
+
+// Walk using pre-built per-lane served distributions (full-logits or top-k
+// candidates). draft_tokens length live-1. Pending is NOT re-sampled.
+// temperature==0 callers should use equality accept, not this path.
+inline SpecRejectResult spec_rejection_accept(const ServedDistribution* lane_dists,
+                                              uint32_t live,
+                                              const uint32_t* draft_tokens,
+                                              std::mt19937_64& random) {
+    if(!lane_dists || live<2)
+        throw std::runtime_error("q27: spec rejection needs live>=2 lanes");
+    if(!draft_tokens)
+        throw std::runtime_error("q27: spec rejection needs draft tokens");
+    const uint32_t max_draft = live - 1;
+    SpecRejectResult r;
+    r.stop_lane = max_draft; // all-accept → free bonus on last lane
+    r.exclude = -1;
+    for(uint32_t k=0;k<max_draft;k++) {
+        const double p = served_probability(lane_dists[k],draft_tokens[k]);
+        // u ~ U[0,1). Accept when u < p (CUDA k_spec_accept). p==0 ⇒ always reject.
+        std::uniform_real_distribution<double> unit(0.0,1.0);
+        const double u = unit(random);
+        if(u < p) continue;
+        r.stop_lane = k;
+        r.exclude = (int32_t)draft_tokens[k];
+        break;
+    }
+    r.n = r.stop_lane + 1;
+    r.pending = sample_served(lane_dists[r.stop_lane],random,r.exclude);
+    return r;
+}
+
+// lanes_logits: contiguous [live * vocab] floats from multi-lane verify.
+// draft_tokens: length live-1 — greedy proposals (lanes[1..live-1]).
+inline SpecRejectResult spec_rejection_accept(const float* lanes_logits,uint32_t live,
+                                              uint32_t vocab,
+                                              const uint32_t* draft_tokens,
+                                              const SamplingParams& params,
+                                              std::mt19937_64& random) {
+    validate_sampling(params);
+    if(!lanes_logits || live<2)
+        throw std::runtime_error("q27: spec rejection needs live>=2 lanes");
+    if(!draft_tokens)
+        throw std::runtime_error("q27: spec rejection needs draft tokens");
+    std::vector<ServedDistribution> dists(live);
+    for(uint32_t k=0;k<live;k++)
+        dists[k]=build_served_distribution(lanes_logits+(size_t)k*vocab,vocab,params);
+    return spec_rejection_accept(dists.data(),live,draft_tokens,random);
+}
+
+// Convenience overload: drafts as vector; lanes as flat vector length live*vocab.
+inline SpecRejectResult spec_rejection_accept(const std::vector<float>& lanes_logits,
+                                              uint32_t live,uint32_t vocab,
+                                              const std::vector<uint32_t>& drafts,
+                                              const SamplingParams& params,
+                                              std::mt19937_64& random) {
+    if(drafts.size()+1!=live)
+        throw std::runtime_error("q27: drafts size must be live-1");
+    if(lanes_logits.size()<(size_t)live*vocab)
+        throw std::runtime_error("q27: lanes_logits shorter than live*vocab");
+    return spec_rejection_accept(lanes_logits.data(),live,vocab,drafts.data(),params,random);
+}
+
+} // namespace q27

--- a/src/sampling.h
+++ b/src/sampling.h
@@ -137,11 +137,11 @@ inline uint32_t sample_candidates_cpu(const std::vector<float>& values,
     return indices[order.back()];
 }
 
-// ---- Spec rejection sampling (Metal sampled-MTP Phase 0) --------------------
+// ---- Backend rejection sampling -------------------------------------------
 // Host-side Leviathan/Chen accept walk with greedy drafts (q = delta at draft).
 // Served p matches sample_logits_cpu (temp / top_p / top_k, boundary ties).
-// Used by Metal mtp_sample_round; CUDA already has device kernels for this.
-// See docs/metal/plans/2026-07-21-metal-sampled-mtp.md.
+// Backends may use this implementation directly or provide an equivalent
+// device-side path.
 
 // Unnormalized nucleus weights for one lane's logits under SamplingParams.
 // tokens[i] is a vocab id; weights[i] > 0; total = sum(weights). Empty when
@@ -215,10 +215,10 @@ inline ServedDistribution build_served_distribution(const std::vector<float>& lo
     return build_served_distribution(logits.data(),(uint32_t)logits.size(),p);
 }
 
-// Served nucleus from a GPU top-k over-set (value, index pairs containing the
-// true top-k). Arithmetic mirrors sample_candidates_cpu so accept probs match
-// plain sampling under the same top_k. Used by Metal mtp_sample_round to avoid
-// full-vocab readback when top_k is in 1..256.
+// Served nucleus from a top-k over-set (value, index pairs containing the true
+// top-k). Arithmetic mirrors sample_candidates_cpu so accept probabilities
+// match plain sampling under the same top_k without a full-vocabulary transfer
+// when top_k is in 1..256.
 inline ServedDistribution build_served_from_candidates(const float* values,
                                                        const uint32_t* indices,
                                                        uint32_t count,
@@ -278,12 +278,10 @@ inline double served_probability(const ServedDistribution& d,uint32_t token) {
 }
 
 // Sample from the served nucleus, optionally excluding one token (residual
-// resample after a rejected draft). Never returns `exclude`. If exclude
-// removes all mass (singleton nucleus on the rejected draft), throws —
-// re-emitting the excluded token would violate the residual distribution
-// Callers that need a soft fallback must widen the nucleus (e.g. drop top_k)
-// before sampling; the Metal sample round keeps
-// vocab-wide logits and only hits this when p(draft) was already ~1.
+// resample after a rejected draft). Never returns `exclude`. If exclude removes
+// all mass (singleton nucleus on the rejected draft), throws: re-emitting the
+// excluded token would violate the residual distribution. Callers needing a
+// soft fallback must widen the nucleus before sampling.
 inline uint32_t sample_served(const ServedDistribution& d,std::mt19937_64& random,
                               int32_t exclude=-1) {
     if(d.tokens.empty()) throw std::runtime_error("q27: empty served distribution");

--- a/src/sampling.h
+++ b/src/sampling.h
@@ -23,10 +23,17 @@ inline void validate_sampling(const SamplingParams& p) {
         throw std::runtime_error("q27: top_p must be in (0,1]");
 }
 
+inline void validate_logits(const float* values,size_t count) {
+    for(size_t i=0;i<count;i++)
+        if(std::isnan(values[i]))
+            throw std::runtime_error("q27: logits contain NaN");
+}
+
 inline uint32_t sample_logits_cpu(const std::vector<float>& logits,const SamplingParams& p,
                                   std::mt19937_64& random) {
     validate_sampling(p);
     if(logits.empty()) throw std::runtime_error("q27: logits are empty");
+    validate_logits(logits.data(),logits.size());
     auto argmax=[&] {
         return (uint32_t)std::distance(logits.begin(),std::max_element(logits.begin(),logits.end()));
     };
@@ -86,6 +93,7 @@ inline uint32_t sample_candidates_cpu(const std::vector<float>& values,
     if(!count) throw std::runtime_error("q27: candidate list is empty");
     if(values.size()<count || indices.size()<count)
         throw std::runtime_error("q27: candidate list shorter than count");
+    validate_logits(values.data(),count);
     std::vector<uint32_t> order(count);
     for(uint32_t i=0;i<count;i++) order[i]=i;
     auto before=[&](uint32_t a,uint32_t b) {
@@ -144,6 +152,7 @@ inline ServedDistribution build_served_distribution(const float* logits,uint32_t
                                                     const SamplingParams& p) {
     validate_sampling(p);
     if(!logits || !vocab) throw std::runtime_error("q27: logits/vocab empty for served dist");
+    validate_logits(logits,vocab);
     ServedDistribution d;
     uint32_t argmax = 0;
     float best = logits[0];
@@ -210,6 +219,7 @@ inline ServedDistribution build_served_from_candidates(const float* values,
     validate_sampling(p);
     if(!values || !indices || !count)
         throw std::runtime_error("q27: empty candidates for served dist");
+    validate_logits(values,count);
     ServedDistribution d;
     std::vector<uint32_t> order(count);
     for(uint32_t i=0;i<count;i++) order[i]=i;

--- a/src/sampling.h
+++ b/src/sampling.h
@@ -48,7 +48,7 @@ inline uint32_t sample_logits_cpu(const std::vector<float>& logits,const Samplin
 
     std::vector<uint32_t> order(logits.size());
     for(uint32_t i=0;i<order.size();i++) order[i]=i;
-    // Ties break index-ascending (codex P2 on the boundary-tie fix): the
+    // Ties break index-ascending: the
     // candidates path already orders ties by index, and with boundary ties
     // now inside the nucleus the two paths must map the same draw to the
     // same token — unspecified sort order here would break that.
@@ -70,7 +70,7 @@ inline uint32_t sample_logits_cpu(const std::vector<float>& logits,const Samplin
     if(p.top_p<1.0f) {
         const double cutoff=total*p.top_p; double cumulative=0.0; size_t retained=0;
         do { cumulative+=weights[retained++]; } while(retained<weights.size() && cumulative<cutoff);
-        // Boundary ties stay in the nucleus (parity audit 2026-07-17): the
+        // Boundary ties stay in the nucleus: the
         // CUDA sampler keeps every token at or above its threshold value, so
         // exact ties at the truncation boundary must not be dropped by sort
         // order here. Extends through logits exactly equal to the boundary.
@@ -125,8 +125,8 @@ inline uint32_t sample_candidates_cpu(const std::vector<float>& values,
     if(p.top_p<1.0f) {
         const double cutoff=total*p.top_p; double cumulative=0.0; size_t retained=0;
         do { cumulative+=weights[retained++]; } while(retained<weights.size() && cumulative<cutoff);
-        // Boundary ties stay in the nucleus — same rule as sample_logits_cpu
-        // (parity audit 2026-07-17), keyed on the exact candidate values.
+        // Boundary ties stay in the nucleus, using the same rule as
+        // sample_logits_cpu and keyed on exact candidate values.
         while(retained<weights.size() && values[order[retained]]==values[order[retained-1]])
             cumulative+=weights[retained++];
         order.resize(retained); weights.resize(retained); total=cumulative;
@@ -281,8 +281,8 @@ inline double served_probability(const ServedDistribution& d,uint32_t token) {
 // resample after a rejected draft). Never returns `exclude`. If exclude
 // removes all mass (singleton nucleus on the rejected draft), throws —
 // re-emitting the excluded token would violate the residual distribution
-// (codex P2 on Phase 0). Callers that need a soft fallback must widen the
-// nucleus (e.g. drop top_k) before sampling; the Metal sample round keeps
+// Callers that need a soft fallback must widen the nucleus (e.g. drop top_k)
+// before sampling; the Metal sample round keeps
 // vocab-wide logits and only hits this when p(draft) was already ~1.
 inline uint32_t sample_served(const ServedDistribution& d,std::mt19937_64& random,
                               int32_t exclude=-1) {

--- a/src/test_kernels.cu
+++ b/src/test_kernels.cu
@@ -14,6 +14,7 @@
 #include "kernels.cuh"
 #include "loader.h"
 #include "prefill.cuh"
+#include "sampling.h"
 #include "spec3.cuh"
 #include "turbo3.cuh"
 #include "turbo5.cuh"
@@ -2450,6 +2451,56 @@ static void test_wy_stream_isolation() {
     unsetenv("Q27_DS_MODE");
 }
 
+static void check_nucleus_contract(const char* name, const std::vector<float>& logits,
+                                   float temperature, float top_p) {
+    float* d_logits;
+    float* d_nucleus;
+    q27k::SampleParams* d_params;
+    CUDA_CHECK(cudaMalloc(&d_logits, logits.size() * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&d_nucleus, 4 * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&d_params, sizeof(q27k::SampleParams)));
+    CUDA_CHECK(cudaMemcpy(d_logits, logits.data(), logits.size() * sizeof(float),
+                          cudaMemcpyHostToDevice));
+
+    const q27k::SampleParams device_params{1.0f / temperature, top_p, 0};
+    CUDA_CHECK(cudaMemcpy(d_params, &device_params, sizeof device_params,
+                          cudaMemcpyHostToDevice));
+    q27k::nucleus(d_logits, (int)logits.size(), d_params, d_nucleus);
+    float nucleus[4];
+    CUDA_CHECK(cudaMemcpy(nucleus, d_nucleus, sizeof nucleus, cudaMemcpyDeviceToHost));
+
+    const q27::SamplingParams host_params{temperature, top_p, 0, 0};
+    const auto host = q27::build_served_distribution(logits, host_params);
+    std::vector<uint8_t> host_kept(logits.size(), 0);
+    for (uint32_t token : host.tokens) host_kept[token] = 1;
+
+    int support_mismatches = 0;
+    double max_probability_error = 0.0;
+    for (uint32_t token = 0; token < logits.size(); token++) {
+        const bool device_kept = logits[token] >= nucleus[0];
+        support_mismatches += device_kept != (host_kept[token] != 0);
+        const double device_probability =
+            device_kept
+                ? std::exp((double)device_params.inv_temp * (logits[token] - nucleus[1]) -
+                           nucleus[2]) /
+                      nucleus[3]
+                : 0.0;
+        max_probability_error =
+            std::max(max_probability_error,
+                     std::fabs(device_probability - q27::served_probability(host, token)));
+    }
+
+    char label[128];
+    std::snprintf(label, sizeof label, "%s support", name);
+    check(label, (double)support_mismatches, 0.5);
+    std::snprintf(label, sizeof label, "%s probabilities", name);
+    check(label, max_probability_error, 2e-5);
+
+    CUDA_CHECK(cudaFree(d_logits));
+    CUDA_CHECK(cudaFree(d_nucleus));
+    CUDA_CHECK(cudaFree(d_params));
+}
+
 // Sampling Phase 1: nucleus stats + top-p threshold + Gumbel-max, on synthetic
 // logits (no model). Greedy argmax is untouched by construction -- this only
 // exercises the new sample() path (temp>0). Determinism lets every check use a
@@ -2459,6 +2510,13 @@ static void test_sample() {
     // spread logits so a few tokens dominate (realistic nucleus shapes)
     std::vector<float> x = rand_vec(n, 4242);
     for (auto& v : x) v *= 2.5f;
+    check_nucleus_contract("sample host/CUDA T=0.8 p=0.95", x, 0.8f, 0.95f);
+    check_nucleus_contract("sample host/CUDA T=1.5 p=0.95", x, 1.5f, 0.95f);
+    std::vector<float> tied(64, -5.0f);
+    tied[0] = 4.0f;
+    tied[1] = 3.0f;
+    tied[2] = tied[3] = tied[4] = 2.0f;
+    check_nucleus_contract("sample host/CUDA cutoff ties", tied, 1.0f, 0.8f);
     // CPU argmax + full-softmax probs at a given inv_temp
     auto cpu_argmax = [&]() {
         int bi = 0; for (int i = 1; i < n; i++) if (x[i] > x[bi]) bi = i; return bi;

--- a/src/test_loader_contracts.cpp
+++ b/src/test_loader_contracts.cpp
@@ -2,6 +2,8 @@
 
 #include <cstdio>
 
+#include <stdexcept>
+
 int main() {
     using q27::DType;
 
@@ -18,6 +20,44 @@ int main() {
                          q27::dtype_name(dtype));
             return 1;
         }
+    }
+
+    q27::Model model;
+    q27::Tensor embedding;
+    embedding.name = "token_embd.weight";
+    embedding.dtype = DType::Q8_G128;
+    model.index.emplace(embedding.name, model.tensors.size());
+    model.tensors.push_back(embedding);
+    q27::validate_cuda_model(model);
+
+    q27::Tensor packed;
+    packed.name = "blk.0.ffn_gate.weight";
+    packed.dtype = DType::T2_G128;
+    model.index.emplace(packed.name, model.tensors.size());
+    model.tensors.push_back(packed);
+    bool packed_rejected = false;
+    try {
+        q27::validate_cuda_model(model);
+    } catch (const std::runtime_error& error) {
+        packed_rejected = std::string(error.what()).find(
+            "unsupported weight dtype T2_G128") != std::string::npos;
+    }
+    if (!packed_rejected) {
+        std::fputs("Metal-only model was accepted by CUDA\n", stderr);
+        return 1;
+    }
+
+    model.tensors[0].dtype = DType::T2_G128;
+    bool embedding_rejected = false;
+    try {
+        q27::validate_cuda_model(model);
+    } catch (const std::runtime_error& error) {
+        embedding_rejected = std::string(error.what()).find(
+            "token_embd.weight must be Q8_G128") != std::string::npos;
+    }
+    if (!embedding_rejected) {
+        std::fputs("non-Q8 CUDA embedding was accepted\n", stderr);
+        return 1;
     }
 
     uint8_t data[128] = {};

--- a/src/test_loader_contracts.cpp
+++ b/src/test_loader_contracts.cpp
@@ -1,0 +1,45 @@
+#include "loader.h"
+
+#include <cstdio>
+
+int main() {
+    using q27::DType;
+
+    for (DType dtype : {DType::F32, DType::F16, DType::Q8_G128, DType::Q4_G64}) {
+        if (!q27::cuda_weight_dtype_supported(dtype)) {
+            std::fprintf(stderr, "CUDA-compatible dtype rejected: %s\n",
+                         q27::dtype_name(dtype));
+            return 1;
+        }
+    }
+    for (DType dtype : {DType::T2_G128, DType::T3_G128, DType::B1_G128}) {
+        if (q27::cuda_weight_dtype_supported(dtype)) {
+            std::fprintf(stderr, "Metal-only packed dtype accepted by CUDA: %s\n",
+                         q27::dtype_name(dtype));
+            return 1;
+        }
+    }
+
+    uint8_t data[128] = {};
+    uint8_t scales[2] = {};
+    q27::Tensor tensor;
+    tensor.name = "test.q8";
+    tensor.dtype = DType::Q8_G128;
+    tensor.shape = {1, 128};
+    tensor.data = data;
+    tensor.data_size = sizeof(data);
+    tensor.scales_size = sizeof(scales);
+    if (q27::validate_tensor_payload(tensor) != "scale payload is missing") {
+        std::fputs("missing quantization scales were accepted\n", stderr);
+        return 1;
+    }
+    tensor.data = nullptr;
+    tensor.scales = scales;
+    if (q27::validate_tensor_payload(tensor) != "data payload is missing") {
+        std::fputs("missing tensor data were accepted\n", stderr);
+        return 1;
+    }
+
+    std::puts("loader CUDA dtype contracts: PASS");
+    return 0;
+}

--- a/src/test_loader_contracts.cpp
+++ b/src/test_loader_contracts.cpp
@@ -21,6 +21,11 @@ int main() {
             return 1;
         }
     }
+    q27::Tensor selective;
+    selective.name = "blk.0.ffn_gate.weight";
+    selective.dtype = DType::Q4_G64;
+    q27::validate_cuda_tensor(selective);
+
 
     q27::Model model;
     q27::Tensor embedding;
@@ -46,6 +51,18 @@ int main() {
         std::fputs("Metal-only model was accepted by CUDA\n", stderr);
         return 1;
     }
+    bool selective_packed_rejected = false;
+    try {
+        q27::validate_cuda_tensor(packed);
+    } catch (const std::runtime_error& error) {
+        selective_packed_rejected = std::string(error.what()).find(
+            "unsupported weight dtype T2_G128") != std::string::npos;
+    }
+    if (!selective_packed_rejected) {
+        std::fputs("Metal-only selective tensor was accepted by CUDA\n", stderr);
+        return 1;
+    }
+
 
     model.tensors[0].dtype = DType::T2_G128;
     bool embedding_rejected = false;

--- a/src/test_loader_contracts.cpp
+++ b/src/test_loader_contracts.cpp
@@ -16,7 +16,7 @@ int main() {
     }
     for (DType dtype : {DType::T2_G128, DType::T3_G128, DType::B1_G128}) {
         if (q27::cuda_weight_dtype_supported(dtype)) {
-            std::fprintf(stderr, "Metal-only packed dtype accepted by CUDA: %s\n",
+            std::fprintf(stderr, "CUDA-unsupported packed dtype accepted: %s\n",
                          q27::dtype_name(dtype));
             return 1;
         }
@@ -48,7 +48,7 @@ int main() {
             "unsupported weight dtype T2_G128") != std::string::npos;
     }
     if (!packed_rejected) {
-        std::fputs("Metal-only model was accepted by CUDA\n", stderr);
+        std::fputs("CUDA-unsupported packed model was accepted\n", stderr);
         return 1;
     }
     bool selective_packed_rejected = false;
@@ -59,7 +59,7 @@ int main() {
             "unsupported weight dtype T2_G128") != std::string::npos;
     }
     if (!selective_packed_rejected) {
-        std::fputs("Metal-only selective tensor was accepted by CUDA\n", stderr);
+        std::fputs("CUDA-unsupported packed tensor was accepted\n", stderr);
         return 1;
     }
 

--- a/src/test_sampling.cpp
+++ b/src/test_sampling.cpp
@@ -112,6 +112,86 @@ int main() {
             if (q27::sample_served(distribution, residual_rng, 2) == 2) return 1;
     }
 
+    // The rejection walk commits the pending token plus accepted drafts,
+    // stops on the first p=0 draft, and samples the next pending from that
+    // lane's residual distribution.
+    auto point_mass = [](uint32_t token) {
+        q27::ServedDistribution d;
+        d.argmax_token = token;
+        d.tokens = {token};
+        d.weights = {1.0};
+        d.total = 1.0;
+        return d;
+    };
+    {
+        std::vector<q27::ServedDistribution> lanes = {point_mass(7), point_mass(8)};
+        const uint32_t drafts[] = {99};
+        std::mt19937_64 reject_rng(1);
+        const auto result = q27::spec_rejection_accept(
+            lanes.data(), (uint32_t)lanes.size(), drafts, reject_rng);
+        if (result.n != 1 || result.stop_lane != 0 || result.exclude != 99 ||
+            result.pending != 7)
+            return 1;
+    }
+    {
+        std::vector<q27::ServedDistribution> lanes = {
+            point_mass(1), point_mass(7), point_mass(9)};
+        const uint32_t drafts[] = {1, 99};
+        std::mt19937_64 reject_rng(2);
+        const auto result = q27::spec_rejection_accept(
+            lanes.data(), (uint32_t)lanes.size(), drafts, reject_rng);
+        if (result.n != 2 || result.stop_lane != 1 || result.exclude != 99 ||
+            result.pending != 7)
+            return 1;
+    }
+
+    // p=1 drafts all commit and the last verify lane supplies the free bonus.
+    {
+        const float masked = -std::numeric_limits<float>::infinity();
+        const std::vector<float> lanes = {
+            0.0f, masked, masked,
+            masked, 0.0f, masked,
+            masked, masked, 0.0f,
+        };
+        const std::vector<uint32_t> drafts = {0, 1};
+        std::mt19937_64 accept_rng(3);
+        const auto result = q27::spec_rejection_accept(
+            lanes, 3, 3, drafts, {1.0f, 1.0f, 0, 0}, accept_rng);
+        if (result.n != 3 || result.stop_lane != 2 || result.exclude != -1 ||
+            result.pending != 2)
+            return 1;
+    }
+
+    // Nucleus probabilities are renormalized over retained mass, and a
+    // shuffled candidate-built distribution drives the same rejection walk.
+    {
+        const std::vector<float> full = {
+            std::log(4.0f), std::log(3.0f), std::log(2.0f), 0.0f};
+        const std::vector<uint32_t> ids = {2, 0, 3, 1};
+        const std::vector<float> values = {full[2], full[0], full[3], full[1]};
+        const q27::SamplingParams nucleus{1.0f, 0.5f, 0, 0};
+        const auto full_dist = q27::build_served_distribution(full, nucleus);
+        const auto candidate_dist = q27::build_served_from_candidates(
+            values.data(), ids.data(), (uint32_t)ids.size(), nucleus);
+        const double p0 = q27::served_probability(candidate_dist, 0);
+        const double p1 = q27::served_probability(candidate_dist, 1);
+        if (candidate_dist.tokens != full_dist.tokens ||
+            candidate_dist.weights != full_dist.weights ||
+            candidate_dist.total != full_dist.total ||
+            std::fabs(p0 - 4.0 / 7.0) > 1e-6 ||
+            std::fabs(p0 + p1 - 1.0) > 1e-12)
+            return 1;
+        std::vector<q27::ServedDistribution> lanes = {
+            candidate_dist, point_mass(9)};
+        const uint32_t drafts[] = {99};
+        std::mt19937_64 candidate_rng(4);
+        const auto result = q27::spec_rejection_accept(
+            lanes.data(), (uint32_t)lanes.size(), drafts, candidate_rng);
+        if (result.n != 1 || result.stop_lane != 0 || result.exclude != 99 ||
+            (result.pending != 0 && result.pending != 1))
+            return 1;
+    }
+
     std::puts("CPU sampling: PASS");
     return 0;
 }

--- a/src/test_sampling.cpp
+++ b/src/test_sampling.cpp
@@ -29,6 +29,29 @@ int main() {
     }
     if (!rejected) return 1;
 
+    // NaNs must never reach argmax or sorting comparators; -inf remains a
+    // valid mask value.
+    {
+        std::vector<float> nan_logits = {
+            std::numeric_limits<float>::quiet_NaN(), 1.0f,
+            -std::numeric_limits<float>::infinity()
+        };
+        std::vector<uint32_t> ids = {0, 1, 2};
+        int throws = 0;
+        try { (void)q27::sample_logits_cpu(nan_logits, greedy, rng); }
+        catch (const std::runtime_error&) { throws++; }
+        try { (void)q27::sample_candidates_cpu(nan_logits, ids, 3, greedy, rng); }
+        catch (const std::runtime_error&) { throws++; }
+        try { (void)q27::build_served_distribution(nan_logits, greedy); }
+        catch (const std::runtime_error&) { throws++; }
+        try { (void)q27::build_served_from_candidates(
+            nan_logits.data(), ids.data(), 3, greedy); }
+        catch (const std::runtime_error&) { throws++; }
+        if (throws != 4) return 1;
+        std::vector<float> masked = {-std::numeric_limits<float>::infinity(), 1.0f};
+        if (q27::sample_logits_cpu(masked, greedy, rng) != 1) return 1;
+    }
+
     // A shuffled exact top-k over-set must consume RNG and select tokens
     // identically to the full-logits path.
     {

--- a/src/test_sampling.cpp
+++ b/src/test_sampling.cpp
@@ -29,26 +29,29 @@ int main() {
     }
     if (!rejected) return 1;
 
-    // NaNs must never reach argmax or sorting comparators; -inf remains a
-    // valid mask value.
+    // NaNs, positive infinity, and fully masked rows cannot define a served
+    // distribution. Negative infinity remains a valid mask when at least one
+    // finite logit survives.
     {
-        std::vector<float> nan_logits = {
-            std::numeric_limits<float>::quiet_NaN(), 1.0f,
-            -std::numeric_limits<float>::infinity()
-        };
         std::vector<uint32_t> ids = {0, 1, 2};
-        int throws = 0;
-        try { (void)q27::sample_logits_cpu(nan_logits, greedy, rng); }
-        catch (const std::runtime_error&) { throws++; }
-        try { (void)q27::sample_candidates_cpu(nan_logits, ids, 3, greedy, rng); }
-        catch (const std::runtime_error&) { throws++; }
-        try { (void)q27::build_served_distribution(nan_logits, greedy); }
-        catch (const std::runtime_error&) { throws++; }
-        try { (void)q27::build_served_from_candidates(
-            nan_logits.data(), ids.data(), 3, greedy); }
-        catch (const std::runtime_error&) { throws++; }
-        if (throws != 4) return 1;
-        std::vector<float> masked = {-std::numeric_limits<float>::infinity(), 1.0f};
+        auto rejected_by_all = [&](const std::vector<float>& invalid) {
+            int throws = 0;
+            try { (void)q27::sample_logits_cpu(invalid, greedy, rng); }
+            catch (const std::runtime_error&) { throws++; }
+            try { (void)q27::sample_candidates_cpu(invalid, ids, 3, greedy, rng); }
+            catch (const std::runtime_error&) { throws++; }
+            try { (void)q27::build_served_distribution(invalid, greedy); }
+            catch (const std::runtime_error&) { throws++; }
+            try { (void)q27::build_served_from_candidates(
+                invalid.data(), ids.data(), 3, greedy); }
+            catch (const std::runtime_error&) { throws++; }
+            return throws == 4;
+        };
+        const float inf = std::numeric_limits<float>::infinity();
+        if (!rejected_by_all({std::numeric_limits<float>::quiet_NaN(), 1.0f, -inf})) return 1;
+        if (!rejected_by_all({inf, 1.0f, -inf})) return 1;
+        if (!rejected_by_all({-inf, -inf, -inf})) return 1;
+        std::vector<float> masked = {-inf, 1.0f};
         if (q27::sample_logits_cpu(masked, greedy, rng) != 1) return 1;
     }
 

--- a/src/test_sampling.cpp
+++ b/src/test_sampling.cpp
@@ -1,0 +1,91 @@
+#include "sampling.h"
+
+#include <cstdio>
+#include <random>
+#include <vector>
+
+int main() {
+    std::vector<float> logits = {-2.0f, 1.0f, 4.0f, 3.0f};
+    q27::SamplingParams greedy;
+    std::mt19937_64 rng(1);
+    if (q27::sample_logits_cpu(logits, greedy, rng) != 2) return 1;
+
+    q27::SamplingParams k1{0.8f, 1.0f, 1, 7};
+    for (int i = 0; i < 20; i++)
+        if (q27::sample_logits_cpu(logits, k1, rng) != 2) return 1;
+
+    q27::SamplingParams sampled{1.0f, 0.9f, 3, 12345};
+    std::mt19937_64 a(sampled.seed), b(sampled.seed);
+    for (int i = 0; i < 100; i++)
+        if (q27::sample_logits_cpu(logits, sampled, a) !=
+            q27::sample_logits_cpu(logits, sampled, b))
+            return 1;
+
+    bool rejected = false;
+    try {
+        q27::sample_logits_cpu(logits, {1.0f, 0.0f, 0, 0}, rng);
+    } catch (const std::runtime_error&) {
+        rejected = true;
+    }
+    if (!rejected) return 1;
+
+    // A shuffled exact top-k over-set must consume RNG and select tokens
+    // identically to the full-logits path.
+    {
+        const uint32_t n = 4096, k = 40, count = 57;
+        std::vector<float> full(n);
+        uint32_t state = 2468;
+        for (float& value : full) {
+            state = state * 1664525u + 1013904223u;
+            value = (float)(state >> 8) / 8388608.0f * 12.0f - 6.0f;
+        }
+        std::vector<uint32_t> rank(n);
+        for (uint32_t i = 0; i < n; i++) rank[i] = i;
+        std::sort(rank.begin(), rank.end(), [&](uint32_t x, uint32_t y) {
+            return full[x] != full[y] ? full[x] > full[y] : x < y;
+        });
+        std::vector<float> values(count);
+        std::vector<uint32_t> indices(count);
+        for (uint32_t i = 0; i < count; i++) {
+            indices[i] = rank[(i * 17) % count];
+            values[i] = full[indices[i]];
+        }
+        q27::SamplingParams params{0.9f, 0.95f, k, 777};
+        std::mt19937_64 full_rng(params.seed), candidate_rng(params.seed);
+        for (int i = 0; i < 100; i++) {
+            uint32_t want = q27::sample_logits_cpu(full, params, full_rng);
+            uint32_t got = q27::sample_candidates_cpu(
+                values, indices, count, params, candidate_rng);
+            if (got != want || !(candidate_rng == full_rng)) return 1;
+        }
+    }
+
+    // Exact ties at the top-p cutoff all remain reachable and both sampling
+    // paths map the same random draw to the same token.
+    {
+        std::vector<float> tied = {0.0f, 0.0f, 0.0f, -100.0f};
+        std::vector<uint32_t> ids = {0, 1, 2, 3};
+        q27::SamplingParams params{1.0f, 0.5f, 0, 9001};
+        std::mt19937_64 full_rng(params.seed), candidate_rng(params.seed);
+        bool seen[3] = {};
+        for (int i = 0; i < 300; i++) {
+            uint32_t want = q27::sample_logits_cpu(tied, params, full_rng);
+            uint32_t got = q27::sample_candidates_cpu(
+                tied, ids, (uint32_t)tied.size(), params, candidate_rng);
+            if (got != want || got > 2) return 1;
+            seen[got] = true;
+        }
+        if (!(seen[0] && seen[1] && seen[2])) return 1;
+    }
+
+    // Residual sampling never re-emits an excluded draft token.
+    {
+        auto distribution = q27::build_served_distribution(logits, {1.0f, 1.0f, 0, 0});
+        std::mt19937_64 residual_rng(99);
+        for (int i = 0; i < 500; i++)
+            if (q27::sample_served(distribution, residual_rng, 2) == 2) return 1;
+    }
+
+    std::puts("CPU sampling: PASS");
+    return 0;
+}

--- a/src/tokenizer.h
+++ b/src/tokenizer.h
@@ -3,6 +3,7 @@
 // regex for ASCII + "non-ASCII == letter" approximation; exactness is gated
 // against llama-tokenize on an English/code corpus (see test_tokenizer).
 #pragma once
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -16,6 +17,10 @@ class Tokenizer {
     std::vector<int> encode(const std::string& text) const; // handles special tokens
     std::string decode(const std::vector<int>& ids) const;
     std::string decode_one(int id) const;
+
+    // Vocabulary size. Backends that build their own logit buffers need it
+    // without reaching into the tokenizer's internals.
+    size_t vocab_size() const { return tokens_.size(); }
 
     int bos() const { return bos_; }
     int eos() const { return eos_; }

--- a/tools/test_inspect.py
+++ b/tools/test_inspect.py
@@ -26,7 +26,9 @@ def align(value):
 
 def make_fixture(path, corrupt_size=False, misaligned=False, bad_t2=False,
                  bad_t3_range=False, bad_t3_padding=False, overflow=False,
-                 bad_offset=False, zero_scale_offset=False, bad_dtype=False):
+                 bad_offset=False, zero_scale_offset=False, bad_dtype=False,
+                 bad_data_alignment=False, bad_scale_alignment=False,
+                 nonzero_absent_scale_offset=False):
     meta = b'{}'
     entries = []
     blobs = bytearray()
@@ -39,7 +41,9 @@ def make_fixture(path, corrupt_size=False, misaligned=False, bad_t2=False,
         if overflow and dtype == 5:
             shape = [(1 << 63) + 1, 128]
         data_off = align(len(blobs))
-        stored_data_off = (1 << 64) - 128 if bad_offset and dtype == 4 else data_off
+        stored_data_off = (1 << 64) - 256 if bad_offset and dtype == 4 else data_off
+        if bad_data_alignment and index == 0:
+            stored_data_off += 1
         blobs.extend(b'\0' * (data_off - len(blobs)))
         stored_data_size = data_size + (1 if corrupt_size and index == 1 else 0)
         data = bytearray(bytes([index + 1]) * stored_data_size)
@@ -62,13 +66,19 @@ def make_fixture(path, corrupt_size=False, misaligned=False, bad_t2=False,
             blobs.extend(b'\0<' * (scale_size // 2))
             if zero_scale_offset and index == 1:
                 scale_off = 0
+        stored_scale_off = scale_off
+        if bad_scale_alignment and index == 0:
+            stored_scale_off += 1
+        if nonzero_absent_scale_offset and index == 4:
+            stored_scale_off = ALIGN
 
         name_bytes = name.encode()
         entry = bytearray(struct.pack('<H', len(name_bytes)))
         entry.extend(name_bytes)
         entry.extend(struct.pack('<BB', dtype, len(shape)))
         entry.extend(struct.pack('<' + 'Q' * len(shape), *shape))
-        entry.extend(struct.pack('<QQQQ', stored_data_off, stored_data_size, scale_off, scale_size))
+        entry.extend(struct.pack('<QQQQ', stored_data_off, stored_data_size,
+                                 stored_scale_off, scale_size))
         entries.append(entry)
 
     header = struct.pack('<IIII', MAGIC, VERSION, len(entries), len(meta)) + meta
@@ -101,6 +111,9 @@ def main():
         bad_offset = root / 'bad-offset.q27'
         bad_dtype = root / 'bad-dtype.q27'
         zero_scale_offset = root / 'zero-scale-offset.q27'
+        bad_data_alignment = root / 'bad-data-alignment.q27'
+        bad_scale_alignment = root / 'bad-scale-alignment.q27'
+        nonzero_absent_scale_offset = root / 'nonzero-absent-scale-offset.q27'
         make_fixture(valid)
         make_fixture(corrupt, corrupt_size=True)
         make_fixture(misaligned, misaligned=True)
@@ -112,6 +125,10 @@ def main():
 
         make_fixture(bad_offset, bad_offset=True)
         make_fixture(zero_scale_offset, zero_scale_offset=True)
+        make_fixture(bad_data_alignment, bad_data_alignment=True)
+        make_fixture(bad_scale_alignment, bad_scale_alignment=True)
+        make_fixture(nonzero_absent_scale_offset,
+                     nonzero_absent_scale_offset=True)
         good = run(inspect, valid)
         if good.returncode != 0 or '\nOK\n' not in good.stdout:
             sys.stderr.write(good.stdout + good.stderr)
@@ -171,6 +188,24 @@ def main():
                 'tensor scale offset is zero' not in output(invalid_scale_offset)):
             sys.stderr.write(output(invalid_scale_offset))
             raise SystemExit('zero scale offset was not detected')
+        invalid_data_alignment = run(inspect, bad_data_alignment)
+        if (invalid_data_alignment.returncode == 0 or
+                'tensor data offset is not 256-byte aligned' not in
+                output(invalid_data_alignment)):
+            sys.stderr.write(output(invalid_data_alignment))
+            raise SystemExit('unaligned tensor data offset was not detected')
+        invalid_scale_alignment = run(inspect, bad_scale_alignment)
+        if (invalid_scale_alignment.returncode == 0 or
+                'tensor scale offset is not 256-byte aligned' not in
+                output(invalid_scale_alignment)):
+            sys.stderr.write(output(invalid_scale_alignment))
+            raise SystemExit('unaligned tensor scale offset was not detected')
+        invalid_absent_scale = run(inspect, nonzero_absent_scale_offset)
+        if (invalid_absent_scale.returncode == 0 or
+                'tensor scale offset must be zero without scales' not in
+                output(invalid_absent_scale)):
+            sys.stderr.write(output(invalid_absent_scale))
+            raise SystemExit('nonzero absent-scale offset was not detected')
 
     print('inspect packed dtype fixtures: PASS')
 

--- a/tools/test_inspect.py
+++ b/tools/test_inspect.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import pathlib
+import struct
+import subprocess
+import sys
+import tempfile
+
+MAGIC = 0x46373251
+VERSION = 1
+ALIGN = 256
+
+TENSORS = [
+    ("token_embd.weight", 4, [1, 128], 32, 2),
+    ("blk.0.ffn_gate.weight", 5, [1, 128], 26, 2),
+    ("blk.3.attn_q.weight", 6, [1, 128], 16, 2),
+    ("blk.64.nextn.eh_proj.weight", 2, [1, 128], 128, 2),
+    ("output_norm.weight", 0, [4], 16, 0),
+    ("test.f16", 1, [2], 4, 0),
+    ("test.q4", 3, [1, 64], 32, 2),
+]
+
+
+def align(value):
+    return (value + ALIGN - 1) // ALIGN * ALIGN
+
+
+def make_fixture(path, corrupt=False, misaligned=False):
+    meta = b'{}'
+    entries = []
+    blobs = bytearray()
+
+    for index, (name, dtype, shape, data_size, scale_size) in enumerate(TENSORS):
+        if misaligned and index == 0:
+            shape = [1, 129]
+        data_off = align(len(blobs))
+        blobs.extend(b'\0' * (data_off - len(blobs)))
+        stored_data_size = data_size + (1 if corrupt and index == 1 else 0)
+        data = bytearray(bytes([index + 1]) * stored_data_size)
+        if dtype == 5:
+            # The final T3 byte carries three real codes followed by two
+            # canonical zero padding codes (1*27 + 1*81).
+            data[25] = 108
+        blobs.extend(data)
+
+        scale_off = 0
+        if scale_size:
+            scale_off = align(len(blobs))
+            blobs.extend(b'\0' * (scale_off - len(blobs)))
+            blobs.extend(b'\0<' * (scale_size // 2))
+
+        name_bytes = name.encode()
+        entry = bytearray(struct.pack('<H', len(name_bytes)))
+        entry.extend(name_bytes)
+        entry.extend(struct.pack('<BB', dtype, len(shape)))
+        entry.extend(struct.pack('<' + 'Q' * len(shape), *shape))
+        entry.extend(struct.pack('<QQQQ', data_off, stored_data_size, scale_off, scale_size))
+        entries.append(entry)
+
+    header = struct.pack('<IIII', MAGIC, VERSION, len(entries), len(meta)) + meta
+    table = b''.join(entries)
+    data_base = align(len(header) + len(table))
+    path.write_bytes(header + table + b'\0' * (data_base - len(header) - len(table)) + blobs)
+
+
+def run(inspect, fixture):
+    return subprocess.run([inspect, str(fixture)], text=True, capture_output=True)
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit(f'usage: {sys.argv[0]} build/inspect')
+    inspect = sys.argv[1]
+    with tempfile.TemporaryDirectory(prefix='q27-inspect-') as tmp:
+        root = pathlib.Path(tmp)
+        valid = root / 'valid.q27'
+        corrupt = root / 'corrupt.q27'
+        misaligned = root / 'misaligned.q27'
+        make_fixture(valid)
+        make_fixture(corrupt, corrupt=True)
+        make_fixture(misaligned, misaligned=True)
+
+        good = run(inspect, valid)
+        if good.returncode != 0 or '\nOK\n' not in good.stdout:
+            sys.stderr.write(good.stdout + good.stderr)
+            raise SystemExit('valid packed-dtype fixture failed inspection')
+
+        bad = run(inspect, corrupt)
+        if bad.returncode == 0 or 'INVARIANT FAIL blk.0.ffn_gate.weight' not in bad.stdout:
+            sys.stderr.write(bad.stdout + bad.stderr)
+            raise SystemExit('one-byte packed-dtype corruption was not detected')
+
+        bad_shape = run(inspect, misaligned)
+        if (bad_shape.returncode == 0 or
+                'not divisible by group 128' not in bad_shape.stdout):
+            sys.stderr.write(bad_shape.stdout + bad_shape.stderr)
+            raise SystemExit('misaligned packed-dtype shape was not detected')
+
+    print('inspect packed dtype fixtures: PASS')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/test_inspect.py
+++ b/tools/test_inspect.py
@@ -24,7 +24,9 @@ def align(value):
     return (value + ALIGN - 1) // ALIGN * ALIGN
 
 
-def make_fixture(path, corrupt=False, misaligned=False):
+def make_fixture(path, corrupt_size=False, misaligned=False, bad_t2=False,
+                 bad_t3_range=False, bad_t3_padding=False, overflow=False,
+                 bad_offset=False):
     meta = b'{}'
     entries = []
     blobs = bytearray()
@@ -32,14 +34,23 @@ def make_fixture(path, corrupt=False, misaligned=False):
     for index, (name, dtype, shape, data_size, scale_size) in enumerate(TENSORS):
         if misaligned and index == 0:
             shape = [1, 129]
+        if overflow and dtype == 5:
+            shape = [(1 << 63) + 1, 128]
         data_off = align(len(blobs))
+        stored_data_off = (1 << 64) - 128 if bad_offset and dtype == 4 else data_off
         blobs.extend(b'\0' * (data_off - len(blobs)))
-        stored_data_size = data_size + (1 if corrupt and index == 1 else 0)
+        stored_data_size = data_size + (1 if corrupt_size and index == 1 else 0)
         data = bytearray(bytes([index + 1]) * stored_data_size)
         if dtype == 5:
             # The final T3 byte carries three real codes followed by two
             # canonical zero padding codes (1*27 + 1*81).
             data[25] = 108
+            if bad_t3_range:
+                data[0] = 243
+            if bad_t3_padding:
+                data[25] = 0
+        if dtype == 4 and bad_t2:
+            data[0] = 3
         blobs.extend(data)
 
         scale_off = 0
@@ -53,7 +64,7 @@ def make_fixture(path, corrupt=False, misaligned=False):
         entry.extend(name_bytes)
         entry.extend(struct.pack('<BB', dtype, len(shape)))
         entry.extend(struct.pack('<' + 'Q' * len(shape), *shape))
-        entry.extend(struct.pack('<QQQQ', data_off, stored_data_size, scale_off, scale_size))
+        entry.extend(struct.pack('<QQQQ', stored_data_off, stored_data_size, scale_off, scale_size))
         entries.append(entry)
 
     header = struct.pack('<IIII', MAGIC, VERSION, len(entries), len(meta)) + meta
@@ -75,10 +86,20 @@ def main():
         valid = root / 'valid.q27'
         corrupt = root / 'corrupt.q27'
         misaligned = root / 'misaligned.q27'
+        bad_t2 = root / 'bad-t2.q27'
+        bad_t3_range = root / 'bad-t3-range.q27'
+        bad_t3_padding = root / 'bad-t3-padding.q27'
+        overflow = root / 'overflow.q27'
+        bad_offset = root / 'bad-offset.q27'
         make_fixture(valid)
-        make_fixture(corrupt, corrupt=True)
+        make_fixture(corrupt, corrupt_size=True)
         make_fixture(misaligned, misaligned=True)
+        make_fixture(bad_t2, bad_t2=True)
+        make_fixture(bad_t3_range, bad_t3_range=True)
+        make_fixture(bad_t3_padding, bad_t3_padding=True)
+        make_fixture(overflow, overflow=True)
 
+        make_fixture(bad_offset, bad_offset=True)
         good = run(inspect, valid)
         if good.returncode != 0 or '\nOK\n' not in good.stdout:
             sys.stderr.write(good.stdout + good.stderr)
@@ -94,6 +115,37 @@ def main():
                 'not divisible by group 128' not in bad_shape.stdout):
             sys.stderr.write(bad_shape.stdout + bad_shape.stderr)
             raise SystemExit('misaligned packed-dtype shape was not detected')
+
+        invalid_t2 = run(inspect, bad_t2)
+        if (invalid_t2.returncode == 0 or
+                'T2 payload contains reserved code 3' not in invalid_t2.stdout):
+            sys.stderr.write(invalid_t2.stdout + invalid_t2.stderr)
+            raise SystemExit('reserved T2 code was not detected')
+
+        invalid_t3_range = run(inspect, bad_t3_range)
+        if (invalid_t3_range.returncode == 0 or
+                'T3 payload byte exceeds 242' not in invalid_t3_range.stdout):
+            sys.stderr.write(invalid_t3_range.stdout + invalid_t3_range.stderr)
+            raise SystemExit('out-of-range T3 byte was not detected')
+
+        invalid_t3_padding = run(inspect, bad_t3_padding)
+        if (invalid_t3_padding.returncode == 0 or
+                'T3 final-byte padding is noncanonical' not in invalid_t3_padding.stdout):
+            sys.stderr.write(invalid_t3_padding.stdout + invalid_t3_padding.stderr)
+            raise SystemExit('noncanonical T3 padding was not detected')
+
+        invalid_overflow = run(inspect, overflow)
+        if (invalid_overflow.returncode == 0 or
+                'tensor element count overflows uint64' not in
+                invalid_overflow.stdout + invalid_overflow.stderr):
+            sys.stderr.write(invalid_overflow.stdout + invalid_overflow.stderr)
+            raise SystemExit('packed payload size overflow was not detected')
+
+        invalid_offset = run(inspect, bad_offset)
+        if (invalid_offset.returncode == 0 or
+                'tensor data out of range' not in invalid_offset.stdout + invalid_offset.stderr):
+            sys.stderr.write(invalid_offset.stdout + invalid_offset.stderr)
+            raise SystemExit('overflowing tensor offset was not detected')
 
     print('inspect packed dtype fixtures: PASS')
 

--- a/tools/test_inspect.py
+++ b/tools/test_inspect.py
@@ -26,7 +26,8 @@ def align(value):
 
 def make_fixture(path, corrupt_size=False, misaligned=False, bad_t2=False,
                  bad_t3_range=False, bad_t3_padding=False, overflow=False,
-                 bad_offset=False, bad_embedding=False, bad_dtype=False):
+                 bad_offset=False, zero_scale_offset=False,
+                 bad_embedding=False, bad_dtype=False):
     meta = b'{}'
     entries = []
     blobs = bytearray()
@@ -62,6 +63,8 @@ def make_fixture(path, corrupt_size=False, misaligned=False, bad_t2=False,
             scale_off = align(len(blobs))
             blobs.extend(b'\0' * (scale_off - len(blobs)))
             blobs.extend(b'\0<' * (scale_size // 2))
+            if zero_scale_offset and index == 1:
+                scale_off = 0
 
         name_bytes = name.encode()
         entry = bytearray(struct.pack('<H', len(name_bytes)))
@@ -101,6 +104,7 @@ def main():
         bad_offset = root / 'bad-offset.q27'
         bad_embedding = root / 'bad-embedding.q27'
         bad_dtype = root / 'bad-dtype.q27'
+        zero_scale_offset = root / 'zero-scale-offset.q27'
         make_fixture(valid)
         make_fixture(corrupt, corrupt_size=True)
         make_fixture(misaligned, misaligned=True)
@@ -112,6 +116,7 @@ def main():
         make_fixture(bad_dtype, bad_dtype=True)
 
         make_fixture(bad_offset, bad_offset=True)
+        make_fixture(zero_scale_offset, zero_scale_offset=True)
         good = run(inspect, valid)
         if good.returncode != 0 or '\nOK\n' not in good.stdout:
             sys.stderr.write(good.stdout + good.stderr)
@@ -172,6 +177,11 @@ def main():
                 'tensor data out of range' not in invalid_offset.stdout + invalid_offset.stderr):
             sys.stderr.write(invalid_offset.stdout + invalid_offset.stderr)
             raise SystemExit('overflowing tensor offset was not detected')
+        invalid_scale_offset = run(inspect, zero_scale_offset)
+        if (invalid_scale_offset.returncode == 0 or
+                'tensor scale offset is zero' not in output(invalid_scale_offset)):
+            sys.stderr.write(output(invalid_scale_offset))
+            raise SystemExit('zero scale offset was not detected')
 
     print('inspect packed dtype fixtures: PASS')
 

--- a/tools/test_inspect.py
+++ b/tools/test_inspect.py
@@ -26,15 +26,12 @@ def align(value):
 
 def make_fixture(path, corrupt_size=False, misaligned=False, bad_t2=False,
                  bad_t3_range=False, bad_t3_padding=False, overflow=False,
-                 bad_offset=False, zero_scale_offset=False,
-                 bad_embedding=False, bad_dtype=False):
+                 bad_offset=False, zero_scale_offset=False, bad_dtype=False):
     meta = b'{}'
     entries = []
     blobs = bytearray()
 
     for index, (name, dtype, shape, data_size, scale_size) in enumerate(TENSORS):
-        if bad_embedding and name == "token_embd.weight":
-            dtype, data_size = 4, 32
         if bad_dtype and index == 1:
             dtype, data_size, scale_size = 255, 0, 0
         if misaligned and index == 0:
@@ -102,7 +99,6 @@ def main():
         bad_t3_padding = root / 'bad-t3-padding.q27'
         overflow = root / 'overflow.q27'
         bad_offset = root / 'bad-offset.q27'
-        bad_embedding = root / 'bad-embedding.q27'
         bad_dtype = root / 'bad-dtype.q27'
         zero_scale_offset = root / 'zero-scale-offset.q27'
         make_fixture(valid)
@@ -112,7 +108,6 @@ def main():
         make_fixture(bad_t3_range, bad_t3_range=True)
         make_fixture(bad_t3_padding, bad_t3_padding=True)
         make_fixture(overflow, overflow=True)
-        make_fixture(bad_embedding, bad_embedding=True)
         make_fixture(bad_dtype, bad_dtype=True)
 
         make_fixture(bad_offset, bad_offset=True)
@@ -122,12 +117,6 @@ def main():
             sys.stderr.write(good.stdout + good.stderr)
             raise SystemExit('valid packed-dtype fixture failed inspection')
 
-        invalid_embedding = run(inspect, bad_embedding)
-        if (invalid_embedding.returncode == 0 or
-                'token_embd.weight: CUDA row lookup requires Q8_G128' not in
-                output(invalid_embedding)):
-            sys.stderr.write(output(invalid_embedding))
-            raise SystemExit('non-Q8 CUDA embedding was not rejected')
         invalid_dtype = run(inspect, bad_dtype)
         if (invalid_dtype.returncode == 0 or
                 'unsupported dtype 255' not in output(invalid_dtype)):

--- a/tools/test_inspect.py
+++ b/tools/test_inspect.py
@@ -81,6 +81,10 @@ def run(inspect, fixture):
     return subprocess.run([inspect, str(fixture)], text=True, capture_output=True)
 
 
+def output(result):
+    return result.stdout + result.stderr
+
+
 def main():
     if len(sys.argv) != 2:
         raise SystemExit(f'usage: {sys.argv[0]} build/inspect')
@@ -116,43 +120,44 @@ def main():
         invalid_embedding = run(inspect, bad_embedding)
         if (invalid_embedding.returncode == 0 or
                 'token_embd.weight: CUDA row lookup requires Q8_G128' not in
-                invalid_embedding.stdout):
-            sys.stderr.write(invalid_embedding.stdout + invalid_embedding.stderr)
+                output(invalid_embedding)):
+            sys.stderr.write(output(invalid_embedding))
             raise SystemExit('non-Q8 CUDA embedding was not rejected')
         invalid_dtype = run(inspect, bad_dtype)
         if (invalid_dtype.returncode == 0 or
-                'unsupported dtype 255' not in invalid_dtype.stdout):
-            sys.stderr.write(invalid_dtype.stdout + invalid_dtype.stderr)
+                'unsupported dtype 255' not in output(invalid_dtype)):
+            sys.stderr.write(output(invalid_dtype))
             raise SystemExit('undeclared packed dtype was not rejected')
 
 
         bad = run(inspect, corrupt)
-        if bad.returncode == 0 or 'INVARIANT FAIL blk.0.ffn_gate.weight' not in bad.stdout:
-            sys.stderr.write(bad.stdout + bad.stderr)
+        if (bad.returncode == 0 or
+                'invalid tensor payload blk.0.ffn_gate.weight' not in output(bad)):
+            sys.stderr.write(output(bad))
             raise SystemExit('one-byte packed-dtype corruption was not detected')
 
         bad_shape = run(inspect, misaligned)
         if (bad_shape.returncode == 0 or
-                'not divisible by group 128' not in bad_shape.stdout):
-            sys.stderr.write(bad_shape.stdout + bad_shape.stderr)
+                'not divisible by group 128' not in output(bad_shape)):
+            sys.stderr.write(output(bad_shape))
             raise SystemExit('misaligned packed-dtype shape was not detected')
 
         invalid_t2 = run(inspect, bad_t2)
         if (invalid_t2.returncode == 0 or
-                'T2 payload contains reserved code 3' not in invalid_t2.stdout):
-            sys.stderr.write(invalid_t2.stdout + invalid_t2.stderr)
+                'T2 payload contains reserved code 3' not in output(invalid_t2)):
+            sys.stderr.write(output(invalid_t2))
             raise SystemExit('reserved T2 code was not detected')
 
         invalid_t3_range = run(inspect, bad_t3_range)
         if (invalid_t3_range.returncode == 0 or
-                'T3 payload byte exceeds 242' not in invalid_t3_range.stdout):
-            sys.stderr.write(invalid_t3_range.stdout + invalid_t3_range.stderr)
+                'T3 payload byte exceeds 242' not in output(invalid_t3_range)):
+            sys.stderr.write(output(invalid_t3_range))
             raise SystemExit('out-of-range T3 byte was not detected')
 
         invalid_t3_padding = run(inspect, bad_t3_padding)
         if (invalid_t3_padding.returncode == 0 or
-                'T3 final-byte padding is noncanonical' not in invalid_t3_padding.stdout):
-            sys.stderr.write(invalid_t3_padding.stdout + invalid_t3_padding.stderr)
+                'T3 final-byte padding is noncanonical' not in output(invalid_t3_padding)):
+            sys.stderr.write(output(invalid_t3_padding))
             raise SystemExit('noncanonical T3 padding was not detected')
 
         invalid_overflow = run(inspect, overflow)

--- a/tools/test_inspect.py
+++ b/tools/test_inspect.py
@@ -26,7 +26,7 @@ def align(value):
 
 def make_fixture(path, corrupt_size=False, misaligned=False, bad_t2=False,
                  bad_t3_range=False, bad_t3_padding=False, overflow=False,
-                 bad_offset=False, bad_embedding=False):
+                 bad_offset=False, bad_embedding=False, bad_dtype=False):
     meta = b'{}'
     entries = []
     blobs = bytearray()
@@ -34,6 +34,8 @@ def make_fixture(path, corrupt_size=False, misaligned=False, bad_t2=False,
     for index, (name, dtype, shape, data_size, scale_size) in enumerate(TENSORS):
         if bad_embedding and name == "token_embd.weight":
             dtype, data_size = 4, 32
+        if bad_dtype and index == 1:
+            dtype, data_size, scale_size = 255, 0, 0
         if misaligned and index == 0:
             shape = [1, 129]
         if overflow and dtype == 5:
@@ -94,6 +96,7 @@ def main():
         overflow = root / 'overflow.q27'
         bad_offset = root / 'bad-offset.q27'
         bad_embedding = root / 'bad-embedding.q27'
+        bad_dtype = root / 'bad-dtype.q27'
         make_fixture(valid)
         make_fixture(corrupt, corrupt_size=True)
         make_fixture(misaligned, misaligned=True)
@@ -102,6 +105,7 @@ def main():
         make_fixture(bad_t3_padding, bad_t3_padding=True)
         make_fixture(overflow, overflow=True)
         make_fixture(bad_embedding, bad_embedding=True)
+        make_fixture(bad_dtype, bad_dtype=True)
 
         make_fixture(bad_offset, bad_offset=True)
         good = run(inspect, valid)
@@ -115,6 +119,12 @@ def main():
                 invalid_embedding.stdout):
             sys.stderr.write(invalid_embedding.stdout + invalid_embedding.stderr)
             raise SystemExit('non-Q8 CUDA embedding was not rejected')
+        invalid_dtype = run(inspect, bad_dtype)
+        if (invalid_dtype.returncode == 0 or
+                'unsupported dtype 255' not in invalid_dtype.stdout):
+            sys.stderr.write(invalid_dtype.stdout + invalid_dtype.stderr)
+            raise SystemExit('undeclared packed dtype was not rejected')
+
 
         bad = run(inspect, corrupt)
         if bad.returncode == 0 or 'INVARIANT FAIL blk.0.ffn_gate.weight' not in bad.stdout:

--- a/tools/test_inspect.py
+++ b/tools/test_inspect.py
@@ -10,10 +10,10 @@ VERSION = 1
 ALIGN = 256
 
 TENSORS = [
-    ("token_embd.weight", 4, [1, 128], 32, 2),
+    ("token_embd.weight", 2, [1, 128], 128, 2),
     ("blk.0.ffn_gate.weight", 5, [1, 128], 26, 2),
     ("blk.3.attn_q.weight", 6, [1, 128], 16, 2),
-    ("blk.64.nextn.eh_proj.weight", 2, [1, 128], 128, 2),
+    ("blk.64.nextn.eh_proj.weight", 4, [1, 128], 32, 2),
     ("output_norm.weight", 0, [4], 16, 0),
     ("test.f16", 1, [2], 4, 0),
     ("test.q4", 3, [1, 64], 32, 2),
@@ -26,12 +26,14 @@ def align(value):
 
 def make_fixture(path, corrupt_size=False, misaligned=False, bad_t2=False,
                  bad_t3_range=False, bad_t3_padding=False, overflow=False,
-                 bad_offset=False):
+                 bad_offset=False, bad_embedding=False):
     meta = b'{}'
     entries = []
     blobs = bytearray()
 
     for index, (name, dtype, shape, data_size, scale_size) in enumerate(TENSORS):
+        if bad_embedding and name == "token_embd.weight":
+            dtype, data_size = 4, 32
         if misaligned and index == 0:
             shape = [1, 129]
         if overflow and dtype == 5:
@@ -91,6 +93,7 @@ def main():
         bad_t3_padding = root / 'bad-t3-padding.q27'
         overflow = root / 'overflow.q27'
         bad_offset = root / 'bad-offset.q27'
+        bad_embedding = root / 'bad-embedding.q27'
         make_fixture(valid)
         make_fixture(corrupt, corrupt_size=True)
         make_fixture(misaligned, misaligned=True)
@@ -98,12 +101,20 @@ def main():
         make_fixture(bad_t3_range, bad_t3_range=True)
         make_fixture(bad_t3_padding, bad_t3_padding=True)
         make_fixture(overflow, overflow=True)
+        make_fixture(bad_embedding, bad_embedding=True)
 
         make_fixture(bad_offset, bad_offset=True)
         good = run(inspect, valid)
         if good.returncode != 0 or '\nOK\n' not in good.stdout:
             sys.stderr.write(good.stdout + good.stderr)
             raise SystemExit('valid packed-dtype fixture failed inspection')
+
+        invalid_embedding = run(inspect, bad_embedding)
+        if (invalid_embedding.returncode == 0 or
+                'token_embd.weight: CUDA row lookup requires Q8_G128' not in
+                invalid_embedding.stdout):
+            sys.stderr.write(invalid_embedding.stdout + invalid_embedding.stderr)
+            raise SystemExit('non-Q8 CUDA embedding was not rejected')
 
         bad = run(inspect, corrupt)
         if bad.returncode == 0 or 'INVARIANT FAIL blk.0.ffn_gate.weight' not in bad.stdout:


### PR DESCRIPTION
## Problem

The Metal backend needs a backend-neutral execution contract, but that contract must land without hiding Metal implementation or weakening CUDA/model validation. Packed tensor payloads and sampling inputs also need one shared set of structural and numeric checks before either backend consumes them.

## Change

- add backend-neutral buffer, tensor, quantization, and compute interfaces under `src/backend.h`;
- centralize deterministic full-row and candidate sampling contracts in `src/sampling.h`, including NaN/+inf/no-finite rejection and mixed `-inf` masking;
- validate tensor payload sizes, offsets, scales, dtype declarations, and packed encodings during runtime loading and inspection;
- reject CUDA-incompatible embedding/layer dtypes before allocation or kernel launch;
- add CPU fixtures for loader, inspector, and sampling boundaries.

This PR contains no Metal implementation. Its CUDA runtime delta is limited to validation calls before upload/allocation.

## Verification

Exact tip `d0979cb4` on upstream `e7e4b2554848`:

- `make -B build/inspect build/test_loader_contracts build/test_sampling`
- `python3 tools/test_inspect.py ./build/inspect` — `inspect packed dtype fixtures: PASS`
- `./build/test_loader_contracts` — `loader CUDA dtype contracts: PASS`
- `./build/test_sampling` — `CPU sampling: PASS`
- `git diff --check upstream/master...HEAD`
- final Codex branch review: no accepted/actionable findings, correctness 0.91

Independent seam approved in issue #8; Metal backend, shaders, engine, and CLI/tests remain separate follow-up stages.