### PR TITLE
argmax: resolve exact and signed-zero ties to the lowest index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NVCCFLAGS ?= -O2 -std=c++17 -gencode arch=compute_86,code=sm_86 \
              -gencode arch=compute_120,code=sm_120 -Xcompiler -Wall
 
 .PHONY: all clean
-all: build/inspect build/test_kernels build/q27 build/q27-server build/test_tokenizer build/test_depthctl build/test_toolconstrain
+all: build/inspect build/test_kernels build/test_argmax_tie build/q27 build/q27-server build/test_tokenizer build/test_depthctl build/test_toolconstrain
 
 build/q27: src/engine.cu src/engine.cuh src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp \
            src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/device_model.h src/loader.h src/cuda_common.h src/depthctl.h src/prefix_cache.h src/prefix_ram.h | build
@@ -44,6 +44,9 @@ build/mma16_bench: tools/mma16_bench.cu src/kernels.cu src/device_model.cu src/l
 build/test_kernels: src/test_kernels.cu src/kernels.cu src/prefill.cu src/blocks.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp \
                     src/kernels.cuh src/prefill.cuh src/blocks.cuh src/spec3.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/device_model.h src/loader.h src/cuda_common.h | build
 	$(NVCC) $(NVCCFLAGS) src/test_kernels.cu src/kernels.cu src/prefill.cu src/blocks.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp -o $@
+
+build/test_argmax_tie: tools/test_argmax_tie.cu src/blocks.cu src/blocks.cuh | build
+	$(NVCC) $(NVCCFLAGS) tools/test_argmax_tie.cu src/blocks.cu -o $@
 
 
 build/q27-server: src/server.cu src/engine.cuh src/conductor.h src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu \

--- a/src/blocks.cu
+++ b/src/blocks.cu
@@ -401,8 +401,18 @@ void add_inplace(float* x, const float* y, int n, cudaStream_t st) {
 // Multi-block argmax: pack (orderable float bits, index) into u64, atomicMax.
 __device__ __forceinline__ unsigned long long am_pack(float v, int idx) {
     unsigned u = __float_as_uint(v);
+    // IEEE equality treats both zero signs as one value. Canonicalize their
+    // bit patterns before the order transform so the index tie-break decides.
+    if ((u & 0x7fffffffu) == 0) u = 0;
     u = (u & 0x80000000u) ? ~u : (u | 0x80000000u); // monotonic float->uint map
-    return ((unsigned long long)u << 32) | (unsigned)idx;
+    // Invert the index bits so max reductions resolve exact value ties to the
+    // lowest index, matching the CPU and Metal implementations. Per-thread
+    // strided scans already preserve their lowest index by using strict >.
+    return ((unsigned long long)u << 32) | (unsigned)~idx;
+}
+
+__device__ __forceinline__ int am_unpack_idx(unsigned long long p) {
+    return (int)~(unsigned)(p & 0xffffffffull);
 }
 
 // Exact inverse of am_pack's monotonic map (recovers the packed float value).
@@ -434,7 +444,7 @@ __global__ void k_argmax(const float* __restrict__ x, int n,
 }
 
 __global__ void k_argmax_extract(const unsigned long long* best, int* out) {
-    *out = (int)(unsigned)(*best & 0xffffffffull);
+    *out = am_unpack_idx(*best);
 }
 
 void argmax(const float* x, int n, int* d_out, unsigned long long* d_scratch, cudaStream_t st) {
@@ -506,7 +516,7 @@ __global__ void k_top2_finalize(const unsigned long long* __restrict__ blk1,
         __syncthreads();
     }
     if (t == 0) {
-        tok[0] = (int)(unsigned)(s1[0] & 0xffffffffull);
+        tok[0] = am_unpack_idx(s1[0]);
         margin_out[0] = am_unpack_val(s1[0]) - s2[0];
     }
 }

--- a/src/test_kernels.cu
+++ b/src/test_kernels.cu
@@ -597,8 +597,8 @@ static void test_margin() {
 // P14: fused draft argmax+margin. The single pass must reproduce, EXACTLY:
 //  - argmax()'s token (same tie semantics, since the grid partition matches), and
 //  - margin()'s value == CPU top1-top2 (pure selection, no fp reassociation).
-// Cases: random logits, all-equal (ties everywhere), max@0, max@last, and a
-// duplicated max value at two indices (pins margin==0 and the higher-index win).
+// Cases: random logits, all-equal (ties everywhere), max@0, max@last,
+// duplicated maxima, and both signed-zero orderings.
 static void test_argmax_top2() {
     const int N = 248320;
     float *d_x, *d_margin, *d_margin2, *d_blk2;
@@ -612,8 +612,12 @@ static void test_argmax_top2() {
     CUDA_CHECK(cudaMalloc(&d_blk1, 128 * 8));
     CUDA_CHECK(cudaMalloc(&d_blk2, 128 * 4));
     CUDA_CHECK(cudaMalloc(&d_scr, 8));
-    double worst_tok = 0, worst_cpu = 0, worst_kern = 0;
+    double worst_tok = 0, worst_cpu = 0, worst_kern = 0, worst_tie = 0;
     auto run_case = [&](std::vector<float>& logits) {
+        // Exact value ties select the lowest index across the CPU, CUDA, and
+        // Metal implementations. Assert that rule for every case.
+        int lowest = 0;
+        for (int i = 1; i < N; i++) if (logits[i] > logits[lowest]) lowest = i;
         float m1 = -1e30f, m2 = -1e30f;
         for (int i = 0; i < N; i++) {
             float v = logits[i];
@@ -633,6 +637,7 @@ static void test_argmax_top2() {
         float kmargin;
         CUDA_CHECK(cudaMemcpy(&kmargin, d_margin2, 4, cudaMemcpyDeviceToHost));
         worst_tok = std::max(worst_tok, (double)std::abs(ftok - atok));
+        worst_tie = std::max(worst_tie, (double)std::abs(atok - lowest));
         // exact float equality: any nonzero diff is a bug (both are pure selection)
         worst_cpu = std::max(worst_cpu, fmargin == cpu_margin ? 0.0 : 1.0);
         worst_kern = std::max(worst_kern, fmargin == kmargin ? 0.0 : 1.0);
@@ -643,6 +648,12 @@ static void test_argmax_top2() {
     { std::vector<float> l = rand_vec(N, 17); l[N - 1] = 1e4f; run_case(l); }    // max@last
     { std::vector<float> l = rand_vec(N, 23); l[100] = 5e3f; l[200000] = 5e3f;   // dup max
       run_case(l); }
+    { std::vector<float> l = rand_vec(N, 29); l[7] = 5e3f; l[8] = 5e3f; l[N - 2] = 5e3f;
+      run_case(l); }                                                // triple tie, adjacent pair
+    { std::vector<float> l(N, -1.0f); l[0] = -0.0f; l[N - 1] = +0.0f;
+      run_case(l); }                                                // -0 then +0
+    { std::vector<float> l(N, -1.0f); l[0] = +0.0f; l[N - 1] = -0.0f;
+      run_case(l); }                                                // +0 then -0
     CUDA_CHECK(cudaFree(d_x));
     CUDA_CHECK(cudaFree(d_margin));
     CUDA_CHECK(cudaFree(d_margin2));
@@ -652,6 +663,7 @@ static void test_argmax_top2() {
     CUDA_CHECK(cudaFree(d_blk2));
     CUDA_CHECK(cudaFree(d_scr));
     check("argmax_top2 token == argmax()", worst_tok, 0.5);
+    check("argmax tie -> lowest index (Metal/CPU rule)", worst_tie, 0.5);
     check("argmax_top2 margin == CPU top1-top2", worst_cpu, 0.5);
     check("argmax_top2 margin == margin() kernel", worst_kern, 0.5);
 }

--- a/tools/test_argmax_tie.cu
+++ b/tools/test_argmax_tie.cu
@@ -1,0 +1,51 @@
+// Model-free gate for the backend-independent argmax tie contract.
+// IEEE-equal values select the lowest index, including -0.0f versus +0.0f.
+#include "../src/blocks.cuh"
+
+#include <cstdio>
+#include <vector>
+
+int main() {
+    constexpr int N = 32769; // spans the multi-block reduction
+    float* d_logits = nullptr;
+    int *d_plain = nullptr, *d_fused = nullptr;
+    float* d_margin = nullptr;
+    unsigned long long *d_scratch = nullptr, *d_blk1 = nullptr;
+    float* d_blk2 = nullptr;
+    CUDA_CHECK(cudaMalloc(&d_logits, (size_t)N * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&d_plain, sizeof(int)));
+    CUDA_CHECK(cudaMalloc(&d_fused, sizeof(int)));
+    CUDA_CHECK(cudaMalloc(&d_margin, sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&d_scratch, sizeof(unsigned long long)));
+    CUDA_CHECK(cudaMalloc(&d_blk1, 128 * sizeof(unsigned long long)));
+    CUDA_CHECK(cudaMalloc(&d_blk2, 128 * sizeof(float)));
+
+    auto run = [&](float first, float second, const char* label) {
+        std::vector<float> logits(N, -1.0f);
+        logits[0] = first;
+        logits[256] = second; // different block: forces the packed reduction tie-break
+        CUDA_CHECK(cudaMemcpy(d_logits, logits.data(), (size_t)N * sizeof(float),
+                              cudaMemcpyHostToDevice));
+        q27k::argmax(d_logits, N, d_plain, d_scratch);
+        q27k::argmax_margin(d_logits, N, d_fused, d_margin, d_blk1, d_blk2);
+        int plain = -1, fused = -1;
+        CUDA_CHECK(cudaMemcpy(&plain, d_plain, sizeof(int), cudaMemcpyDeviceToHost));
+        CUDA_CHECK(cudaMemcpy(&fused, d_fused, sizeof(int), cudaMemcpyDeviceToHost));
+        const bool ok = plain == 0 && fused == 0;
+        std::printf("%s: plain=%d fused=%d expected=0 %s\n", label, plain, fused,
+                    ok ? "PASS" : "FAIL");
+        return ok;
+    };
+
+    bool ok = run(-0.0f, +0.0f, "-0 then +0");
+    ok = run(+0.0f, -0.0f, "+0 then -0") && ok;
+
+    CUDA_CHECK(cudaFree(d_logits));
+    CUDA_CHECK(cudaFree(d_plain));
+    CUDA_CHECK(cudaFree(d_fused));
+    CUDA_CHECK(cudaFree(d_margin));
+    CUDA_CHECK(cudaFree(d_scratch));
+    CUDA_CHECK(cudaFree(d_blk1));
+    CUDA_CHECK(cudaFree(d_blk2));
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- make exact-value ties resolve to the lowest index in both CUDA argmax paths
- treat `-0.0f` and `+0.0f` as IEEE-equal instead of ordering them by sign bit
- carry the winning index through intra-block and multi-block reductions
- add a focused CUDA regression target covering ordinary, signed-zero, fused/plain, and cross-block ties

This matches the existing CPU and Metal contract: equal maximum values select the lowest token index.

## Validation

Exact tip: `20b50692aee0b0877ad9e098cd939bf58c88bd1f`.

RunPod NVIDIA A40 (Ampere `sm_86`), CUDA 12.8.93:

```text
make -B build/test_argmax_tie build/test_kernels
./build/test_argmax_tie
  -0 then +0: plain=0 fused=0 expected=0 PASS
  +0 then -0: plain=0 fused=0 expected=0 PASS
./build/test_kernels /path/to/qwen36-27b-mtp-q4s.q27
  argmax tie -> lowest index (Metal/CPU rule) PASS
  ALL PASS
CANON_ARCH=sm86 tools/sampling_gate.sh /path/to/qwen36-27b-mtp-q4s.q27
  greedy canonical md5: 6894254e3b1a184ee3802771ddd59c2b
  SAMPLING GATES: ALL PASS
```

Final structured review reported no actionable findings. The maintainer's offered Blackwell leg can follow this clean Ampere-gated send.