### PR TITLE
fix: clear pending boundary after stray tool close

### DIFF
--- a/src/stream_split.h
+++ b/src/stream_split.h
@@ -64,7 +64,10 @@ struct StreamSplitter {
                         chan = TOOL;
                         continue;
                     }
-                    if (sc > 0) out.push_back({TEXT, hold.substr(0, sc)});
+                    if (sc > 0) {
+                        out.push_back({TEXT, hold.substr(0, sc)});
+                        tool_boundary = false;
+                    }
                     hold.erase(0, sc + strlen(C_CLOSE)); // strip stray close
                     continue;
                 }

--- a/tools/test_stream_split.cpp
+++ b/tools/test_stream_split.cpp
@@ -75,6 +75,11 @@ int main() {
     const std::vector<Segment> text_between_want = {
         {Chan::TOOL, "a"}, {Chan::TEXT, "x"}, {Chan::TOOL, "b"}};
 
+    const std::string text_then_stray_close =
+        "<tool_call>a</tool_call>x</tool_call><think></think>";
+    const std::vector<Segment> text_then_stray_close_want = {
+        {Chan::TOOL, "a"}, {Chan::TEXT, "x"}};
+
     bool ok = true;
     ok = expect("adjacent/full", split(adjacent, false), adjacent_want) && ok;
     ok = expect("adjacent/bytewise", split(adjacent, true), adjacent_want) && ok;
@@ -82,6 +87,9 @@ int main() {
     ok = expect("empty-think/bytewise", split(empty_think, true), empty_think_want) && ok;
     ok = expect("nonempty-think/bytewise", split(nonempty_think, true), nonempty_think_want) && ok;
     ok = expect("text-between/bytewise", split(text_between, true), text_between_want) && ok;
+    ok = expect("text-before-stray clears boundary",
+                split(text_then_stray_close, false),
+                text_then_stray_close_want) && ok;
 
     q27::StreamSplitter unfinished;
     std::vector<Segment> unfinished_got = unfinished.feed("<tool_call>a</tool_call><think>");


### PR DESCRIPTION
## Problem

After a TOOL segment closes, `tool_boundary` records the pending segment boundary. If visible TEXT and a stray `</tool_call>` arrive in the same `feed()` call, the TEXT is emitted but the pending flag was left set. A later empty THINK block or tool opener could therefore emit an extra empty boundary segment.

## Fix

Clear `tool_boundary` when the visible prefix before a stray close is emitted, matching the other TEXT emission paths.

## Regression

`<tool_call>a</tool_call>x</tool_call><think></think>` now emits only TOOL `a` followed by TEXT `x`.

## Verification

- reproduced the merged behavior with a focused standalone probe
- `build/test_stream_split`: all 17 cases PASS, including the new regression
- `git diff --check`: clean
- structured Codex autoreview: no accepted/actionable findings
