### PR TITLE
metal: add native compute backend primitives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NVCCFLAGS ?= -O2 -std=c++17 -gencode arch=compute_86,code=sm_86 \
              -gencode arch=compute_89,code=sm_89 \
              -gencode arch=compute_120,code=sm_120 -Xcompiler -Wall
 
-.PHONY: all clean test-inspect
+.PHONY: all clean test-inspect test-metal-backend
 all: build/inspect build/test_sampling build/test_kernels build/test_argmax_tie build/q27 build/q27-server build/test_tokenizer build/test_stream_split build/test_depthctl build/test_toolconstrain
 
 build/q27: src/engine.cu src/engine.cuh src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp \
@@ -138,3 +138,30 @@ build/q27-server-w16: src/server.cu src/engine.cuh src/conductor.h src/blocks.cu
                       src/depthctl.h src/toolconstrain.h src/tokenizer.h src/prefix_cache.h src/prefix_ram.h | build
 	$(NVCC) $(NVCCFLAGS) -DQ27_W_MAX=16 -Xcompiler -pthread src/server.cu src/blocks.cu src/prefill.cu src/kernels.cu \
 	        src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp src/tokenizer.cpp -o $@
+
+# Native Metal backend primitives. Kept separate from the engine/CLI targets so
+# this dependency cut stays buildable and testable on its own.
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+METALFLAGS := $(CXXFLAGS) -Werror -fobjc-arc -pthread -I src/metal
+METALLIBS := -framework Foundation -framework Metal
+
+build/test-metal-backend: src/metal/test_metal.cpp src/metal/metal_backend.mm \
+                          src/metal/metal_backend.h src/metal/q27_kernels.metal \
+                          src/backend.h src/loader.cpp src/loader.h | build
+	$(CXX) $(METALFLAGS) src/metal/test_metal.cpp src/metal/metal_backend.mm \
+	       src/loader.cpp $(METALLIBS) -o $@
+
+build/test-metal-ops: src/metal/test_metal_ops.cpp src/metal/metal_backend.mm \
+                      src/metal/metal_backend.h src/metal/q27_kernels.metal \
+                      src/backend.h src/loader.cpp src/loader.h | build
+	$(CXX) $(METALFLAGS) src/metal/test_metal_ops.cpp src/metal/metal_backend.mm \
+	       src/loader.cpp $(METALLIBS) -o $@
+
+test-metal-backend: build/test-metal-backend build/test-metal-ops
+	./build/test-metal-backend
+	./build/test-metal-ops
+else
+test-metal-backend:
+	@echo "test-metal-backend requires macOS" >&2; exit 1
+endif

--- a/src/metal/metal_backend.h
+++ b/src/metal/metal_backend.h
@@ -1,0 +1,187 @@
+#pragma once
+
+#include "../backend.h"
+
+#include <memory>
+#include <string>
+
+namespace q27 {
+
+class MetalBackend final : public ComputeBackend {
+  public:
+    MetalBackend();
+    ~MetalBackend() override;
+    MetalBackend(const MetalBackend&) = delete;
+    MetalBackend& operator=(const MetalBackend&) = delete;
+
+    std::string name() const override;
+    std::shared_ptr<BackendBuffer> allocate(uint64_t bytes) override;
+    void write(BackendBuffer& dst, uint64_t offset, const void* src,
+               uint64_t bytes) override;
+    void read(const BackendBuffer& src, uint64_t offset, void* dst,
+              uint64_t bytes) override;
+    void zero(BackendBuffer& dst) override;
+    void copy(const BackendBuffer& src, uint64_t src_offset,
+              BackendBuffer& dst, uint64_t dst_offset, uint64_t bytes) override;
+    BackendTensor upload(const Tensor& tensor) override;
+    BackendTensor upload(const Model& model, const Tensor& tensor) override;
+    void begin_commands() override;
+    void end_commands() override;
+    void abort_commands() noexcept override;
+    void matvec(const BackendTensor& weight, const BackendBuffer& x,
+                BackendBuffer& y) override;
+    void matvec_pair(const BackendTensor& a, BackendBuffer& a_out,
+                     const BackendTensor& b, BackendBuffer& b_out,
+                     const BackendBuffer& x) override;
+    BackendQuantized allocate_quantized(uint32_t count) override;
+    void quantize(const BackendBuffer& x, BackendQuantized& out) override;
+    void matvec_quantized(const BackendTensor& weight,
+                          const BackendQuantized& x, BackendBuffer& y) override;
+    void matvec_quantized_pair(const BackendTensor& a, BackendBuffer& a_out,
+                               const BackendTensor& b, BackendBuffer& b_out,
+                               const BackendQuantized& x) override;
+    void matmul_quantized(const BackendTensor& weight,const BackendQuantized& x,
+                          uint32_t x_rows,BackendBuffer& y) override;
+    void embedding_q8(const BackendTensor& weight, uint32_t token,
+                      BackendBuffer& out) override;
+    void rmsnorm(const BackendBuffer& x, const BackendTensor& weight,
+                 BackendBuffer& out, uint32_t n, float eps) override;
+    void rmsnorm_quantized(const BackendBuffer& x, const BackendTensor& weight,
+                           BackendBuffer& out, uint32_t n, float eps,
+                           BackendQuantized& quantized) override;
+    void rmsnorm_heads(BackendBuffer& x, const BackendTensor& weight,
+                       uint32_t heads, uint32_t head_dim, uint32_t stride,
+                       float eps) override;
+    void l2norm_heads(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
+                      float eps) override;
+    void silu_mul(const BackendBuffer& gate, const BackendBuffer& up,
+                  BackendBuffer& out, uint32_t n) override;
+    void add_inplace(BackendBuffer& x, const BackendBuffer& y, uint32_t n) override;
+    void concat(const BackendBuffer& a, uint32_t a_count,
+                const BackendBuffer& b, uint32_t b_count,
+                BackendBuffer& out) override;
+    void sigmoid_gate_mul(BackendBuffer& out, const BackendBuffer& qg,
+                          uint32_t heads, uint32_t head_dim) override;
+    void rope_neox(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
+                   uint32_t n_rot, uint32_t stride, uint32_t position,
+                   float freq_base) override;
+    void argmax(const BackendBuffer& x, uint32_t n, BackendBuffer& out_index) override;
+    void kv_store(const BackendBuffer& k, const BackendBuffer& v,
+                  BackendBuffer& k_cache, BackendBuffer& v_cache,
+                  uint32_t position, uint32_t kv_heads, uint32_t head_dim,
+                  KvFormat format) override;
+    void turbo_wht(BackendBuffer& x, uint32_t heads, uint32_t stride,
+                   bool inverse) override;
+    void attention(const BackendBuffer& q, uint32_t q_stride,
+                   const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                   BackendBuffer& out, uint32_t seq_len, uint32_t q_heads,
+                   uint32_t kv_heads, uint32_t head_dim, float scale,
+                   KvFormat format, BackendBuffer* partials) override;
+    void gdn_gates(const BackendBuffer& alpha, const BackendBuffer& beta_raw,
+                   const BackendTensor& ssm_a, const BackendTensor& ssm_dt,
+                   BackendBuffer& g, BackendBuffer& beta, uint32_t heads) override;
+    void conv_step(const BackendBuffer& ring_src, BackendBuffer& ring_dst,
+                   const BackendBuffer& qkv, const BackendTensor& conv_weight,
+                   BackendBuffer& out, uint32_t channels) override;
+    void delta_step(const BackendBuffer& state_src, BackendBuffer& state_dst,
+                    const BackendBuffer& conv, const BackendBuffer& g,
+                    const BackendBuffer& beta, BackendBuffer& out,
+                    uint32_t value_heads, uint32_t qk_heads,
+                    uint32_t head_dim) override;
+    void gated_norm_gdn(const BackendBuffer& x, const BackendTensor& weight,
+                        const BackendBuffer& gate, BackendBuffer& out,
+                        uint32_t heads, uint32_t head_dim, float eps) override;
+    void embedding_q8_rows(const BackendTensor& weight, const uint32_t* tokens,
+                           uint32_t count, BackendBuffer& out) override;
+    void rmsnorm_rows_quantized(const BackendBuffer& x, const BackendTensor& weight,
+                                BackendBuffer& out, uint32_t n, uint32_t rows,
+                                float eps, BackendQuantized& quantized) override;
+    void matvec_f16_pair_rows(const BackendTensor& a, BackendBuffer& a_out,
+                              const BackendTensor& b, BackendBuffer& b_out,
+                              const BackendBuffer& x, uint32_t rows) override;
+    void gdn_gates_rows(const BackendBuffer& alpha, const BackendBuffer& beta_raw,
+                        const BackendTensor& ssm_a, const BackendTensor& ssm_dt,
+                        BackendBuffer& g, BackendBuffer& beta,
+                        uint32_t heads, uint32_t tokens) override;
+    void conv_chunk(const BackendBuffer& ring_src, BackendBuffer& ring_dst,
+                    const BackendBuffer& qkv,
+                    const BackendTensor& conv_weight, BackendBuffer& out,
+                    uint32_t channels, uint32_t tokens) override;
+    void delta_chunk(const BackendBuffer& state_src, BackendBuffer& state_dst,
+                     const BackendBuffer& conv,
+                     const BackendBuffer& g, const BackendBuffer& beta,
+                     BackendBuffer& out, uint32_t value_heads, uint32_t qk_heads,
+                     uint32_t head_dim, uint32_t tokens) override;
+    void l2norm_rows(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
+                     uint32_t row_stride, uint32_t tokens, float eps) override;
+    void rope_neox_rows(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
+                        uint32_t n_rot, uint32_t stride, uint32_t row_stride,
+                        uint32_t position, uint32_t tokens, float freq_base) override;
+    void kv_store_rows(const BackendBuffer& k, const BackendBuffer& v,
+                       BackendBuffer& k_cache, BackendBuffer& v_cache,
+                       uint32_t position, uint32_t kv_heads, uint32_t head_dim,
+                       uint32_t tokens, KvFormat format) override;
+    void attention_causal(const BackendBuffer& q, uint32_t q_stride,
+                          uint32_t q_row_stride, const BackendBuffer& k_cache,
+                          const BackendBuffer& v_cache,
+                          BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
+                          uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
+                          float scale, KvFormat format, BackendBuffer* partials) override;
+    void sigmoid_gate_mul_rows(BackendBuffer& out, const BackendBuffer& qg,
+                               uint32_t heads, uint32_t head_dim, uint32_t tokens) override;
+    void argmax_rows(const BackendBuffer& x, uint32_t n, uint32_t rows,
+                     BackendBuffer& out_indices) override;
+    void nll_rows(const BackendBuffer& logits, const BackendBuffer& targets,
+                  BackendBuffer& nll, uint32_t n, uint32_t rows) override;
+    void synchronize() override;
+
+    // Clears Q27_METAL_PROFILE accumulation (stats, command-buffer and
+    // busy/wait counters) so benches can exclude their warmup dispatches
+    // from the attribution table. No-op when profiling is disabled.
+    void profile_reset();
+
+    uint64_t recommended_working_set_size() const;
+    uint64_t max_buffer_length() const;
+    uint64_t max_threadgroup_memory_length() const;
+    bool supports_quantized_matmul() const;
+
+  private:
+    void kv_store_f16(const BackendBuffer& k, const BackendBuffer& v,
+                      BackendBuffer& k_cache, BackendBuffer& v_cache,
+                      uint32_t position, uint32_t row_length);
+    void kv_store_turbo3(const BackendBuffer& k, const BackendBuffer& v,
+                         BackendBuffer& k_cache, BackendBuffer& v_cache,
+                         uint32_t position, uint32_t kv_heads);
+    void attention_f16(const BackendBuffer& q, uint32_t q_stride,
+                       const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                       BackendBuffer& out, uint32_t seq_len,
+                       uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
+                       float scale, BackendBuffer* partials);
+    void attention_turbo3(const BackendBuffer& q, uint32_t q_stride,
+                          const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                          BackendBuffer& out, uint32_t seq_len,
+                          uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
+                          float scale, BackendBuffer* partials);
+    void kv_store_f16_rows(const BackendBuffer& k, const BackendBuffer& v,
+                           BackendBuffer& k_cache, BackendBuffer& v_cache,
+                           uint32_t position, uint32_t row_length, uint32_t tokens);
+    void kv_store_turbo3_rows(const BackendBuffer& k, const BackendBuffer& v,
+                              BackendBuffer& k_cache, BackendBuffer& v_cache,
+                              uint32_t position, uint32_t kv_heads, uint32_t tokens);
+    void attention_f16_causal(const BackendBuffer& q, uint32_t q_stride,
+                              uint32_t q_row_stride, const BackendBuffer& k_cache,
+                              const BackendBuffer& v_cache,
+                              BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
+                              uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
+                              float scale, BackendBuffer* partials);
+    void attention_turbo3_causal(const BackendBuffer& q, uint32_t q_stride,
+                                 uint32_t q_row_stride, const BackendBuffer& k_cache,
+                                 const BackendBuffer& v_cache,
+                                 BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
+                                 uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
+                                 float scale, BackendBuffer* partials);
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace q27

--- a/src/metal/metal_backend.h
+++ b/src/metal/metal_backend.h
@@ -24,6 +24,7 @@ class MetalBackend final : public ComputeBackend {
     void copy(const BackendBuffer& src, uint64_t src_offset,
               BackendBuffer& dst, uint64_t dst_offset, uint64_t bytes) override;
     BackendTensor upload(const Tensor& tensor) override;
+    // Aliases model's mapped bytes; model must outlive the returned tensor.
     BackendTensor upload(const Model& model, const Tensor& tensor) override;
     void begin_commands() override;
     void end_commands() override;

--- a/src/metal/metal_backend.mm
+++ b/src/metal/metal_backend.mm
@@ -1,0 +1,1741 @@
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+#include "metal_backend.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <map>
+#include <stdexcept>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <vector>
+
+namespace q27 {
+namespace {
+
+class MetalBuffer final : public BackendBuffer {
+  public:
+    explicit MetalBuffer(id<MTLBuffer> buffer, bool writable = true)
+        : buffer_(buffer), writable_(writable) {}
+    uint64_t size() const override { return (uint64_t)buffer_.length; }
+    id<MTLBuffer> handle() const { return buffer_; }
+    bool writable() const { return writable_; }
+
+  private:
+    id<MTLBuffer> buffer_;
+    bool writable_;
+};
+
+MetalBuffer& metal_buffer(BackendBuffer& buffer) {
+    auto* result = dynamic_cast<MetalBuffer*>(&buffer);
+    if (!result) throw std::runtime_error("q27 Metal: buffer belongs to another backend");
+    if (!result->writable()) throw std::runtime_error("q27 Metal: buffer is read-only");
+    return *result;
+}
+
+const MetalBuffer& metal_buffer(const BackendBuffer& buffer) {
+    auto* result = dynamic_cast<const MetalBuffer*>(&buffer);
+    if (!result) throw std::runtime_error("q27 Metal: buffer belongs to another backend");
+    return *result;
+}
+
+const MetalBuffer& metal_buffer_view(const std::shared_ptr<BackendBuffer>& buffer) {
+    if (!buffer) throw std::runtime_error("q27 Metal: missing buffer");
+    return metal_buffer(static_cast<const BackendBuffer&>(*buffer));
+}
+
+const MetalBuffer& tensor_data(const BackendTensor& tensor, DType dtype, const char* operation) {
+    if (tensor.dtype != dtype || !tensor.data)
+        throw std::runtime_error(std::string("q27 Metal: invalid tensor for ") + operation);
+    return metal_buffer_view(tensor.data);
+}
+
+void check_range(uint64_t size, uint64_t offset, uint64_t bytes, const char* operation) {
+    if (offset > size || bytes > size - offset)
+        throw std::runtime_error(std::string("q27 Metal: buffer range error in ") + operation);
+}
+
+// Must match the "Q27_SHADER_ABI" tag in q27_kernels.metal. Shaders compile
+// from that file at runtime, so a host binary built before a buffer-binding
+// change would otherwise misbind silently against a newer shader file.
+constexpr const char* kShaderAbiTag = "// Q27_SHADER_ABI 6";
+
+NSString* load_kernel_source() {
+    NSFileManager* files = [NSFileManager defaultManager];
+    NSMutableArray<NSString*>* candidates = [NSMutableArray array];
+    if (const char* override_path = getenv("Q27_METAL_SOURCE"))
+        [candidates addObject:[NSString stringWithUTF8String:override_path]];
+    [candidates addObject:@"src/metal/q27_kernels.metal"];
+    [candidates addObject:@"./src/metal/q27_kernels.metal"];
+
+    for (NSString* path in candidates) {
+        if (![files fileExistsAtPath:path]) continue;
+        NSError* error = nil;
+        NSString* source = [NSString stringWithContentsOfFile:path
+                                                      encoding:NSUTF8StringEncoding
+                                                         error:&error];
+        if (!source)
+            throw std::runtime_error("q27 Metal: cannot read shader source: " +
+                                     std::string(error.localizedDescription.UTF8String));
+        // Match the tag as a complete logical line (any line ending), so
+        // ABI 2 does not accept ABI 20 and CRLF sources still load.
+        bool tag_found = false;
+        for (NSString* line in [source componentsSeparatedByCharactersInSet:
+                                           NSCharacterSet.newlineCharacterSet])
+            if ([[line stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet]
+                    isEqualToString:@(kShaderAbiTag)]) { tag_found = true; break; }
+        if (!tag_found)
+            throw std::runtime_error(std::string("q27 Metal: shader ABI mismatch: ") +
+                                     path.UTF8String + " does not carry \"" + kShaderAbiTag +
+                                     "\"; rebuild this binary against the current shader source");
+        return source;
+    }
+    throw std::runtime_error("q27 Metal: src/metal/q27_kernels.metal not found "
+                             "(set Q27_METAL_SOURCE)");
+}
+
+id<MTLComputePipelineState> make_pipeline(id<MTLDevice> device, id<MTLLibrary> library,
+                                          NSString* name) {
+    id<MTLFunction> function = [library newFunctionWithName:name];
+    if (!function)
+        throw std::runtime_error("q27 Metal: shader function not found: " +
+                                 std::string(name.UTF8String));
+    NSError* error = nil;
+    id<MTLComputePipelineState> pipeline = [device newComputePipelineStateWithFunction:function
+                                                                                  error:&error];
+    if (!pipeline)
+        throw std::runtime_error("q27 Metal: pipeline creation failed for " +
+                                 std::string(name.UTF8String) + ": " +
+                                 std::string(error.localizedDescription.UTF8String));
+    if (pipeline.threadExecutionWidth != 32 || pipeline.maxTotalThreadsPerThreadgroup < 256)
+        throw std::runtime_error("q27 Metal: matvec requires simd width 32 and 256-thread groups");
+    return pipeline;
+}
+
+struct MatvecArgs {
+    uint32_t rows;
+    uint32_t cols;
+    uint32_t simdgroups;
+};
+struct MatvecPairArgs { uint32_t rows_a, rows_b, cols, simdgroups; };
+struct MatmulArgs { uint32_t rows,cols,x_rows,simdgroups; };
+struct VectorArgs { uint32_t n, groups; float eps; };
+struct HeadArgs { uint32_t heads, head_dim, stride, groups; float eps; };
+struct GateArgs { uint32_t heads, head_dim; };
+struct ConcatArgs { uint32_t a_count, b_count; };
+struct RopeArgs { uint32_t heads, head_dim, n_rot, stride, position; float freq_base; };
+struct KvStoreArgs { uint32_t position, row_length; };
+struct TurboWhtArgs { uint32_t heads, stride, inverse; };
+struct TurboStoreArgs { uint32_t position, kv_heads; };
+struct AttentionArgs { uint32_t q_stride, seq_len, q_heads, kv_heads, head_dim; float scale; };
+struct DeltaArgs { uint32_t value_heads, qk_heads, head_dim; };
+struct EmbedRowsArgs { uint32_t cols, count, tokens[12]; };
+struct RowsNormArgs { uint32_t n, rows, groups; float eps; };
+struct MatvecPairRowsArgs { uint32_t rows_a, rows_b, cols, tokens; };
+struct GatesRowsArgs { uint32_t heads, tokens; };
+struct ConvChunkArgs { uint32_t channels, tokens; };
+struct DeltaChunkArgs { uint32_t value_heads, qk_heads, head_dim, tokens; };
+struct L2RowsArgs { uint32_t heads, head_dim, row_stride, tokens; float eps; };
+struct RopeRowsArgs { uint32_t heads, head_dim, n_rot, stride, row_stride, position, tokens; float freq_base; };
+struct KvStoreRowsArgs { uint32_t position, row_length, tokens; };
+struct TurboStoreRowsArgs { uint32_t position, kv_heads, tokens; };
+struct GateRowsArgs { uint32_t heads, head_dim, tokens; };
+struct ArgmaxRowsArgs { uint32_t n, rows; };
+struct AttentionCausalArgs { uint32_t q_stride, q_row_stride, base_len, q_heads, kv_heads, head_dim, tokens; float scale; };
+
+} // namespace
+
+struct MetalBackend::Impl {
+    id<MTLDevice> device;
+    id<MTLCommandQueue> queue;
+    id<MTLLibrary> library;
+    id<MTLComputePipelineState> f32;
+    id<MTLComputePipelineState> f16;
+    id<MTLComputePipelineState> q8;
+    id<MTLComputePipelineState> q4;
+    id<MTLComputePipelineState> t2;
+    id<MTLComputePipelineState> quantize;
+    id<MTLComputePipelineState> q8_quantized;
+    id<MTLComputePipelineState> q4_quantized;
+    id<MTLComputePipelineState> t2_quantized;
+    id<MTLComputePipelineState> f16_pair;
+    id<MTLComputePipelineState> q4_quantized_matmul;
+    id<MTLComputePipelineState> q8_quantized_matmul;
+    id<MTLComputePipelineState> t2_quantized_matmul;
+    id<MTLComputePipelineState> embedding;
+    id<MTLComputePipelineState> embedding_t2;
+    id<MTLComputePipelineState> embedding_t2_rows;
+    id<MTLComputePipelineState> rms;
+    id<MTLComputePipelineState> rms_quantized;
+    id<MTLComputePipelineState> rms_heads;
+    id<MTLComputePipelineState> l2_heads;
+    id<MTLComputePipelineState> silu;
+    id<MTLComputePipelineState> add;
+    id<MTLComputePipelineState> concat;
+    id<MTLComputePipelineState> copy_bytes;
+    id<MTLComputePipelineState> sigmoid_gate;
+    id<MTLComputePipelineState> rope;
+    id<MTLComputePipelineState> argmax;
+    id<MTLComputePipelineState> kv_store;
+    id<MTLComputePipelineState> turbo_wht;
+    id<MTLComputePipelineState> kv_store_turbo3;
+    id<MTLComputePipelineState> attention_turbo3;
+    id<MTLComputePipelineState> attention;
+    id<MTLComputePipelineState> gates;
+    id<MTLComputePipelineState> conv;
+    id<MTLComputePipelineState> delta;
+    id<MTLComputePipelineState> gated_norm;
+    id<MTLComputePipelineState> embedding_rows;
+    id<MTLComputePipelineState> rms_rows_quantized;
+    id<MTLComputePipelineState> f16_pair_rows;
+    id<MTLComputePipelineState> gates_rows;
+    id<MTLComputePipelineState> conv_chunked;
+    id<MTLComputePipelineState> delta_chunked;
+    id<MTLComputePipelineState> l2_rows;
+    id<MTLComputePipelineState> rope_rows;
+    id<MTLComputePipelineState> kv_store_rows;
+    id<MTLComputePipelineState> kv_store_turbo3_rows;
+    id<MTLComputePipelineState> attention_causal;
+    id<MTLComputePipelineState> attention_turbo3_causal_p;
+    id<MTLComputePipelineState> sigmoid_gate_rows;
+    id<MTLComputePipelineState> argmax_rows_p;
+    id<MTLComputePipelineState> nll_rows_p;
+    id<MTLCommandBuffer> command;
+    id<MTLComputeCommandEncoder> encoder;
+    bool batching = false;
+
+    // Model mappings that fit maxBufferLength are wrapped as a single
+    // MTLBuffer (tensors bind at offsets), and on macOS 15+ that buffer joins
+    // a residency set attached to the queue: pages stay wired between command
+    // buffers, so file-backed weight pages are neither faulted in token by
+    // token on first touch nor evictable under memory pressure mid-run.
+    std::map<const void*, std::weak_ptr<MetalBuffer>> model_wraps;
+    API_AVAILABLE(macos(15.0)) id<MTLResidencySet> residency_set;
+
+    // Q27_METAL_PROFILE=1: per-dispatch GPU-time attribution. Every operation
+    // runs in its own compute encoder bracketed by stage-boundary timestamp
+    // samples, so independent dispatches no longer overlap; absolute wall time
+    // is inflated, the per-kernel shares are the signal.
+    static constexpr uint32_t kMaxProfiledOps = 2048;
+    struct ProfileStat { uint64_t calls = 0; uint64_t ticks = 0; };
+    bool profile = false;
+    id<MTLCounterSampleBuffer> counter_buffer;
+    std::vector<const char*> op_labels;
+    std::map<std::string, ProfileStat> profile_stats;
+    uint64_t profiled_command_buffers = 0;
+    double gpu_busy_seconds = 0.0;
+    double cpu_wait_seconds = 0.0;
+    MTLTimestamp calibration_cpu = 0, calibration_gpu = 0;
+
+    void start_command(bool explicit_batch) {
+        if (encoder) throw std::runtime_error("q27 Metal: command batch already active");
+        command = [queue commandBuffer];
+        if (!command) throw std::runtime_error("q27 Metal: command creation failed");
+        if (profile) {
+            op_labels.clear();
+        } else {
+            encoder = [command computeCommandEncoder];
+            if (!encoder) throw std::runtime_error("q27 Metal: command creation failed");
+        }
+        batching = explicit_batch;
+    }
+
+    id<MTLComputeCommandEncoder> encoder_for_operation(bool& own_command, const char* label) {
+        own_command = !batching;
+        if (own_command) start_command(false);
+        if (profile) {
+            if (op_labels.size() >= kMaxProfiledOps) {
+                // Split the batch so the sample buffer never overflows; the
+                // queue preserves ordering across the two command buffers.
+                const bool was_batching = batching;
+                finish_command("profiling split");
+                start_command(was_batching);
+            }
+            if (encoder) { [encoder endEncoding]; encoder = nil; }
+            MTLComputePassDescriptor* pass = [MTLComputePassDescriptor computePassDescriptor];
+            MTLComputePassSampleBufferAttachmentDescriptor* attachment = pass.sampleBufferAttachments[0];
+            attachment.sampleBuffer = counter_buffer;
+            attachment.startOfEncoderSampleIndex = op_labels.size() * 2;
+            attachment.endOfEncoderSampleIndex = op_labels.size() * 2 + 1;
+            encoder = [command computeCommandEncoderWithDescriptor:pass];
+            if (!encoder) throw std::runtime_error("q27 Metal: profiled encoder creation failed");
+            op_labels.push_back(label);
+        }
+        return encoder;
+    }
+
+    void finish_command(const char* label) {
+        if (!command || (!encoder && !profile))
+            throw std::runtime_error("q27 Metal: no active command batch");
+        if (encoder) { [encoder endEncoding]; encoder = nil; }
+        const auto wait_start = std::chrono::steady_clock::now();
+        [command commit];
+        [command waitUntilCompleted];
+        cpu_wait_seconds += std::chrono::duration<double>(std::chrono::steady_clock::now() - wait_start).count();
+        if (command.status == MTLCommandBufferStatusError) {
+            std::string message = std::string("q27 Metal: ") + label + " failed";
+            if (command.error) message += ": " + std::string(command.error.localizedDescription.UTF8String);
+            command = nil;
+            batching = false;
+            throw std::runtime_error(message);
+        }
+        if (profile) resolve_profile_samples();
+        command = nil;
+        batching = false;
+    }
+
+    void resolve_profile_samples() {
+        profiled_command_buffers++;
+        if (command.GPUEndTime > command.GPUStartTime)
+            gpu_busy_seconds += command.GPUEndTime - command.GPUStartTime;
+        if (op_labels.empty()) return;
+        NSData* data = [counter_buffer resolveCounterRange:NSMakeRange(0, op_labels.size() * 2)];
+        if (data && data.length >= op_labels.size() * 2 * sizeof(MTLCounterResultTimestamp)) {
+            const auto* samples = (const MTLCounterResultTimestamp*)data.bytes;
+            for (size_t i = 0; i < op_labels.size(); i++) {
+                const uint64_t begin = samples[2 * i].timestamp, end = samples[2 * i + 1].timestamp;
+                if (begin == MTLCounterErrorValue || end == MTLCounterErrorValue || end < begin) continue;
+                ProfileStat& stat = profile_stats[op_labels[i]];
+                stat.calls++;
+                stat.ticks += end - begin;
+            }
+        }
+        op_labels.clear();
+    }
+
+    void report_profile() {
+        if (!profile || profile_stats.empty()) return;
+        // Convert GPU timestamp ticks to nanoseconds with a session-spanning
+        // calibration pair; on Apple Silicon the timebase is usually already
+        // nanoseconds, but that is not contractual.
+        MTLTimestamp cpu_now = 0, gpu_now = 0;
+        [device sampleTimestamps:&cpu_now gpuTimestamp:&gpu_now];
+        double ns_per_tick = 1.0;
+        if (gpu_now > calibration_gpu && cpu_now > calibration_cpu)
+            ns_per_tick = double(cpu_now - calibration_cpu) / double(gpu_now - calibration_gpu);
+        std::vector<std::pair<std::string, ProfileStat>> rows(profile_stats.begin(), profile_stats.end());
+        std::sort(rows.begin(), rows.end(),
+                  [](const auto& a, const auto& b) { return a.second.ticks > b.second.ticks; });
+        double total_ns = 0.0;
+        uint64_t total_calls = 0;
+        for (const auto& row : rows) { total_ns += double(row.second.ticks) * ns_per_tick; total_calls += row.second.calls; }
+        fprintf(stderr, "q27 Metal profile (per-op encoders; overlap suppressed, shares are the signal)\n");
+        fprintf(stderr, "%-36s %10s %12s %10s %6s\n", "kernel", "calls", "total ms", "avg us", "share");
+        for (const auto& row : rows) {
+            const double ns = double(row.second.ticks) * ns_per_tick;
+            fprintf(stderr, "%-36s %10llu %12.2f %10.1f %5.1f%%\n", row.first.c_str(),
+                    (unsigned long long)row.second.calls, ns / 1e6,
+                    ns / 1e3 / double(row.second.calls), 100.0 * ns / total_ns);
+        }
+        fprintf(stderr, "%-36s %10llu %12.2f\n", "total sampled", (unsigned long long)total_calls, total_ns / 1e6);
+        fprintf(stderr, "command buffers %llu, GPU busy %.3f s, CPU wait %.3f s\n",
+                (unsigned long long)profiled_command_buffers, gpu_busy_seconds, cpu_wait_seconds);
+    }
+};
+
+MetalBackend::MetalBackend() : impl_(new Impl) {
+    @autoreleasepool {
+        impl_->device = MTLCreateSystemDefaultDevice();
+        if (!impl_->device) throw std::runtime_error("q27 Metal: no Metal device");
+        impl_->queue = [impl_->device newCommandQueue];
+        if (!impl_->queue) throw std::runtime_error("q27 Metal: cannot create command queue");
+
+        if (@available(macOS 15.0, *)) {
+            const char* env = getenv("Q27_METAL_NO_RESIDENCY");
+            if (!env || !*env || *env == '0') {
+                MTLResidencySetDescriptor* residency_descriptor = [MTLResidencySetDescriptor new];
+                residency_descriptor.label = @"q27 model weights";
+                NSError* residency_error = nil;
+                impl_->residency_set =
+                    [impl_->device newResidencySetWithDescriptor:residency_descriptor
+                                                           error:&residency_error];
+                if (impl_->residency_set) [impl_->queue addResidencySet:impl_->residency_set];
+            }
+        }
+
+        MTLCompileOptions* options = [MTLCompileOptions new];
+        // Correctness baseline; enable relaxed math only after CUDA comparison.
+        if (@available(macOS 15.0, *)) {
+            options.mathMode = MTLMathModeSafe;
+        } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            options.fastMathEnabled = NO;
+#pragma clang diagnostic pop
+        }
+        NSError* error = nil;
+        impl_->library = [impl_->device newLibraryWithSource:load_kernel_source()
+                                                      options:options
+                                                        error:&error];
+        if (!impl_->library)
+            throw std::runtime_error("q27 Metal: shader compilation failed: " +
+                                     std::string(error.localizedDescription.UTF8String));
+        impl_->f32 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_f32");
+        impl_->f16 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_f16");
+        impl_->q8 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_q8_g128");
+        impl_->q4 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_q4_g64");
+        impl_->t2 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_t2_g128");
+        impl_->quantize = make_pipeline(impl_->device, impl_->library, @"q27_quantize_x");
+        impl_->q8_quantized = make_pipeline(impl_->device, impl_->library, @"q27_matvec_q8_quantized");
+        impl_->q4_quantized = make_pipeline(impl_->device, impl_->library, @"q27_matvec_q4_quantized");
+        impl_->t2_quantized = make_pipeline(impl_->device, impl_->library, @"q27_matvec_t2_quantized");
+        impl_->f16_pair = make_pipeline(impl_->device, impl_->library, @"q27_matvec_f16_pair");
+        // SIMD-scoped matrix multiply is optional on older Intel-family Metal
+        // devices. Decode GEMV remains available there; only small-N GEMM is gated.
+        if ([impl_->device supportsFamily:MTLGPUFamilyApple7]) {
+            impl_->q4_quantized_matmul = make_pipeline(impl_->device, impl_->library, @"q27_matmul_q4_mm");
+            impl_->q8_quantized_matmul = make_pipeline(impl_->device, impl_->library, @"q27_matmul_q8_mm");
+            impl_->t2_quantized_matmul = make_pipeline(impl_->device, impl_->library, @"q27_matmul_t2_mm");
+        }
+        impl_->embedding = make_pipeline(impl_->device, impl_->library, @"q27_embedding_q8");
+        impl_->embedding_t2 = make_pipeline(impl_->device, impl_->library, @"q27_embedding_t2");
+        impl_->embedding_t2_rows = make_pipeline(impl_->device, impl_->library, @"q27_embedding_t2_rows");
+        impl_->rms = make_pipeline(impl_->device, impl_->library, @"q27_rmsnorm");
+        impl_->rms_quantized = make_pipeline(impl_->device, impl_->library, @"q27_rmsnorm_quantized");
+        impl_->rms_heads = make_pipeline(impl_->device, impl_->library, @"q27_rmsnorm_heads");
+        impl_->l2_heads = make_pipeline(impl_->device, impl_->library, @"q27_l2norm_heads");
+        impl_->silu = make_pipeline(impl_->device, impl_->library, @"q27_silu_mul");
+        impl_->add = make_pipeline(impl_->device, impl_->library, @"q27_add_inplace");
+        impl_->concat = make_pipeline(impl_->device, impl_->library, @"q27_concat");
+        impl_->copy_bytes = make_pipeline(impl_->device, impl_->library, @"q27_copy_bytes");
+        impl_->sigmoid_gate = make_pipeline(impl_->device, impl_->library, @"q27_sigmoid_gate_mul");
+        impl_->rope = make_pipeline(impl_->device, impl_->library, @"q27_rope_neox");
+        impl_->argmax = make_pipeline(impl_->device, impl_->library, @"q27_argmax");
+        impl_->kv_store = make_pipeline(impl_->device, impl_->library, @"q27_kv_store_f16");
+        impl_->turbo_wht = make_pipeline(impl_->device, impl_->library, @"q27_turbo_wht");
+        impl_->kv_store_turbo3 = make_pipeline(impl_->device, impl_->library, @"q27_kv_store_turbo3");
+        impl_->attention_turbo3 = make_pipeline(impl_->device, impl_->library, @"q27_attention_turbo3");
+        impl_->attention = make_pipeline(impl_->device, impl_->library, @"q27_attention_f16");
+        impl_->gates = make_pipeline(impl_->device, impl_->library, @"q27_gdn_gates");
+        impl_->conv = make_pipeline(impl_->device, impl_->library, @"q27_conv_step");
+        impl_->delta = make_pipeline(impl_->device, impl_->library, @"q27_delta_step");
+        impl_->gated_norm = make_pipeline(impl_->device, impl_->library, @"q27_gated_norm_gdn");
+        impl_->embedding_rows = make_pipeline(impl_->device, impl_->library, @"q27_embedding_q8_rows");
+        impl_->rms_rows_quantized = make_pipeline(impl_->device, impl_->library, @"q27_rmsnorm_rows_quantized");
+        impl_->f16_pair_rows = make_pipeline(impl_->device, impl_->library, @"q27_matvec_f16_pair_rows");
+        impl_->gates_rows = make_pipeline(impl_->device, impl_->library, @"q27_gdn_gates_rows");
+        impl_->conv_chunked = make_pipeline(impl_->device, impl_->library, @"q27_conv_chunk");
+        impl_->delta_chunked = make_pipeline(impl_->device, impl_->library, @"q27_delta_chunk");
+        impl_->l2_rows = make_pipeline(impl_->device, impl_->library, @"q27_l2norm_rows");
+        impl_->rope_rows = make_pipeline(impl_->device, impl_->library, @"q27_rope_neox_rows");
+        impl_->kv_store_rows = make_pipeline(impl_->device, impl_->library, @"q27_kv_store_f16_rows");
+        impl_->kv_store_turbo3_rows = make_pipeline(impl_->device, impl_->library, @"q27_kv_store_turbo3_rows");
+        impl_->attention_causal = make_pipeline(impl_->device, impl_->library, @"q27_attention_f16_causal");
+        impl_->attention_turbo3_causal_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_turbo3_causal");
+        impl_->sigmoid_gate_rows = make_pipeline(impl_->device, impl_->library, @"q27_sigmoid_gate_mul_rows");
+        impl_->argmax_rows_p = make_pipeline(impl_->device, impl_->library, @"q27_argmax_rows");
+        impl_->nll_rows_p = make_pipeline(impl_->device, impl_->library, @"q27_nll_rows");
+
+        if (const char* env = getenv("Q27_METAL_PROFILE"); env && *env && *env != '0') {
+            id<MTLCounterSet> timestamps = nil;
+            for (id<MTLCounterSet> set in impl_->device.counterSets)
+                if ([set.name isEqualToString:MTLCommonCounterSetTimestamp]) timestamps = set;
+            if (timestamps &&
+                [impl_->device supportsCounterSampling:MTLCounterSamplingPointAtStageBoundary]) {
+                MTLCounterSampleBufferDescriptor* descriptor = [MTLCounterSampleBufferDescriptor new];
+                descriptor.counterSet = timestamps;
+                descriptor.storageMode = MTLStorageModeShared;
+                descriptor.sampleCount = Impl::kMaxProfiledOps * 2;
+                NSError* error = nil;
+                impl_->counter_buffer = [impl_->device newCounterSampleBufferWithDescriptor:descriptor
+                                                                                       error:&error];
+            }
+            if (impl_->counter_buffer) {
+                impl_->profile = true;
+                [impl_->device sampleTimestamps:&impl_->calibration_cpu
+                                    gpuTimestamp:&impl_->calibration_gpu];
+                fprintf(stderr, "q27 Metal: per-dispatch profiling enabled\n");
+            } else {
+                fprintf(stderr, "q27 Metal: Q27_METAL_PROFILE set but stage-boundary "
+                                "timestamp sampling is unavailable; profiling disabled\n");
+            }
+        }
+    }
+}
+
+MetalBackend::~MetalBackend() {
+    @autoreleasepool { impl_->report_profile(); }
+}
+
+std::string MetalBackend::name() const {
+    return std::string(impl_->device.name.UTF8String);
+}
+
+std::shared_ptr<BackendBuffer> MetalBackend::allocate(uint64_t bytes) {
+    if (!bytes || bytes > (uint64_t)impl_->device.maxBufferLength ||
+        bytes > (uint64_t)std::numeric_limits<NSUInteger>::max())
+        throw std::runtime_error("q27 Metal: invalid buffer length");
+    id<MTLBuffer> buffer = [impl_->device newBufferWithLength:(NSUInteger)bytes
+                                                      options:MTLResourceStorageModeShared];
+    if (!buffer) throw std::runtime_error("q27 Metal: buffer allocation failed");
+    return std::make_shared<MetalBuffer>(buffer);
+}
+
+void MetalBackend::write(BackendBuffer& dst, uint64_t offset, const void* src, uint64_t bytes) {
+    MetalBuffer& buffer = metal_buffer(dst);
+    check_range(buffer.size(), offset, bytes, "write");
+    if (bytes && !src) throw std::runtime_error("q27 Metal: null write source");
+    if (bytes) std::memcpy((uint8_t*)buffer.handle().contents + offset, src, (size_t)bytes);
+}
+
+void MetalBackend::read(const BackendBuffer& src, uint64_t offset, void* dst, uint64_t bytes) {
+    const MetalBuffer& buffer = metal_buffer(src);
+    check_range(buffer.size(), offset, bytes, "read");
+    if (bytes && !dst) throw std::runtime_error("q27 Metal: null read destination");
+    synchronize();
+    if (bytes) std::memcpy(dst, (const uint8_t*)buffer.handle().contents + offset, (size_t)bytes);
+}
+
+void MetalBackend::zero(BackendBuffer& dst) {
+    MetalBuffer& buffer = metal_buffer(dst);
+    if (impl_->batching) throw std::runtime_error("q27 Metal: cannot CPU-clear during command batch");
+    std::memset(buffer.handle().contents, 0, (size_t)buffer.size());
+}
+
+void MetalBackend::copy(const BackendBuffer& src, uint64_t src_offset,
+                        BackendBuffer& dst, uint64_t dst_offset, uint64_t bytes) {
+    const MetalBuffer& sb=metal_buffer(src); MetalBuffer& db=metal_buffer(dst);
+    check_range(sb.size(),src_offset,bytes,"copy source"); check_range(db.size(),dst_offset,bytes,"copy destination");
+    if (!bytes) return;
+    if (bytes > UINT32_MAX) throw std::runtime_error("q27 Metal: single copy exceeds kernel limit");
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_copy_bytes"); [enc setComputePipelineState:impl_->copy_bytes];
+        [enc setBuffer:sb.handle() offset:(NSUInteger)src_offset atIndex:0];
+        [enc setBuffer:db.handle() offset:(NSUInteger)dst_offset atIndex:1];
+        [enc setBytes:&bytes length:sizeof(bytes) atIndex:2];
+        [enc dispatchThreads:MTLSizeMake((NSUInteger)bytes,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("copy");
+    }
+}
+
+BackendTensor MetalBackend::upload(const Tensor& tensor) {
+    if (tensor.dtype == DType::T2_G128) {
+        if (tensor.data_size && !tensor.data)
+            throw std::runtime_error("q27 Metal: T2 data payload is missing");
+        for (uint64_t i = 0; i < tensor.data_size; i++) {
+            const uint8_t byte = tensor.data[i];
+            for (int shift = 0; shift < 8; shift += 2)
+                if (((byte >> shift) & 3u) == 3u)
+                    throw std::runtime_error("q27 Metal: T2 payload contains reserved code 3");
+        }
+    }
+    BackendTensor result;
+    result.dtype = tensor.dtype;
+    result.rows = tensor.rows();
+    result.cols = tensor.cols();
+    result.data = allocate(tensor.data_size);
+    write(*result.data, 0, tensor.data, tensor.data_size);
+    if (tensor.scales_size) {
+        result.scales = allocate(tensor.scales_size);
+        write(*result.scales, 0, tensor.scales, tensor.scales_size);
+    }
+    return result;
+}
+
+BackendTensor MetalBackend::upload(const Model& model, const Tensor& tensor) {
+    // Preferred form: one MTLBuffer wraps the whole mapping and every tensor
+    // binds at an offset. One buffer instead of two per tensor keeps the
+    // per-commit residency/tracking work constant in model size, and gives
+    // the residency set a single allocation to wire. Mappings larger than
+    // maxBufferLength (the 5.25 bpw tier) keep per-tensor page-aligned views
+    // and stay unwired -- they do not fit in memory either way.
+    auto wrap_mapping = [&]() -> std::shared_ptr<MetalBuffer> {
+        void* base = (void*)model.mapping_base();
+        const uint64_t size = model.mapping_size();
+        auto& slot = impl_->model_wraps[base];
+        if (auto held = slot.lock()) return held;
+        madvise(base, (size_t)size, MADV_WILLNEED);
+        id<MTLBuffer> buffer = [impl_->device newBufferWithBytesNoCopy:base
+                                                                length:(NSUInteger)size
+                                                               options:MTLResourceStorageModeShared
+                                                           deallocator:nil];
+        if (!buffer) throw std::runtime_error("q27 Metal: cannot wrap model mmap");
+        std::shared_ptr<MetalBuffer> wrapped;
+        if (@available(macOS 15.0, *)) {
+            if (id<MTLResidencySet> set = impl_->residency_set) {
+                [set addAllocation:buffer];
+                [set commit];
+                [set requestResidency];
+                // The set retains the buffer and keeps its pages wired; drop
+                // it when the last tensor goes away so a later munmap cannot
+                // leave the set holding a dead address range.
+                wrapped = std::shared_ptr<MetalBuffer>(
+                    new MetalBuffer(buffer, false), [set](MetalBuffer* wrapper) {
+                        if (@available(macOS 15.0, *)) {
+                            [set removeAllocation:wrapper->handle()];
+                            [set commit];
+                        }
+                        delete wrapper;
+                    });
+            }
+        }
+        if (!wrapped) wrapped = std::make_shared<MetalBuffer>(buffer, false);
+        slot = wrapped;
+        return wrapped;
+    };
+
+    auto mapping_offset = [&](const uint8_t* ptr, uint64_t bytes) -> uint64_t {
+        if (!ptr || !bytes) throw std::runtime_error("q27 Metal: invalid model view");
+        const uintptr_t base = (uintptr_t)model.mapping_base();
+        const uintptr_t address = (uintptr_t)ptr;
+        if (address < base) throw std::runtime_error("q27 Metal: tensor precedes model mapping");
+        const uint64_t offset = (uint64_t)(address - base);
+        if (offset > model.mapping_size() || bytes > model.mapping_size() - offset)
+            throw std::runtime_error("q27 Metal: tensor outside model mapping");
+        return offset;
+    };
+
+    if (!model.mapping_base() || !model.mapping_size())
+        throw std::runtime_error("q27 Metal: invalid model view");
+    if (model.mapping_size() <= (uint64_t)impl_->device.maxBufferLength) {
+        BackendTensor result;
+        result.dtype = tensor.dtype;
+        result.rows = tensor.rows();
+        result.cols = tensor.cols();
+        result.data_offset = mapping_offset(tensor.data, tensor.data_size);
+        result.data = wrap_mapping();
+        if (tensor.scales_size) {
+            result.scales_offset = mapping_offset(tensor.scales, tensor.scales_size);
+            result.scales = result.data;
+        }
+        return result;
+    }
+
+    auto wrap = [&](const uint8_t* ptr, uint64_t bytes, uint64_t& inner) {
+        if (!ptr || !bytes || !model.mapping_base() || !model.mapping_size())
+            throw std::runtime_error("q27 Metal: invalid model view");
+        const uintptr_t base = (uintptr_t)model.mapping_base();
+        const uintptr_t address = (uintptr_t)ptr;
+        if (address < base) throw std::runtime_error("q27 Metal: tensor precedes model mapping");
+        const uint64_t offset = (uint64_t)(address - base);
+        const uint64_t model_size = model.mapping_size();
+        if (offset > model_size || bytes > model_size - offset)
+            throw std::runtime_error("q27 Metal: tensor outside model mapping");
+
+        const uint64_t page = (uint64_t)getpagesize();
+        const uint64_t page_offset = offset - offset % page;
+        inner = offset - page_offset;
+        if (bytes > UINT64_MAX - inner)
+            throw std::runtime_error("q27 Metal: model view size overflow");
+        uint64_t view_bytes = inner + bytes;
+        if (view_bytes > UINT64_MAX - (page - 1))
+            throw std::runtime_error("q27 Metal: model view alignment overflow");
+        view_bytes = (view_bytes + page - 1) / page * page;
+        if (view_bytes > model_size - page_offset) view_bytes = model_size - page_offset;
+        if (inner + bytes > view_bytes || view_bytes > (uint64_t)impl_->device.maxBufferLength)
+            throw std::runtime_error("q27 Metal: model view exceeds Metal buffer limits");
+
+        void* view_base = (void*)(base + page_offset);
+        id<MTLBuffer> buffer = [impl_->device newBufferWithBytesNoCopy:view_base
+                                                               length:(NSUInteger)view_bytes
+                                                              options:MTLResourceStorageModeShared
+                                                          deallocator:nil];
+        if (!buffer) throw std::runtime_error("q27 Metal: cannot wrap model mmap");
+        return std::shared_ptr<BackendBuffer>(std::make_shared<MetalBuffer>(buffer, false));
+    };
+
+    BackendTensor result;
+    result.dtype = tensor.dtype;
+    result.rows = tensor.rows();
+    result.cols = tensor.cols();
+    result.data = wrap(tensor.data, tensor.data_size, result.data_offset);
+    if (tensor.scales_size)
+        result.scales = wrap(tensor.scales, tensor.scales_size, result.scales_offset);
+    return result;
+}
+
+void MetalBackend::begin_commands() {
+    @autoreleasepool { impl_->start_command(true); }
+}
+
+void MetalBackend::end_commands() {
+    @autoreleasepool { impl_->finish_command("command batch"); }
+}
+
+void MetalBackend::abort_commands() noexcept {
+    @autoreleasepool {
+        if (impl_->encoder) [impl_->encoder endEncoding];
+        impl_->encoder = nil;
+        impl_->command = nil;
+        impl_->batching = false;
+    }
+}
+
+void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
+                          BackendBuffer& y) {
+    if (!weight.data) throw std::runtime_error("q27 Metal: matvec weight has no data");
+    if (!weight.rows || !weight.cols || weight.rows > UINT32_MAX || weight.cols > UINT32_MAX)
+        throw std::runtime_error("q27 Metal: unsupported matvec dimensions");
+    check_range(x.size(), 0, weight.cols * sizeof(float), "matvec input");
+    check_range(y.size(), 0, weight.rows * sizeof(float), "matvec output");
+
+    const MetalBuffer& data = metal_buffer_view(weight.data);
+    const MetalBuffer& input = metal_buffer(x);
+    MetalBuffer& output = metal_buffer(y);
+    const uint64_t quant_group = weight.dtype == DType::Q8_G128 ? 128 :
+                                 weight.dtype == DType::T2_G128 ? 128 :
+                                 weight.dtype == DType::Q4_G64 ? 64 : 0;
+    if (quant_group && weight.cols % quant_group)
+        throw std::runtime_error("q27 Metal: matvec columns do not match quantization group");
+    uint64_t data_bytes = weight.rows * weight.cols;
+    if (weight.dtype == DType::F32) data_bytes *= 4;
+    if (weight.dtype == DType::F16) data_bytes *= 2;
+    if (weight.dtype == DType::Q4_G64) data_bytes /= 2;
+    if (weight.dtype == DType::T2_G128) data_bytes /= 4;
+    check_range(data.size(), weight.data_offset, data_bytes, "matvec weight");
+    id<MTLComputePipelineState> pipeline = nil;
+    const char* label = nullptr;
+    switch (weight.dtype) {
+        case DType::F32: pipeline = impl_->f32; label = "q27_matvec_f32"; break;
+        case DType::F16: pipeline = impl_->f16; label = "q27_matvec_f16"; break;
+        case DType::Q8_G128: pipeline = impl_->q8; label = "q27_matvec_q8_g128"; break;
+        case DType::Q4_G64: pipeline = impl_->q4; label = "q27_matvec_q4_g64"; break;
+        case DType::T2_G128: pipeline = impl_->t2; label = "q27_matvec_t2_g128"; break;
+        case DType::T3_G128:
+        case DType::B1_G128:
+            throw std::runtime_error("q27 Metal: unsupported matvec dtype");
+    }
+    const MetalBuffer* quant_scales = nullptr;
+    if (quant_group) {
+        if (!weight.scales) throw std::runtime_error("q27 Metal: quantized weight has no scales");
+        quant_scales = &metal_buffer_view(weight.scales);
+        const uint64_t group = quant_group;
+        const uint64_t scale_bytes = weight.rows * (weight.cols / group) * 2;
+        check_range(quant_scales->size(), weight.scales_offset, scale_bytes, "matvec scales");
+    }
+
+    MatvecArgs args{(uint32_t)weight.rows, (uint32_t)weight.cols, 8};
+    @autoreleasepool {
+        bool own_command;
+        id<MTLComputeCommandEncoder> encoder = impl_->encoder_for_operation(own_command, label);
+        [encoder setComputePipelineState:pipeline];
+        if (weight.dtype == DType::F32 || weight.dtype == DType::F16) {
+            [encoder setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
+            [encoder setBuffer:input.handle() offset:0 atIndex:1];
+            [encoder setBuffer:output.handle() offset:0 atIndex:2];
+            [encoder setBytes:&args length:sizeof(args) atIndex:3];
+        } else {
+            [encoder setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
+            [encoder setBuffer:quant_scales->handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
+            [encoder setBuffer:input.handle() offset:0 atIndex:2];
+            [encoder setBuffer:output.handle() offset:0 atIndex:3];
+            [encoder setBytes:&args length:sizeof(args) atIndex:4];
+        }
+        // T2 runs 4 rows per simdgroup (32 per threadgroup); others 1 (8).
+        const NSUInteger row_groups = weight.dtype == DType::T2_G128
+            ? (NSUInteger)(weight.rows + 31) / 32 : (NSUInteger)(weight.rows + 7) / 8;
+        [encoder dispatchThreadgroups:MTLSizeMake(row_groups, 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        if (own_command) impl_->finish_command("matvec");
+    }
+}
+
+void MetalBackend::matvec_pair(const BackendTensor& a, BackendBuffer& a_out,
+                               const BackendTensor& b, BackendBuffer& b_out,
+                               const BackendBuffer& x) {
+    if(a.dtype!=DType::F16 || b.dtype!=DType::F16 || a.cols!=b.cols) {
+        matvec(a,x,a_out); matvec(b,x,b_out); return;
+    }
+    if(!a.data || !b.data || !a.rows || !b.rows || !a.cols || a.rows>UINT32_MAX ||
+       b.rows>UINT32_MAX || a.cols>UINT32_MAX)
+        throw std::runtime_error("q27 Metal: invalid fused F16 matvec");
+    check_range(x.size(),0,a.cols*4,"fused matvec input");
+    check_range(a_out.size(),0,a.rows*4,"fused matvec output A");
+    check_range(b_out.size(),0,b.rows*4,"fused matvec output B");
+    const MetalBuffer& ad=metal_buffer_view(a.data); const MetalBuffer& bd=metal_buffer_view(b.data);
+    const MetalBuffer& input=metal_buffer(x); MetalBuffer& ao=metal_buffer(a_out); MetalBuffer& bo=metal_buffer(b_out);
+    check_range(ad.size(),a.data_offset,a.rows*a.cols*2,"fused matvec weight A");
+    check_range(bd.size(),b.data_offset,b.rows*b.cols*2,"fused matvec weight B");
+    MatvecPairArgs args{(uint32_t)a.rows,(uint32_t)b.rows,(uint32_t)a.cols,8};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_matvec_f16_pair"); [enc setComputePipelineState:impl_->f16_pair];
+        [enc setBuffer:ad.handle() offset:(NSUInteger)a.data_offset atIndex:0]; [enc setBuffer:ao.handle() offset:0 atIndex:1];
+        [enc setBuffer:bd.handle() offset:(NSUInteger)b.data_offset atIndex:2]; [enc setBuffer:bo.handle() offset:0 atIndex:3];
+        [enc setBuffer:input.handle() offset:0 atIndex:4]; [enc setBytes:&args length:sizeof(args) atIndex:5];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)std::max(a.rows,b.rows),1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("fused matvec pair");
+    }
+}
+
+BackendQuantized MetalBackend::allocate_quantized(uint32_t count) {
+    if (!count || count % 32) throw std::runtime_error("q27 Metal: quantized activation count must be a multiple of 32");
+    BackendQuantized result; result.count=count;
+    result.values=allocate(count); result.scales=allocate((uint64_t)(count/32)*sizeof(float));
+    return result;
+}
+
+void MetalBackend::quantize(const BackendBuffer& x, BackendQuantized& out) {
+    if (!out.count || out.count%32 || !out.values || !out.scales)
+        throw std::runtime_error("q27 Metal: invalid quantized activation");
+    const MetalBuffer& xb=metal_buffer(x); MetalBuffer& values=metal_buffer(*out.values); MetalBuffer& scales=metal_buffer(*out.scales);
+    check_range(xb.size(),0,(uint64_t)out.count*4,"quantize input"); check_range(values.size(),0,out.count,"quantize values");
+    check_range(scales.size(),0,(uint64_t)(out.count/32)*4,"quantize scales");
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_quantize_x"); [enc setComputePipelineState:impl_->quantize];
+        [enc setBuffer:xb.handle() offset:0 atIndex:0]; [enc setBuffer:values.handle() offset:0 atIndex:1];
+        [enc setBuffer:scales.handle() offset:0 atIndex:2]; [enc setBytes:&out.count length:4 atIndex:3];
+        [enc dispatchThreadgroups:MTLSizeMake(out.count/32,1,1) threadsPerThreadgroup:MTLSizeMake(32,1,1)];
+        if(own) impl_->finish_command("activation quantize");
+    }
+}
+
+void MetalBackend::matvec_quantized(const BackendTensor& weight,
+                                     const BackendQuantized& x, BackendBuffer& y) {
+    if ((weight.dtype!=DType::Q4_G64 && weight.dtype!=DType::Q8_G128 &&
+         weight.dtype!=DType::T2_G128) || !weight.data || !weight.scales)
+        throw std::runtime_error("q27 Metal: quantized matvec requires Q4/Q8/T2 weight");
+    const uint64_t group=weight.dtype==DType::Q4_G64?64:128;
+    if (!weight.rows || !weight.cols || weight.rows>UINT32_MAX || weight.cols>UINT32_MAX ||
+        weight.cols%group)
+        throw std::runtime_error("q27 Metal: invalid quantized matvec dimensions");
+    if (x.count!=weight.cols || !x.values || !x.scales)
+        throw std::runtime_error("q27 Metal: quantized matvec activation mismatch");
+    check_range(y.size(),0,weight.rows*4,"quantized matvec output");
+    const MetalBuffer& data=metal_buffer_view(weight.data); const MetalBuffer& ws=metal_buffer_view(weight.scales);
+    const MetalBuffer& xv=metal_buffer_view(x.values); const MetalBuffer& xs=metal_buffer_view(x.scales); MetalBuffer& out=metal_buffer(y);
+    const uint64_t divisor=weight.dtype==DType::Q4_G64?2:weight.dtype==DType::T2_G128?4:1;
+    const uint64_t data_bytes=weight.rows*weight.cols/divisor;
+    check_range(data.size(),weight.data_offset,data_bytes,"quantized matvec weight");
+    check_range(ws.size(),weight.scales_offset,weight.rows*(weight.cols/group)*2,"quantized matvec weight scales");
+    check_range(xv.size(),0,x.count,"quantized matvec values"); check_range(xs.size(),0,(uint64_t)(x.count/32)*4,"quantized matvec activation scales");
+    MatvecArgs args{(uint32_t)weight.rows,(uint32_t)weight.cols,8};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own,
+            weight.dtype==DType::Q8_G128?"q27_matvec_q8_quantized":
+            weight.dtype==DType::T2_G128?"q27_matvec_t2_quantized":"q27_matvec_q4_quantized");
+        [enc setComputePipelineState:weight.dtype==DType::Q8_G128?impl_->q8_quantized:
+                                     weight.dtype==DType::T2_G128?impl_->t2_quantized:impl_->q4_quantized];
+        [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
+        [enc setBuffer:ws.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
+        [enc setBuffer:xv.handle() offset:0 atIndex:2]; [enc setBuffer:xs.handle() offset:0 atIndex:3];
+        [enc setBuffer:out.handle() offset:0 atIndex:4]; [enc setBytes:&args length:sizeof(args) atIndex:5];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(weight.rows+7)/8,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("quantized matvec");
+    }
+}
+
+// Two independent packed-dot dispatches now beat a fused pair kernel: the
+// rewritten GEMV is weight-stream-bound, so sharing the (cached) activation
+// bytes buys nothing, while the fused kernel's doubled register pressure
+// measured 47-55 GB/s against 67-69 GB/s for back-to-back singles (Q4,
+// 17408x5120-class shapes, M4). The entry point survives as the engine's
+// sibling-projection idiom.
+void MetalBackend::matvec_quantized_pair(const BackendTensor& a, BackendBuffer& a_out,
+                                         const BackendTensor& b, BackendBuffer& b_out,
+                                         const BackendQuantized& x) {
+    matvec_quantized(a,x,a_out); matvec_quantized(b,x,b_out);
+}
+
+void MetalBackend::matmul_quantized(const BackendTensor& weight,const BackendQuantized& x,
+                                    uint32_t x_rows,BackendBuffer& y) {
+    if(!impl_->q4_quantized_matmul || !impl_->q8_quantized_matmul || !impl_->t2_quantized_matmul) {
+        if(x_rows==1) { matvec_quantized(weight,x,y); return; }
+        throw std::runtime_error("q27 Metal: quantized matmul requires Apple GPU family 7 or newer");
+    }
+    if((weight.dtype!=DType::Q4_G64 && weight.dtype!=DType::Q8_G128 &&
+        weight.dtype!=DType::T2_G128) || !weight.data || !weight.scales)
+        throw std::runtime_error("q27 Metal: quantized matmul requires Q4/Q8/T2 weight");
+    uint64_t group=weight.dtype==DType::Q4_G64?64:128;
+    if(!x_rows || x_rows>12 || !weight.rows || !weight.cols || weight.rows>UINT32_MAX || weight.cols>UINT32_MAX ||
+       weight.cols%group || (uint64_t)weight.cols*x_rows>UINT32_MAX || x.count!=weight.cols*x_rows || !x.values || !x.scales)
+        throw std::runtime_error("q27 Metal: invalid quantized matmul dimensions");
+    check_range(y.size(),0,weight.rows*x_rows*4,"quantized matmul output");
+    const MetalBuffer& data=metal_buffer_view(weight.data); const MetalBuffer& ws=metal_buffer_view(weight.scales);
+    const MetalBuffer& xv=metal_buffer_view(x.values); const MetalBuffer& xs=metal_buffer_view(x.scales); MetalBuffer& out=metal_buffer(y);
+    uint64_t divisor=weight.dtype==DType::Q4_G64?2:weight.dtype==DType::T2_G128?4:1;
+    check_range(data.size(),weight.data_offset,weight.rows*weight.cols/divisor,"quantized matmul weight");
+    check_range(ws.size(),weight.scales_offset,weight.rows*(weight.cols/group)*2,"quantized matmul weight scales");
+    check_range(xv.size(),0,x.count,"quantized matmul values"); check_range(xs.size(),0,(uint64_t)(x.count/32)*4,"quantized matmul scales");
+    MatmulArgs args{(uint32_t)weight.rows,(uint32_t)weight.cols,x_rows,1};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own,
+            weight.dtype==DType::Q8_G128?"q27_matmul_q8_mm":
+            weight.dtype==DType::T2_G128?"q27_matmul_t2_mm":"q27_matmul_q4_mm");
+        [enc setComputePipelineState:weight.dtype==DType::Q8_G128?impl_->q8_quantized_matmul:
+                                     weight.dtype==DType::T2_G128?impl_->t2_quantized_matmul:impl_->q4_quantized_matmul];
+        [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0]; [enc setBuffer:ws.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
+        [enc setBuffer:xv.handle() offset:0 atIndex:2]; [enc setBuffer:xs.handle() offset:0 atIndex:3]; [enc setBuffer:out.handle() offset:0 atIndex:4];
+        [enc setBytes:&args length:sizeof(args) atIndex:5];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(weight.rows+31)/32,1,1) threadsPerThreadgroup:MTLSizeMake(128,1,1)];
+        if(own) impl_->finish_command("quantized simdgroup matmul");
+    }
+}
+
+void MetalBackend::embedding_q8(const BackendTensor& weight, uint32_t token,
+                                 BackendBuffer& out) {
+    const bool t2 = weight.dtype == DType::T2_G128;
+    if ((weight.dtype != DType::Q8_G128 && !t2) || !weight.data || !weight.scales ||
+        token >= weight.rows ||
+        !weight.rows || !weight.cols || weight.rows > UINT32_MAX || weight.cols > UINT32_MAX ||
+        weight.cols % 128)
+        throw std::runtime_error("q27 Metal: invalid embedding tensor/token");
+    check_range(out.size(), 0, weight.cols * 4, "embedding output");
+    const MetalBuffer& data = metal_buffer_view(weight.data);
+    const MetalBuffer& scales = metal_buffer_view(weight.scales);
+    check_range(data.size(), weight.data_offset,
+                weight.rows * weight.cols / (t2 ? 4 : 1), "embedding weight");
+    check_range(scales.size(), weight.scales_offset,
+                weight.rows * (weight.cols / 128) * 2, "embedding scales");
+    MetalBuffer& output = metal_buffer(out);
+    @autoreleasepool {
+        bool own; id<MTLComputeCommandEncoder> enc = impl_->encoder_for_operation(own,
+            t2 ? "q27_embedding_t2" : "q27_embedding_q8");
+        [enc setComputePipelineState:t2 ? impl_->embedding_t2 : impl_->embedding];
+        [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
+        [enc setBuffer:scales.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
+        [enc setBuffer:output.handle() offset:0 atIndex:2];
+        [enc setBytes:&token length:sizeof(token) atIndex:3];
+        uint32_t cols = (uint32_t)weight.cols;
+        [enc setBytes:&cols length:sizeof(cols) atIndex:4];
+        [enc dispatchThreads:MTLSizeMake(cols, 1, 1) threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        if (own) impl_->finish_command("embedding");
+    }
+}
+
+void MetalBackend::rmsnorm(const BackendBuffer& x, const BackendTensor& weight,
+                            BackendBuffer& out, uint32_t n, float eps) {
+    const MetalBuffer& w = tensor_data(weight, DType::F32, "rmsnorm");
+    const MetalBuffer& input = metal_buffer(x); MetalBuffer& output = metal_buffer(out);
+    check_range(input.size(), 0, (uint64_t)n * 4, "rmsnorm input");
+    check_range(output.size(), 0, (uint64_t)n * 4, "rmsnorm output");
+    check_range(w.size(), weight.data_offset, (uint64_t)n * 4, "rmsnorm weight");
+    VectorArgs args{n, 8, eps};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_rmsnorm");
+        [enc setComputePipelineState:impl_->rms];
+        [enc setBuffer:input.handle() offset:0 atIndex:0];
+        [enc setBuffer:w.handle() offset:(NSUInteger)weight.data_offset atIndex:1];
+        [enc setBuffer:output.handle() offset:0 atIndex:2];
+        [enc setBytes:&args length:sizeof(args) atIndex:3];
+        [enc dispatchThreadgroups:MTLSizeMake(1,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if (own) impl_->finish_command("rmsnorm");
+    }
+}
+
+void MetalBackend::rmsnorm_quantized(const BackendBuffer& x,const BackendTensor& weight,
+                                     BackendBuffer& out,uint32_t n,float eps,
+                                     BackendQuantized& quantized) {
+    if(!n || n%32 || quantized.count!=n || !quantized.values || !quantized.scales)
+        throw std::runtime_error("q27 Metal: invalid fused rmsnorm quantization");
+    const MetalBuffer& w=tensor_data(weight,DType::F32,"fused rmsnorm");
+    const MetalBuffer& input=metal_buffer(x); MetalBuffer& output=metal_buffer(out);
+    MetalBuffer& values=metal_buffer(*quantized.values); MetalBuffer& scales=metal_buffer(*quantized.scales);
+    check_range(input.size(),0,(uint64_t)n*4,"fused rmsnorm input"); check_range(output.size(),0,(uint64_t)n*4,"fused rmsnorm output");
+    check_range(w.size(),weight.data_offset,(uint64_t)n*4,"fused rmsnorm weight"); check_range(values.size(),0,n,"fused rmsnorm values");
+    check_range(scales.size(),0,(uint64_t)(n/32)*4,"fused rmsnorm scales"); VectorArgs args{n,8,eps};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_rmsnorm_quantized"); [enc setComputePipelineState:impl_->rms_quantized];
+        [enc setBuffer:input.handle() offset:0 atIndex:0]; [enc setBuffer:w.handle() offset:(NSUInteger)weight.data_offset atIndex:1];
+        [enc setBuffer:output.handle() offset:0 atIndex:2]; [enc setBuffer:values.handle() offset:0 atIndex:3];
+        [enc setBuffer:scales.handle() offset:0 atIndex:4]; [enc setBytes:&args length:sizeof(args) atIndex:5];
+        [enc dispatchThreadgroups:MTLSizeMake(1,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("fused rmsnorm quantize");
+    }
+}
+
+void MetalBackend::rmsnorm_heads(BackendBuffer& x, const BackendTensor& weight,
+                                  uint32_t heads, uint32_t head_dim, uint32_t stride,
+                                  float eps) {
+    const MetalBuffer& w = tensor_data(weight, DType::F32, "head rmsnorm");
+    MetalBuffer& input = metal_buffer(x);
+    check_range(input.size(), 0, ((uint64_t)(heads - 1) * stride + head_dim) * 4, "head rmsnorm input");
+    check_range(w.size(), weight.data_offset, (uint64_t)head_dim * 4, "head rmsnorm weight");
+    HeadArgs args{heads, head_dim, stride, 8, eps};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_rmsnorm_heads");
+        [enc setComputePipelineState:impl_->rms_heads];
+        [enc setBuffer:input.handle() offset:0 atIndex:0];
+        [enc setBuffer:w.handle() offset:(NSUInteger)weight.data_offset atIndex:1];
+        [enc setBytes:&args length:sizeof(args) atIndex:2];
+        [enc dispatchThreadgroups:MTLSizeMake(heads,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if (own) impl_->finish_command("head rmsnorm");
+    }
+}
+
+void MetalBackend::l2norm_heads(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
+                                 float eps) {
+    MetalBuffer& input = metal_buffer(x);
+    check_range(input.size(), 0, (uint64_t)heads * head_dim * 4, "l2norm input");
+    HeadArgs args{heads, head_dim, head_dim, 8, eps};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_l2norm_heads");
+        [enc setComputePipelineState:impl_->l2_heads];
+        [enc setBuffer:input.handle() offset:0 atIndex:0];
+        [enc setBytes:&args length:sizeof(args) atIndex:1];
+        [enc dispatchThreadgroups:MTLSizeMake(heads,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if (own) impl_->finish_command("l2norm");
+    }
+}
+
+void MetalBackend::silu_mul(const BackendBuffer& gate, const BackendBuffer& up,
+                             BackendBuffer& out, uint32_t n) {
+    const MetalBuffer& g = metal_buffer(gate); const MetalBuffer& u = metal_buffer(up);
+    MetalBuffer& o = metal_buffer(out);
+    check_range(g.size(),0,(uint64_t)n*4,"silu gate"); check_range(u.size(),0,(uint64_t)n*4,"silu up");
+    check_range(o.size(),0,(uint64_t)n*4,"silu output");
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_silu_mul"); [enc setComputePipelineState:impl_->silu];
+        [enc setBuffer:g.handle() offset:0 atIndex:0]; [enc setBuffer:u.handle() offset:0 atIndex:1];
+        [enc setBuffer:o.handle() offset:0 atIndex:2]; [enc setBytes:&n length:4 atIndex:3];
+        [enc dispatchThreads:MTLSizeMake(n,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("silu multiply");
+    }
+}
+
+void MetalBackend::add_inplace(BackendBuffer& x, const BackendBuffer& y, uint32_t n) {
+    MetalBuffer& a=metal_buffer(x); const MetalBuffer& b=metal_buffer(y);
+    check_range(a.size(),0,(uint64_t)n*4,"add x"); check_range(b.size(),0,(uint64_t)n*4,"add y");
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_add_inplace"); [enc setComputePipelineState:impl_->add];
+        [enc setBuffer:a.handle() offset:0 atIndex:0]; [enc setBuffer:b.handle() offset:0 atIndex:1];
+        [enc setBytes:&n length:4 atIndex:2];
+        [enc dispatchThreads:MTLSizeMake(n,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("residual add");
+    }
+}
+
+void MetalBackend::concat(const BackendBuffer& a, uint32_t a_count,
+                           const BackendBuffer& b, uint32_t b_count,
+                           BackendBuffer& out) {
+    const MetalBuffer& ab=metal_buffer(a); const MetalBuffer& bb=metal_buffer(b); MetalBuffer& ob=metal_buffer(out);
+    check_range(ab.size(),0,(uint64_t)a_count*4,"concat a"); check_range(bb.size(),0,(uint64_t)b_count*4,"concat b");
+    check_range(ob.size(),0,(uint64_t)(a_count+b_count)*4,"concat output"); ConcatArgs args{a_count,b_count};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_concat"); [enc setComputePipelineState:impl_->concat];
+        [enc setBuffer:ab.handle() offset:0 atIndex:0]; [enc setBuffer:bb.handle() offset:0 atIndex:1]; [enc setBuffer:ob.handle() offset:0 atIndex:2];
+        [enc setBytes:&args length:sizeof(args) atIndex:3];
+        [enc dispatchThreads:MTLSizeMake((NSUInteger)a_count+b_count,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("concat");
+    }
+}
+
+void MetalBackend::sigmoid_gate_mul(BackendBuffer& out, const BackendBuffer& qg,
+                                     uint32_t heads, uint32_t head_dim) {
+    MetalBuffer& o=metal_buffer(out); const MetalBuffer& gates=metal_buffer(qg);
+    const uint32_t n=heads*head_dim; GateArgs args{heads,head_dim};
+    check_range(o.size(),0,(uint64_t)n*4,"sigmoid output"); check_range(gates.size(),0,(uint64_t)n*2*4,"sigmoid gates");
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_sigmoid_gate_mul"); [enc setComputePipelineState:impl_->sigmoid_gate];
+        [enc setBuffer:o.handle() offset:0 atIndex:0]; [enc setBuffer:gates.handle() offset:0 atIndex:1];
+        [enc setBytes:&args length:sizeof(args) atIndex:2];
+        [enc dispatchThreads:MTLSizeMake(n,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("sigmoid gate");
+    }
+}
+
+void MetalBackend::rope_neox(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
+                              uint32_t n_rot, uint32_t stride, uint32_t position,
+                              float freq_base) {
+    if (!n_rot || n_rot > head_dim || (n_rot & 1)) throw std::runtime_error("q27 Metal: invalid RoPE dimensions");
+    MetalBuffer& input=metal_buffer(x); RopeArgs args{heads,head_dim,n_rot,stride,position,freq_base};
+    check_range(input.size(),0,((uint64_t)(heads-1)*stride+head_dim)*4,"rope input");
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_rope_neox"); [enc setComputePipelineState:impl_->rope];
+        [enc setBuffer:input.handle() offset:0 atIndex:0]; [enc setBytes:&args length:sizeof(args) atIndex:1];
+        [enc dispatchThreads:MTLSizeMake(n_rot/2,heads,1) threadsPerThreadgroup:MTLSizeMake(n_rot/2,1,1)];
+        if(own) impl_->finish_command("rope");
+    }
+}
+
+void MetalBackend::argmax(const BackendBuffer& x, uint32_t n, BackendBuffer& out_index) {
+    const MetalBuffer& input=metal_buffer(x); MetalBuffer& output=metal_buffer(out_index);
+    check_range(input.size(),0,(uint64_t)n*4,"argmax input"); check_range(output.size(),0,4,"argmax output");
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_argmax"); [enc setComputePipelineState:impl_->argmax];
+        [enc setBuffer:input.handle() offset:0 atIndex:0]; [enc setBuffer:output.handle() offset:0 atIndex:1];
+        [enc setBytes:&n length:4 atIndex:2];
+        [enc dispatchThreadgroups:MTLSizeMake(1,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("argmax");
+    }
+}
+
+void MetalBackend::kv_store(const BackendBuffer& k, const BackendBuffer& v,
+                            BackendBuffer& k_cache, BackendBuffer& v_cache,
+                            uint32_t position, uint32_t kv_heads, uint32_t head_dim,
+                            KvFormat format) {
+    if (!kv_heads || !head_dim)
+        throw std::runtime_error("q27 Metal: invalid KV dimensions");
+    switch (format) {
+        case KvFormat::F16: {
+            const uint64_t row_length = uint64_t(kv_heads) * head_dim;
+            if (row_length > UINT32_MAX)
+                throw std::runtime_error("q27 Metal: KV row is too large");
+            return kv_store_f16(k, v, k_cache, v_cache, position,
+                                static_cast<uint32_t>(row_length));
+        }
+        case KvFormat::TURBO3:
+            if (head_dim != 256)
+                throw std::runtime_error("q27 Metal: turbo3 requires head_dim 256");
+            return kv_store_turbo3(k, v, k_cache, v_cache, position, kv_heads);
+        default:
+            throw std::runtime_error("q27 Metal: unsupported KV format");
+    }
+}
+
+void MetalBackend::attention(const BackendBuffer& q, uint32_t q_stride,
+                             const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                             BackendBuffer& out, uint32_t seq_len, uint32_t q_heads,
+                             uint32_t kv_heads, uint32_t head_dim, float scale,
+                             KvFormat format, BackendBuffer* partials) {
+    switch (format) {
+        case KvFormat::F16:
+            return attention_f16(q, q_stride, k_cache, v_cache, out, seq_len,
+                                 q_heads, kv_heads, head_dim, scale, partials);
+        case KvFormat::TURBO3:
+            return attention_turbo3(q, q_stride, k_cache, v_cache, out, seq_len,
+                                    q_heads, kv_heads, head_dim, scale, partials);
+        default:
+            throw std::runtime_error("q27 Metal: unsupported KV format");
+    }
+}
+
+void MetalBackend::kv_store_f16(const BackendBuffer& k, const BackendBuffer& v,
+                                 BackendBuffer& k_cache, BackendBuffer& v_cache,
+                                 uint32_t position, uint32_t row_length) {
+    const MetalBuffer& kb=metal_buffer(k); const MetalBuffer& vb=metal_buffer(v);
+    MetalBuffer& kc=metal_buffer(k_cache); MetalBuffer& vc=metal_buffer(v_cache);
+    check_range(kb.size(),0,(uint64_t)row_length*4,"K row"); check_range(vb.size(),0,(uint64_t)row_length*4,"V row");
+    check_range(kc.size(),(uint64_t)position*row_length*2,(uint64_t)row_length*2,"K cache");
+    check_range(vc.size(),(uint64_t)position*row_length*2,(uint64_t)row_length*2,"V cache");
+    KvStoreArgs args{position,row_length};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_kv_store_f16"); [enc setComputePipelineState:impl_->kv_store];
+        [enc setBuffer:kb.handle() offset:0 atIndex:0]; [enc setBuffer:vb.handle() offset:0 atIndex:1];
+        [enc setBuffer:kc.handle() offset:0 atIndex:2]; [enc setBuffer:vc.handle() offset:0 atIndex:3];
+        [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreads:MTLSizeMake(row_length,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("KV store");
+    }
+}
+
+void MetalBackend::turbo_wht(BackendBuffer& x, uint32_t heads, uint32_t stride,
+                              bool inverse) {
+    if (!heads || stride < 256) throw std::runtime_error("q27 Metal: invalid turbo3 WHT dimensions");
+    MetalBuffer& xb = metal_buffer(x);
+    check_range(xb.size(), 0, ((uint64_t)(heads - 1) * stride + 256) * 4, "turbo3 WHT");
+    TurboWhtArgs args{heads, stride, inverse ? 1u : 0u};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_turbo_wht"); [enc setComputePipelineState:impl_->turbo_wht];
+        [enc setBuffer:xb.handle() offset:0 atIndex:0]; [enc setBytes:&args length:sizeof(args) atIndex:1];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)heads*2,1,1) threadsPerThreadgroup:MTLSizeMake(128,1,1)];
+        if(own) impl_->finish_command("turbo3 WHT");
+    }
+}
+
+void MetalBackend::kv_store_turbo3(const BackendBuffer& k, const BackendBuffer& v,
+                                    BackendBuffer& k_cache, BackendBuffer& v_cache,
+                                    uint32_t position, uint32_t kv_heads) {
+    if (!kv_heads) throw std::runtime_error("q27 Metal: invalid turbo3 KV dimensions");
+    const MetalBuffer& kb=metal_buffer(k); const MetalBuffer& vb=metal_buffer(v);
+    MetalBuffer& kc=metal_buffer(k_cache); MetalBuffer& vc=metal_buffer(v_cache);
+    const uint64_t row_bytes=(uint64_t)kv_heads*2*50;
+    check_range(kb.size(),0,(uint64_t)kv_heads*256*4,"turbo3 K row");
+    check_range(vb.size(),0,(uint64_t)kv_heads*256*4,"turbo3 V row");
+    check_range(kc.size(),(uint64_t)position*row_bytes,row_bytes,"turbo3 K cache");
+    check_range(vc.size(),(uint64_t)position*row_bytes,row_bytes,"turbo3 V cache");
+    TurboStoreArgs args{position,kv_heads};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_kv_store_turbo3"); [enc setComputePipelineState:impl_->kv_store_turbo3];
+        [enc setBuffer:kb.handle() offset:0 atIndex:0]; [enc setBuffer:vb.handle() offset:0 atIndex:1];
+        [enc setBuffer:kc.handle() offset:0 atIndex:2]; [enc setBuffer:vc.handle() offset:0 atIndex:3];
+        [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)kv_heads*2,2,1) threadsPerThreadgroup:MTLSizeMake(128,1,1)];
+        if(own) impl_->finish_command("turbo3 KV store");
+    }
+}
+
+void MetalBackend::attention_turbo3(const BackendBuffer& q, uint32_t q_stride,
+                                     const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                                     BackendBuffer& out, uint32_t seq_len,
+                                     uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
+                                     float scale, BackendBuffer* partials) {
+    (void)partials;
+    if (!seq_len || !kv_heads || q_heads%kv_heads || head_dim != 256)
+        throw std::runtime_error("q27 Metal: invalid turbo3 attention dimensions");
+    const MetalBuffer& qb=metal_buffer(q); const MetalBuffer& kc=metal_buffer(k_cache); const MetalBuffer& vc=metal_buffer(v_cache);
+    MetalBuffer& output=metal_buffer(out);
+    check_range(qb.size(),0,((uint64_t)(q_heads-1)*q_stride+head_dim)*4,"turbo3 attention Q");
+    const uint64_t cache_bytes=(uint64_t)seq_len*kv_heads*2*50;
+    check_range(kc.size(),0,cache_bytes,"turbo3 K cache"); check_range(vc.size(),0,cache_bytes,"turbo3 V cache");
+    check_range(output.size(),0,(uint64_t)q_heads*head_dim*4,"turbo3 attention output");
+    AttentionArgs args{q_stride,seq_len,q_heads,kv_heads,head_dim,scale};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_attention_turbo3"); [enc setComputePipelineState:impl_->attention_turbo3];
+        [enc setBuffer:qb.handle() offset:0 atIndex:0]; [enc setBuffer:kc.handle() offset:0 atIndex:1]; [enc setBuffer:vc.handle() offset:0 atIndex:2];
+        [enc setBuffer:output.handle() offset:0 atIndex:3]; [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake(q_heads,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("turbo3 attention");
+    }
+}
+
+void MetalBackend::attention_f16(const BackendBuffer& q, uint32_t q_stride,
+                                  const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                                  BackendBuffer& out, uint32_t seq_len,
+                                  uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
+                                  float scale, BackendBuffer* partials) {
+    (void)partials;
+    if (!seq_len || !kv_heads || q_heads%kv_heads || !head_dim || head_dim > 256)
+        throw std::runtime_error("q27 Metal: invalid attention dimensions");
+    const MetalBuffer& qb=metal_buffer(q); const MetalBuffer& kc=metal_buffer(k_cache); const MetalBuffer& vc=metal_buffer(v_cache);
+    MetalBuffer& output=metal_buffer(out);
+    check_range(qb.size(),0,((uint64_t)(q_heads-1)*q_stride+head_dim)*4,"attention Q");
+    const uint64_t cache_bytes=(uint64_t)seq_len*kv_heads*head_dim*2;
+    check_range(kc.size(),0,cache_bytes,"attention K cache"); check_range(vc.size(),0,cache_bytes,"attention V cache");
+    check_range(output.size(),0,(uint64_t)q_heads*head_dim*4,"attention output");
+    AttentionArgs args{q_stride,seq_len,q_heads,kv_heads,head_dim,scale};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_attention_f16"); [enc setComputePipelineState:impl_->attention];
+        [enc setBuffer:qb.handle() offset:0 atIndex:0]; [enc setBuffer:kc.handle() offset:0 atIndex:1]; [enc setBuffer:vc.handle() offset:0 atIndex:2];
+        [enc setBuffer:output.handle() offset:0 atIndex:3]; [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake(q_heads,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("FP16 attention");
+    }
+}
+
+void MetalBackend::gdn_gates(const BackendBuffer& alpha, const BackendBuffer& beta_raw,
+                              const BackendTensor& ssm_a, const BackendTensor& ssm_dt,
+                              BackendBuffer& g, BackendBuffer& beta, uint32_t heads) {
+    const MetalBuffer& ar=metal_buffer(alpha); const MetalBuffer& br=metal_buffer(beta_raw);
+    const MetalBuffer& a=tensor_data(ssm_a,DType::F32,"GDN a"); const MetalBuffer& dt=tensor_data(ssm_dt,DType::F32,"GDN dt");
+    MetalBuffer& go=metal_buffer(g); MetalBuffer& bo=metal_buffer(beta);
+    check_range(ar.size(),0,(uint64_t)heads*4,"GDN alpha"); check_range(br.size(),0,(uint64_t)heads*4,"GDN beta raw");
+    check_range(go.size(),0,(uint64_t)heads*4,"GDN g"); check_range(bo.size(),0,(uint64_t)heads*4,"GDN beta");
+    check_range(a.size(),ssm_a.data_offset,(uint64_t)heads*4,"GDN a"); check_range(dt.size(),ssm_dt.data_offset,(uint64_t)heads*4,"GDN dt");
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_gdn_gates"); [enc setComputePipelineState:impl_->gates];
+        [enc setBuffer:ar.handle() offset:0 atIndex:0]; [enc setBuffer:br.handle() offset:0 atIndex:1];
+        [enc setBuffer:a.handle() offset:(NSUInteger)ssm_a.data_offset atIndex:2]; [enc setBuffer:dt.handle() offset:(NSUInteger)ssm_dt.data_offset atIndex:3];
+        [enc setBuffer:go.handle() offset:0 atIndex:4]; [enc setBuffer:bo.handle() offset:0 atIndex:5]; [enc setBytes:&heads length:4 atIndex:6];
+        [enc dispatchThreads:MTLSizeMake(heads,1,1) threadsPerThreadgroup:MTLSizeMake(64,1,1)]; if(own) impl_->finish_command("GDN gates");
+    }
+}
+
+void MetalBackend::conv_step(const BackendBuffer& ring_src, BackendBuffer& ring_dst,
+                              const BackendBuffer& qkv, const BackendTensor& conv_weight,
+                              BackendBuffer& out, uint32_t channels) {
+    const MetalBuffer& src=metal_buffer(ring_src); MetalBuffer& dst=metal_buffer(ring_dst); const MetalBuffer& q=metal_buffer(qkv);
+    const MetalBuffer& w=tensor_data(conv_weight,DType::F32,"GDN convolution"); MetalBuffer& o=metal_buffer(out);
+    check_range(src.size(),0,(uint64_t)channels*3*4,"conv ring source"); check_range(dst.size(),0,(uint64_t)channels*3*4,"conv ring destination");
+    check_range(q.size(),0,(uint64_t)channels*4,"conv input"); check_range(w.size(),conv_weight.data_offset,(uint64_t)channels*4*4,"conv weight"); check_range(o.size(),0,(uint64_t)channels*4,"conv output");
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_conv_step"); [enc setComputePipelineState:impl_->conv];
+        [enc setBuffer:src.handle() offset:0 atIndex:0]; [enc setBuffer:dst.handle() offset:0 atIndex:1]; [enc setBuffer:q.handle() offset:0 atIndex:2];
+        [enc setBuffer:w.handle() offset:(NSUInteger)conv_weight.data_offset atIndex:3]; [enc setBuffer:o.handle() offset:0 atIndex:4]; [enc setBytes:&channels length:4 atIndex:5];
+        [enc dispatchThreads:MTLSizeMake(channels,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; if(own) impl_->finish_command("GDN convolution");
+    }
+}
+
+void MetalBackend::delta_step(const BackendBuffer& state_src, BackendBuffer& state_dst,
+                               const BackendBuffer& conv, const BackendBuffer& g,
+                               const BackendBuffer& beta, BackendBuffer& out,
+                               uint32_t value_heads, uint32_t qk_heads,
+                               uint32_t head_dim) {
+    if(head_dim!=128 || qk_heads!=16 || impl_->delta.maxTotalThreadsPerThreadgroup<512) throw std::runtime_error("q27 Metal: unsupported DeltaNet shape");
+    const MetalBuffer& src=metal_buffer(state_src); MetalBuffer& dst=metal_buffer(state_dst); const MetalBuffer& cv=metal_buffer(conv);
+    const MetalBuffer& gb=metal_buffer(g); const MetalBuffer& bb=metal_buffer(beta); MetalBuffer& o=metal_buffer(out);
+    const uint64_t state_bytes=(uint64_t)value_heads*head_dim*head_dim*4;
+    check_range(src.size(),0,state_bytes,"delta state source"); check_range(dst.size(),0,state_bytes,"delta state destination");
+    check_range(cv.size(),0,(uint64_t)(qk_heads*2+value_heads)*head_dim*4,"delta conv"); check_range(gb.size(),0,(uint64_t)value_heads*4,"delta g"); check_range(bb.size(),0,(uint64_t)value_heads*4,"delta beta"); check_range(o.size(),0,(uint64_t)value_heads*head_dim*4,"delta output");
+    DeltaArgs args{value_heads,qk_heads,head_dim};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_delta_step"); [enc setComputePipelineState:impl_->delta];
+        [enc setBuffer:src.handle() offset:0 atIndex:0]; [enc setBuffer:dst.handle() offset:0 atIndex:1]; [enc setBuffer:cv.handle() offset:0 atIndex:2];
+        [enc setBuffer:gb.handle() offset:0 atIndex:3]; [enc setBuffer:bb.handle() offset:0 atIndex:4]; [enc setBuffer:o.handle() offset:0 atIndex:5]; [enc setBytes:&args length:sizeof(args) atIndex:6];
+        [enc dispatchThreadgroups:MTLSizeMake(value_heads,1,1) threadsPerThreadgroup:MTLSizeMake(512,1,1)]; if(own) impl_->finish_command("DeltaNet recurrence");
+    }
+}
+
+void MetalBackend::gated_norm_gdn(const BackendBuffer& x, const BackendTensor& weight,
+                                   const BackendBuffer& gate, BackendBuffer& out,
+                                   uint32_t heads, uint32_t head_dim, float eps) {
+    const MetalBuffer& xb=metal_buffer(x); const MetalBuffer& w=tensor_data(weight,DType::F32,"GDN norm"); const MetalBuffer& gb=metal_buffer(gate); MetalBuffer& o=metal_buffer(out);
+    const uint64_t bytes=(uint64_t)heads*head_dim*4;
+    check_range(xb.size(),0,bytes,"GDN norm input"); check_range(gb.size(),0,bytes,"GDN norm gate"); check_range(o.size(),0,bytes,"GDN norm output"); check_range(w.size(),weight.data_offset,(uint64_t)head_dim*4,"GDN norm weight");
+    HeadArgs args{heads,head_dim,head_dim,8,eps};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_gated_norm_gdn"); [enc setComputePipelineState:impl_->gated_norm];
+        [enc setBuffer:xb.handle() offset:0 atIndex:0]; [enc setBuffer:w.handle() offset:(NSUInteger)weight.data_offset atIndex:1]; [enc setBuffer:gb.handle() offset:0 atIndex:2]; [enc setBuffer:o.handle() offset:0 atIndex:3]; [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake(heads,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; if(own) impl_->finish_command("GDN gated norm");
+    }
+}
+
+void MetalBackend::embedding_q8_rows(const BackendTensor& weight, const uint32_t* tokens,
+                                      uint32_t count, BackendBuffer& out) {
+    if (!tokens || !count || count > 12)
+        throw std::runtime_error("q27 Metal: chunked embedding requires 1..12 tokens");
+    const bool t2 = weight.dtype == DType::T2_G128;
+    if ((weight.dtype != DType::Q8_G128 && !t2) || !weight.data || !weight.scales ||
+        !weight.rows || !weight.cols || weight.rows > UINT32_MAX || weight.cols > UINT32_MAX ||
+        weight.cols % 128)
+        throw std::runtime_error("q27 Metal: invalid chunked embedding tensor");
+    EmbedRowsArgs args{(uint32_t)weight.cols, count, {}};
+    for (uint32_t i = 0; i < count; i++) {
+        if (tokens[i] >= weight.rows) throw std::runtime_error("q27 Metal: chunked embedding token out of range");
+        args.tokens[i] = tokens[i];
+    }
+    check_range(out.size(), 0, (uint64_t)count * weight.cols * 4, "chunked embedding output");
+    const MetalBuffer& data = metal_buffer_view(weight.data);
+    const MetalBuffer& scales = metal_buffer_view(weight.scales);
+    check_range(data.size(), weight.data_offset,
+                weight.rows * weight.cols / (t2 ? 4 : 1), "chunked embedding weight");
+    check_range(scales.size(), weight.scales_offset, weight.rows * (weight.cols / 128) * 2, "chunked embedding scales");
+    MetalBuffer& output = metal_buffer(out);
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own,
+            t2 ? "q27_embedding_t2_rows" : "q27_embedding_q8_rows");
+        [enc setComputePipelineState:t2 ? impl_->embedding_t2_rows : impl_->embedding_rows];
+        [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
+        [enc setBuffer:scales.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
+        [enc setBuffer:output.handle() offset:0 atIndex:2];
+        [enc setBytes:&args length:sizeof(args) atIndex:3];
+        [enc dispatchThreads:MTLSizeMake(weight.cols, count, 1) threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        if (own) impl_->finish_command("chunked embedding");
+    }
+}
+
+void MetalBackend::rmsnorm_rows_quantized(const BackendBuffer& x, const BackendTensor& weight,
+                                          BackendBuffer& out, uint32_t n, uint32_t rows,
+                                          float eps, BackendQuantized& quantized) {
+    if (!n || n % 32 || !rows || quantized.count != n * rows || !quantized.values || !quantized.scales)
+        throw std::runtime_error("q27 Metal: invalid chunked rmsnorm quantization");
+    const MetalBuffer& w = tensor_data(weight, DType::F32, "chunked rmsnorm");
+    const MetalBuffer& input = metal_buffer(x); MetalBuffer& output = metal_buffer(out);
+    MetalBuffer& values = metal_buffer(*quantized.values); MetalBuffer& scales = metal_buffer(*quantized.scales);
+    const uint64_t total = (uint64_t)n * rows;
+    check_range(input.size(), 0, total * 4, "chunked rmsnorm input");
+    check_range(output.size(), 0, total * 4, "chunked rmsnorm output");
+    check_range(w.size(), weight.data_offset, (uint64_t)n * 4, "chunked rmsnorm weight");
+    check_range(values.size(), 0, total, "chunked rmsnorm values");
+    check_range(scales.size(), 0, (total / 32) * 4, "chunked rmsnorm scales");
+    RowsNormArgs args{n, rows, 8, eps};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_rmsnorm_rows_quantized");
+        [enc setComputePipelineState:impl_->rms_rows_quantized];
+        [enc setBuffer:input.handle() offset:0 atIndex:0];
+        [enc setBuffer:w.handle() offset:(NSUInteger)weight.data_offset atIndex:1];
+        [enc setBuffer:output.handle() offset:0 atIndex:2];
+        [enc setBuffer:values.handle() offset:0 atIndex:3];
+        [enc setBuffer:scales.handle() offset:0 atIndex:4];
+        [enc setBytes:&args length:sizeof(args) atIndex:5];
+        [enc dispatchThreadgroups:MTLSizeMake(rows,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if (own) impl_->finish_command("chunked rmsnorm quantize");
+    }
+}
+
+void MetalBackend::matvec_f16_pair_rows(const BackendTensor& a, BackendBuffer& a_out,
+                                        const BackendTensor& b, BackendBuffer& b_out,
+                                        const BackendBuffer& x, uint32_t rows) {
+    if (a.dtype != DType::F16 || b.dtype != DType::F16 || a.cols != b.cols || !a.data || !b.data ||
+        !a.rows || !b.rows || !a.cols || a.rows > UINT32_MAX || b.rows > UINT32_MAX || a.cols > UINT32_MAX)
+        throw std::runtime_error("q27 Metal: chunked F16 matvec pair requires compatible F16 weights");
+    if (!rows || rows > 12) throw std::runtime_error("q27 Metal: chunked F16 matvec pair requires 1..12 rows");
+    check_range(x.size(), 0, (uint64_t)rows * a.cols * 4, "chunked matvec input");
+    check_range(a_out.size(), 0, (uint64_t)rows * a.rows * 4, "chunked matvec output A");
+    check_range(b_out.size(), 0, (uint64_t)rows * b.rows * 4, "chunked matvec output B");
+    const MetalBuffer& ad = metal_buffer_view(a.data); const MetalBuffer& bd = metal_buffer_view(b.data);
+    const MetalBuffer& input = metal_buffer(x);
+    MetalBuffer& ao = metal_buffer(a_out); MetalBuffer& bo = metal_buffer(b_out);
+    check_range(ad.size(), a.data_offset, a.rows * a.cols * 2, "chunked matvec weight A");
+    check_range(bd.size(), b.data_offset, b.rows * b.cols * 2, "chunked matvec weight B");
+    MatvecPairRowsArgs args{(uint32_t)a.rows, (uint32_t)b.rows, (uint32_t)a.cols, rows};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_matvec_f16_pair_rows");
+        [enc setComputePipelineState:impl_->f16_pair_rows];
+        [enc setBuffer:ad.handle() offset:(NSUInteger)a.data_offset atIndex:0]; [enc setBuffer:ao.handle() offset:0 atIndex:1];
+        [enc setBuffer:bd.handle() offset:(NSUInteger)b.data_offset atIndex:2]; [enc setBuffer:bo.handle() offset:0 atIndex:3];
+        [enc setBuffer:input.handle() offset:0 atIndex:4]; [enc setBytes:&args length:sizeof(args) atIndex:5];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)std::max(a.rows,b.rows), rows, 1)
+                threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if (own) impl_->finish_command("chunked F16 matvec pair");
+    }
+}
+
+void MetalBackend::gdn_gates_rows(const BackendBuffer& alpha, const BackendBuffer& beta_raw,
+                                  const BackendTensor& ssm_a, const BackendTensor& ssm_dt,
+                                  BackendBuffer& g, BackendBuffer& beta,
+                                  uint32_t heads, uint32_t tokens) {
+    if (!heads || !tokens || tokens > 12) throw std::runtime_error("q27 Metal: invalid chunked GDN gates");
+    const MetalBuffer& ar = metal_buffer(alpha); const MetalBuffer& br = metal_buffer(beta_raw);
+    const MetalBuffer& a = tensor_data(ssm_a, DType::F32, "chunked GDN a");
+    const MetalBuffer& dt = tensor_data(ssm_dt, DType::F32, "chunked GDN dt");
+    MetalBuffer& go = metal_buffer(g); MetalBuffer& bo = metal_buffer(beta);
+    const uint64_t total = (uint64_t)heads * tokens * 4;
+    check_range(ar.size(), 0, total, "chunked GDN alpha"); check_range(br.size(), 0, total, "chunked GDN beta raw");
+    check_range(go.size(), 0, total, "chunked GDN g"); check_range(bo.size(), 0, total, "chunked GDN beta");
+    check_range(a.size(), ssm_a.data_offset, (uint64_t)heads * 4, "chunked GDN a");
+    check_range(dt.size(), ssm_dt.data_offset, (uint64_t)heads * 4, "chunked GDN dt");
+    GatesRowsArgs args{heads, tokens};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_gdn_gates_rows");
+        [enc setComputePipelineState:impl_->gates_rows];
+        [enc setBuffer:ar.handle() offset:0 atIndex:0]; [enc setBuffer:br.handle() offset:0 atIndex:1];
+        [enc setBuffer:a.handle() offset:(NSUInteger)ssm_a.data_offset atIndex:2];
+        [enc setBuffer:dt.handle() offset:(NSUInteger)ssm_dt.data_offset atIndex:3];
+        [enc setBuffer:go.handle() offset:0 atIndex:4]; [enc setBuffer:bo.handle() offset:0 atIndex:5];
+        [enc setBytes:&args length:sizeof(args) atIndex:6];
+        [enc dispatchThreads:MTLSizeMake((NSUInteger)heads * tokens, 1, 1) threadsPerThreadgroup:MTLSizeMake(64,1,1)];
+        if (own) impl_->finish_command("chunked GDN gates");
+    }
+}
+
+void MetalBackend::conv_chunk(const BackendBuffer& ring_src, BackendBuffer& ring_dst,
+                              const BackendBuffer& qkv,
+                              const BackendTensor& conv_weight, BackendBuffer& out,
+                              uint32_t channels, uint32_t tokens) {
+    if (!channels || !tokens || tokens > 12) throw std::runtime_error("q27 Metal: invalid chunked convolution");
+    const MetalBuffer& rs = metal_buffer(ring_src); MetalBuffer& rd = metal_buffer(ring_dst);
+    const MetalBuffer& q = metal_buffer(qkv);
+    const MetalBuffer& w = tensor_data(conv_weight, DType::F32, "chunked GDN convolution");
+    MetalBuffer& o = metal_buffer(out);
+    check_range(rs.size(), 0, (uint64_t)channels * 3 * 4, "chunked conv ring src");
+    check_range(rd.size(), 0, (uint64_t)channels * 3 * 4, "chunked conv ring dst");
+    check_range(q.size(), 0, (uint64_t)channels * tokens * 4, "chunked conv input");
+    check_range(w.size(), conv_weight.data_offset, (uint64_t)channels * 4 * 4, "chunked conv weight");
+    check_range(o.size(), 0, (uint64_t)channels * tokens * 4, "chunked conv output");
+    ConvChunkArgs args{channels, tokens};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_conv_chunk");
+        [enc setComputePipelineState:impl_->conv_chunked];
+        [enc setBuffer:rs.handle() offset:0 atIndex:0]; [enc setBuffer:rd.handle() offset:0 atIndex:1];
+        [enc setBuffer:q.handle() offset:0 atIndex:2];
+        [enc setBuffer:w.handle() offset:(NSUInteger)conv_weight.data_offset atIndex:3];
+        [enc setBuffer:o.handle() offset:0 atIndex:4]; [enc setBytes:&args length:sizeof(args) atIndex:5];
+        [enc dispatchThreads:MTLSizeMake(channels,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if (own) impl_->finish_command("chunked GDN convolution");
+    }
+}
+
+void MetalBackend::delta_chunk(const BackendBuffer& state_src, BackendBuffer& state_dst,
+                               const BackendBuffer& conv,
+                               const BackendBuffer& g, const BackendBuffer& beta,
+                               BackendBuffer& out, uint32_t value_heads, uint32_t qk_heads,
+                               uint32_t head_dim, uint32_t tokens) {
+    if (head_dim != 128 || qk_heads != 16 || !tokens || tokens > 12 ||
+        impl_->delta_chunked.maxTotalThreadsPerThreadgroup < 512)
+        throw std::runtime_error("q27 Metal: unsupported chunked DeltaNet shape");
+    const MetalBuffer& ss = metal_buffer(state_src); MetalBuffer& sd = metal_buffer(state_dst);
+    const MetalBuffer& cv = metal_buffer(conv);
+    const MetalBuffer& gb = metal_buffer(g); const MetalBuffer& bb = metal_buffer(beta);
+    MetalBuffer& o = metal_buffer(out);
+    const uint64_t state_bytes = (uint64_t)value_heads * head_dim * head_dim * 4;
+    check_range(ss.size(), 0, state_bytes, "chunked delta state src");
+    check_range(sd.size(), 0, state_bytes, "chunked delta state dst");
+    check_range(cv.size(), 0, (uint64_t)(qk_heads * 2 + value_heads) * head_dim * tokens * 4, "chunked delta conv");
+    check_range(gb.size(), 0, (uint64_t)value_heads * tokens * 4, "chunked delta g");
+    check_range(bb.size(), 0, (uint64_t)value_heads * tokens * 4, "chunked delta beta");
+    check_range(o.size(), 0, (uint64_t)value_heads * head_dim * tokens * 4, "chunked delta output");
+    DeltaChunkArgs args{value_heads, qk_heads, head_dim, tokens};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_delta_chunk");
+        [enc setComputePipelineState:impl_->delta_chunked];
+        [enc setBuffer:ss.handle() offset:0 atIndex:0]; [enc setBuffer:sd.handle() offset:0 atIndex:1];
+        [enc setBuffer:cv.handle() offset:0 atIndex:2];
+        [enc setBuffer:gb.handle() offset:0 atIndex:3]; [enc setBuffer:bb.handle() offset:0 atIndex:4];
+        [enc setBuffer:o.handle() offset:0 atIndex:5]; [enc setBytes:&args length:sizeof(args) atIndex:6];
+        [enc dispatchThreadgroups:MTLSizeMake(value_heads,1,1) threadsPerThreadgroup:MTLSizeMake(512,1,1)];
+        if (own) impl_->finish_command("chunked DeltaNet recurrence");
+    }
+}
+
+void MetalBackend::l2norm_rows(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
+                               uint32_t row_stride, uint32_t tokens, float eps) {
+    if (!heads || !tokens || tokens > 12 || row_stride < heads * head_dim)
+        throw std::runtime_error("q27 Metal: invalid chunked l2norm");
+    MetalBuffer& input = metal_buffer(x);
+    check_range(input.size(), 0, ((uint64_t)(tokens - 1) * row_stride + (uint64_t)heads * head_dim) * 4,
+                "chunked l2norm input");
+    L2RowsArgs args{heads, head_dim, row_stride, tokens, eps};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_l2norm_rows");
+        [enc setComputePipelineState:impl_->l2_rows];
+        [enc setBuffer:input.handle() offset:0 atIndex:0];
+        [enc setBytes:&args length:sizeof(args) atIndex:1];
+        [enc dispatchThreadgroups:MTLSizeMake(heads,tokens,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if (own) impl_->finish_command("chunked l2norm");
+    }
+}
+
+void MetalBackend::rope_neox_rows(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
+                                  uint32_t n_rot, uint32_t stride, uint32_t row_stride,
+                                  uint32_t position, uint32_t tokens, float freq_base) {
+    if (!n_rot || n_rot > head_dim || (n_rot & 1) || !tokens || tokens > 12)
+        throw std::runtime_error("q27 Metal: invalid chunked RoPE dimensions");
+    MetalBuffer& input = metal_buffer(x);
+    check_range(input.size(), 0,
+                ((uint64_t)(tokens - 1) * row_stride + (uint64_t)(heads - 1) * stride + head_dim) * 4,
+                "chunked rope input");
+    RopeRowsArgs args{heads, head_dim, n_rot, stride, row_stride, position, tokens, freq_base};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_rope_neox_rows");
+        [enc setComputePipelineState:impl_->rope_rows];
+        [enc setBuffer:input.handle() offset:0 atIndex:0]; [enc setBytes:&args length:sizeof(args) atIndex:1];
+        [enc dispatchThreads:MTLSizeMake(n_rot/2,heads,tokens) threadsPerThreadgroup:MTLSizeMake(n_rot/2,1,1)];
+        if (own) impl_->finish_command("chunked rope");
+    }
+}
+
+void MetalBackend::kv_store_rows(const BackendBuffer& k, const BackendBuffer& v,
+                                 BackendBuffer& k_cache, BackendBuffer& v_cache,
+                                 uint32_t position, uint32_t kv_heads, uint32_t head_dim,
+                                 uint32_t tokens, KvFormat format) {
+    if (!kv_heads || !head_dim)
+        throw std::runtime_error("q27 Metal: invalid chunked KV dimensions");
+    switch (format) {
+        case KvFormat::F16: {
+            const uint64_t row_length = uint64_t(kv_heads) * head_dim;
+            if (row_length > UINT32_MAX)
+                throw std::runtime_error("q27 Metal: chunked KV row is too large");
+            return kv_store_f16_rows(k, v, k_cache, v_cache, position,
+                                     static_cast<uint32_t>(row_length), tokens);
+        }
+        case KvFormat::TURBO3:
+            if (head_dim != 256)
+                throw std::runtime_error("q27 Metal: turbo3 requires head_dim 256");
+            return kv_store_turbo3_rows(k, v, k_cache, v_cache, position, kv_heads, tokens);
+        default:
+            throw std::runtime_error("q27 Metal: unsupported KV format");
+    }
+}
+
+void MetalBackend::attention_causal(const BackendBuffer& q, uint32_t q_stride,
+                                    uint32_t q_row_stride, const BackendBuffer& k_cache,
+                                    const BackendBuffer& v_cache,
+                                    BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
+                                    uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
+                                    float scale, KvFormat format, BackendBuffer* partials) {
+    switch (format) {
+        case KvFormat::F16:
+            return attention_f16_causal(q, q_stride, q_row_stride, k_cache, v_cache,
+                                        out, base_len, q_heads, kv_heads, head_dim,
+                                        tokens, scale, partials);
+        case KvFormat::TURBO3:
+            return attention_turbo3_causal(q, q_stride, q_row_stride, k_cache, v_cache,
+                                           out, base_len, q_heads, kv_heads, head_dim,
+                                           tokens, scale, partials);
+        default:
+            throw std::runtime_error("q27 Metal: unsupported KV format");
+    }
+}
+
+void MetalBackend::kv_store_f16_rows(const BackendBuffer& k, const BackendBuffer& v,
+                                     BackendBuffer& k_cache, BackendBuffer& v_cache,
+                                     uint32_t position, uint32_t row_length, uint32_t tokens) {
+    if (!tokens || tokens > 12) throw std::runtime_error("q27 Metal: invalid chunked KV store");
+    const MetalBuffer& kb = metal_buffer(k); const MetalBuffer& vb = metal_buffer(v);
+    MetalBuffer& kc = metal_buffer(k_cache); MetalBuffer& vc = metal_buffer(v_cache);
+    check_range(kb.size(), 0, (uint64_t)row_length * tokens * 4, "chunked K rows");
+    check_range(vb.size(), 0, (uint64_t)row_length * tokens * 4, "chunked V rows");
+    check_range(kc.size(), (uint64_t)position * row_length * 2, (uint64_t)row_length * tokens * 2, "chunked K cache");
+    check_range(vc.size(), (uint64_t)position * row_length * 2, (uint64_t)row_length * tokens * 2, "chunked V cache");
+    KvStoreRowsArgs args{position, row_length, tokens};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_kv_store_f16_rows");
+        [enc setComputePipelineState:impl_->kv_store_rows];
+        [enc setBuffer:kb.handle() offset:0 atIndex:0]; [enc setBuffer:vb.handle() offset:0 atIndex:1];
+        [enc setBuffer:kc.handle() offset:0 atIndex:2]; [enc setBuffer:vc.handle() offset:0 atIndex:3];
+        [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreads:MTLSizeMake(row_length,tokens,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if (own) impl_->finish_command("chunked KV store");
+    }
+}
+
+void MetalBackend::kv_store_turbo3_rows(const BackendBuffer& k, const BackendBuffer& v,
+                                        BackendBuffer& k_cache, BackendBuffer& v_cache,
+                                        uint32_t position, uint32_t kv_heads, uint32_t tokens) {
+    if (!kv_heads || !tokens || tokens > 12)
+        throw std::runtime_error("q27 Metal: invalid chunked turbo3 KV store");
+    const MetalBuffer& kb = metal_buffer(k); const MetalBuffer& vb = metal_buffer(v);
+    MetalBuffer& kc = metal_buffer(k_cache); MetalBuffer& vc = metal_buffer(v_cache);
+    const uint64_t row_bytes = (uint64_t)kv_heads * 2 * 50;
+    check_range(kb.size(), 0, (uint64_t)kv_heads * 256 * tokens * 4, "chunked turbo3 K rows");
+    check_range(vb.size(), 0, (uint64_t)kv_heads * 256 * tokens * 4, "chunked turbo3 V rows");
+    check_range(kc.size(), (uint64_t)position * row_bytes, row_bytes * tokens, "chunked turbo3 K cache");
+    check_range(vc.size(), (uint64_t)position * row_bytes, row_bytes * tokens, "chunked turbo3 V cache");
+    TurboStoreRowsArgs args{position, kv_heads, tokens};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_kv_store_turbo3_rows");
+        [enc setComputePipelineState:impl_->kv_store_turbo3_rows];
+        [enc setBuffer:kb.handle() offset:0 atIndex:0]; [enc setBuffer:vb.handle() offset:0 atIndex:1];
+        [enc setBuffer:kc.handle() offset:0 atIndex:2]; [enc setBuffer:vc.handle() offset:0 atIndex:3];
+        [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)kv_heads*2,2,tokens)
+                threadsPerThreadgroup:MTLSizeMake(128,1,1)];
+        if (own) impl_->finish_command("chunked turbo3 KV store");
+    }
+}
+
+void MetalBackend::attention_f16_causal(const BackendBuffer& q, uint32_t q_stride,
+                                        uint32_t q_row_stride, const BackendBuffer& k_cache,
+                                        const BackendBuffer& v_cache,
+                                        BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
+                                        uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
+                                        float scale, BackendBuffer* partials) {
+    (void)partials;
+    if (!base_len || !kv_heads || q_heads % kv_heads || !head_dim || head_dim > 256 ||
+        !tokens || tokens > 12)
+        throw std::runtime_error("q27 Metal: invalid chunked attention dimensions");
+    if (base_len > UINT32_MAX - (tokens - 1))
+        throw std::runtime_error("q27 Metal: chunked attention sequence length overflow");
+    const MetalBuffer& qb = metal_buffer(q); const MetalBuffer& kc = metal_buffer(k_cache);
+    const MetalBuffer& vc = metal_buffer(v_cache);
+    MetalBuffer& output = metal_buffer(out);
+    const uint32_t max_seq = base_len + tokens - 1;
+    check_range(qb.size(), 0,
+                ((uint64_t)(tokens-1)*q_row_stride + (uint64_t)(q_heads-1)*q_stride + head_dim)*4,
+                "chunked attention Q");
+    const uint64_t cache_bytes = (uint64_t)max_seq * kv_heads * head_dim * 2;
+    check_range(kc.size(), 0, cache_bytes, "chunked attention K cache");
+    check_range(vc.size(), 0, cache_bytes, "chunked attention V cache");
+    check_range(output.size(), 0, (uint64_t)tokens * q_heads * head_dim * 4, "chunked attention output");
+    AttentionCausalArgs args{q_stride, q_row_stride, base_len, q_heads, kv_heads, head_dim, tokens, scale};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_attention_f16_causal");
+        [enc setComputePipelineState:impl_->attention_causal];
+        [enc setBuffer:qb.handle() offset:0 atIndex:0]; [enc setBuffer:kc.handle() offset:0 atIndex:1];
+        [enc setBuffer:vc.handle() offset:0 atIndex:2];
+        [enc setBuffer:output.handle() offset:0 atIndex:3]; [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake(q_heads,tokens,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if (own) impl_->finish_command("chunked FP16 attention");
+    }
+}
+
+void MetalBackend::attention_turbo3_causal(const BackendBuffer& q, uint32_t q_stride,
+                                           uint32_t q_row_stride, const BackendBuffer& k_cache,
+                                           const BackendBuffer& v_cache,
+                                           BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
+                                           uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
+                                           float scale, BackendBuffer* partials) {
+    (void)partials;
+    if (!base_len || !kv_heads || q_heads % kv_heads || head_dim != 256 || !tokens || tokens > 12)
+        throw std::runtime_error("q27 Metal: invalid chunked turbo3 attention dimensions");
+    if (base_len > UINT32_MAX - (tokens - 1))
+        throw std::runtime_error("q27 Metal: chunked attention sequence length overflow");
+    const MetalBuffer& qb = metal_buffer(q); const MetalBuffer& kc = metal_buffer(k_cache);
+    const MetalBuffer& vc = metal_buffer(v_cache);
+    MetalBuffer& output = metal_buffer(out);
+    const uint32_t max_seq = base_len + tokens - 1;
+    check_range(qb.size(), 0,
+                ((uint64_t)(tokens-1)*q_row_stride + (uint64_t)(q_heads-1)*q_stride + head_dim)*4,
+                "chunked turbo3 attention Q");
+    const uint64_t cache_bytes = (uint64_t)max_seq * kv_heads * 2 * 50;
+    check_range(kc.size(), 0, cache_bytes, "chunked turbo3 K cache");
+    check_range(vc.size(), 0, cache_bytes, "chunked turbo3 V cache");
+    check_range(output.size(), 0, (uint64_t)tokens * q_heads * head_dim * 4, "chunked turbo3 attention output");
+    AttentionCausalArgs args{q_stride, q_row_stride, base_len, q_heads, kv_heads, head_dim, tokens, scale};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_attention_turbo3_causal");
+        [enc setComputePipelineState:impl_->attention_turbo3_causal_p];
+        [enc setBuffer:qb.handle() offset:0 atIndex:0]; [enc setBuffer:kc.handle() offset:0 atIndex:1];
+        [enc setBuffer:vc.handle() offset:0 atIndex:2];
+        [enc setBuffer:output.handle() offset:0 atIndex:3]; [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake(q_heads,tokens,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if (own) impl_->finish_command("chunked turbo3 attention");
+    }
+}
+
+void MetalBackend::sigmoid_gate_mul_rows(BackendBuffer& out, const BackendBuffer& qg,
+                                         uint32_t heads, uint32_t head_dim, uint32_t tokens) {
+    if (!heads || !head_dim || !tokens || tokens > 12)
+        throw std::runtime_error("q27 Metal: invalid chunked sigmoid gate");
+    MetalBuffer& o = metal_buffer(out); const MetalBuffer& gates = metal_buffer(qg);
+    const uint64_t n = (uint64_t)heads * head_dim * tokens;
+    check_range(o.size(), 0, n * 4, "chunked sigmoid output");
+    check_range(gates.size(), 0, n * 2 * 4, "chunked sigmoid gates");
+    GateRowsArgs args{heads, head_dim, tokens};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_sigmoid_gate_mul_rows");
+        [enc setComputePipelineState:impl_->sigmoid_gate_rows];
+        [enc setBuffer:o.handle() offset:0 atIndex:0]; [enc setBuffer:gates.handle() offset:0 atIndex:1];
+        [enc setBytes:&args length:sizeof(args) atIndex:2];
+        [enc dispatchThreads:MTLSizeMake((NSUInteger)n,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if (own) impl_->finish_command("chunked sigmoid gate");
+    }
+}
+
+void MetalBackend::argmax_rows(const BackendBuffer& x, uint32_t n, uint32_t rows,
+                               BackendBuffer& out_indices) {
+    if (!n || !rows || rows > 12) throw std::runtime_error("q27 Metal: invalid chunked argmax");
+    const MetalBuffer& input = metal_buffer(x); MetalBuffer& output = metal_buffer(out_indices);
+    check_range(input.size(), 0, (uint64_t)n * rows * 4, "chunked argmax input");
+    check_range(output.size(), 0, (uint64_t)rows * 4, "chunked argmax output");
+    ArgmaxRowsArgs args{n, rows};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_argmax_rows");
+        [enc setComputePipelineState:impl_->argmax_rows_p];
+        [enc setBuffer:input.handle() offset:0 atIndex:0];
+        [enc setBuffer:output.handle() offset:0 atIndex:1];
+        [enc setBytes:&args length:sizeof(args) atIndex:2];
+        [enc dispatchThreadgroups:MTLSizeMake(rows,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if (own) impl_->finish_command("chunked argmax");
+    }
+}
+
+void MetalBackend::nll_rows(const BackendBuffer& logits, const BackendBuffer& targets,
+                            BackendBuffer& nll, uint32_t n, uint32_t rows) {
+    if (!n || !rows) throw std::runtime_error("q27 Metal: invalid NLL shape");
+    const uint64_t elements = uint64_t(n) * rows;
+    if (elements > UINT64_MAX / 4)
+        throw std::runtime_error("q27 Metal: size overflow in NLL logits");
+    const MetalBuffer& input = metal_buffer(logits);
+    const MetalBuffer& tgt = metal_buffer(targets);
+    MetalBuffer& out = metal_buffer(nll);
+    check_range(input.size(), 0, elements * 4, "NLL logits");
+    check_range(tgt.size(), 0, uint64_t(rows) * 4, "NLL targets");
+    check_range(out.size(), 0, uint64_t(rows) * 4, "NLL output");
+    struct NllRowsArgs { uint32_t n; uint32_t rows; } args{n, rows};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_nll_rows");
+        [enc setComputePipelineState:impl_->nll_rows_p];
+        [enc setBuffer:input.handle() offset:0 atIndex:0];
+        [enc setBuffer:tgt.handle() offset:0 atIndex:1];
+        [enc setBuffer:out.handle() offset:0 atIndex:2];
+        [enc setBytes:&args length:sizeof(args) atIndex:3];
+        [enc dispatchThreadgroups:MTLSizeMake(rows, 1, 1)
+            threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        if (own) impl_->finish_command("nll rows");
+    }
+}
+
+void MetalBackend::synchronize() {
+    @autoreleasepool {
+        if (impl_->batching)
+            throw std::runtime_error("q27 Metal: end command batch before synchronizing");
+        id<MTLCommandBuffer> command = [impl_->queue commandBuffer];
+        if (!command) throw std::runtime_error("q27 Metal: command creation failed");
+        [command commit];
+        [command waitUntilCompleted];
+        if (command.status == MTLCommandBufferStatusError)
+            throw std::runtime_error("q27 Metal: synchronization failed");
+    }
+}
+
+void MetalBackend::profile_reset() {
+    if (!impl_->profile) return;
+    impl_->profile_stats.clear();
+    impl_->profiled_command_buffers = 0;
+    impl_->gpu_busy_seconds = 0.0;
+    impl_->cpu_wait_seconds = 0.0;
+}
+
+uint64_t MetalBackend::recommended_working_set_size() const {
+    return (uint64_t)impl_->device.recommendedMaxWorkingSetSize;
+}
+
+uint64_t MetalBackend::max_buffer_length() const {
+    return (uint64_t)impl_->device.maxBufferLength;
+}
+
+bool MetalBackend::supports_quantized_matmul() const {
+    return impl_->q4_quantized_matmul && impl_->q8_quantized_matmul && impl_->t2_quantized_matmul;
+}
+
+uint64_t MetalBackend::max_threadgroup_memory_length() const {
+    return (uint64_t)impl_->device.maxThreadgroupMemoryLength;
+}
+
+} // namespace q27

--- a/src/metal/metal_backend.mm
+++ b/src/metal/metal_backend.mm
@@ -11,6 +11,7 @@
 #include <limits>
 #include <map>
 #include <stdexcept>
+#include <mach-o/dyld.h>
 #include <sys/mman.h>
 #include <unistd.h>
 #include <vector>
@@ -60,18 +61,54 @@ void check_range(uint64_t size, uint64_t offset, uint64_t bytes, const char* ope
         throw std::runtime_error(std::string("q27 Metal: buffer range error in ") + operation);
 }
 
+// Bounds a tensor access by its logical extent, not just its buffer: shared
+// whole-mapping buffers would otherwise let a per-tensor byte-count error
+// read silently into the neighboring tensor.
+uint64_t tensor_limit(uint64_t buffer_size, uint64_t offset, uint64_t logical_size) {
+    if (!logical_size) return buffer_size;
+    const uint64_t end = offset > UINT64_MAX - logical_size ? UINT64_MAX : offset + logical_size;
+    return end < buffer_size ? end : buffer_size;
+}
+
+uint64_t checked_mul(uint64_t a, uint64_t b, const char* operation) {
+    if (a && b > UINT64_MAX / a)
+        throw std::runtime_error(std::string("q27 Metal: size overflow in ") + operation);
+    return a * b;
+}
+
 // Must match the "Q27_SHADER_ABI" tag in q27_kernels.metal. Shaders compile
 // from that file at runtime, so a host binary built before a buffer-binding
 // change would otherwise misbind silently against a newer shader file.
 constexpr const char* kShaderAbiTag = "// Q27_SHADER_ABI 6";
+
+NSString* source_tree_shader_path() {
+    uint32_t size = 0;
+    (void)_NSGetExecutablePath(nullptr, &size);
+    if (!size) return nil;
+    std::vector<char> path(size);
+    if (_NSGetExecutablePath(path.data(), &size) != 0) return nil;
+    NSString* executable = [NSString stringWithUTF8String:path.data()];
+    if (!executable) return nil;
+    executable = executable.stringByStandardizingPath;
+    NSString* checkout = [[executable stringByDeletingLastPathComponent]
+                                      stringByDeletingLastPathComponent];
+    return [checkout stringByAppendingPathComponent:@"src/metal/q27_kernels.metal"];
+}
 
 NSString* load_kernel_source() {
     NSFileManager* files = [NSFileManager defaultManager];
     NSMutableArray<NSString*>* candidates = [NSMutableArray array];
     if (const char* override_path = getenv("Q27_METAL_SOURCE"))
         [candidates addObject:[NSString stringWithUTF8String:override_path]];
+#ifdef Q27_SHADER_PATH
+    [candidates addObject:@Q27_SHADER_PATH];
+#else
+    // Source-tree binaries live under build/. Resolve from the executable so
+    // invoking them outside the checkout does not depend on process cwd.
+    if (NSString* path = source_tree_shader_path()) [candidates addObject:path];
+    // Preserve direct compiler/test invocations that place the binary elsewhere.
     [candidates addObject:@"src/metal/q27_kernels.metal"];
-    [candidates addObject:@"./src/metal/q27_kernels.metal"];
+#endif
 
     for (NSString* path in candidates) {
         if (![files fileExistsAtPath:path]) continue;
@@ -95,8 +132,7 @@ NSString* load_kernel_source() {
                                      "\"; rebuild this binary against the current shader source");
         return source;
     }
-    throw std::runtime_error("q27 Metal: src/metal/q27_kernels.metal not found "
-                             "(set Q27_METAL_SOURCE)");
+    throw std::runtime_error("q27 Metal: shader source not found (set Q27_METAL_SOURCE)");
 }
 
 id<MTLComputePipelineState> make_pipeline(id<MTLDevice> device, id<MTLLibrary> library,
@@ -231,30 +267,55 @@ struct MetalBackend::Impl {
     double gpu_busy_seconds = 0.0;
     double cpu_wait_seconds = 0.0;
     MTLTimestamp calibration_cpu = 0, calibration_gpu = 0;
+    bool poisoned = false;
+    std::string poison_reason;
+
+    void ensure_healthy() const {
+        if (!poisoned) return;
+        throw std::runtime_error("q27 Metal: backend is unusable after command failure; "
+                                 "reconstruct the Metal engine (original failure: " +
+                                 poison_reason + ")");
+    }
+
+    void poison(const std::string& reason) {
+        poisoned = true;
+        poison_reason = reason;
+    }
+
+    void abort_command() noexcept {
+        if (encoder) [encoder endEncoding];
+        encoder = nil;
+        command = nil;
+        batching = false;
+        op_labels.clear();
+    }
 
     void start_command(bool explicit_batch) {
-        if (encoder) throw std::runtime_error("q27 Metal: command batch already active");
+        ensure_healthy();
+        if (command || encoder || batching)
+            throw std::runtime_error("q27 Metal: command batch already active");
         command = [queue commandBuffer];
         if (!command) throw std::runtime_error("q27 Metal: command creation failed");
         if (profile) {
             op_labels.clear();
         } else {
             encoder = [command computeCommandEncoder];
-            if (!encoder) throw std::runtime_error("q27 Metal: command creation failed");
+            if (!encoder) {
+                abort_command();
+                throw std::runtime_error("q27 Metal: command creation failed");
+            }
         }
         batching = explicit_batch;
     }
 
     id<MTLComputeCommandEncoder> encoder_for_operation(bool& own_command, const char* label) {
+        ensure_healthy();
         own_command = !batching;
         if (own_command) start_command(false);
         if (profile) {
             if (op_labels.size() >= kMaxProfiledOps) {
-                // Split the batch so the sample buffer never overflows; the
-                // queue preserves ordering across the two command buffers.
-                const bool was_batching = batching;
-                finish_command("profiling split");
-                start_command(was_batching);
+                abort_command();
+                throw std::runtime_error("q27 Metal: profiled command batch exceeds operation limit");
             }
             if (encoder) { [encoder endEncoding]; encoder = nil; }
             MTLComputePassDescriptor* pass = [MTLComputePassDescriptor computePassDescriptor];
@@ -263,13 +324,17 @@ struct MetalBackend::Impl {
             attachment.startOfEncoderSampleIndex = op_labels.size() * 2;
             attachment.endOfEncoderSampleIndex = op_labels.size() * 2 + 1;
             encoder = [command computeCommandEncoderWithDescriptor:pass];
-            if (!encoder) throw std::runtime_error("q27 Metal: profiled encoder creation failed");
+            if (!encoder) {
+                abort_command();
+                throw std::runtime_error("q27 Metal: profiled encoder creation failed");
+            }
             op_labels.push_back(label);
         }
         return encoder;
     }
 
     void finish_command(const char* label) {
+        ensure_healthy();
         if (!command || (!encoder && !profile))
             throw std::runtime_error("q27 Metal: no active command batch");
         if (encoder) { [encoder endEncoding]; encoder = nil; }
@@ -282,6 +347,8 @@ struct MetalBackend::Impl {
             if (command.error) message += ": " + std::string(command.error.localizedDescription.UTF8String);
             command = nil;
             batching = false;
+            op_labels.clear();
+            poison(message);
             throw std::runtime_error(message);
         }
         if (profile) resolve_profile_samples();
@@ -467,6 +534,7 @@ std::string MetalBackend::name() const {
 }
 
 std::shared_ptr<BackendBuffer> MetalBackend::allocate(uint64_t bytes) {
+    impl_->ensure_healthy();
     if (!bytes || bytes > (uint64_t)impl_->device.maxBufferLength ||
         bytes > (uint64_t)std::numeric_limits<NSUInteger>::max())
         throw std::runtime_error("q27 Metal: invalid buffer length");
@@ -477,7 +545,9 @@ std::shared_ptr<BackendBuffer> MetalBackend::allocate(uint64_t bytes) {
 }
 
 void MetalBackend::write(BackendBuffer& dst, uint64_t offset, const void* src, uint64_t bytes) {
+    impl_->ensure_healthy();
     MetalBuffer& buffer = metal_buffer(dst);
+    if (impl_->batching) throw std::runtime_error("q27 Metal: cannot CPU-write during command batch");
     check_range(buffer.size(), offset, bytes, "write");
     if (bytes && !src) throw std::runtime_error("q27 Metal: null write source");
     if (bytes) std::memcpy((uint8_t*)buffer.handle().contents + offset, src, (size_t)bytes);
@@ -492,6 +562,7 @@ void MetalBackend::read(const BackendBuffer& src, uint64_t offset, void* dst, ui
 }
 
 void MetalBackend::zero(BackendBuffer& dst) {
+    impl_->ensure_healthy();
     MetalBuffer& buffer = metal_buffer(dst);
     if (impl_->batching) throw std::runtime_error("q27 Metal: cannot CPU-clear during command batch");
     std::memset(buffer.handle().contents, 0, (size_t)buffer.size());
@@ -529,29 +600,35 @@ BackendTensor MetalBackend::upload(const Tensor& tensor) {
     result.rows = tensor.rows();
     result.cols = tensor.cols();
     result.data = allocate(tensor.data_size);
+    result.data_size = tensor.data_size;
     write(*result.data, 0, tensor.data, tensor.data_size);
     if (tensor.scales_size) {
         result.scales = allocate(tensor.scales_size);
+        result.scales_size = tensor.scales_size;
         write(*result.scales, 0, tensor.scales, tensor.scales_size);
     }
     return result;
 }
 
 BackendTensor MetalBackend::upload(const Model& model, const Tensor& tensor) {
-    // Preferred form: one MTLBuffer wraps the whole mapping and every tensor
-    // binds at an offset. One buffer instead of two per tensor keeps the
-    // per-commit residency/tracking work constant in model size, and gives
-    // the residency set a single allocation to wire. Mappings larger than
-    // maxBufferLength (the 5.25 bpw tier) keep per-tensor page-aligned views
-    // and stay unwired -- they do not fit in memory either way.
+    if (!model.mapping_base() || !model.mapping_size())
+        throw std::runtime_error("q27 Metal: invalid model view");
+    const uint64_t logical_size = model.mapping_size();
+    const uint64_t page_size = (uint64_t)getpagesize();
+    if (logical_size > UINT64_MAX - (page_size - 1))
+        throw std::runtime_error("q27 Metal: model mapping size overflow");
+    const uint64_t mapped_size = (logical_size + page_size - 1) / page_size * page_size;
+
+    // Preferred form: one MTLBuffer wraps the page-rounded mapping and every
+    // tensor binds at an offset. Metal requires no-copy lengths to cover whole
+    // virtual-memory pages; logical tensor extents remain independently bounded.
     auto wrap_mapping = [&]() -> std::shared_ptr<MetalBuffer> {
         void* base = (void*)model.mapping_base();
-        const uint64_t size = model.mapping_size();
         auto& slot = impl_->model_wraps[base];
         if (auto held = slot.lock()) return held;
-        madvise(base, (size_t)size, MADV_WILLNEED);
+        madvise(base, (size_t)mapped_size, MADV_WILLNEED);
         id<MTLBuffer> buffer = [impl_->device newBufferWithBytesNoCopy:base
-                                                                length:(NSUInteger)size
+                                                                length:(NSUInteger)mapped_size
                                                                options:MTLResourceStorageModeShared
                                                            deallocator:nil];
         if (!buffer) throw std::runtime_error("q27 Metal: cannot wrap model mmap");
@@ -561,9 +638,8 @@ BackendTensor MetalBackend::upload(const Model& model, const Tensor& tensor) {
                 [set addAllocation:buffer];
                 [set commit];
                 [set requestResidency];
-                // The set retains the buffer and keeps its pages wired; drop
-                // it when the last tensor goes away so a later munmap cannot
-                // leave the set holding a dead address range.
+                // The set retains the buffer and requests best-effort residency;
+                // remove it before a later Model destruction can unmap the pages.
                 wrapped = std::shared_ptr<MetalBuffer>(
                     new MetalBuffer(buffer, false), [set](MetalBuffer* wrapper) {
                         if (@available(macOS 15.0, *)) {
@@ -585,49 +661,46 @@ BackendTensor MetalBackend::upload(const Model& model, const Tensor& tensor) {
         const uintptr_t address = (uintptr_t)ptr;
         if (address < base) throw std::runtime_error("q27 Metal: tensor precedes model mapping");
         const uint64_t offset = (uint64_t)(address - base);
-        if (offset > model.mapping_size() || bytes > model.mapping_size() - offset)
+        if (offset > logical_size || bytes > logical_size - offset)
             throw std::runtime_error("q27 Metal: tensor outside model mapping");
         return offset;
     };
 
-    if (!model.mapping_base() || !model.mapping_size())
-        throw std::runtime_error("q27 Metal: invalid model view");
-    if (model.mapping_size() <= (uint64_t)impl_->device.maxBufferLength) {
+    if (mapped_size <= (uint64_t)impl_->device.maxBufferLength) {
         BackendTensor result;
         result.dtype = tensor.dtype;
         result.rows = tensor.rows();
         result.cols = tensor.cols();
         result.data_offset = mapping_offset(tensor.data, tensor.data_size);
         result.data = wrap_mapping();
+        result.data_size = tensor.data_size;
         if (tensor.scales_size) {
             result.scales_offset = mapping_offset(tensor.scales, tensor.scales_size);
             result.scales = result.data;
+            result.scales_size = tensor.scales_size;
         }
         return result;
     }
 
     auto wrap = [&](const uint8_t* ptr, uint64_t bytes, uint64_t& inner) {
-        if (!ptr || !bytes || !model.mapping_base() || !model.mapping_size())
-            throw std::runtime_error("q27 Metal: invalid model view");
+        if (!ptr || !bytes) throw std::runtime_error("q27 Metal: invalid model view");
         const uintptr_t base = (uintptr_t)model.mapping_base();
         const uintptr_t address = (uintptr_t)ptr;
         if (address < base) throw std::runtime_error("q27 Metal: tensor precedes model mapping");
         const uint64_t offset = (uint64_t)(address - base);
-        const uint64_t model_size = model.mapping_size();
-        if (offset > model_size || bytes > model_size - offset)
+        if (offset > logical_size || bytes > logical_size - offset)
             throw std::runtime_error("q27 Metal: tensor outside model mapping");
 
-        const uint64_t page = (uint64_t)getpagesize();
-        const uint64_t page_offset = offset - offset % page;
+        const uint64_t page_offset = offset - offset % page_size;
         inner = offset - page_offset;
         if (bytes > UINT64_MAX - inner)
             throw std::runtime_error("q27 Metal: model view size overflow");
         uint64_t view_bytes = inner + bytes;
-        if (view_bytes > UINT64_MAX - (page - 1))
+        if (view_bytes > UINT64_MAX - (page_size - 1))
             throw std::runtime_error("q27 Metal: model view alignment overflow");
-        view_bytes = (view_bytes + page - 1) / page * page;
-        if (view_bytes > model_size - page_offset) view_bytes = model_size - page_offset;
-        if (inner + bytes > view_bytes || view_bytes > (uint64_t)impl_->device.maxBufferLength)
+        view_bytes = (view_bytes + page_size - 1) / page_size * page_size;
+        if (view_bytes > mapped_size - page_offset || inner + bytes > view_bytes ||
+            view_bytes > (uint64_t)impl_->device.maxBufferLength)
             throw std::runtime_error("q27 Metal: model view exceeds Metal buffer limits");
 
         void* view_base = (void*)(base + page_offset);
@@ -644,8 +717,11 @@ BackendTensor MetalBackend::upload(const Model& model, const Tensor& tensor) {
     result.rows = tensor.rows();
     result.cols = tensor.cols();
     result.data = wrap(tensor.data, tensor.data_size, result.data_offset);
-    if (tensor.scales_size)
+    result.data_size = tensor.data_size;
+    if (tensor.scales_size) {
         result.scales = wrap(tensor.scales, tensor.scales_size, result.scales_offset);
+        result.scales_size = tensor.scales_size;
+    }
     return result;
 }
 
@@ -658,12 +734,7 @@ void MetalBackend::end_commands() {
 }
 
 void MetalBackend::abort_commands() noexcept {
-    @autoreleasepool {
-        if (impl_->encoder) [impl_->encoder endEncoding];
-        impl_->encoder = nil;
-        impl_->command = nil;
-        impl_->batching = false;
-    }
+    @autoreleasepool { impl_->abort_command(); }
 }
 
 void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
@@ -671,6 +742,12 @@ void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
     if (!weight.data) throw std::runtime_error("q27 Metal: matvec weight has no data");
     if (!weight.rows || !weight.cols || weight.rows > UINT32_MAX || weight.cols > UINT32_MAX)
         throw std::runtime_error("q27 Metal: unsupported matvec dimensions");
+    const uint64_t elements = checked_mul(weight.rows, weight.cols, "matvec weight");
+    uint64_t data_bytes = elements;
+    if (weight.dtype == DType::F32) data_bytes = checked_mul(elements, 4, "matvec weight");
+    if (weight.dtype == DType::F16) data_bytes = checked_mul(elements, 2, "matvec weight");
+    if (weight.dtype == DType::Q4_G64) data_bytes /= 2;
+    if (weight.dtype == DType::T2_G128) data_bytes /= 4;
     check_range(x.size(), 0, weight.cols * sizeof(float), "matvec input");
     check_range(y.size(), 0, weight.rows * sizeof(float), "matvec output");
 
@@ -682,12 +759,8 @@ void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
                                  weight.dtype == DType::Q4_G64 ? 64 : 0;
     if (quant_group && weight.cols % quant_group)
         throw std::runtime_error("q27 Metal: matvec columns do not match quantization group");
-    uint64_t data_bytes = weight.rows * weight.cols;
-    if (weight.dtype == DType::F32) data_bytes *= 4;
-    if (weight.dtype == DType::F16) data_bytes *= 2;
-    if (weight.dtype == DType::Q4_G64) data_bytes /= 2;
-    if (weight.dtype == DType::T2_G128) data_bytes /= 4;
-    check_range(data.size(), weight.data_offset, data_bytes, "matvec weight");
+    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size),
+                weight.data_offset, data_bytes, "matvec weight");
     id<MTLComputePipelineState> pipeline = nil;
     const char* label = nullptr;
     switch (weight.dtype) {
@@ -706,7 +779,8 @@ void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
         quant_scales = &metal_buffer_view(weight.scales);
         const uint64_t group = quant_group;
         const uint64_t scale_bytes = weight.rows * (weight.cols / group) * 2;
-        check_range(quant_scales->size(), weight.scales_offset, scale_bytes, "matvec scales");
+        check_range(tensor_limit(quant_scales->size(), weight.scales_offset, weight.scales_size),
+                    weight.scales_offset, scale_bytes, "matvec scales");
     }
 
     MatvecArgs args{(uint32_t)weight.rows, (uint32_t)weight.cols, 8};
@@ -744,13 +818,19 @@ void MetalBackend::matvec_pair(const BackendTensor& a, BackendBuffer& a_out,
     if(!a.data || !b.data || !a.rows || !b.rows || !a.cols || a.rows>UINT32_MAX ||
        b.rows>UINT32_MAX || a.cols>UINT32_MAX)
         throw std::runtime_error("q27 Metal: invalid fused F16 matvec");
+    const uint64_t a_weight_bytes = checked_mul(checked_mul(a.rows, a.cols, "fused matvec weight A"),
+                                                2, "fused matvec weight A");
+    const uint64_t b_weight_bytes = checked_mul(checked_mul(b.rows, b.cols, "fused matvec weight B"),
+                                                2, "fused matvec weight B");
     check_range(x.size(),0,a.cols*4,"fused matvec input");
     check_range(a_out.size(),0,a.rows*4,"fused matvec output A");
     check_range(b_out.size(),0,b.rows*4,"fused matvec output B");
     const MetalBuffer& ad=metal_buffer_view(a.data); const MetalBuffer& bd=metal_buffer_view(b.data);
     const MetalBuffer& input=metal_buffer(x); MetalBuffer& ao=metal_buffer(a_out); MetalBuffer& bo=metal_buffer(b_out);
-    check_range(ad.size(),a.data_offset,a.rows*a.cols*2,"fused matvec weight A");
-    check_range(bd.size(),b.data_offset,b.rows*b.cols*2,"fused matvec weight B");
+    check_range(tensor_limit(ad.size(), a.data_offset, a.data_size),
+                a.data_offset,a_weight_bytes,"fused matvec weight A");
+    check_range(tensor_limit(bd.size(), b.data_offset, b.data_size),
+                b.data_offset,b_weight_bytes,"fused matvec weight B");
     MatvecPairArgs args{(uint32_t)a.rows,(uint32_t)b.rows,(uint32_t)a.cols,8};
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_matvec_f16_pair"); [enc setComputePipelineState:impl_->f16_pair];
@@ -800,8 +880,10 @@ void MetalBackend::matvec_quantized(const BackendTensor& weight,
     const MetalBuffer& xv=metal_buffer_view(x.values); const MetalBuffer& xs=metal_buffer_view(x.scales); MetalBuffer& out=metal_buffer(y);
     const uint64_t divisor=weight.dtype==DType::Q4_G64?2:weight.dtype==DType::T2_G128?4:1;
     const uint64_t data_bytes=weight.rows*weight.cols/divisor;
-    check_range(data.size(),weight.data_offset,data_bytes,"quantized matvec weight");
-    check_range(ws.size(),weight.scales_offset,weight.rows*(weight.cols/group)*2,"quantized matvec weight scales");
+    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size),
+                weight.data_offset,data_bytes,"quantized matvec weight");
+    check_range(tensor_limit(ws.size(), weight.scales_offset, weight.scales_size),
+                weight.scales_offset,weight.rows*(weight.cols/group)*2,"quantized matvec weight scales");
     check_range(xv.size(),0,x.count,"quantized matvec values"); check_range(xs.size(),0,(uint64_t)(x.count/32)*4,"quantized matvec activation scales");
     MatvecArgs args{(uint32_t)weight.rows,(uint32_t)weight.cols,8};
     @autoreleasepool {
@@ -848,8 +930,10 @@ void MetalBackend::matmul_quantized(const BackendTensor& weight,const BackendQua
     const MetalBuffer& data=metal_buffer_view(weight.data); const MetalBuffer& ws=metal_buffer_view(weight.scales);
     const MetalBuffer& xv=metal_buffer_view(x.values); const MetalBuffer& xs=metal_buffer_view(x.scales); MetalBuffer& out=metal_buffer(y);
     uint64_t divisor=weight.dtype==DType::Q4_G64?2:weight.dtype==DType::T2_G128?4:1;
-    check_range(data.size(),weight.data_offset,weight.rows*weight.cols/divisor,"quantized matmul weight");
-    check_range(ws.size(),weight.scales_offset,weight.rows*(weight.cols/group)*2,"quantized matmul weight scales");
+    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size),
+                weight.data_offset,weight.rows*weight.cols/divisor,"quantized matmul weight");
+    check_range(tensor_limit(ws.size(), weight.scales_offset, weight.scales_size),
+                weight.scales_offset,weight.rows*(weight.cols/group)*2,"quantized matmul weight scales");
     check_range(xv.size(),0,x.count,"quantized matmul values"); check_range(xs.size(),0,(uint64_t)(x.count/32)*4,"quantized matmul scales");
     MatmulArgs args{(uint32_t)weight.rows,(uint32_t)weight.cols,x_rows,1};
     @autoreleasepool {
@@ -877,10 +961,10 @@ void MetalBackend::embedding_q8(const BackendTensor& weight, uint32_t token,
     check_range(out.size(), 0, weight.cols * 4, "embedding output");
     const MetalBuffer& data = metal_buffer_view(weight.data);
     const MetalBuffer& scales = metal_buffer_view(weight.scales);
-    check_range(data.size(), weight.data_offset,
+    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,
                 weight.rows * weight.cols / (t2 ? 4 : 1), "embedding weight");
-    check_range(scales.size(), weight.scales_offset,
-                weight.rows * (weight.cols / 128) * 2, "embedding scales");
+    check_range(tensor_limit(scales.size(), weight.scales_offset, weight.scales_size),
+                weight.scales_offset, weight.rows * (weight.cols / 128) * 2, "embedding scales");
     MetalBuffer& output = metal_buffer(out);
     @autoreleasepool {
         bool own; id<MTLComputeCommandEncoder> enc = impl_->encoder_for_operation(own,
@@ -903,7 +987,8 @@ void MetalBackend::rmsnorm(const BackendBuffer& x, const BackendTensor& weight,
     const MetalBuffer& input = metal_buffer(x); MetalBuffer& output = metal_buffer(out);
     check_range(input.size(), 0, (uint64_t)n * 4, "rmsnorm input");
     check_range(output.size(), 0, (uint64_t)n * 4, "rmsnorm output");
-    check_range(w.size(), weight.data_offset, (uint64_t)n * 4, "rmsnorm weight");
+    check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size),
+                weight.data_offset, (uint64_t)n * 4, "rmsnorm weight");
     VectorArgs args{n, 8, eps};
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own, "q27_rmsnorm");
@@ -926,7 +1011,8 @@ void MetalBackend::rmsnorm_quantized(const BackendBuffer& x,const BackendTensor&
     const MetalBuffer& input=metal_buffer(x); MetalBuffer& output=metal_buffer(out);
     MetalBuffer& values=metal_buffer(*quantized.values); MetalBuffer& scales=metal_buffer(*quantized.scales);
     check_range(input.size(),0,(uint64_t)n*4,"fused rmsnorm input"); check_range(output.size(),0,(uint64_t)n*4,"fused rmsnorm output");
-    check_range(w.size(),weight.data_offset,(uint64_t)n*4,"fused rmsnorm weight"); check_range(values.size(),0,n,"fused rmsnorm values");
+    check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size), weight.data_offset,
+                (uint64_t)n*4,"fused rmsnorm weight"); check_range(values.size(),0,n,"fused rmsnorm values");
     check_range(scales.size(),0,(uint64_t)(n/32)*4,"fused rmsnorm scales"); VectorArgs args{n,8,eps};
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_rmsnorm_quantized"); [enc setComputePipelineState:impl_->rms_quantized];
@@ -944,7 +1030,8 @@ void MetalBackend::rmsnorm_heads(BackendBuffer& x, const BackendTensor& weight,
     const MetalBuffer& w = tensor_data(weight, DType::F32, "head rmsnorm");
     MetalBuffer& input = metal_buffer(x);
     check_range(input.size(), 0, ((uint64_t)(heads - 1) * stride + head_dim) * 4, "head rmsnorm input");
-    check_range(w.size(), weight.data_offset, (uint64_t)head_dim * 4, "head rmsnorm weight");
+    check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size),
+                weight.data_offset, (uint64_t)head_dim * 4, "head rmsnorm weight");
     HeadArgs args{heads, head_dim, stride, 8, eps};
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own, "q27_rmsnorm_heads");
@@ -1002,14 +1089,17 @@ void MetalBackend::add_inplace(BackendBuffer& x, const BackendBuffer& y, uint32_
 void MetalBackend::concat(const BackendBuffer& a, uint32_t a_count,
                            const BackendBuffer& b, uint32_t b_count,
                            BackendBuffer& out) {
+    const uint64_t total = (uint64_t)a_count + b_count;
+    if (total > UINT32_MAX)
+        throw std::runtime_error("q27 Metal: concat element count overflow");
     const MetalBuffer& ab=metal_buffer(a); const MetalBuffer& bb=metal_buffer(b); MetalBuffer& ob=metal_buffer(out);
     check_range(ab.size(),0,(uint64_t)a_count*4,"concat a"); check_range(bb.size(),0,(uint64_t)b_count*4,"concat b");
-    check_range(ob.size(),0,(uint64_t)(a_count+b_count)*4,"concat output"); ConcatArgs args{a_count,b_count};
+    check_range(ob.size(),0,total*4,"concat output"); ConcatArgs args{a_count,b_count};
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_concat"); [enc setComputePipelineState:impl_->concat];
         [enc setBuffer:ab.handle() offset:0 atIndex:0]; [enc setBuffer:bb.handle() offset:0 atIndex:1]; [enc setBuffer:ob.handle() offset:0 atIndex:2];
         [enc setBytes:&args length:sizeof(args) atIndex:3];
-        [enc dispatchThreads:MTLSizeMake((NSUInteger)a_count+b_count,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        [enc dispatchThreads:MTLSizeMake((NSUInteger)total,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
         if(own) impl_->finish_command("concat");
     }
 }
@@ -1205,7 +1295,8 @@ void MetalBackend::gdn_gates(const BackendBuffer& alpha, const BackendBuffer& be
     MetalBuffer& go=metal_buffer(g); MetalBuffer& bo=metal_buffer(beta);
     check_range(ar.size(),0,(uint64_t)heads*4,"GDN alpha"); check_range(br.size(),0,(uint64_t)heads*4,"GDN beta raw");
     check_range(go.size(),0,(uint64_t)heads*4,"GDN g"); check_range(bo.size(),0,(uint64_t)heads*4,"GDN beta");
-    check_range(a.size(),ssm_a.data_offset,(uint64_t)heads*4,"GDN a"); check_range(dt.size(),ssm_dt.data_offset,(uint64_t)heads*4,"GDN dt");
+    check_range(tensor_limit(a.size(), ssm_a.data_offset, ssm_a.data_size), ssm_a.data_offset,(uint64_t)heads*4,"GDN a");
+    check_range(tensor_limit(dt.size(), ssm_dt.data_offset, ssm_dt.data_size), ssm_dt.data_offset,(uint64_t)heads*4,"GDN dt");
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_gdn_gates"); [enc setComputePipelineState:impl_->gates];
         [enc setBuffer:ar.handle() offset:0 atIndex:0]; [enc setBuffer:br.handle() offset:0 atIndex:1];
@@ -1221,7 +1312,7 @@ void MetalBackend::conv_step(const BackendBuffer& ring_src, BackendBuffer& ring_
     const MetalBuffer& src=metal_buffer(ring_src); MetalBuffer& dst=metal_buffer(ring_dst); const MetalBuffer& q=metal_buffer(qkv);
     const MetalBuffer& w=tensor_data(conv_weight,DType::F32,"GDN convolution"); MetalBuffer& o=metal_buffer(out);
     check_range(src.size(),0,(uint64_t)channels*3*4,"conv ring source"); check_range(dst.size(),0,(uint64_t)channels*3*4,"conv ring destination");
-    check_range(q.size(),0,(uint64_t)channels*4,"conv input"); check_range(w.size(),conv_weight.data_offset,(uint64_t)channels*4*4,"conv weight"); check_range(o.size(),0,(uint64_t)channels*4,"conv output");
+    check_range(q.size(),0,(uint64_t)channels*4,"conv input"); check_range(tensor_limit(w.size(), conv_weight.data_offset, conv_weight.data_size),conv_weight.data_offset,(uint64_t)channels*4*4,"conv weight"); check_range(o.size(),0,(uint64_t)channels*4,"conv output");
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_conv_step"); [enc setComputePipelineState:impl_->conv];
         [enc setBuffer:src.handle() offset:0 atIndex:0]; [enc setBuffer:dst.handle() offset:0 atIndex:1]; [enc setBuffer:q.handle() offset:0 atIndex:2];
@@ -1255,7 +1346,7 @@ void MetalBackend::gated_norm_gdn(const BackendBuffer& x, const BackendTensor& w
                                    uint32_t heads, uint32_t head_dim, float eps) {
     const MetalBuffer& xb=metal_buffer(x); const MetalBuffer& w=tensor_data(weight,DType::F32,"GDN norm"); const MetalBuffer& gb=metal_buffer(gate); MetalBuffer& o=metal_buffer(out);
     const uint64_t bytes=(uint64_t)heads*head_dim*4;
-    check_range(xb.size(),0,bytes,"GDN norm input"); check_range(gb.size(),0,bytes,"GDN norm gate"); check_range(o.size(),0,bytes,"GDN norm output"); check_range(w.size(),weight.data_offset,(uint64_t)head_dim*4,"GDN norm weight");
+    check_range(xb.size(),0,bytes,"GDN norm input"); check_range(gb.size(),0,bytes,"GDN norm gate"); check_range(o.size(),0,bytes,"GDN norm output"); check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size),weight.data_offset,(uint64_t)head_dim*4,"GDN norm weight");
     HeadArgs args{heads,head_dim,head_dim,8,eps};
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_gated_norm_gdn"); [enc setComputePipelineState:impl_->gated_norm];
@@ -1281,9 +1372,10 @@ void MetalBackend::embedding_q8_rows(const BackendTensor& weight, const uint32_t
     check_range(out.size(), 0, (uint64_t)count * weight.cols * 4, "chunked embedding output");
     const MetalBuffer& data = metal_buffer_view(weight.data);
     const MetalBuffer& scales = metal_buffer_view(weight.scales);
-    check_range(data.size(), weight.data_offset,
+    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,
                 weight.rows * weight.cols / (t2 ? 4 : 1), "chunked embedding weight");
-    check_range(scales.size(), weight.scales_offset, weight.rows * (weight.cols / 128) * 2, "chunked embedding scales");
+    check_range(tensor_limit(scales.size(), weight.scales_offset, weight.scales_size),
+                weight.scales_offset, weight.rows * (weight.cols / 128) * 2, "chunked embedding scales");
     MetalBuffer& output = metal_buffer(out);
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own,
@@ -1309,7 +1401,8 @@ void MetalBackend::rmsnorm_rows_quantized(const BackendBuffer& x, const BackendT
     const uint64_t total = (uint64_t)n * rows;
     check_range(input.size(), 0, total * 4, "chunked rmsnorm input");
     check_range(output.size(), 0, total * 4, "chunked rmsnorm output");
-    check_range(w.size(), weight.data_offset, (uint64_t)n * 4, "chunked rmsnorm weight");
+    check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size),
+                weight.data_offset, (uint64_t)n * 4, "chunked rmsnorm weight");
     check_range(values.size(), 0, total, "chunked rmsnorm values");
     check_range(scales.size(), 0, (total / 32) * 4, "chunked rmsnorm scales");
     RowsNormArgs args{n, rows, 8, eps};
@@ -1334,14 +1427,20 @@ void MetalBackend::matvec_f16_pair_rows(const BackendTensor& a, BackendBuffer& a
         !a.rows || !b.rows || !a.cols || a.rows > UINT32_MAX || b.rows > UINT32_MAX || a.cols > UINT32_MAX)
         throw std::runtime_error("q27 Metal: chunked F16 matvec pair requires compatible F16 weights");
     if (!rows || rows > 12) throw std::runtime_error("q27 Metal: chunked F16 matvec pair requires 1..12 rows");
+    const uint64_t a_weight_bytes = checked_mul(checked_mul(a.rows, a.cols, "chunked matvec weight A"),
+                                                2, "chunked matvec weight A");
+    const uint64_t b_weight_bytes = checked_mul(checked_mul(b.rows, b.cols, "chunked matvec weight B"),
+                                                2, "chunked matvec weight B");
     check_range(x.size(), 0, (uint64_t)rows * a.cols * 4, "chunked matvec input");
     check_range(a_out.size(), 0, (uint64_t)rows * a.rows * 4, "chunked matvec output A");
     check_range(b_out.size(), 0, (uint64_t)rows * b.rows * 4, "chunked matvec output B");
     const MetalBuffer& ad = metal_buffer_view(a.data); const MetalBuffer& bd = metal_buffer_view(b.data);
     const MetalBuffer& input = metal_buffer(x);
     MetalBuffer& ao = metal_buffer(a_out); MetalBuffer& bo = metal_buffer(b_out);
-    check_range(ad.size(), a.data_offset, a.rows * a.cols * 2, "chunked matvec weight A");
-    check_range(bd.size(), b.data_offset, b.rows * b.cols * 2, "chunked matvec weight B");
+    check_range(tensor_limit(ad.size(), a.data_offset, a.data_size), a.data_offset,
+                a_weight_bytes, "chunked matvec weight A");
+    check_range(tensor_limit(bd.size(), b.data_offset, b.data_size), b.data_offset,
+                b_weight_bytes, "chunked matvec weight B");
     MatvecPairRowsArgs args{(uint32_t)a.rows, (uint32_t)b.rows, (uint32_t)a.cols, rows};
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own, "q27_matvec_f16_pair_rows");
@@ -1367,8 +1466,10 @@ void MetalBackend::gdn_gates_rows(const BackendBuffer& alpha, const BackendBuffe
     const uint64_t total = (uint64_t)heads * tokens * 4;
     check_range(ar.size(), 0, total, "chunked GDN alpha"); check_range(br.size(), 0, total, "chunked GDN beta raw");
     check_range(go.size(), 0, total, "chunked GDN g"); check_range(bo.size(), 0, total, "chunked GDN beta");
-    check_range(a.size(), ssm_a.data_offset, (uint64_t)heads * 4, "chunked GDN a");
-    check_range(dt.size(), ssm_dt.data_offset, (uint64_t)heads * 4, "chunked GDN dt");
+    check_range(tensor_limit(a.size(), ssm_a.data_offset, ssm_a.data_size),
+                ssm_a.data_offset, (uint64_t)heads * 4, "chunked GDN a");
+    check_range(tensor_limit(dt.size(), ssm_dt.data_offset, ssm_dt.data_size),
+                ssm_dt.data_offset, (uint64_t)heads * 4, "chunked GDN dt");
     GatesRowsArgs args{heads, tokens};
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own, "q27_gdn_gates_rows");
@@ -1395,7 +1496,8 @@ void MetalBackend::conv_chunk(const BackendBuffer& ring_src, BackendBuffer& ring
     check_range(rs.size(), 0, (uint64_t)channels * 3 * 4, "chunked conv ring src");
     check_range(rd.size(), 0, (uint64_t)channels * 3 * 4, "chunked conv ring dst");
     check_range(q.size(), 0, (uint64_t)channels * tokens * 4, "chunked conv input");
-    check_range(w.size(), conv_weight.data_offset, (uint64_t)channels * 4 * 4, "chunked conv weight");
+    check_range(tensor_limit(w.size(), conv_weight.data_offset, conv_weight.data_size),
+                conv_weight.data_offset, (uint64_t)channels * 4 * 4, "chunked conv weight");
     check_range(o.size(), 0, (uint64_t)channels * tokens * 4, "chunked conv output");
     ConvChunkArgs args{channels, tokens};
     @autoreleasepool {
@@ -1702,6 +1804,7 @@ void MetalBackend::nll_rows(const BackendBuffer& logits, const BackendBuffer& ta
 }
 
 void MetalBackend::synchronize() {
+    impl_->ensure_healthy();
     @autoreleasepool {
         if (impl_->batching)
             throw std::runtime_error("q27 Metal: end command batch before synchronizing");
@@ -1709,8 +1812,12 @@ void MetalBackend::synchronize() {
         if (!command) throw std::runtime_error("q27 Metal: command creation failed");
         [command commit];
         [command waitUntilCompleted];
-        if (command.status == MTLCommandBufferStatusError)
-            throw std::runtime_error("q27 Metal: synchronization failed");
+        if (command.status == MTLCommandBufferStatusError) {
+            std::string message = "q27 Metal: synchronization failed";
+            if (command.error) message += ": " + std::string(command.error.localizedDescription.UTF8String);
+            impl_->poison(message);
+            throw std::runtime_error(message);
+        }
     }
 }
 

--- a/src/metal/q27_kernels.metal
+++ b/src/metal/q27_kernels.metal
@@ -1,0 +1,1794 @@
+// Q27_SHADER_ABI 6
+//
+// Shaders compile from this file at RUNTIME, so a host binary built before a
+// buffer-binding change silently misbinds against a newer file (this exact
+// mismatch produced coherent-but-wrong decode output on 2026-07-14). The tag
+// above names the binding layout; metal_backend.mm refuses to load a source
+// whose tag differs from the one it was compiled against. Bump both on any
+// change to kernel buffer indices or argument structs.
+#include <metal_stdlib>
+#include <metal_simdgroup_matrix>
+using namespace metal;
+
+struct MatvecArgs {
+    uint rows;
+    uint cols;
+    uint simdgroups;
+};
+struct MatvecPairArgs { uint rows_a; uint rows_b; uint cols; uint simdgroups; };
+struct MatmulArgs { uint rows; uint cols; uint x_rows; uint simdgroups; };
+
+inline float stable_softplus(float value) {
+    if (value > 20.0f) return value;
+    if (value < -10.0f) return exp(value);
+    return log(1.0f + exp(value));
+}
+
+inline void reduce_row(float sum, device float *out, uint row,
+                       threadgroup float *partial, ushort lane, ushort simdgroup,
+                       uint simdgroups) {
+    sum = simd_sum(sum);
+    if (lane == 0) partial[simdgroup] = sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simdgroup == 0) {
+        float total = lane < simdgroups ? partial[lane] : 0.0f;
+        total = simd_sum(total);
+        if (lane == 0) out[row] = total;
+    }
+}
+
+kernel void q27_matvec_f32(
+        device const float *weights [[buffer(0)]],
+        device const float *x       [[buffer(1)]],
+        device       float *out     [[buffer(2)]],
+        constant MatvecArgs &args   [[buffer(3)]],
+        uint group                   [[threadgroup_position_in_grid]],
+        ushort lane                  [[thread_index_in_simdgroup]],
+        ushort simdgroup             [[simdgroup_index_in_threadgroup]]) {
+    const uint row = group * 8 + simdgroup;
+    if (row >= args.rows) return;
+    float sum = 0.0f;
+    const ulong base = (ulong)row * args.cols;
+    for (uint col = lane; col < args.cols; col += 32) sum += weights[base + col] * x[col];
+    sum = simd_sum(sum);
+    if (lane == 0) out[row] = sum;
+}
+
+kernel void q27_matvec_f16(
+        device const half  *weights [[buffer(0)]],
+        device const float *x       [[buffer(1)]],
+        device       float *out     [[buffer(2)]],
+        constant MatvecArgs &args   [[buffer(3)]],
+        uint group                   [[threadgroup_position_in_grid]],
+        ushort lane                  [[thread_index_in_simdgroup]],
+        ushort simdgroup             [[simdgroup_index_in_threadgroup]]) {
+    const uint row = group * 8 + simdgroup;
+    if (row >= args.rows) return;
+    float sum = 0.0f;
+    const ulong base = (ulong)row * args.cols;
+    for (uint col = lane; col < args.cols; col += 32) sum += float(weights[base + col]) * x[col];
+    sum = simd_sum(sum);
+    if (lane == 0) out[row] = sum;
+}
+
+// One 256-thread threadgroup per row pair. The production users are the
+// 48-row GDN alpha/beta projections; a simdgroup-per-row layout put only
+// 1,536 threads on the whole GPU and measured ~11 GB/s. packed_half4 keeps
+// 2-byte alignment so mmap-aliased tensor offsets stay valid.
+kernel void q27_matvec_f16_pair(
+        device const half *weights_a [[buffer(0)]], device float *out_a [[buffer(1)]],
+        device const half *weights_b [[buffer(2)]], device float *out_b [[buffer(3)]],
+        device const float *x [[buffer(4)]], constant MatvecPairArgs &args [[buffer(5)]],
+        uint row [[threadgroup_position_in_grid]], ushort tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]], ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    const bool row_a = row < args.rows_a, row_b = row < args.rows_b;
+    const ulong base = (ulong)row * args.cols;
+    device const packed_half4 *wa4 = (device const packed_half4 *)(weights_a + base);
+    device const packed_half4 *wb4 = (device const packed_half4 *)(weights_b + base);
+    const uint vectors = args.cols / 4;
+    float sa = 0.0f, sb = 0.0f;
+    for (uint v = tid; v < vectors; v += 256) {
+        const float4 xv = float4(x[v * 4], x[v * 4 + 1], x[v * 4 + 2], x[v * 4 + 3]);
+        if (row_a) sa += dot(float4(wa4[v]), xv);
+        if (row_b) sb += dot(float4(wb4[v]), xv);
+    }
+    for (uint col = vectors * 4 + tid; col < args.cols; col += 256) {
+        const float xv = x[col];
+        if (row_a) sa += float(weights_a[base + col]) * xv;
+        if (row_b) sb += float(weights_b[base + col]) * xv;
+    }
+    threadgroup float partial[8];
+    sa = simd_sum(sa);
+    if (lane == 0) partial[simdgroup] = sa;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (simdgroup == 0) {
+        float total = lane < 8 ? partial[lane] : 0.0f;
+        total = simd_sum(total);
+        if (lane == 0 && row_a) out_a[row] = total;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    sb = simd_sum(sb);
+    if (lane == 0) partial[simdgroup] = sb;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (simdgroup == 0) {
+        float total = lane < 8 ? partial[lane] : 0.0f;
+        total = simd_sum(total);
+        if (lane == 0 && row_b) out_b[row] = total;
+    }
+}
+
+kernel void q27_matvec_q8_g128(
+        device const char  *weights [[buffer(0)]],
+        device const half  *scales  [[buffer(1)]],
+        device const float *x       [[buffer(2)]],
+        device       float *out     [[buffer(3)]],
+        constant MatvecArgs &args   [[buffer(4)]],
+        uint group                   [[threadgroup_position_in_grid]],
+        ushort lane                  [[thread_index_in_simdgroup]],
+        ushort simdgroup             [[simdgroup_index_in_threadgroup]]) {
+    const uint row = group * 8 + simdgroup;
+    if (row >= args.rows) return;
+    float sum = 0.0f;
+    const ulong base = (ulong)row * args.cols;
+    const ulong scale_base = (ulong)row * (args.cols / 128);
+    for (uint col = lane; col < args.cols; col += 32) {
+        const float scale = float(scales[scale_base + col / 128]);
+        sum += float(weights[base + col]) * scale * x[col];
+    }
+    sum = simd_sum(sum);
+    if (lane == 0) out[row] = sum;
+}
+
+kernel void q27_matvec_q4_g64(
+        device const uchar *weights [[buffer(0)]],
+        device const half  *scales  [[buffer(1)]],
+        device const float *x       [[buffer(2)]],
+        device       float *out     [[buffer(3)]],
+        constant MatvecArgs &args   [[buffer(4)]],
+        uint group                   [[threadgroup_position_in_grid]],
+        ushort lane                  [[thread_index_in_simdgroup]],
+        ushort simdgroup             [[simdgroup_index_in_threadgroup]]) {
+    const uint row = group * 8 + simdgroup;
+    if (row >= args.rows) return;
+    float sum = 0.0f;
+    const ulong packed_base = (ulong)row * (args.cols / 2);
+    const ulong scale_base = (ulong)row * (args.cols / 64);
+    for (uint col = lane; col < args.cols; col += 32) {
+        const uchar packed = weights[packed_base + col / 2];
+        const int quant = int((col & 1) ? (packed >> 4) : (packed & 0x0f)) - 8;
+        const float scale = float(scales[scale_base + col / 64]);
+        sum += float(quant) * scale * x[col];
+    }
+    sum = simd_sum(sum);
+    if (lane == 0) out[row] = sum;
+}
+
+// T2_G128 ternary weights (FORMAT.md): element i of a row -> byte i/4, 2-bit
+// field at bit offset (i%4)*2 (sequential, LSB-first); code c in {0,1,2}
+// decodes to (c-1)*scale, one fp16 scale per 128 columns. Code 3 never
+// appears in valid artifacts (repack.py hard-fails on it).
+//
+// This is the intended production decode path for ternary weights: FLOAT
+// activations, so the math is exact ternary (+x/-x/0, no activation
+// quantization error). Two structural choices, both taken from measuring
+// against the PrismML fork's kernel (theirs sustains ~60 GB/s effective on
+// M4; a Q4-style shift/mask/imad loop and a byte->float4 LUT+fma variant
+// both saturated ~125 Gelem/s ≈ 33 GB/s at 2.27 bpw):
+//   1. select-form dot, no multiplies and no decode:
+//        sum((c-1)*y) = sum_lo(y) + 2*sum_hi(y) - sum(y)
+//      where sum_lo/sum_hi conditionally add y where the code's low/high
+//      bit is set, and sum(y) is computed once per block slice.
+//   2. four rows per simdgroup with the y-slice held in registers, so
+//      activation reads amortize across rows.
+// Lane layout: lane/8 picks one of four 128-column blocks in flight,
+// (lane%8)*16 the 16-element slice within it; each lane's slice sits inside
+// one scale group by construction.
+kernel void q27_matvec_t2_g128(
+        device const uchar *weights [[buffer(0)]],
+        device const half  *scales  [[buffer(1)]],
+        device const float *x       [[buffer(2)]],
+        device       float *out     [[buffer(3)]],
+        constant MatvecArgs &args   [[buffer(4)]],
+        uint group                   [[threadgroup_position_in_grid]],
+        ushort lane                  [[thread_index_in_simdgroup]],
+        ushort simdgroup             [[simdgroup_index_in_threadgroup]]) {
+    const uint row0 = group * 32 + (uint)simdgroup * 4;   // 32 rows per threadgroup
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint nb = args.cols / 128;
+    const uint ix = lane / 8;              // block in flight (4 per simdgroup)
+    const uint il = (lane % 8) * 16;       // element offset within the block
+    float sumf[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    device const float *yb = x + ix * 128 + il;
+    for (uint ib = ix; ib < nb; ib += 4) {
+        float yl[16];
+        float sumy = 0.0f;
+        for (uint i = 0; i < 16; i++) { yl[i] = yb[i]; sumy += yb[i]; }
+        for (uint r = 0; r < 4; r++) {
+            const uint row = min(row0 + r, rlast);   // clamped rows compute, don't store
+            device const uchar *qs = weights + (ulong)row * (args.cols / 4) + ib * 32 + il / 4;
+            const float d = float(scales[(ulong)row * nb + ib]);
+            const uchar4 b = *(device const uchar4 *)qs;
+            float acc_lo = 0.0f, acc_hi = 0.0f;
+            for (uint i = 0; i < 16; i++) {
+                acc_lo += select(0.0f, yl[i], bool(b[i / 4] & (1u << (2 * (i % 4)))));
+                acc_hi += select(0.0f, yl[i], bool(b[i / 4] & (2u << (2 * (i % 4)))));
+            }
+            sumf[r] += d * (acc_lo + 2.0f * acc_hi - sumy);
+        }
+        yb += 512;
+    }
+    for (uint r = 0; r < 4; r++) {
+        const float tot = simd_sum(sumf[r]);
+        if (lane == 0 && row0 + r < args.rows) out[row0 + r] = tot;
+    }
+}
+
+struct VectorArgs {
+    uint n;
+    uint groups;
+    float eps;
+};
+
+struct HeadArgs {
+    uint heads;
+    uint head_dim;
+    uint stride;
+    uint groups;
+    float eps;
+};
+
+inline float reduce_sum(float value, threadgroup float *partial,
+                        ushort lane, ushort simdgroup, uint groups) {
+    value = simd_sum(value);
+    if (lane == 0) partial[simdgroup] = value;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (simdgroup == 0) {
+        float total = lane < groups ? partial[lane] : 0.0f;
+        total = simd_sum(total);
+        if (lane == 0) partial[0] = total;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    return partial[0];
+}
+
+kernel void q27_embedding_q8(
+        device const char *weights [[buffer(0)]],
+        device const half *scales  [[buffer(1)]],
+        device float *out          [[buffer(2)]],
+        constant uint &token       [[buffer(3)]],
+        constant uint &cols        [[buffer(4)]],
+        uint gid [[thread_position_in_grid]]) {
+    if (gid >= cols) return;
+    const ulong wi = (ulong)token * cols + gid;
+    const ulong si = (ulong)token * (cols / 128) + gid / 128;
+    out[gid] = float(weights[wi]) * float(scales[si]);
+}
+
+kernel void q27_embedding_t2(
+        device const uchar *weights [[buffer(0)]],
+        device const half *scales   [[buffer(1)]],
+        device float *out           [[buffer(2)]],
+        constant uint &token        [[buffer(3)]],
+        constant uint &cols         [[buffer(4)]],
+        uint gid [[thread_position_in_grid]]) {
+    if (gid >= cols) return;
+    const ulong wi = (ulong)token * cols + gid;   // cols % 128 == 0, so wi/4 is exact bytes
+    const uint code = (weights[wi >> 2] >> ((wi & 3) * 2)) & 3;
+    const ulong si = (ulong)token * (cols / 128) + gid / 128;
+    out[gid] = float(int(code) - 1) * float(scales[si]);
+}
+
+kernel void q27_rmsnorm(
+        device const float *x [[buffer(0)]],
+        device const float *w [[buffer(1)]],
+        device float *out     [[buffer(2)]],
+        constant VectorArgs &args [[buffer(3)]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    float sum = 0.0f;
+    for (uint i = tid; i < args.n; i += 256) sum += x[i] * x[i];
+    threadgroup float partial[32];
+    sum = reduce_sum(sum, partial, lane, simdgroup, args.groups);
+    const float inv = rsqrt(sum / float(args.n) + args.eps);
+    for (uint i = tid; i < args.n; i += 256) out[i] = x[i] * inv * w[i];
+}
+
+kernel void q27_rmsnorm_quantized(
+        device const float *x [[buffer(0)]], device const float *w [[buffer(1)]],
+        device float *out [[buffer(2)]], device char *values [[buffer(3)]],
+        device float *scales [[buffer(4)]], constant VectorArgs &args [[buffer(5)]],
+        uint tid [[thread_index_in_threadgroup]], ushort lane [[thread_index_in_simdgroup]],
+        ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    float sum=0.0f;
+    for(uint i=tid;i<args.n;i+=256) sum+=x[i]*x[i];
+    threadgroup float partial[32];
+    sum=reduce_sum(sum,partial,lane,simdgroup,args.groups);
+    const float inv=rsqrt(sum/float(args.n)+args.eps);
+    for(uint i=tid;i<args.n;i+=256) out[i]=x[i]*inv*w[i];
+    threadgroup_barrier(mem_flags::mem_device);
+    const uint blocks=args.n/32;
+    for(uint block=simdgroup;block<blocks;block+=8) {
+        const uint i=block*32+lane; const float v=out[i];
+        const float amax=simd_max(abs(v)); const float scale=amax/127.0f;
+        int q=scale>0.0f?int(rint(v/scale)):0; q=clamp(q,-127,127);
+        values[i]=char(q); if(lane==0) scales[block]=scale;
+    }
+}
+
+kernel void q27_rmsnorm_heads(
+        device float *x         [[buffer(0)]],
+        device const float *w   [[buffer(1)]],
+        constant HeadArgs &args [[buffer(2)]],
+        uint head [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    if (head >= args.heads) return;
+    device float *xh = x + (ulong)head * args.stride;
+    float sum = 0.0f;
+    for (uint i = tid; i < args.head_dim; i += 256) sum += xh[i] * xh[i];
+    threadgroup float partial[32];
+    sum = reduce_sum(sum, partial, lane, simdgroup, args.groups);
+    const float inv = rsqrt(sum / float(args.head_dim) + args.eps);
+    for (uint i = tid; i < args.head_dim; i += 256) xh[i] = xh[i] * inv * w[i];
+}
+
+kernel void q27_l2norm_heads(
+        device float *x         [[buffer(0)]],
+        constant HeadArgs &args [[buffer(1)]],
+        uint head [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    if (head >= args.heads) return;
+    device float *xh = x + (ulong)head * args.head_dim;
+    float sum = 0.0f;
+    for (uint i = tid; i < args.head_dim; i += 256) sum += xh[i] * xh[i];
+    threadgroup float partial[32];
+    sum = reduce_sum(sum, partial, lane, simdgroup, args.groups);
+    const float inv = rsqrt(max(sum, args.eps * args.eps));
+    for (uint i = tid; i < args.head_dim; i += 256) xh[i] *= inv;
+}
+
+kernel void q27_silu_mul(device const float *gate [[buffer(0)]],
+                         device const float *up   [[buffer(1)]],
+                         device float *out        [[buffer(2)]],
+                         constant uint &n         [[buffer(3)]],
+                         uint gid [[thread_position_in_grid]]) {
+    if (gid < n) out[gid] = (gate[gid] / (1.0f + exp(-gate[gid]))) * up[gid];
+}
+
+kernel void q27_add_inplace(device float *x       [[buffer(0)]],
+                            device const float *y [[buffer(1)]],
+                            constant uint &n       [[buffer(2)]],
+                            uint gid [[thread_position_in_grid]]) {
+    if (gid < n) x[gid] += y[gid];
+}
+
+struct GateArgs { uint heads; uint head_dim; };
+kernel void q27_sigmoid_gate_mul(device float *out     [[buffer(0)]],
+                                  device const float *qg [[buffer(1)]],
+                                  constant GateArgs &args [[buffer(2)]],
+                                  uint gid [[thread_position_in_grid]]) {
+    const uint n = args.heads * args.head_dim;
+    if (gid >= n) return;
+    const uint h = gid / args.head_dim;
+    const uint d = gid % args.head_dim;
+    const float gate = qg[(ulong)h * (2 * args.head_dim) + args.head_dim + d];
+    out[gid] *= 1.0f / (1.0f + exp(-gate));
+}
+
+struct RopeArgs {
+    uint heads;
+    uint head_dim;
+    uint n_rot;
+    uint stride;
+    uint position;
+    float freq_base;
+};
+kernel void q27_rope_neox(device float *x [[buffer(0)]],
+                           constant RopeArgs &args [[buffer(1)]],
+                           uint2 gid [[thread_position_in_grid]]) {
+    const uint d = gid.x, head = gid.y;
+    if (head >= args.heads || d >= args.n_rot / 2) return;
+    device float *xh = x + (ulong)head * args.stride;
+    const float theta = float(args.position) * pow(args.freq_base, -2.0f * float(d) / float(args.n_rot));
+    const float cs = cos(theta), sn = sin(theta);
+    const float x0 = xh[d], x1 = xh[d + args.n_rot / 2];
+    xh[d] = x0 * cs - x1 * sn;
+    xh[d + args.n_rot / 2] = x0 * sn + x1 * cs;
+}
+
+kernel void q27_argmax(device const float *x [[buffer(0)]],
+                        device uint *out       [[buffer(1)]],
+                        constant uint &n       [[buffer(2)]],
+                        uint tid [[thread_index_in_threadgroup]]) {
+    float best = -INFINITY;
+    uint best_i = 0;
+    for (uint i = tid; i < n; i += 256) {
+        const float value = x[i];
+        if (value > best || (value == best && i < best_i)) { best = value; best_i = i; }
+    }
+    threadgroup float values[256];
+    threadgroup uint indices[256];
+    values[tid] = best; indices[tid] = best_i;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint step = 128; step; step >>= 1) {
+        if (tid < step) {
+            const float other = values[tid + step];
+            const uint other_i = indices[tid + step];
+            if (other > values[tid] || (other == values[tid] && other_i < indices[tid])) {
+                values[tid] = other; indices[tid] = other_i;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (tid == 0) out[0] = indices[0];
+}
+
+struct KvStoreArgs { uint position; uint row_length; };
+kernel void q27_kv_store_f16(device const float *k [[buffer(0)]],
+                              device const float *v [[buffer(1)]],
+                              device half *kc       [[buffer(2)]],
+                              device half *vc       [[buffer(3)]],
+                              constant KvStoreArgs &args [[buffer(4)]],
+                              uint gid [[thread_position_in_grid]]) {
+    if (gid >= args.row_length) return;
+    const ulong off = (ulong)args.position * args.row_length + gid;
+    kc[off] = half(k[gid]); vc[off] = half(v[gid]);
+}
+
+struct AttentionArgs {
+    uint q_stride;
+    uint seq_len;
+    uint q_heads;
+    uint kv_heads;
+    uint head_dim;
+    float scale;
+};
+// Online-softmax decode attention: one threadgroup per query head, eight
+// simdgroups striping the sequence. Each simdgroup keeps a running
+// (max, denominator, weighted-value) triple entirely in registers — one
+// lane holds head_dim/32 output dims — and the eight partials merge through
+// threadgroup memory in log2 rounds. No probability scratch is materialized,
+// so the cost is one streaming pass over the head's K and V rows.
+kernel void q27_attention_f16(device const float *q [[buffer(0)]],
+                               device const half *kc [[buffer(1)]],
+                               device const half *vc [[buffer(2)]],
+                               device float *out      [[buffer(3)]],
+                               constant AttentionArgs &args [[buffer(4)]],
+                               uint qh [[threadgroup_position_in_grid]],
+                               ushort lane [[thread_index_in_simdgroup]],
+                               ushort sg [[simdgroup_index_in_threadgroup]]) {
+    if (qh >= args.q_heads) return;
+    const uint gqa = args.q_heads / args.kv_heads;
+    const uint kvh = qh / gqa;
+    device const float *qh_ptr = q + (ulong)qh * args.q_stride;
+
+    float acc[8];                       // head_dim <= 256 -> at most 8 dims per lane
+    for (uint i = 0; i < 8; i++) acc[i] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    for (uint p = sg; p < args.seq_len; p += 8) {
+        device const half *kh = kc + ((ulong)p * args.kv_heads + kvh) * args.head_dim;
+        float partial = 0.0f;
+        for (uint d = lane; d < args.head_dim; d += 32) partial += qh_ptr[d] * float(kh[d]);
+        const float score = simd_sum(partial) * args.scale;
+        const float m_new = max(m, score);
+        const float correction = exp(m - m_new);    // first iteration: exp(-inf) = 0
+        const float weight = exp(score - m_new);
+        l = l * correction + weight;
+        device const half *vh = vc + ((ulong)p * args.kv_heads + kvh) * args.head_dim;
+        for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+            acc[i] = acc[i] * correction + weight * float(vh[d]);
+        m = m_new;
+    }
+
+    // Merge the eight simdgroup partials: rounds of 4, 2, 1. A simdgroup that
+    // saw no positions carries m = -inf, l = 0 and merges as a no-op.
+    threadgroup float tg_m[4], tg_l[4], tg_acc[4][256];
+    for (uint offset = 4; offset >= 1; offset /= 2) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (sg >= offset && sg < 2 * offset) {
+            if (lane == 0) { tg_m[sg - offset] = m; tg_l[sg - offset] = l; }
+            for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+                tg_acc[sg - offset][d] = acc[i];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (sg < offset) {
+            const float m_other = tg_m[sg], l_other = tg_l[sg];
+            const float m_new = max(m, m_other);
+            if (m_new == -INFINITY) continue;       // both stripes empty
+            const float c_mine = exp(m - m_new), c_other = exp(m_other - m_new);
+            l = l * c_mine + l_other * c_other;
+            for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+                acc[i] = acc[i] * c_mine + tg_acc[sg][d] * c_other;
+            m = m_new;
+        }
+    }
+    if (sg == 0) {
+        const float inv = l > 0.0f ? 1.0f / l : 0.0f;
+        for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+            out[(ulong)qh * args.head_dim + d] = acc[i] * inv;
+    }
+}
+
+kernel void q27_gdn_gates(device const float *alpha [[buffer(0)]],
+                           device const float *beta_raw [[buffer(1)]],
+                           device const float *ssm_a [[buffer(2)]],
+                           device const float *ssm_dt [[buffer(3)]],
+                           device float *g [[buffer(4)]],
+                           device float *beta [[buffer(5)]],
+                           constant uint &heads [[buffer(6)]],
+                           uint gid [[thread_position_in_grid]]) {
+    if (gid >= heads) return;
+    const float value = alpha[gid] + ssm_dt[gid];
+    const float softplus = stable_softplus(value);
+    g[gid] = ssm_a[gid] * softplus;
+    beta[gid] = 1.0f / (1.0f + exp(-beta_raw[gid]));
+}
+
+kernel void q27_conv_step(device const float *ring_src [[buffer(0)]],
+                           device float *ring_dst       [[buffer(1)]],
+                           device const float *qkv      [[buffer(2)]],
+                           device const float *weight   [[buffer(3)]],
+                           device float *out            [[buffer(4)]],
+                           constant uint &channels      [[buffer(5)]],
+                           uint gid [[thread_position_in_grid]]) {
+    if (gid >= channels) return;
+    const float value = ring_src[gid] * weight[(ulong)gid * 4] +
+                        ring_src[channels + gid] * weight[(ulong)gid * 4 + 1] +
+                        ring_src[(ulong)2 * channels + gid] * weight[(ulong)gid * 4 + 2] +
+                        qkv[gid] * weight[(ulong)gid * 4 + 3];
+    out[gid] = value / (1.0f + exp(-value));
+    ring_dst[gid] = ring_src[channels + gid];
+    ring_dst[channels + gid] = ring_src[(ulong)2 * channels + gid];
+    ring_dst[(ulong)2 * channels + gid] = qkv[gid];
+}
+
+struct DeltaArgs { uint value_heads; uint qk_heads; uint head_dim; };
+kernel void q27_delta_step(device const float *state_src [[buffer(0)]],
+                            device float *state_dst       [[buffer(1)]],
+                            device const float *conv      [[buffer(2)]],
+                            device const float *g         [[buffer(3)]],
+                            device const float *beta      [[buffer(4)]],
+                            device float *out             [[buffer(5)]],
+                            constant DeltaArgs &args      [[buffer(6)]],
+                            uint head [[threadgroup_position_in_grid]],
+                            uint tid [[thread_index_in_threadgroup]]) {
+    if (head >= args.value_heads || args.head_dim != 128 || args.qk_heads != 16) return;
+    const uint j = tid & 127;
+    const uint tile = tid >> 7;
+    const uint i0 = tile * 32;
+    const uint qk = head % args.qk_heads;
+    threadgroup float q[128], k[128], part[4][128], delta[128];
+    if (tile == 0) { q[j] = conv[(ulong)qk * 128 + j] * rsqrt(128.0f); k[j] = conv[2048 + (ulong)qk * 128 + j]; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const float decay = exp(g[head]);
+    device const float *source = state_src + (ulong)head * 128 * 128;
+    device float *dest = state_dst + (ulong)head * 128 * 128;
+    float saved[32];
+    float prediction = 0.0f;
+    for (uint n = 0; n < 32; n++) {
+        const uint i = i0 + n;
+        const float value = source[(ulong)i * 128 + j] * decay;
+        saved[n] = value;
+        prediction += k[i] * value;
+    }
+    part[tile][j] = prediction;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tile == 0) {
+        const float predicted = part[0][j] + part[1][j] + part[2][j] + part[3][j];
+        delta[j] = beta[head] * (conv[4096 + (ulong)head * 128 + j] - predicted);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float result = 0.0f;
+    for (uint n = 0; n < 32; n++) {
+        const uint i = i0 + n;
+        const float value = saved[n] + k[i] * delta[j];
+        dest[(ulong)i * 128 + j] = value;
+        result += q[i] * value;
+    }
+    part[tile][j] = result;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tile == 0) out[(ulong)head * 128 + j] = part[0][j] + part[1][j] + part[2][j] + part[3][j];
+}
+
+kernel void q27_gated_norm_gdn(device const float *x [[buffer(0)]],
+                                device const float *weight [[buffer(1)]],
+                                device const float *gate [[buffer(2)]],
+                                device float *out [[buffer(3)]],
+                                constant HeadArgs &args [[buffer(4)]],
+                                uint head [[threadgroup_position_in_grid]],
+                                uint tid [[thread_index_in_threadgroup]],
+                                ushort lane [[thread_index_in_simdgroup]],
+                                ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    if (head >= args.heads) return;
+    device const float *xh = x + (ulong)head * args.head_dim;
+    device const float *gh = gate + (ulong)head * args.head_dim;
+    float sum = 0.0f;
+    for (uint i = tid; i < args.head_dim; i += 256) sum += xh[i] * xh[i];
+    threadgroup float partial[32];
+    sum = reduce_sum(sum, partial, lane, simdgroup, args.groups);
+    const float inv = rsqrt(sum / float(args.head_dim) + args.eps);
+    for (uint i = tid; i < args.head_dim; i += 256) {
+        const float gv = gh[i];
+        out[(ulong)head * args.head_dim + i] = xh[i] * inv * weight[i] * (gv / (1.0f + exp(-gv)));
+    }
+}
+
+struct ConcatArgs { uint a_count; uint b_count; };
+kernel void q27_concat(device const float *a [[buffer(0)]],
+                        device const float *b [[buffer(1)]],
+                        device float *out [[buffer(2)]],
+                        constant ConcatArgs &args [[buffer(3)]],
+                        uint gid [[thread_position_in_grid]]) {
+    if (gid < args.a_count) out[gid] = a[gid];
+    else if (gid < args.a_count + args.b_count) out[gid] = b[gid - args.a_count];
+}
+
+kernel void q27_quantize_x(device const float *x [[buffer(0)]],
+                            device char *values [[buffer(1)]],
+                            device float *scales [[buffer(2)]],
+                            constant uint &count [[buffer(3)]],
+                            uint group [[threadgroup_position_in_grid]],
+                            ushort lane [[thread_index_in_simdgroup]]) {
+    const uint i = group * 32 + lane;
+    float v = i < count ? x[i] : 0.0f;
+    float amax = simd_max(abs(v));
+    float scale = amax / 127.0f;
+    int q = scale > 0.0f ? int(rint(v / scale)) : 0;
+    q = clamp(q, -127, 127);
+    if (i < count) values[i] = char(q);
+    if (lane == 0) scales[group] = scale;
+}
+
+// Packed-dot GEMV: each lane loads 16 weight values at once, computes an
+// exact integer dot against 16 int8 activations (max magnitude 16*127*127,
+// exactly representable in float), applies the combined scale per lane, and
+// reduces once per row. Tensor blobs are 256-byte aligned (loader ALIGN), so
+// the vector loads are safe. A lane's 16 columns never straddle a weight or
+// activation scale group. The 128-column tail loop covers synthetic shapes;
+// production columns are all multiples of 512.
+inline int q27_dot4(char4 a, char4 b) {
+    return int(a.x) * int(b.x) + int(a.y) * int(b.y) +
+           int(a.z) * int(b.z) + int(a.w) * int(b.w);
+}
+
+// Even columns sit in low nibbles, odd columns in high nibbles (even=low
+// order). Scalar shift-extract measures faster on M4 than the vectorized
+// mask/shuffle decode (54-64 vs 39-44 GB/s).
+inline int q27_dot8_q4(uint packed, char4 x0, char4 x1) {
+    int sum = (int(packed         & 15u) - 8) * x0.x;
+    sum += (int((packed >>  4) & 15u) - 8) * x0.y;
+    sum += (int((packed >>  8) & 15u) - 8) * x0.z;
+    sum += (int((packed >> 12) & 15u) - 8) * x0.w;
+    sum += (int((packed >> 16) & 15u) - 8) * x1.x;
+    sum += (int((packed >> 20) & 15u) - 8) * x1.y;
+    sum += (int((packed >> 24) & 15u) - 8) * x1.z;
+    sum += (int((packed >> 28)      ) - 8) * x1.w;
+    return sum;
+}
+
+kernel void q27_matvec_q8_quantized(device const char *weights [[buffer(0)]],
+                                     device const half *weight_scales [[buffer(1)]],
+                                     device const char *x [[buffer(2)]],
+                                     device const float *x_scales [[buffer(3)]],
+                                     device float *out [[buffer(4)]],
+                                     constant MatvecArgs &args [[buffer(5)]],
+                                     uint group [[threadgroup_position_in_grid]],
+                                     ushort lane [[thread_index_in_simdgroup]],
+                                     ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    const uint row = group * 8 + simdgroup;
+    if (row >= args.rows) return;
+    device const int4 *w16 = (device const int4 *)(weights + (ulong)row * args.cols);
+    device const int4 *x16 = (device const int4 *)x;
+    const ulong scale_base = (ulong)row * (args.cols / 128);
+    float acc = 0.0f;
+    const uint chunks = args.cols / 1024;
+    for (uint chunk = 0; chunk < chunks; chunk++) {
+        const uint idx = chunk * 64 + lane * 2;
+        const int4 wp0 = w16[idx], wp1 = w16[idx + 1];
+        const int4 xp0 = x16[idx], xp1 = x16[idx + 1];
+        const int dot0 = q27_dot4(as_type<char4>(wp0.x), as_type<char4>(xp0.x)) +
+                         q27_dot4(as_type<char4>(wp0.y), as_type<char4>(xp0.y)) +
+                         q27_dot4(as_type<char4>(wp0.z), as_type<char4>(xp0.z)) +
+                         q27_dot4(as_type<char4>(wp0.w), as_type<char4>(xp0.w));
+        const int dot1 = q27_dot4(as_type<char4>(wp1.x), as_type<char4>(xp1.x)) +
+                         q27_dot4(as_type<char4>(wp1.y), as_type<char4>(xp1.y)) +
+                         q27_dot4(as_type<char4>(wp1.z), as_type<char4>(xp1.z)) +
+                         q27_dot4(as_type<char4>(wp1.w), as_type<char4>(xp1.w));
+        // A lane's 32 columns are 32-aligned: both 16-column halves share one
+        // activation-scale block and one weight-scale group, and the summed
+        // integer dot (<= 32*127*127) stays exactly representable in float.
+        const uint c = chunk * 1024 + lane * 32;
+        acc += float(dot0 + dot1) *
+               float(weight_scales[scale_base + c / 128]) * x_scales[c / 32];
+    }
+    for (uint c = chunks * 1024 + lane * 4; c < args.cols; c += 128) {
+        const char4 wp = *(device const char4 *)(weights + (ulong)row * args.cols + c);
+        const char4 xp = *(device const char4 *)(x + c);
+        acc += float(q27_dot4(wp, xp)) *
+               float(weight_scales[scale_base + c / 128]) * x_scales[c / 32];
+    }
+    acc = simd_sum(acc);
+    if (lane == 0) out[row] = acc;
+}
+
+kernel void q27_matvec_q4_quantized(device const uchar *weights [[buffer(0)]],
+                                     device const half *weight_scales [[buffer(1)]],
+                                     device const char *x [[buffer(2)]],
+                                     device const float *x_scales [[buffer(3)]],
+                                     device float *out [[buffer(4)]],
+                                     constant MatvecArgs &args [[buffer(5)]],
+                                     uint group [[threadgroup_position_in_grid]],
+                                     ushort lane [[thread_index_in_simdgroup]],
+                                     ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    const uint row = group * 8 + simdgroup;
+    if (row >= args.rows) return;
+    device const uint4 *w4x8 = (device const uint4 *)(weights + (ulong)row * (args.cols / 2));
+    device const int4 *x16 = (device const int4 *)x;
+    const ulong scale_base = (ulong)row * (args.cols / 64);
+    float acc = 0.0f;
+    const uint chunks = args.cols / 1024;
+    for (uint chunk = 0; chunk < chunks; chunk++) {
+        const uint idx = chunk * 32 + lane;
+        const uint4 wp = w4x8[idx];
+        const int4 xp0 = x16[idx * 2];
+        const int4 xp1 = x16[idx * 2 + 1];
+        const int dot0 = q27_dot8_q4(wp.x, as_type<char4>(xp0.x), as_type<char4>(xp0.y)) +
+                         q27_dot8_q4(wp.y, as_type<char4>(xp0.z), as_type<char4>(xp0.w));
+        const int dot1 = q27_dot8_q4(wp.z, as_type<char4>(xp1.x), as_type<char4>(xp1.y)) +
+                         q27_dot8_q4(wp.w, as_type<char4>(xp1.z), as_type<char4>(xp1.w));
+        // Same 32-aligned lane layout as the Q8 kernel: one activation-scale
+        // block and one weight-scale group cover the lane's 32 columns.
+        const uint c = chunk * 1024 + lane * 32;
+        acc += float(dot0 + dot1) *
+               float(weight_scales[scale_base + c / 64]) * x_scales[c / 32];
+    }
+    for (uint c = chunks * 1024 + lane * 4; c < args.cols; c += 128) {
+        const uchar2 wp = *(device const uchar2 *)(weights + (ulong)row * (args.cols / 2) + c / 2);
+        const char4 xp = *(device const char4 *)(x + c);
+        const int dot = (int(wp.x & 15u) - 8) * xp.x + (int(wp.x >> 4) - 8) * xp.y +
+                        (int(wp.y & 15u) - 8) * xp.z + (int(wp.y >> 4) - 8) * xp.w;
+        acc += float(dot) * float(weight_scales[scale_base + c / 64]) * x_scales[c / 32];
+    }
+    acc = simd_sum(acc);
+    if (lane == 0) out[row] = acc;
+}
+
+// 16 sequential LSB-first 2-bit codes per uint; code c contributes (c-1)*x.
+// The integer dot is exact: |dot| <= 16*1*127 = 2032 per uint, 4064 per
+// lane-chunk, well inside float's exact-integer range.
+inline int q27_dot16_t2(uint packed, int4 xp) {
+    const char4 x0 = as_type<char4>(xp.x), x1 = as_type<char4>(xp.y);
+    const char4 x2 = as_type<char4>(xp.z), x3 = as_type<char4>(xp.w);
+    int sum = (int(packed         & 3u) - 1) * x0.x;
+    sum += (int((packed >>  2) & 3u) - 1) * x0.y;
+    sum += (int((packed >>  4) & 3u) - 1) * x0.z;
+    sum += (int((packed >>  6) & 3u) - 1) * x0.w;
+    sum += (int((packed >>  8) & 3u) - 1) * x1.x;
+    sum += (int((packed >> 10) & 3u) - 1) * x1.y;
+    sum += (int((packed >> 12) & 3u) - 1) * x1.z;
+    sum += (int((packed >> 14) & 3u) - 1) * x1.w;
+    sum += (int((packed >> 16) & 3u) - 1) * x2.x;
+    sum += (int((packed >> 18) & 3u) - 1) * x2.y;
+    sum += (int((packed >> 20) & 3u) - 1) * x2.z;
+    sum += (int((packed >> 22) & 3u) - 1) * x2.w;
+    sum += (int((packed >> 24) & 3u) - 1) * x3.x;
+    sum += (int((packed >> 26) & 3u) - 1) * x3.y;
+    sum += (int((packed >> 28) & 3u) - 1) * x3.z;
+    sum += (int((packed >> 30)      ) - 1) * x3.w;
+    return sum;
+}
+
+// Packed-dot ternary GEMV, same skeleton as the Q4/Q8 kernels: a lane's 32
+// columns (one uint2 of codes) are 32-aligned, so they share one activation-
+// scale block and sit inside one 128-column weight-scale group.
+kernel void q27_matvec_t2_quantized(device const uchar *weights [[buffer(0)]],
+                                     device const half *weight_scales [[buffer(1)]],
+                                     device const char *x [[buffer(2)]],
+                                     device const float *x_scales [[buffer(3)]],
+                                     device float *out [[buffer(4)]],
+                                     constant MatvecArgs &args [[buffer(5)]],
+                                     uint group [[threadgroup_position_in_grid]],
+                                     ushort lane [[thread_index_in_simdgroup]],
+                                     ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    const uint row = group * 8 + simdgroup;
+    if (row >= args.rows) return;
+    device const uint2 *w2 = (device const uint2 *)(weights + (ulong)row * (args.cols / 4));
+    device const int4 *x16 = (device const int4 *)x;
+    const ulong scale_base = (ulong)row * (args.cols / 128);
+    float acc = 0.0f;
+    const uint chunks = args.cols / 1024;
+    for (uint chunk = 0; chunk < chunks; chunk++) {
+        const uint idx = chunk * 32 + lane;      // one uint2 = 32 columns
+        const uint2 wp = w2[idx];
+        const int dot0 = q27_dot16_t2(wp.x, x16[idx * 2]);
+        const int dot1 = q27_dot16_t2(wp.y, x16[idx * 2 + 1]);
+        const uint c = chunk * 1024 + lane * 32;
+        acc += float(dot0 + dot1) *
+               float(weight_scales[scale_base + c / 128]) * x_scales[c / 32];
+    }
+    for (uint c = chunks * 1024 + lane * 4; c < args.cols; c += 128) {
+        const uchar wp = weights[(ulong)row * (args.cols / 4) + c / 4];
+        const char4 xp = *(device const char4 *)(x + c);
+        const int dot = (int(wp         & 3u) - 1) * xp.x + (int((wp >> 2) & 3u) - 1) * xp.y +
+                        (int((wp >> 4) & 3u) - 1) * xp.z + (int((wp >> 6)      ) - 1) * xp.w;
+        acc += float(dot) * float(weight_scales[scale_base + c / 128]) * x_scales[c / 32];
+    }
+    acc = simd_sum(acc);
+    if (lane == 0) out[row] = acc;
+}
+
+// Tiled simdgroup-matrix GEMM (x_rows 1..12) for chunked prefill and
+// batched MTP verification. A 128-thread threadgroup (4 simdgroups) owns a
+// 32-row x 16-token output tile and walks K in 64-column tiles: weights are
+// staged in threadgroup memory as raw dequantized integers (exact in f32),
+// activations as their int8 value times the per-32-column activation scale,
+// and each simdgroup accumulates its 8-row stripe with 8x8x8
+// multiply-accumulates. Every K-tile coincides with (or subdivides) one
+// weight-scale group, so accumulators flush through per-simdgroup scratch
+// once per tile, scaled by the row's weight scale, into per-lane running
+// totals. This replaces a packed-dot scalar variant that was issue-bound at
+// ~4 ops per multiply-add (2 char->int converts, mul, add): the matrix unit
+// converts operands once per staged tile, not once per MAC. Numerics: the
+// weight side stays integer-exact; the activation side rounds once per
+// value at staging; cross-tile accumulation is sequential in K per output
+// element. Not bit-identical to the serial GEMV (whose per-lane K-striping
+// plus simd_sum tree orders float additions differently), but the committed-
+// token A/B gates cover the difference, as with the earlier tile kernel.
+// Row slots past rows-1 clamp their loads and drop their stores; token
+// slots past x_rows-1 stage zeros and skip their stores.
+kernel void q27_matmul_q4_mm(
+        device const uchar *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const char *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup float Wt[32 * 64];   // [row within tile][col within K-tile]
+    threadgroup float Xt[64 * 16];   // [col within K-tile][token], prescaled
+    threadgroup float Sc[4 * 128];   // per-simdgroup flush scratch
+    const uint row0 = group * 32;
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    // Staging assignments: one weight row / 16 columns and one token /
+    // 8 transposed columns per thread.
+    const uint wrow = tid / 4, wcb = (tid % 4) * 16;
+    device const uchar *wsrc = weights + (ulong)min(row0 + wrow, rlast) * (args.cols / 2);
+    const uint xtok = tid % 16, xcb = (tid / 16) * 8;
+    const bool xvalid = xtok < args.x_rows;
+    device const char *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * args.cols;
+    const uint xsbase = min(xtok, args.x_rows - 1) * (args.cols / 32);
+    // The flush scratch holds both 8x8 tiles row-major: element i covers
+    // tile i/64, row (i%64)/8, token (i/64)*8 + i%8. Each lane owns
+    // elements lane, lane+32, lane+64, lane+96 as its running totals:
+    // components x/z sit in row lane/8, components y/w in row lane/8 + 4.
+    const uint rowA = row0 + sg * 8 + lane / 8, rowB = rowA + 4;
+    const ulong wsrowA = (ulong)min(rowA, rlast) * (args.cols / 64);
+    const ulong wsrowB = (ulong)min(rowB, rlast) * (args.cols / 64);
+    simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    float4 racc = 0.0f;
+    threadgroup float *sc = Sc + sg * 128;
+    for (uint c0 = 0; c0 < args.cols; c0 += 64) {
+        {
+            const uint2 wp = *(device const uint2 *)(wsrc + (c0 + wcb) / 2);
+            threadgroup float *dst = Wt + wrow * 64 + wcb;
+            dst[0]  = float(int(wp.x         & 15u) - 8);
+            dst[1]  = float(int((wp.x >>  4) & 15u) - 8);
+            dst[2]  = float(int((wp.x >>  8) & 15u) - 8);
+            dst[3]  = float(int((wp.x >> 12) & 15u) - 8);
+            dst[4]  = float(int((wp.x >> 16) & 15u) - 8);
+            dst[5]  = float(int((wp.x >> 20) & 15u) - 8);
+            dst[6]  = float(int((wp.x >> 24) & 15u) - 8);
+            dst[7]  = float(int((wp.x >> 28)      ) - 8);
+            dst[8]  = float(int(wp.y         & 15u) - 8);
+            dst[9]  = float(int((wp.y >>  4) & 15u) - 8);
+            dst[10] = float(int((wp.y >>  8) & 15u) - 8);
+            dst[11] = float(int((wp.y >> 12) & 15u) - 8);
+            dst[12] = float(int((wp.y >> 16) & 15u) - 8);
+            dst[13] = float(int((wp.y >> 20) & 15u) - 8);
+            dst[14] = float(int((wp.y >> 24) & 15u) - 8);
+            dst[15] = float(int((wp.y >> 28)      ) - 8);
+        }
+        {
+            const float xs = xvalid ? x_scales[xsbase + (c0 + xcb) / 32] : 0.0f;
+            const char4 xa = *(device const char4 *)(xsrc + c0 + xcb);
+            const char4 xb = *(device const char4 *)(xsrc + c0 + xcb + 4);
+            threadgroup float *dst = Xt + xcb * 16 + xtok;
+            dst[0 * 16] = float(xa.x) * xs; dst[1 * 16] = float(xa.y) * xs;
+            dst[2 * 16] = float(xa.z) * xs; dst[3 * 16] = float(xa.w) * xs;
+            dst[4 * 16] = float(xb.x) * xs; dst[5 * 16] = float(xb.y) * xs;
+            dst[6 * 16] = float(xb.z) * xs; dst[7 * 16] = float(xb.w) * xs;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint k8 = 0; k8 < 64; k8 += 8) {
+            simdgroup_float8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc1, a, b, acc1);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        simdgroup_store(acc0, sc, 8);
+        simdgroup_store(acc1, sc + 64, 8);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        const float wsA = float(weight_scales[wsrowA + c0 / 64]);
+        const float wsB = float(weight_scales[wsrowB + c0 / 64]);
+        racc += float4(sc[lane], sc[lane + 32], sc[lane + 64], sc[lane + 96]) *
+                float4(wsA, wsB, wsA, wsB);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    }
+    const uint tokA = lane % 8, tokB = 8 + lane % 8;
+    if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
+    if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
+    if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
+    if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = racc.w;
+}
+
+kernel void q27_matmul_q8_mm(
+        device const char *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const char *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup float Wt[32 * 64];
+    threadgroup float Xt[64 * 16];
+    threadgroup float Sc[4 * 128];
+    const uint row0 = group * 32;
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint wrow = tid / 4, wcb = (tid % 4) * 16;
+    device const char *wsrc = weights + (ulong)min(row0 + wrow, rlast) * args.cols;
+    const uint xtok = tid % 16, xcb = (tid / 16) * 8;
+    const bool xvalid = xtok < args.x_rows;
+    device const char *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * args.cols;
+    const uint xsbase = min(xtok, args.x_rows - 1) * (args.cols / 32);
+    // Lane element rows as in the Q4 kernel; the 64-column K-tile subdivides
+    // the 128-column Q8 scale group, so the per-tile flush scale stays
+    // constant within the tile as required.
+    const uint rowA = row0 + sg * 8 + lane / 8, rowB = rowA + 4;
+    const ulong wsrowA = (ulong)min(rowA, rlast) * (args.cols / 128);
+    const ulong wsrowB = (ulong)min(rowB, rlast) * (args.cols / 128);
+    simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    float4 racc = 0.0f;
+    threadgroup float *sc = Sc + sg * 128;
+    for (uint c0 = 0; c0 < args.cols; c0 += 64) {
+        {
+            const int4 wp = *(device const int4 *)(wsrc + c0 + wcb);
+            const char4 w0 = as_type<char4>(wp.x), w1 = as_type<char4>(wp.y);
+            const char4 w2 = as_type<char4>(wp.z), w3 = as_type<char4>(wp.w);
+            threadgroup float *dst = Wt + wrow * 64 + wcb;
+            dst[0]  = float(w0.x); dst[1]  = float(w0.y); dst[2]  = float(w0.z); dst[3]  = float(w0.w);
+            dst[4]  = float(w1.x); dst[5]  = float(w1.y); dst[6]  = float(w1.z); dst[7]  = float(w1.w);
+            dst[8]  = float(w2.x); dst[9]  = float(w2.y); dst[10] = float(w2.z); dst[11] = float(w2.w);
+            dst[12] = float(w3.x); dst[13] = float(w3.y); dst[14] = float(w3.z); dst[15] = float(w3.w);
+        }
+        {
+            const float xs = xvalid ? x_scales[xsbase + (c0 + xcb) / 32] : 0.0f;
+            const char4 xa = *(device const char4 *)(xsrc + c0 + xcb);
+            const char4 xb = *(device const char4 *)(xsrc + c0 + xcb + 4);
+            threadgroup float *dst = Xt + xcb * 16 + xtok;
+            dst[0 * 16] = float(xa.x) * xs; dst[1 * 16] = float(xa.y) * xs;
+            dst[2 * 16] = float(xa.z) * xs; dst[3 * 16] = float(xa.w) * xs;
+            dst[4 * 16] = float(xb.x) * xs; dst[5 * 16] = float(xb.y) * xs;
+            dst[6 * 16] = float(xb.z) * xs; dst[7 * 16] = float(xb.w) * xs;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint k8 = 0; k8 < 64; k8 += 8) {
+            simdgroup_float8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc1, a, b, acc1);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        simdgroup_store(acc0, sc, 8);
+        simdgroup_store(acc1, sc + 64, 8);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        const float wsA = float(weight_scales[wsrowA + c0 / 128]);
+        const float wsB = float(weight_scales[wsrowB + c0 / 128]);
+        racc += float4(sc[lane], sc[lane + 32], sc[lane + 64], sc[lane + 96]) *
+                float4(wsA, wsB, wsA, wsB);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    }
+    const uint tokA = lane % 8, tokB = 8 + lane % 8;
+    if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
+    if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
+    if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
+    if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = racc.w;
+}
+
+// Ternary tiled chunk GEMM. Identical structure to q27_matmul_q8_mm — the
+// 64-column K-tile subdivides the 128-column T2 scale group, so the per-tile
+// flush scale stays constant within the tile — with the staging block
+// decoding 16 sequential LSB-first 2-bit codes per uint into exact integers.
+kernel void q27_matmul_t2_mm(
+        device const uchar *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const char *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup float Wt[32 * 64];
+    threadgroup float Xt[64 * 16];
+    threadgroup float Sc[4 * 128];
+    const uint row0 = group * 32;
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint wrow = tid / 4, wcb = (tid % 4) * 16;
+    device const uchar *wsrc = weights + (ulong)min(row0 + wrow, rlast) * (args.cols / 4);
+    const uint xtok = tid % 16, xcb = (tid / 16) * 8;
+    const bool xvalid = xtok < args.x_rows;
+    device const char *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * args.cols;
+    const uint xsbase = min(xtok, args.x_rows - 1) * (args.cols / 32);
+    const uint rowA = row0 + sg * 8 + lane / 8, rowB = rowA + 4;
+    const ulong wsrowA = (ulong)min(rowA, rlast) * (args.cols / 128);
+    const ulong wsrowB = (ulong)min(rowB, rlast) * (args.cols / 128);
+    simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    float4 racc = 0.0f;
+    threadgroup float *sc = Sc + sg * 128;
+    for (uint c0 = 0; c0 < args.cols; c0 += 64) {
+        {
+            const uint wp = *(device const uint *)(wsrc + (c0 + wcb) / 4);
+            threadgroup float *dst = Wt + wrow * 64 + wcb;
+            dst[0]  = float(int(wp         & 3u) - 1);
+            dst[1]  = float(int((wp >>  2) & 3u) - 1);
+            dst[2]  = float(int((wp >>  4) & 3u) - 1);
+            dst[3]  = float(int((wp >>  6) & 3u) - 1);
+            dst[4]  = float(int((wp >>  8) & 3u) - 1);
+            dst[5]  = float(int((wp >> 10) & 3u) - 1);
+            dst[6]  = float(int((wp >> 12) & 3u) - 1);
+            dst[7]  = float(int((wp >> 14) & 3u) - 1);
+            dst[8]  = float(int((wp >> 16) & 3u) - 1);
+            dst[9]  = float(int((wp >> 18) & 3u) - 1);
+            dst[10] = float(int((wp >> 20) & 3u) - 1);
+            dst[11] = float(int((wp >> 22) & 3u) - 1);
+            dst[12] = float(int((wp >> 24) & 3u) - 1);
+            dst[13] = float(int((wp >> 26) & 3u) - 1);
+            dst[14] = float(int((wp >> 28) & 3u) - 1);
+            dst[15] = float(int((wp >> 30)      ) - 1);
+        }
+        {
+            const float xs = xvalid ? x_scales[xsbase + (c0 + xcb) / 32] : 0.0f;
+            const char4 xa = *(device const char4 *)(xsrc + c0 + xcb);
+            const char4 xb = *(device const char4 *)(xsrc + c0 + xcb + 4);
+            threadgroup float *dst = Xt + xcb * 16 + xtok;
+            dst[0 * 16] = float(xa.x) * xs; dst[1 * 16] = float(xa.y) * xs;
+            dst[2 * 16] = float(xa.z) * xs; dst[3 * 16] = float(xa.w) * xs;
+            dst[4 * 16] = float(xb.x) * xs; dst[5 * 16] = float(xb.y) * xs;
+            dst[6 * 16] = float(xb.z) * xs; dst[7 * 16] = float(xb.w) * xs;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint k8 = 0; k8 < 64; k8 += 8) {
+            simdgroup_float8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc1, a, b, acc1);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        simdgroup_store(acc0, sc, 8);
+        simdgroup_store(acc1, sc + 64, 8);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        const float wsA = float(weight_scales[wsrowA + c0 / 128]);
+        const float wsB = float(weight_scales[wsrowB + c0 / 128]);
+        racc += float4(sc[lane], sc[lane + 32], sc[lane + 64], sc[lane + 96]) *
+                float4(wsA, wsB, wsA, wsB);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    }
+    const uint tokA = lane % 8, tokB = 8 + lane % 8;
+    if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
+    if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
+    if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
+    if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = racc.w;
+}
+
+// ---- Chunked layer-major prefill (2..12 tokens per dispatch) ----
+//
+// These kernels advance a whole token chunk through one operation so the
+// engine can execute prompts layer-major and route projections through the
+// simdgroup GEMM. Recurrent operators (convolution ring, DeltaNet state)
+// stay sequential across the chunk inside a single dispatch and commit
+// their state once per chunk.
+
+struct EmbedRowsArgs { uint cols; uint count; uint tokens[12]; };
+kernel void q27_embedding_q8_rows(
+        device const char *weights [[buffer(0)]],
+        device const half *scales  [[buffer(1)]],
+        device float *out          [[buffer(2)]],
+        constant EmbedRowsArgs &args [[buffer(3)]],
+        uint2 gid [[thread_position_in_grid]]) {
+    if (gid.x >= args.cols || gid.y >= args.count) return;
+    const uint token = args.tokens[gid.y];
+    const ulong wi = (ulong)token * args.cols + gid.x;
+    const ulong si = (ulong)token * (args.cols / 128) + gid.x / 128;
+    out[(ulong)gid.y * args.cols + gid.x] = float(weights[wi]) * float(scales[si]);
+}
+
+kernel void q27_embedding_t2_rows(
+        device const uchar *weights [[buffer(0)]],
+        device const half *scales   [[buffer(1)]],
+        device float *out           [[buffer(2)]],
+        constant EmbedRowsArgs &args [[buffer(3)]],
+        uint2 gid [[thread_position_in_grid]]) {
+    if (gid.x >= args.cols || gid.y >= args.count) return;
+    const uint token = args.tokens[gid.y];
+    const ulong wi = (ulong)token * args.cols + gid.x;
+    const uint code = (weights[wi >> 2] >> ((wi & 3) * 2)) & 3;
+    const ulong si = (ulong)token * (args.cols / 128) + gid.x / 128;
+    out[(ulong)gid.y * args.cols + gid.x] = float(int(code) - 1) * float(scales[si]);
+}
+
+struct RowsNormArgs { uint n; uint rows; uint groups; float eps; };
+kernel void q27_rmsnorm_rows_quantized(
+        device const float *x [[buffer(0)]], device const float *w [[buffer(1)]],
+        device float *out [[buffer(2)]], device char *values [[buffer(3)]],
+        device float *scales [[buffer(4)]], constant RowsNormArgs &args [[buffer(5)]],
+        uint row [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]], ushort lane [[thread_index_in_simdgroup]],
+        ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    if (row >= args.rows) return;
+    device const float *xr = x + (ulong)row * args.n;
+    device float *or_ = out + (ulong)row * args.n;
+    device char *vr = values + (ulong)row * args.n;
+    device float *sr = scales + (ulong)row * (args.n / 32);
+    float sum = 0.0f;
+    for (uint i = tid; i < args.n; i += 256) sum += xr[i] * xr[i];
+    threadgroup float partial[32];
+    sum = reduce_sum(sum, partial, lane, simdgroup, args.groups);
+    const float inv = rsqrt(sum / float(args.n) + args.eps);
+    for (uint i = tid; i < args.n; i += 256) or_[i] = xr[i] * inv * w[i];
+    threadgroup_barrier(mem_flags::mem_device);
+    const uint blocks = args.n / 32;
+    for (uint block = simdgroup; block < blocks; block += 8) {
+        const uint i = block * 32 + lane; const float v = or_[i];
+        const float amax = simd_max(abs(v)); const float scale = amax / 127.0f;
+        int q = scale > 0.0f ? int(rint(v / scale)) : 0; q = clamp(q, -127, 127);
+        vr[i] = char(q); if (lane == 0) sr[block] = scale;
+    }
+}
+
+// Mirrors q27_matvec_f16_pair's per-row structure exactly (threadgroup per
+// row, packed_half4 dots, 8-partial tree) so chunked and serial results stay
+// bit-identical; the grid adds a token dimension.
+struct MatvecPairRowsArgs { uint rows_a; uint rows_b; uint cols; uint tokens; };
+kernel void q27_matvec_f16_pair_rows(
+        device const half *weights_a [[buffer(0)]], device float *out_a [[buffer(1)]],
+        device const half *weights_b [[buffer(2)]], device float *out_b [[buffer(3)]],
+        device const float *x [[buffer(4)]], constant MatvecPairRowsArgs &args [[buffer(5)]],
+        uint2 group [[threadgroup_position_in_grid]], ushort tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]], ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    const uint row = group.x, token = group.y;
+    if (token >= args.tokens) return;
+    device const float *xt = x + (ulong)token * args.cols;
+    const bool row_a = row < args.rows_a, row_b = row < args.rows_b;
+    const ulong base = (ulong)row * args.cols;
+    device const packed_half4 *wa4 = (device const packed_half4 *)(weights_a + base);
+    device const packed_half4 *wb4 = (device const packed_half4 *)(weights_b + base);
+    const uint vectors = args.cols / 4;
+    float sa = 0.0f, sb = 0.0f;
+    for (uint v = tid; v < vectors; v += 256) {
+        const float4 xv = float4(xt[v * 4], xt[v * 4 + 1], xt[v * 4 + 2], xt[v * 4 + 3]);
+        if (row_a) sa += dot(float4(wa4[v]), xv);
+        if (row_b) sb += dot(float4(wb4[v]), xv);
+    }
+    for (uint col = vectors * 4 + tid; col < args.cols; col += 256) {
+        const float xv = xt[col];
+        if (row_a) sa += float(weights_a[base + col]) * xv;
+        if (row_b) sb += float(weights_b[base + col]) * xv;
+    }
+    threadgroup float partial[8];
+    sa = simd_sum(sa);
+    if (lane == 0) partial[simdgroup] = sa;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (simdgroup == 0) {
+        float total = lane < 8 ? partial[lane] : 0.0f;
+        total = simd_sum(total);
+        if (lane == 0 && row_a) out_a[(ulong)token * args.rows_a + row] = total;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    sb = simd_sum(sb);
+    if (lane == 0) partial[simdgroup] = sb;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (simdgroup == 0) {
+        float total = lane < 8 ? partial[lane] : 0.0f;
+        total = simd_sum(total);
+        if (lane == 0 && row_b) out_b[(ulong)token * args.rows_b + row] = total;
+    }
+}
+
+struct GatesRowsArgs { uint heads; uint tokens; };
+kernel void q27_gdn_gates_rows(device const float *alpha [[buffer(0)]],
+                                device const float *beta_raw [[buffer(1)]],
+                                device const float *ssm_a [[buffer(2)]],
+                                device const float *ssm_dt [[buffer(3)]],
+                                device float *g [[buffer(4)]],
+                                device float *beta [[buffer(5)]],
+                                constant GatesRowsArgs &args [[buffer(6)]],
+                                uint gid [[thread_position_in_grid]]) {
+    if (gid >= args.heads * args.tokens) return;
+    const uint head = gid % args.heads;
+    const float value = alpha[gid] + ssm_dt[head];
+    const float softplus = stable_softplus(value);
+    g[gid] = ssm_a[head] * softplus;
+    beta[gid] = 1.0f / (1.0f + exp(-beta_raw[gid]));
+}
+
+// Separate src/dst ring bindings mirror q27_conv_step: MTP verification
+// points dst at a discard slot so the optimistic chunk never commits state,
+// and the acceptance replay commits it from parked inputs (src == dst).
+struct ConvChunkArgs { uint channels; uint tokens; };
+kernel void q27_conv_chunk(device const float *ring_src [[buffer(0)]],
+                            device float *ring_dst [[buffer(1)]],
+                            device const float *qkv [[buffer(2)]],
+                            device const float *weight [[buffer(3)]],
+                            device float *out [[buffer(4)]],
+                            constant ConvChunkArgs &args [[buffer(5)]],
+                            uint gid [[thread_position_in_grid]]) {
+    if (gid >= args.channels) return;
+    float r0 = ring_src[gid], r1 = ring_src[args.channels + gid], r2 = ring_src[(ulong)2 * args.channels + gid];
+    const float w0 = weight[(ulong)gid * 4], w1 = weight[(ulong)gid * 4 + 1];
+    const float w2 = weight[(ulong)gid * 4 + 2], w3 = weight[(ulong)gid * 4 + 3];
+    for (uint t = 0; t < args.tokens; t++) {
+        const float xv = qkv[(ulong)t * args.channels + gid];
+        const float value = r0 * w0 + r1 * w1 + r2 * w2 + xv * w3;
+        out[(ulong)t * args.channels + gid] = value / (1.0f + exp(-value));
+        r0 = r1; r1 = r2; r2 = xv;
+    }
+    ring_dst[gid] = r0; ring_dst[args.channels + gid] = r1; ring_dst[(ulong)2 * args.channels + gid] = r2;
+}
+
+struct DeltaChunkArgs { uint value_heads; uint qk_heads; uint head_dim; uint tokens; };
+kernel void q27_delta_chunk(device const float *state_src [[buffer(0)]],
+                             device float *state_dst [[buffer(1)]],
+                             device const float *conv [[buffer(2)]],
+                             device const float *g [[buffer(3)]],
+                             device const float *beta [[buffer(4)]],
+                             device float *out [[buffer(5)]],
+                             constant DeltaChunkArgs &args [[buffer(6)]],
+                             uint head [[threadgroup_position_in_grid]],
+                             uint tid [[thread_index_in_threadgroup]]) {
+    if (head >= args.value_heads || args.head_dim != 128 || args.qk_heads != 16) return;
+    const uint j = tid & 127;
+    const uint tile = tid >> 7;
+    const uint i0 = tile * 32;
+    const uint qk = head % args.qk_heads;
+    const ulong conv_row = (ulong)(2 * args.qk_heads + args.value_heads) * 128;
+    const ulong out_row = (ulong)args.value_heads * 128;
+    threadgroup float q[128], k[128], part[4][128], delta[128];
+    device const float *sh = state_src + (ulong)head * 128 * 128;
+    device float *sd = state_dst + (ulong)head * 128 * 128;
+    // The chunk's whole state slice lives in registers; it is written back
+    // exactly once, at the chunk boundary, to state_dst (a discard slot for
+    // MTP verification, the live state for prefill and acceptance replay).
+    float saved[32];
+    for (uint n = 0; n < 32; n++) saved[n] = sh[(ulong)(i0 + n) * 128 + j];
+    for (uint t = 0; t < args.tokens; t++) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        device const float *cv = conv + (ulong)t * conv_row;
+        if (tile == 0) { q[j] = cv[(ulong)qk * 128 + j] * rsqrt(128.0f); k[j] = cv[2048 + (ulong)qk * 128 + j]; }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const float decay = exp(g[(ulong)t * args.value_heads + head]);
+        float prediction = 0.0f;
+        for (uint n = 0; n < 32; n++) {
+            saved[n] *= decay;
+            prediction += k[i0 + n] * saved[n];
+        }
+        part[tile][j] = prediction;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (tile == 0) {
+            const float predicted = part[0][j] + part[1][j] + part[2][j] + part[3][j];
+            delta[j] = beta[(ulong)t * args.value_heads + head] * (cv[4096 + (ulong)head * 128 + j] - predicted);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        float result = 0.0f;
+        for (uint n = 0; n < 32; n++) {
+            saved[n] += k[i0 + n] * delta[j];
+            result += q[i0 + n] * saved[n];
+        }
+        part[tile][j] = result;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (tile == 0) out[(ulong)t * out_row + (ulong)head * 128 + j] =
+            part[0][j] + part[1][j] + part[2][j] + part[3][j];
+    }
+    for (uint n = 0; n < 32; n++) sd[(ulong)(i0 + n) * 128 + j] = saved[n];
+}
+
+struct L2RowsArgs { uint heads; uint head_dim; uint row_stride; uint tokens; float eps; };
+kernel void q27_l2norm_rows(device float *x [[buffer(0)]],
+                             constant L2RowsArgs &args [[buffer(1)]],
+                             uint2 group [[threadgroup_position_in_grid]],
+                             uint tid [[thread_index_in_threadgroup]],
+                             ushort lane [[thread_index_in_simdgroup]],
+                             ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    if (group.x >= args.heads || group.y >= args.tokens) return;
+    device float *xh = x + (ulong)group.y * args.row_stride + (ulong)group.x * args.head_dim;
+    float sum = 0.0f;
+    for (uint i = tid; i < args.head_dim; i += 256) sum += xh[i] * xh[i];
+    threadgroup float partial[32];
+    sum = reduce_sum(sum, partial, lane, simdgroup, 8);
+    const float inv = rsqrt(max(sum, args.eps * args.eps));
+    for (uint i = tid; i < args.head_dim; i += 256) xh[i] *= inv;
+}
+
+struct RopeRowsArgs {
+    uint heads; uint head_dim; uint n_rot; uint stride;
+    uint row_stride; uint position; uint tokens; float freq_base;
+};
+kernel void q27_rope_neox_rows(device float *x [[buffer(0)]],
+                                constant RopeRowsArgs &args [[buffer(1)]],
+                                uint3 gid [[thread_position_in_grid]]) {
+    const uint d = gid.x, head = gid.y, token = gid.z;
+    if (head >= args.heads || d >= args.n_rot / 2 || token >= args.tokens) return;
+    device float *xh = x + (ulong)token * args.row_stride + (ulong)head * args.stride;
+    const float theta = float(args.position + token) *
+                        pow(args.freq_base, -2.0f * float(d) / float(args.n_rot));
+    const float cs = cos(theta), sn = sin(theta);
+    const float x0 = xh[d], x1 = xh[d + args.n_rot / 2];
+    xh[d] = x0 * cs - x1 * sn;
+    xh[d + args.n_rot / 2] = x0 * sn + x1 * cs;
+}
+
+struct KvStoreRowsArgs { uint position; uint row_length; uint tokens; };
+kernel void q27_kv_store_f16_rows(device const float *k [[buffer(0)]],
+                                   device const float *v [[buffer(1)]],
+                                   device half *kc       [[buffer(2)]],
+                                   device half *vc       [[buffer(3)]],
+                                   constant KvStoreRowsArgs &args [[buffer(4)]],
+                                   uint2 gid [[thread_position_in_grid]]) {
+    if (gid.x >= args.row_length || gid.y >= args.tokens) return;
+    const ulong src = (ulong)gid.y * args.row_length + gid.x;
+    const ulong dst = (ulong)(args.position + gid.y) * args.row_length + gid.x;
+    kc[dst] = half(k[src]); vc[dst] = half(v[src]);
+}
+
+struct GateRowsArgs { uint heads; uint head_dim; uint tokens; };
+kernel void q27_sigmoid_gate_mul_rows(device float *out [[buffer(0)]],
+                                       device const float *qg [[buffer(1)]],
+                                       constant GateRowsArgs &args [[buffer(2)]],
+                                       uint gid [[thread_position_in_grid]]) {
+    const uint row = args.heads * args.head_dim;
+    if (gid >= row * args.tokens) return;
+    const uint t = gid / row;
+    const uint h = (gid % row) / args.head_dim;
+    const uint d = gid % args.head_dim;
+    const float gate = qg[(ulong)t * row * 2 + (ulong)h * (2 * args.head_dim) + args.head_dim + d];
+    out[gid] *= 1.0f / (1.0f + exp(-gate));
+}
+
+struct ArgmaxRowsArgs { uint n; uint rows; };
+kernel void q27_argmax_rows(device const float *x [[buffer(0)]],
+                             device uint *out       [[buffer(1)]],
+                             constant ArgmaxRowsArgs &args [[buffer(2)]],
+                             uint row [[threadgroup_position_in_grid]],
+                             uint tid [[thread_index_in_threadgroup]]) {
+    if (row >= args.rows) return;
+    device const float *xr = x + (ulong)row * args.n;
+    float best = -INFINITY;
+    uint best_i = 0;
+    for (uint i = tid; i < args.n; i += 256) {
+        const float value = xr[i];
+        if (value > best || (value == best && i < best_i)) { best = value; best_i = i; }
+    }
+    threadgroup float values[256];
+    threadgroup uint indices[256];
+    values[tid] = best; indices[tid] = best_i;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint step = 128; step; step >>= 1) {
+        if (tid < step) {
+            const float other = values[tid + step];
+            const uint other_i = indices[tid + step];
+            if (other > values[tid] || (other == values[tid] && other_i < indices[tid])) {
+                values[tid] = other; indices[tid] = other_i;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (tid == 0) out[row] = indices[0];
+}
+
+// nll[r] = logsumexp(logits[r,:]) - logits[r, tgt[r]]. One threadgroup per
+// row, 256 threads: max pass then sum-exp, matching the CUDA quality-gate
+// protocol so Metal --nll-long is comparable to the CUDA buckets.
+struct NllRowsArgs { uint n; uint rows; };
+kernel void q27_nll_rows(device const float *logits [[buffer(0)]],
+                          device const uint *tgt     [[buffer(1)]],
+                          device float *nll          [[buffer(2)]],
+                          constant NllRowsArgs &args [[buffer(3)]],
+                          uint row [[threadgroup_position_in_grid]],
+                          uint tid [[thread_index_in_threadgroup]]) {
+    if (row >= args.rows) return;
+    device const float *xr = logits + (ulong)row * args.n;
+    float mx = -INFINITY;
+    for (uint i = tid; i < args.n; i += 256) mx = max(mx, xr[i]);
+    threadgroup float values[256];
+    values[tid] = mx;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint step = 128; step; step >>= 1) {
+        if (tid < step) values[tid] = max(values[tid], values[tid + step]);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    mx = values[0];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float se = 0.0f;
+    for (uint i = tid; i < args.n; i += 256) se += exp(xr[i] - mx);
+    values[tid] = se;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint step = 128; step; step >>= 1) {
+        if (tid < step) values[tid] += values[tid + step];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (tid == 0) {
+        const uint target = tgt[row];
+        if (target >= args.n) {
+            nll[row] = INFINITY;
+            return;
+        }
+        nll[row] = log(values[0]) + mx - xr[target];
+    }
+}
+
+struct AttentionCausalArgs {
+    uint q_stride; uint q_row_stride; uint base_len;
+    uint q_heads; uint kv_heads; uint head_dim; uint tokens; float scale;
+};
+// Chunk-causal FP16 attention, online-softmax. Mirrors the decode kernel
+// (q27_attention_f16) exactly — one threadgroup per (query head, chunk
+// token), eight simdgroups striping the token's visible sequence
+// (base_len + token positions) with running max/denominator/weighted-value
+// in registers and a log2 merge through threadgroup memory — so a chunk
+// token's output is bit-identical to the serial decode kernel at the same
+// sequence length, and no probability scratch is materialized (the old
+// kernel serialized scores on thread 0 through a tokens x heads x context
+// device buffer).
+kernel void q27_attention_f16_causal(device const float *q [[buffer(0)]],
+                                      device const half *kc [[buffer(1)]],
+                                      device const half *vc [[buffer(2)]],
+                                      device float *out      [[buffer(3)]],
+                                      constant AttentionCausalArgs &args [[buffer(4)]],
+                                      uint2 group [[threadgroup_position_in_grid]],
+                                      ushort lane [[thread_index_in_simdgroup]],
+                                      ushort sg [[simdgroup_index_in_threadgroup]]) {
+    const uint qh = group.x, token = group.y;
+    if (qh >= args.q_heads || token >= args.tokens) return;
+    const uint seq_len = args.base_len + token;
+    const uint gqa = args.q_heads / args.kv_heads;
+    const uint kvh = qh / gqa;
+    device const float *qh_ptr = q + (ulong)token * args.q_row_stride + (ulong)qh * args.q_stride;
+
+    float acc[8];                       // head_dim <= 256 -> at most 8 dims per lane
+    for (uint i = 0; i < 8; i++) acc[i] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    for (uint p = sg; p < seq_len; p += 8) {
+        device const half *kh = kc + ((ulong)p * args.kv_heads + kvh) * args.head_dim;
+        float partial = 0.0f;
+        for (uint d = lane; d < args.head_dim; d += 32) partial += qh_ptr[d] * float(kh[d]);
+        const float score = simd_sum(partial) * args.scale;
+        const float m_new = max(m, score);
+        const float correction = exp(m - m_new);    // first iteration: exp(-inf) = 0
+        const float weight = exp(score - m_new);
+        l = l * correction + weight;
+        device const half *vh = vc + ((ulong)p * args.kv_heads + kvh) * args.head_dim;
+        for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+            acc[i] = acc[i] * correction + weight * float(vh[d]);
+        m = m_new;
+    }
+
+    // Merge the eight simdgroup partials: rounds of 4, 2, 1. A simdgroup that
+    // saw no positions carries m = -inf, l = 0 and merges as a no-op.
+    threadgroup float tg_m[4], tg_l[4], tg_acc[4][256];
+    for (uint offset = 4; offset >= 1; offset /= 2) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (sg >= offset && sg < 2 * offset) {
+            if (lane == 0) { tg_m[sg - offset] = m; tg_l[sg - offset] = l; }
+            for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+                tg_acc[sg - offset][d] = acc[i];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (sg < offset) {
+            const float m_other = tg_m[sg], l_other = tg_l[sg];
+            const float m_new = max(m, m_other);
+            if (m_new == -INFINITY) continue;       // both stripes empty
+            const float c_mine = exp(m - m_new), c_other = exp(m_other - m_new);
+            l = l * c_mine + l_other * c_other;
+            for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+                acc[i] = acc[i] * c_mine + tg_acc[sg][d] * c_other;
+            m = m_new;
+        }
+    }
+    if (sg == 0) {
+        const float inv = l > 0.0f ? 1.0f / l : 0.0f;
+        for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+            out[((ulong)token * args.q_heads + qh) * args.head_dim + d] = acc[i] * inv;
+    }
+}
+
+kernel void q27_copy_bytes(device const uchar *src [[buffer(0)]],
+                            device uchar *dst [[buffer(1)]],
+                            constant ulong &bytes [[buffer(2)]],
+                            uint gid [[thread_position_in_grid]]) {
+    if (gid < bytes) dst[gid] = src[gid];
+}
+
+constant float turbo_centroids[8] = {
+    -0.190207f, -0.118786f, -0.066822f, -0.021663f,
+     0.021663f,  0.066822f,  0.118786f,  0.190207f };
+constant char turbo_s1[128] = { -1,1,1,-1,-1,1,-1,1,-1,-1,1,1,1,1,1,1,1,-1,1,-1,1,-1,-1,1,1,1,-1,1,1,-1,-1,-1,-1,1,1,-1,1,1,-1,1,-1,1,1,-1,-1,1,-1,1,1,1,1,-1,-1,-1,-1,-1,1,-1,1,1,1,1,-1,1,-1,-1,1,-1,-1,-1,1,-1,-1,-1,1,-1,-1,-1,1,1,1,-1,-1,1,1,1,-1,-1,1,1,-1,1,1,-1,1,-1,-1,1,1,-1,1,-1,1,-1,1,1,1,1,-1,1,-1,1,1,-1,1,1,-1,-1,-1,-1,-1,1,1,-1,1,1,-1,1 };
+constant char turbo_s2[128] = { 1,1,1,1,-1,1,1,-1,1,-1,-1,-1,1,-1,-1,-1,1,1,-1,-1,1,-1,1,-1,1,-1,-1,1,-1,1,1,1,1,1,-1,-1,-1,1,-1,-1,-1,-1,-1,-1,1,1,1,-1,1,-1,1,1,1,-1,-1,1,-1,-1,-1,-1,-1,-1,1,1,1,-1,1,-1,-1,-1,-1,1,-1,1,-1,1,-1,-1,1,1,-1,1,-1,1,1,-1,1,-1,-1,-1,-1,1,-1,-1,1,-1,1,-1,1,1,1,-1,-1,1,-1,1,-1,1,1,-1,-1,1,-1,1,-1,1,1,-1,1,-1,1,-1,-1,-1,-1,-1,1,-1 };
+constant float turbo_inv_sqrt_128 = 0.08838834764831845f;
+
+inline uint turbo_nearest(float v) {
+    if (v < -0.154496f) return 0; if (v < -0.092804f) return 1;
+    if (v < -0.044243f) return 2; if (v < 0.0f) return 3;
+    if (v < 0.044243f) return 4; if (v < 0.092804f) return 5;
+    if (v < 0.154496f) return 6; return 7;
+}
+
+inline void turbo_butterfly(threadgroup float *xs, uint j) {
+    for (uint h = 1; h < 128; h <<= 1) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const float a = xs[j], b = xs[j ^ h];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        xs[j] = (j & h) ? (b - a) : (a + b);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+}
+
+struct TurboWhtArgs { uint heads; uint stride; uint inverse; };
+kernel void q27_turbo_wht(device float *x [[buffer(0)]],
+                           constant TurboWhtArgs &args [[buffer(1)]],
+                           uint group [[threadgroup_position_in_grid]],
+                           uint j [[thread_index_in_threadgroup]]) {
+    const uint head = group >> 1, g = group & 1;
+    if (head >= args.heads || j >= 128) return;
+    device float *xh = x + (ulong)head * args.stride + g * 128;
+    threadgroup float xs[128];
+    xs[j] = xh[j] * float(args.inverse ? turbo_s2[j] : turbo_s1[j]);
+    turbo_butterfly(xs, j);
+    xh[j] = xs[j] * turbo_inv_sqrt_128 * float(args.inverse ? turbo_s1[j] : turbo_s2[j]);
+}
+
+struct TurboStoreArgs { uint position; uint kv_heads; };
+kernel void q27_kv_store_turbo3(device const float *k [[buffer(0)]],
+                                 device const float *v [[buffer(1)]],
+                                 device uchar *kc [[buffer(2)]],
+                                 device uchar *vc [[buffer(3)]],
+                                 constant TurboStoreArgs &args [[buffer(4)]],
+                                 uint2 group [[threadgroup_position_in_grid]],
+                                 uint j [[thread_index_in_threadgroup]]) {
+    const uint h = group.x >> 1, g = group.x & 1;
+    if (h >= args.kv_heads || group.y >= 2 || j >= 128) return;
+    device const float *src = (group.y ? v : k) + (ulong)h * 256 + g * 128;
+    device uchar *cache = group.y ? vc : kc;
+    device uchar *block = cache + ((ulong)args.position * args.kv_heads * 2 + h * 2 + g) * 50;
+    threadgroup float xs[128], red[128];
+    threadgroup uchar indices[128];
+    xs[j] = src[j]; red[j] = src[j] * src[j];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint s = 64; s; s >>= 1) {
+        if (j < s) red[j] += red[j + s];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    const float norm = sqrt(red[0]);
+    xs[j] = xs[j] * (norm > 1e-10f ? 1.0f / norm : 0.0f) * float(turbo_s1[j]);
+    turbo_butterfly(xs, j);
+    const uint index = turbo_nearest(xs[j] * turbo_inv_sqrt_128 * float(turbo_s2[j]));
+    indices[j] = uchar(index); red[j] = turbo_centroids[index] * turbo_centroids[index];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint s = 64; s; s >>= 1) {
+        if (j < s) red[j] += red[j + s];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (j == 0) *(device half *)(block) = half(sqrt(red[0]) > 1e-10f ? norm / sqrt(red[0]) : norm);
+    if ((j & 3) == 0) block[2 + j / 4] = (indices[j] & 3) | ((indices[j+1] & 3) << 2) |
+                                                   ((indices[j+2] & 3) << 4) | ((indices[j+3] & 3) << 6);
+    if ((j & 7) == 0) {
+        uchar bits = 0;
+        for (uint i = 0; i < 8; i++) bits |= uchar((indices[j+i] >> 2) << i);
+        block[34 + j / 8] = bits;
+    }
+}
+
+inline float turbo_dequant(device const uchar *block, uint j) {
+    const uint low = (block[2 + (j >> 2)] >> ((j & 3) * 2)) & 3;
+    const uint high = (block[34 + (j >> 3)] >> (j & 7)) & 1;
+    return turbo_centroids[low | (high << 2)] * float(*(device const half *)block);
+}
+
+// Online-softmax turbo3 decode attention. Mirrors q27_attention_f16 exactly
+// — one threadgroup per query head, eight simdgroups striping the sequence
+// with running max/denominator/weighted-value in registers and a log2 merge
+// through threadgroup memory — with the 50-byte turbo3 blocks dequantized
+// on the fly. No probability scratch is materialized (the old kernel
+// serialized every score on thread 0 through a heads x context buffer).
+kernel void q27_attention_turbo3(device const float *q [[buffer(0)]],
+                                  device const uchar *kc [[buffer(1)]],
+                                  device const uchar *vc [[buffer(2)]],
+                                  device float *out [[buffer(3)]],
+                                  constant AttentionArgs &args [[buffer(4)]],
+                                  uint qh [[threadgroup_position_in_grid]],
+                                  ushort lane [[thread_index_in_simdgroup]],
+                                  ushort sg [[simdgroup_index_in_threadgroup]]) {
+    if (qh >= args.q_heads) return;
+    const uint gqa = args.q_heads / args.kv_heads;
+    const uint kvh = qh / gqa;
+    device const float *qh_ptr = q + (ulong)qh * args.q_stride;
+
+    float acc[8];                       // head_dim <= 256 -> at most 8 dims per lane
+    for (uint i = 0; i < 8; i++) acc[i] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    for (uint p = sg; p < args.seq_len; p += 8) {
+        device const uchar *kb = kc + ((ulong)p * args.kv_heads + kvh) * 2 * 50;
+        float partial = 0.0f;
+        for (uint d = lane; d < args.head_dim; d += 32)
+            partial += qh_ptr[d] * turbo_dequant(kb + (d >> 7) * 50, d & 127);
+        const float score = simd_sum(partial) * args.scale;
+        const float m_new = max(m, score);
+        const float correction = exp(m - m_new);    // first iteration: exp(-inf) = 0
+        const float weight = exp(score - m_new);
+        l = l * correction + weight;
+        device const uchar *vb = vc + ((ulong)p * args.kv_heads + kvh) * 2 * 50;
+        for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+            acc[i] = acc[i] * correction + weight * turbo_dequant(vb + (d >> 7) * 50, d & 127);
+        m = m_new;
+    }
+
+    // Merge the eight simdgroup partials: rounds of 4, 2, 1. A simdgroup that
+    // saw no positions carries m = -inf, l = 0 and merges as a no-op.
+    threadgroup float tg_m[4], tg_l[4], tg_acc[4][256];
+    for (uint offset = 4; offset >= 1; offset /= 2) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (sg >= offset && sg < 2 * offset) {
+            if (lane == 0) { tg_m[sg - offset] = m; tg_l[sg - offset] = l; }
+            for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+                tg_acc[sg - offset][d] = acc[i];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (sg < offset) {
+            const float m_other = tg_m[sg], l_other = tg_l[sg];
+            const float m_new = max(m, m_other);
+            if (m_new == -INFINITY) continue;       // both stripes empty
+            const float c_mine = exp(m - m_new), c_other = exp(m_other - m_new);
+            l = l * c_mine + l_other * c_other;
+            for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+                acc[i] = acc[i] * c_mine + tg_acc[sg][d] * c_other;
+            m = m_new;
+        }
+    }
+    if (sg == 0) {
+        const float inv = l > 0.0f ? 1.0f / l : 0.0f;
+        for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+            out[(ulong)qh * args.head_dim + d] = acc[i] * inv;
+    }
+}
+
+struct TurboStoreRowsArgs { uint position; uint kv_heads; uint tokens; };
+kernel void q27_kv_store_turbo3_rows(device const float *k [[buffer(0)]],
+                                      device const float *v [[buffer(1)]],
+                                      device uchar *kc [[buffer(2)]],
+                                      device uchar *vc [[buffer(3)]],
+                                      constant TurboStoreRowsArgs &args [[buffer(4)]],
+                                      uint3 group [[threadgroup_position_in_grid]],
+                                      uint j [[thread_index_in_threadgroup]]) {
+    const uint h = group.x >> 1, g = group.x & 1, token = group.z;
+    if (h >= args.kv_heads || group.y >= 2 || token >= args.tokens || j >= 128) return;
+    device const float *src = (group.y ? v : k) +
+        (ulong)token * args.kv_heads * 256 + (ulong)h * 256 + g * 128;
+    device uchar *cache = group.y ? vc : kc;
+    device uchar *block = cache +
+        ((ulong)(args.position + token) * args.kv_heads * 2 + h * 2 + g) * 50;
+    threadgroup float xs[128], red[128];
+    threadgroup uchar indices[128];
+    xs[j] = src[j]; red[j] = src[j] * src[j];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint s = 64; s; s >>= 1) {
+        if (j < s) red[j] += red[j + s];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    const float norm = sqrt(red[0]);
+    xs[j] = xs[j] * (norm > 1e-10f ? 1.0f / norm : 0.0f) * float(turbo_s1[j]);
+    turbo_butterfly(xs, j);
+    const uint index = turbo_nearest(xs[j] * turbo_inv_sqrt_128 * float(turbo_s2[j]));
+    indices[j] = uchar(index); red[j] = turbo_centroids[index] * turbo_centroids[index];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint s = 64; s; s >>= 1) {
+        if (j < s) red[j] += red[j + s];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (j == 0) *(device half *)(block) = half(sqrt(red[0]) > 1e-10f ? norm / sqrt(red[0]) : norm);
+    if ((j & 3) == 0) block[2 + j / 4] = (indices[j] & 3) | ((indices[j+1] & 3) << 2) |
+                                                   ((indices[j+2] & 3) << 4) | ((indices[j+3] & 3) << 6);
+    if ((j & 7) == 0) {
+        uchar bits = 0;
+        for (uint i = 0; i < 8; i++) bits |= uchar((indices[j+i] >> 2) << i);
+        block[34 + j / 8] = bits;
+    }
+}
+
+// Chunk-causal turbo3 attention, online-softmax. Mirrors the turbo3 decode
+// kernel exactly — one threadgroup per (query head, chunk token), eight
+// simdgroups striping the token's visible sequence — so a chunk token's
+// output is bit-identical to the decode kernel at the same sequence length,
+// and the last probability-scratch user on the prefill path is gone.
+kernel void q27_attention_turbo3_causal(device const float *q [[buffer(0)]],
+                                         device const uchar *kc [[buffer(1)]],
+                                         device const uchar *vc [[buffer(2)]],
+                                         device float *out [[buffer(3)]],
+                                         constant AttentionCausalArgs &args [[buffer(4)]],
+                                         uint2 group [[threadgroup_position_in_grid]],
+                                         ushort lane [[thread_index_in_simdgroup]],
+                                         ushort sg [[simdgroup_index_in_threadgroup]]) {
+    const uint qh = group.x, token = group.y;
+    if (qh >= args.q_heads || token >= args.tokens) return;
+    const uint seq_len = args.base_len + token;
+    const uint gqa = args.q_heads / args.kv_heads;
+    const uint kvh = qh / gqa;
+    device const float *qh_ptr = q + (ulong)token * args.q_row_stride + (ulong)qh * args.q_stride;
+
+    float acc[8];                       // head_dim <= 256 -> at most 8 dims per lane
+    for (uint i = 0; i < 8; i++) acc[i] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    for (uint p = sg; p < seq_len; p += 8) {
+        device const uchar *kb = kc + ((ulong)p * args.kv_heads + kvh) * 2 * 50;
+        float partial = 0.0f;
+        for (uint d = lane; d < args.head_dim; d += 32)
+            partial += qh_ptr[d] * turbo_dequant(kb + (d >> 7) * 50, d & 127);
+        const float score = simd_sum(partial) * args.scale;
+        const float m_new = max(m, score);
+        const float correction = exp(m - m_new);    // first iteration: exp(-inf) = 0
+        const float weight = exp(score - m_new);
+        l = l * correction + weight;
+        device const uchar *vb = vc + ((ulong)p * args.kv_heads + kvh) * 2 * 50;
+        for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+            acc[i] = acc[i] * correction + weight * turbo_dequant(vb + (d >> 7) * 50, d & 127);
+        m = m_new;
+    }
+
+    // Merge the eight simdgroup partials: rounds of 4, 2, 1. A simdgroup that
+    // saw no positions carries m = -inf, l = 0 and merges as a no-op.
+    threadgroup float tg_m[4], tg_l[4], tg_acc[4][256];
+    for (uint offset = 4; offset >= 1; offset /= 2) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (sg >= offset && sg < 2 * offset) {
+            if (lane == 0) { tg_m[sg - offset] = m; tg_l[sg - offset] = l; }
+            for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+                tg_acc[sg - offset][d] = acc[i];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (sg < offset) {
+            const float m_other = tg_m[sg], l_other = tg_l[sg];
+            const float m_new = max(m, m_other);
+            if (m_new == -INFINITY) continue;       // both stripes empty
+            const float c_mine = exp(m - m_new), c_other = exp(m_other - m_new);
+            l = l * c_mine + l_other * c_other;
+            for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+                acc[i] = acc[i] * c_mine + tg_acc[sg][d] * c_other;
+            m = m_new;
+        }
+    }
+    if (sg == 0) {
+        const float inv = l > 0.0f ? 1.0f / l : 0.0f;
+        for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+            out[((ulong)token * args.q_heads + qh) * args.head_dim + d] = acc[i] * inv;
+    }
+}

--- a/src/metal/test_metal.cpp
+++ b/src/metal/test_metal.cpp
@@ -1,0 +1,679 @@
+#include "metal_backend.h"
+
+#include <cmath>
+#include <cstdio>
+#include <exception>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+template <typename T> void append(std::vector<uint8_t>& out, T value) {
+    const uint8_t* p = reinterpret_cast<const uint8_t*>(&value);
+    out.insert(out.end(), p, p + sizeof(value));
+}
+
+int test_mmap_upload(q27::MetalBackend& backend) {
+    const float weights[12] = {1, 2, 3, 4, -2, 1, 0.5f, 3, 0, 0, 0, 0};
+    std::vector<uint8_t> file;
+    append<uint32_t>(file, 0x46373251);
+    append<uint32_t>(file, 1);
+    append<uint32_t>(file, 1);
+    append<uint32_t>(file, 2);
+    file.push_back('{'); file.push_back('}');
+    append<uint16_t>(file, 1); file.push_back('m');
+    append<uint8_t>(file, 0); append<uint8_t>(file, 2);
+    append<uint64_t>(file, 3); append<uint64_t>(file, 4);
+    append<uint64_t>(file, 0); append<uint64_t>(file, sizeof(weights));
+    append<uint64_t>(file, 0); append<uint64_t>(file, 0);
+    file.resize(256);
+    const uint8_t* bytes = reinterpret_cast<const uint8_t*>(weights);
+    file.insert(file.end(), bytes, bytes + sizeof(weights));
+
+    char path[] = "/tmp/q27-metal-model-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) return 1;
+    size_t done = 0;
+    while (done < file.size()) {
+        ssize_t n = write(fd, file.data() + done, file.size() - done);
+        if (n <= 0) { close(fd); unlink(path); return 1; }
+        done += (size_t)n;
+    }
+    close(fd);
+    try {
+        q27::Model model = q27::Model::open(path);
+        unlink(path);
+        q27::BackendTensor weight = backend.upload(model, model.get("m"));
+        const float x[4] = {2, -1, 0.5f, 3};
+        auto device_x = backend.allocate(sizeof(x));
+        auto device_y = backend.allocate(3 * sizeof(float));
+        backend.write(*device_x, 0, x, sizeof(x));
+        backend.begin_commands();
+        backend.matvec(weight, *device_x, *device_y);
+        backend.end_commands();
+        float got[3];
+        backend.read(*device_y, 0, got, sizeof(got));
+        if (std::fabs(got[0] - 13.5f) > 1e-4f || std::fabs(got[1] - 4.25f) > 1e-4f)
+            return 1;
+        auto expect_read_only = [&](const char* operation, auto&& call) {
+            try { call(); }
+            catch (const std::runtime_error& error) {
+                if (std::string(error.what()).find("read-only") != std::string::npos) return true;
+            }
+            fprintf(stderr, "%s accepted a model-backed read-only destination\n", operation);
+            return false;
+        };
+        const float replacement = 0.0f;
+        if (!expect_read_only("write", [&] {
+                backend.write(*weight.data, weight.data_offset, &replacement, sizeof(replacement));
+            }) ||
+            !expect_read_only("zero", [&] { backend.zero(*weight.data); }) ||
+            !expect_read_only("copy", [&] {
+                backend.copy(*device_x, 0, *weight.data, weight.data_offset, sizeof(replacement));
+            }))
+            return 1;
+        return 0;
+    } catch (...) {
+        unlink(path);
+        throw;
+    }
+}
+
+bool close(float got, float want, float tolerance = 1e-4f) {
+    return std::fabs(got - want) <= tolerance * std::fmax(1.0f, std::fabs(want));
+}
+
+int test_dispatch_validation(q27::MetalBackend& backend) {
+    std::vector<int8_t> short_data(1, 1);
+    std::vector<uint16_t> short_scales(1, 0x3c00);
+    q27::Tensor tensor;
+    tensor.name="short-embedding"; tensor.dtype=q27::DType::Q8_G128; tensor.shape={2,128};
+    tensor.data=reinterpret_cast<const uint8_t*>(short_data.data()); tensor.data_size=short_data.size();
+    tensor.scales=reinterpret_cast<const uint8_t*>(short_scales.data()); tensor.scales_size=2;
+    auto weight=backend.upload(tensor); auto out=backend.allocate(128*4);
+    bool rejected=false;
+    backend.begin_commands();
+    try { backend.embedding_q8(weight,0,*out); }
+    catch(const std::runtime_error&) { rejected=true; }
+    backend.abort_commands();
+    if(!rejected) { fprintf(stderr,"undersized embedding was not rejected\n"); return 1; }
+
+    std::vector<int8_t> bad_group_data(32,1); std::vector<uint16_t> bad_group_scale(1,0x3c00);
+    q27::Tensor bad_group; bad_group.name="bad-group"; bad_group.dtype=q27::DType::Q8_G128;
+    bad_group.shape={1,32}; bad_group.data=reinterpret_cast<const uint8_t*>(bad_group_data.data());
+    bad_group.data_size=bad_group_data.size(); bad_group.scales=reinterpret_cast<const uint8_t*>(bad_group_scale.data()); bad_group.scales_size=2;
+    auto bad_weight=backend.upload(bad_group); auto bad_x=backend.allocate(32*4),bad_y=backend.allocate(4);
+    rejected=false; try { backend.matvec(bad_weight,*bad_x,*bad_y); } catch(const std::runtime_error&) { rejected=true; }
+    if(!rejected) { fprintf(stderr,"invalid quantization group was not rejected\n"); return 1; }
+
+    // Aborting a failed explicit batch must leave the backend reusable.
+    std::vector<float> x={1,2,3,4}; auto xb=backend.allocate(16),yb=backend.allocate(16);
+    backend.write(*xb,0,x.data(),16); backend.copy(*xb,0,*yb,0,16);
+    float got[4]={}; backend.read(*yb,0,got,16);
+    for(int i=0;i<4;i++) if(got[i]!=x[i]) return 1;
+    return 0;
+}
+
+int test_f32(q27::MetalBackend& backend) {
+    std::vector<float> weights = {
+        1, 2, 3, 4,
+        -2, 1, 0.5f, 3,
+        0, 0, 0, 0,
+    };
+    std::vector<float> x = {2, -1, 0.5f, 3};
+    q27::Tensor tensor;
+    tensor.name = "f32-test";
+    tensor.dtype = q27::DType::F32;
+    tensor.shape = {3, 4};
+    tensor.data = reinterpret_cast<const uint8_t*>(weights.data());
+    tensor.data_size = weights.size() * sizeof(float);
+
+    q27::BackendTensor device_weight = backend.upload(tensor);
+    auto device_x = backend.allocate(x.size() * sizeof(float));
+    auto device_y = backend.allocate(3 * sizeof(float));
+    backend.write(*device_x, 0, x.data(), x.size() * sizeof(float));
+    backend.matvec(device_weight, *device_x, *device_y);
+    float got[3];
+    backend.read(*device_y, 0, got, sizeof(got));
+
+    const float want[3] = {13.5f, 4.25f, 0.0f};
+    for (int i = 0; i < 3; i++) {
+        if (!close(got[i], want[i])) {
+            fprintf(stderr, "F32 row %d: got %.7g, want %.7g\n", i, got[i], want[i]);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int test_f16(q27::MetalBackend& backend) {
+    // 1, 2, -1, 0.5 and -2, 0, 3, 1 as IEEE-754 binary16.
+    std::vector<uint16_t> weights = {
+        0x3c00, 0x4000, 0xbc00, 0x3800,
+        0xc000, 0x0000, 0x4200, 0x3c00,
+    };
+    std::vector<float> x = {2, -1, 0.5f, 3};
+    q27::Tensor tensor;
+    tensor.name = "f16-test";
+    tensor.dtype = q27::DType::F16;
+    tensor.shape = {2, 4};
+    tensor.data = reinterpret_cast<const uint8_t*>(weights.data());
+    tensor.data_size = weights.size() * sizeof(uint16_t);
+
+    q27::BackendTensor device_weight = backend.upload(tensor);
+    auto device_x = backend.allocate(x.size() * sizeof(float));
+    auto device_y = backend.allocate(2 * sizeof(float));
+    backend.write(*device_x, 0, x.data(), x.size() * sizeof(float));
+    backend.matvec(device_weight, *device_x, *device_y);
+    float got[2];
+    backend.read(*device_y, 0, got, sizeof(got));
+    const float want[2] = {1.0f, 0.5f};
+    auto paired_y=backend.allocate(2*sizeof(float));
+    backend.matvec_pair(device_weight,*device_y,device_weight,*paired_y,*device_x);
+    float paired[2]; backend.read(*paired_y,0,paired,sizeof(paired));
+    for(int row=0;row<2;row++) if(!close(paired[row],want[row])) return 1;
+    for (int row = 0; row < 2; row++) {
+        if (!close(got[row], want[row])) {
+            fprintf(stderr, "F16 row %d: got %.7g, want %.7g\n", row, got[row], want[row]);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int test_q8(q27::MetalBackend& backend) {
+    constexpr int rows = 2, cols = 128;
+    std::vector<int8_t> weights(rows * cols);
+    std::vector<float> x(cols);
+    float want[rows] = {};
+    for (int i = 0; i < cols; i++) x[i] = (float)((i % 9) - 4) / 8.0f;
+    for (int row = 0; row < rows; row++) {
+        const float scale = row == 0 ? 1.0f : 0.5f;
+        for (int i = 0; i < cols; i++) {
+            int q = row == 0 ? (i % 31) - 15 : 12 - (i % 25);
+            weights[row * cols + i] = (int8_t)q;
+            want[row] += q * scale * x[i];
+        }
+    }
+    std::vector<uint16_t> scales = {0x3c00, 0x3800};
+    q27::Tensor tensor;
+    tensor.name = "q8-test";
+    tensor.dtype = q27::DType::Q8_G128;
+    tensor.shape = {rows, cols};
+    tensor.data = reinterpret_cast<const uint8_t*>(weights.data());
+    tensor.data_size = weights.size();
+    tensor.scales = reinterpret_cast<const uint8_t*>(scales.data());
+    tensor.scales_size = scales.size() * sizeof(uint16_t);
+
+    q27::BackendTensor device_weight = backend.upload(tensor);
+    auto device_x = backend.allocate(x.size() * sizeof(float));
+    auto device_y = backend.allocate(rows * sizeof(float));
+    backend.write(*device_x, 0, x.data(), x.size() * sizeof(float));
+    backend.matvec(device_weight, *device_x, *device_y);
+    float got[rows];
+    backend.read(*device_y, 0, got, sizeof(got));
+    for (int row = 0; row < rows; row++) {
+        if (!close(got[row], want[row])) {
+            fprintf(stderr, "Q8 row %d: got %.7g, want %.7g\n", row, got[row], want[row]);
+            return 1;
+        }
+    }
+    auto quantized=backend.allocate_quantized(cols);
+    backend.begin_commands(); backend.quantize(*device_x,quantized); backend.matvec_quantized(device_weight,quantized,*device_y); backend.end_commands();
+    backend.read(*device_y,0,got,sizeof(got));
+    for(int row=0;row<rows;row++) if(!close(got[row],want[row],2e-2f)) {
+        fprintf(stderr,"Q8 quantized row %d: got %.7g, want %.7g\n",row,got[row],want[row]); return 1;
+    }
+    auto pair_y=backend.allocate(rows*sizeof(float));
+    backend.matvec_quantized_pair(device_weight,*device_y,device_weight,*pair_y,quantized);
+    float pair_got[rows]; backend.read(*pair_y,0,pair_got,sizeof(pair_got));
+    for(int row=0;row<rows;row++) if(!close(pair_got[row],got[row])) return 1;
+    return 0;
+}
+
+int test_q4(q27::MetalBackend& backend) {
+    constexpr int rows = 2, cols = 64;
+    std::vector<uint8_t> packed(rows * cols / 2);
+    std::vector<float> x(cols);
+    float want[rows] = {};
+    for (int i = 0; i < cols; i++) x[i] = (float)((i % 7) - 3) / 4.0f;
+    for (int row = 0; row < rows; row++) {
+        const float scale = row == 0 ? 1.0f : 0.5f;
+        for (int i = 0; i < cols; i += 2) {
+            const int q0 = row == 0 ? (i % 16) - 8 : 7 - (i % 16);
+            const int q1 = row == 0 ? ((i + 1) % 16) - 8 : 7 - ((i + 1) % 16);
+            packed[row * cols / 2 + i / 2] = (uint8_t)((q0 + 8) | ((q1 + 8) << 4));
+            want[row] += q0 * scale * x[i] + q1 * scale * x[i + 1];
+        }
+    }
+    // IEEE-754 binary16 encodings for 1.0 and 0.5.
+    std::vector<uint16_t> scales = {0x3c00, 0x3800};
+
+    q27::Tensor tensor;
+    tensor.name = "q4-test";
+    tensor.dtype = q27::DType::Q4_G64;
+    tensor.shape = {rows, cols};
+    tensor.data = packed.data();
+    tensor.data_size = packed.size();
+    tensor.scales = reinterpret_cast<const uint8_t*>(scales.data());
+    tensor.scales_size = scales.size() * sizeof(uint16_t);
+
+    q27::BackendTensor device_weight = backend.upload(tensor);
+    auto device_x = backend.allocate(x.size() * sizeof(float));
+    auto device_y = backend.allocate(rows * sizeof(float));
+    backend.write(*device_x, 0, x.data(), x.size() * sizeof(float));
+    backend.matvec(device_weight, *device_x, *device_y);
+    float got[rows];
+    backend.read(*device_y, 0, got, sizeof(got));
+
+    for (int row = 0; row < rows; row++) {
+        if (!close(got[row], want[row])) {
+            fprintf(stderr, "Q4 row %d: got %.7g, want %.7g\n", row, got[row], want[row]);
+            return 1;
+        }
+    }
+    auto quantized=backend.allocate_quantized(cols);
+    backend.begin_commands(); backend.quantize(*device_x,quantized); backend.matvec_quantized(device_weight,quantized,*device_y); backend.end_commands();
+    backend.read(*device_y,0,got,sizeof(got));
+    for(int row=0;row<rows;row++) if(!close(got[row],want[row],2e-2f)) {
+        fprintf(stderr,"Q4 quantized row %d: got %.7g, want %.7g\n",row,got[row],want[row]); return 1;
+    }
+    auto pair_y=backend.allocate(rows*sizeof(float));
+    backend.matvec_quantized_pair(device_weight,*device_y,device_weight,*pair_y,quantized);
+    float pair_got[rows]; backend.read(*pair_y,0,pair_got,sizeof(pair_got));
+    for(int row=0;row<rows;row++) if(!close(pair_got[row],got[row])) return 1;
+    return 0;
+}
+
+int test_t2(q27::MetalBackend& backend) {
+    constexpr int rows = 2, cols = 128;
+    std::vector<uint8_t> packed(rows * cols / 4, 0);
+    std::vector<float> x(cols);
+    float want[rows] = {};
+    int8_t q_ref[rows][cols];
+    for (int i = 0; i < cols; i++) x[i] = (float)((i % 11) - 5) / 5.0f;
+    for (int row = 0; row < rows; row++) {
+        const float scale = row == 0 ? 1.0f : 0.5f;
+        for (int i = 0; i < cols; i++) {
+            const int q = ((i * 5 + row * 3) % 3) - 1;   // {-1, 0, +1}
+            q_ref[row][i] = (int8_t)q;
+            packed[(size_t)row * cols / 4 + i / 4] |= (uint8_t)((q + 1) << ((i % 4) * 2));
+            want[row] += q * scale * x[i];
+        }
+    }
+    // IEEE-754 binary16 encodings for 1.0 and 0.5.
+    std::vector<uint16_t> scales = {0x3c00, 0x3800};
+
+    q27::Tensor tensor;
+    tensor.name = "t2-test";
+    tensor.dtype = q27::DType::T2_G128;
+    tensor.shape = {rows, cols};
+    tensor.data = packed.data();
+    tensor.data_size = packed.size();
+    tensor.scales = reinterpret_cast<const uint8_t*>(scales.data());
+    tensor.scales_size = scales.size() * sizeof(uint16_t);
+
+    q27::BackendTensor device_weight = backend.upload(tensor);
+    auto device_x = backend.allocate(x.size() * sizeof(float));
+    auto device_y = backend.allocate(rows * sizeof(float));
+    backend.write(*device_x, 0, x.data(), x.size() * sizeof(float));
+    backend.matvec(device_weight, *device_x, *device_y);
+    float got[rows];
+    backend.read(*device_y, 0, got, sizeof(got));
+    for (int row = 0; row < rows; row++) {
+        if (!close(got[row], want[row])) {
+            fprintf(stderr, "T2 row %d: got %.7g, want %.7g\n", row, got[row], want[row]);
+            return 1;
+        }
+    }
+    auto quantized = backend.allocate_quantized(cols);
+    backend.begin_commands(); backend.quantize(*device_x, quantized);
+    backend.matvec_quantized(device_weight, quantized, *device_y); backend.end_commands();
+    backend.read(*device_y, 0, got, sizeof(got));
+    for (int row = 0; row < rows; row++) if (!close(got[row], want[row], 2e-2f)) {
+        fprintf(stderr, "T2 quantized row %d: got %.7g, want %.7g\n", row, got[row], want[row]);
+        return 1;
+    }
+    auto pair_y = backend.allocate(rows * sizeof(float));
+    backend.matvec_quantized_pair(device_weight, *device_y, device_weight, *pair_y, quantized);
+    float pair_got[rows]; backend.read(*pair_y, 0, pair_got, sizeof(pair_got));
+    for (int row = 0; row < rows; row++) if (!close(pair_got[row], got[row])) return 1;
+
+    // Ternary embedding row-lookup: exact dequant of one row.
+    auto embed_out = backend.allocate(cols * sizeof(float));
+    backend.embedding_q8(device_weight, 1, *embed_out);
+    std::vector<float> embed(cols);
+    backend.read(*embed_out, 0, embed.data(), cols * sizeof(float));
+    for (int i = 0; i < cols; i++) {
+        const float expect = (float)q_ref[1][i] * 0.5f;
+        if (embed[i] != expect) {
+            fprintf(stderr, "T2 embedding col %d: got %.7g, want %.7g\n", i, embed[i], expect);
+            return 1;
+        }
+    }
+    packed[0] |= 3u;
+    bool rejected = false;
+    try { (void)backend.upload(tensor); }
+    catch (const std::runtime_error& error) {
+        rejected = std::string(error.what()).find("reserved code 3") != std::string::npos;
+    }
+    if (!rejected) { fprintf(stderr, "direct T2 upload accepted reserved code 3\n"); return 1; }
+    return 0;
+}
+
+// Wide-shape gate for the select-form float-activation T2 GEMV (the
+// production ternary decode path): rows that span threadgroups and leave a
+// 32-row remainder (clamped compute-only rows), block counts that exercise
+// the four-blocks-in-flight loop with a tail, and scales varied per group.
+int test_t2_wide(q27::MetalBackend& backend) {
+    for (uint32_t cols : {1152u, 5120u}) {
+        constexpr uint32_t rows = 37;   // 32 + 5: second threadgroup clamps rows 37..63
+        const uint32_t groups = cols / 128;
+        std::vector<uint8_t> data((size_t)rows * cols / 4, 0);
+        std::vector<int8_t> w((size_t)rows * cols);
+        for (uint32_t r = 0; r < rows; r++)
+            for (uint32_t c = 0; c < cols; c++) {
+                const int q = (int)((r * 13 + c * 7) % 3) - 1;
+                w[(size_t)r * cols + c] = (int8_t)q;
+                data[(size_t)r * cols / 4 + c / 4] |= (uint8_t)((q + 1) << ((c % 4) * 2));
+            }
+        const uint16_t scale_bits[4] = {0x3400, 0x3800, 0x3c00, 0x4000};
+        const float scale_f32[4] = {0.25f, 0.5f, 1.0f, 2.0f};
+        std::vector<uint16_t> scales((size_t)rows * groups);
+        for (size_t i = 0; i < scales.size(); i++) scales[i] = scale_bits[i % 4];
+        q27::Tensor tensor;
+        tensor.name = "t2-wide";
+        tensor.dtype = q27::DType::T2_G128;
+        tensor.shape = {rows, cols};
+        tensor.data = data.data();
+        tensor.data_size = data.size();
+        tensor.scales = (const uint8_t*)scales.data();
+        tensor.scales_size = scales.size() * 2;
+        auto weight = backend.upload(tensor);
+
+        std::vector<float> x(cols);
+        for (uint32_t c = 0; c < cols; c++)
+            x[c] = (float)((int)((c * 11) % 23) - 11) / 11.0f * (float)(1 + c / 32 % 7);
+        auto xb = backend.allocate(cols * 4);
+        backend.write(*xb, 0, x.data(), cols * 4);
+        auto yb = backend.allocate(rows * 4);
+        backend.matvec(weight, *xb, *yb);
+        std::vector<float> got(rows);
+        backend.read(*yb, 0, got.data(), rows * 4);
+        for (uint32_t r = 0; r < rows; r++) {
+            double want = 0.0, magnitude = 0.0;
+            for (uint32_t g = 0; g < groups; g++) {
+                double dot = 0.0;
+                for (uint32_t c = g * 128; c < g * 128 + 128; c++)
+                    dot += (double)w[(size_t)r * cols + c] * x[c];
+                const double term = dot * scale_f32[((size_t)r * groups + g) % 4];
+                want += term;
+                magnitude += std::fabs(term);
+            }
+            const float bound = (float)(magnitude * 1e-5 + 1e-3);
+            if (std::fabs(got[r] - (float)want) > bound) {
+                fprintf(stderr, "T2 wide cols=%u row %u: got %.7g want %.7g\n",
+                        cols, r, got[r], (float)want);
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+// The tiled simdgroup-matrix GEMM keeps the weight side integer-exact and
+// rounds the activation side once per value at staging, but accumulates
+// K-tiles in a different float-addition order than the serial GEMV, so the
+// comparison is tolerance-based. Shapes cover several K-tile counts, row
+// remainders against the 32-row tile (9, 17), and every token-group width,
+// per the width-gated fast-path lesson: a gate shape must actually enter
+// the fast path it gates.
+int test_matmul_shape(q27::MetalBackend& backend,q27::DType dtype,
+                      uint32_t rows,uint32_t cols) {
+    constexpr uint32_t tokens=12;
+    std::vector<uint8_t> data(dtype==q27::DType::Q4_G64?(size_t)rows*cols/2:
+                              dtype==q27::DType::T2_G128?(size_t)rows*cols/4:(size_t)rows*cols,0);
+    for(uint32_t r=0;r<rows;r++) for(uint32_t c=0;c<cols;c++) {
+        int q=(int)((r*7+c*3)%15)-7;
+        if(dtype==q27::DType::Q4_G64) {
+            size_t i=(size_t)r*cols/2+c/2; uint8_t nibble=(uint8_t)(q+8);
+            if(c&1) data[i]=(data[i]&15)|(nibble<<4); else data[i]=(data[i]&240)|nibble;
+        } else if(dtype==q27::DType::T2_G128) {
+            q=(int)((r*7+c*3)%3)-1;
+            data[(size_t)r*cols/4+c/4]|=(uint8_t)((q+1)<<((c%4)*2));
+        } else data[(size_t)r*cols+c]=(uint8_t)(int8_t)q;
+    }
+    uint32_t groups=cols/(dtype==q27::DType::Q4_G64?64:128);
+    const uint16_t scale_values[4]={0x3400,0x3800,0x3c00,0x4000};
+    std::vector<uint16_t> scales(rows*groups);
+    for(uint32_t r=0;r<rows;r++) for(uint32_t g=0;g<groups;g++) scales[r*groups+g]=scale_values[(r+g)%4];
+    q27::Tensor tensor; tensor.name="matmul-tiles"; tensor.dtype=dtype; tensor.shape={rows,cols};
+    tensor.data=data.data(); tensor.data_size=data.size(); tensor.scales=(const uint8_t*)scales.data(); tensor.scales_size=scales.size()*2;
+    auto weight=backend.upload(tensor); std::vector<float> x(tokens*cols);
+    for(uint32_t t=0;t<tokens;t++) for(uint32_t c=0;c<cols;c++)
+        x[(size_t)t*cols+c]=(((int)((t+1)*11+c*5)%31)-15)*(float)(c/32+1)/(float)(t+3);
+    std::vector<float> reference(tokens*rows);
+    for(uint32_t t=0;t<tokens;t++) {
+        auto xb=backend.allocate(cols*4),yb=backend.allocate(rows*4); backend.write(*xb,0,x.data()+(size_t)t*cols,cols*4);
+        auto q=backend.allocate_quantized(cols); backend.begin_commands(); backend.quantize(*xb,q); backend.matvec_quantized(weight,q,*yb); backend.end_commands();
+        backend.read(*yb,0,reference.data()+(size_t)t*rows,rows*4);
+    }
+    auto all_x=backend.allocate(x.size()*4); backend.write(*all_x,0,x.data(),x.size()*4);
+    for(uint32_t n:{1u,4u,5u,8u,9u,12u}) {
+        auto q=backend.allocate_quantized(n*cols); auto out=backend.allocate((uint64_t)n*rows*4);
+        backend.begin_commands(); backend.quantize(*all_x,q); backend.matmul_quantized(weight,q,n,*out); backend.end_commands();
+        std::vector<float> got(n*rows); backend.read(*out,0,got.data(),got.size()*4);
+        for(size_t i=0;i<got.size();i++) if(!close(got[i],reference[i],3e-4f)) {
+            fprintf(stderr,"%s matmul rows=%u cols=%u n=%u i=%zu got %.9g want %.9g\n",
+                    q27::dtype_name(dtype),rows,cols,n,i,got[i],reference[i]); return 1;
+        }
+    }
+    return 0;
+}
+
+int test_matmul_tiles(q27::MetalBackend& backend,q27::DType dtype) {
+    return test_matmul_shape(backend,dtype,9,256) ||
+           test_matmul_shape(backend,dtype,9,1024) ||
+           test_matmul_shape(backend,dtype,17,1152);
+}
+
+// Production-width GEMV parity. The packed-dot kernels take a vectorized
+// main loop only when cols >= 1024, so the narrow test_q8/test_q4 shapes
+// never reach it; this caught a wrong per-lane activation-scale index that
+// the 64/128-column tests could not see. Scales are deliberately varied per
+// weight group and per 32-column activation block.
+// Wide-shape gate for the threadgroup-per-row F16 pair kernel: the packed
+// vector main loop and the 8-simdgroup reduction tree only fill up past a few
+// hundred columns, so this runs the production alpha/beta shape (48 x 5120),
+// an odd width that leaves a scalar tail, and asymmetric row counts.
+int test_f16_pair_wide(q27::MetalBackend& backend) {
+    for (uint32_t cols : {1030u, 5120u}) {
+        constexpr uint32_t rows_a = 48, rows_b = 16;
+        std::vector<_Float16> wa((size_t)rows_a * cols), wb((size_t)rows_b * cols);
+        for (size_t i = 0; i < wa.size(); i++) wa[i] = (_Float16)(((int)((i * 7) % 31) - 15) * 0.0625f);
+        for (size_t i = 0; i < wb.size(); i++) wb[i] = (_Float16)(((int)((i * 11) % 27) - 13) * 0.125f);
+        std::vector<float> x(cols);
+        for (uint32_t c = 0; c < cols; c++) x[c] = (float)((int)((c * 13) % 21) - 10) / 10.0f;
+
+        q27::Tensor ta; ta.name = "pair-wide-a"; ta.dtype = q27::DType::F16; ta.shape = {rows_a, cols};
+        ta.data = reinterpret_cast<const uint8_t*>(wa.data()); ta.data_size = wa.size() * 2;
+        q27::Tensor tb; tb.name = "pair-wide-b"; tb.dtype = q27::DType::F16; tb.shape = {rows_b, cols};
+        tb.data = reinterpret_cast<const uint8_t*>(wb.data()); tb.data_size = wb.size() * 2;
+        auto weight_a = backend.upload(ta);
+        auto weight_b = backend.upload(tb);
+        auto xb = backend.allocate(cols * 4);
+        backend.write(*xb, 0, x.data(), cols * 4);
+        auto ya = backend.allocate(rows_a * 4), yb = backend.allocate(rows_b * 4);
+        backend.matvec_pair(weight_a, *ya, weight_b, *yb, *xb);
+        std::vector<float> got_a(rows_a), got_b(rows_b);
+        backend.read(*ya, 0, got_a.data(), rows_a * 4);
+        backend.read(*yb, 0, got_b.data(), rows_b * 4);
+        for (uint32_t r = 0; r < rows_a; r++) {
+            double want = 0;
+            for (uint32_t c = 0; c < cols; c++) want += (double)(float)wa[(size_t)r * cols + c] * x[c];
+            if (!close(got_a[r], (float)want, 2e-3f)) {
+                fprintf(stderr, "F16 pair wide A cols=%u row %u: got %.7g want %.7g\n", cols, r, got_a[r], (float)want);
+                return 1;
+            }
+        }
+        for (uint32_t r = 0; r < rows_b; r++) {
+            double want = 0;
+            for (uint32_t c = 0; c < cols; c++) want += (double)(float)wb[(size_t)r * cols + c] * x[c];
+            if (!close(got_b[r], (float)want, 2e-3f)) {
+                fprintf(stderr, "F16 pair wide B cols=%u row %u: got %.7g want %.7g\n", cols, r, got_b[r], (float)want);
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+int test_quantized_wide(q27::MetalBackend& backend, q27::DType dtype) {
+    const uint32_t group = dtype == q27::DType::Q4_G64 ? 64 : 128;
+    // main chunk + tail, then a production column count
+    const uint32_t widths[2] = {1024 + group, 5120};
+    for (uint32_t cols : widths) {
+        constexpr uint32_t rows = 5;
+        const uint32_t groups = cols / group;
+        std::vector<int8_t> w(rows * cols);
+        for (uint32_t r = 0; r < rows; r++)
+            for (uint32_t c = 0; c < cols; c++)
+                w[(size_t)r * cols + c] = (int8_t)((int)((r * 13 + c * 7) % 29) - 14);
+        std::vector<uint8_t> data;
+        if (dtype == q27::DType::T2_G128) {
+            data.assign((size_t)rows * cols / 4, 0);
+            for (uint32_t r = 0; r < rows; r++)
+                for (uint32_t c = 0; c < cols; c++) {
+                    const int q = (int)((r * 13 + c * 7) % 3) - 1;
+                    w[(size_t)r * cols + c] = (int8_t)q;
+                    data[(size_t)r * cols / 4 + c / 4] |= (uint8_t)((q + 1) << ((c % 4) * 2));
+                }
+        } else if (dtype == q27::DType::Q4_G64) {
+            data.resize((size_t)rows * cols / 2);
+            for (uint32_t r = 0; r < rows; r++)
+                for (uint32_t c = 0; c < cols; c++) {
+                    int q = ((int)w[(size_t)r * cols + c] % 8 + 8) % 16 - 8;
+                    w[(size_t)r * cols + c] = (int8_t)q;
+                    uint8_t nibble = (uint8_t)(q + 8);
+                    size_t i = (size_t)r * cols / 2 + c / 2;
+                    if (c & 1) data[i] = (uint8_t)((data[i] & 15) | (nibble << 4));
+                    else data[i] = (uint8_t)((data[i] & 240) | nibble);
+                }
+        } else {
+            data.assign((const uint8_t*)w.data(), (const uint8_t*)w.data() + w.size());
+        }
+        const uint16_t scale_bits[4] = {0x3400, 0x3800, 0x3c00, 0x4000};
+        const float scale_f32[4] = {0.25f, 0.5f, 1.0f, 2.0f};
+        std::vector<uint16_t> scales(rows * groups);
+        for (size_t i = 0; i < scales.size(); i++) scales[i] = scale_bits[i % 4];
+        q27::Tensor tensor;
+        tensor.name = "wide";
+        tensor.dtype = dtype;
+        tensor.shape = {rows, cols};
+        tensor.data = data.data();
+        tensor.data_size = data.size();
+        tensor.scales = (const uint8_t*)scales.data();
+        tensor.scales_size = scales.size() * 2;
+        auto weight = backend.upload(tensor);
+
+        // Distinct magnitude per 32-column block so every activation scale differs.
+        std::vector<float> x(cols);
+        for (uint32_t c = 0; c < cols; c++)
+            x[c] = (float)((int)((c * 11) % 23) - 11) / 11.0f * (float)(1 + c / 32 % 7);
+        auto xb = backend.allocate(cols * 4);
+        backend.write(*xb, 0, x.data(), cols * 4);
+        auto xq = backend.allocate_quantized(cols);
+        auto yb = backend.allocate(rows * 4);
+        auto y2 = backend.allocate(rows * 4);
+        auto y3 = backend.allocate(rows * 4);
+        backend.begin_commands();
+        backend.quantize(*xb, xq);
+        backend.matvec_quantized(weight, xq, *yb);
+        backend.end_commands();
+        backend.matvec_quantized_pair(weight, *y2, weight, *y3, xq);
+
+        std::vector<int8_t> xv(cols);
+        std::vector<float> xs(cols / 32);
+        backend.read(*xq.values, 0, xv.data(), cols);
+        backend.read(*xq.scales, 0, xs.data(), xs.size() * 4);
+        std::vector<float> got(rows), got2(rows), got3(rows);
+        backend.read(*yb, 0, got.data(), rows * 4);
+        backend.read(*y2, 0, got2.data(), rows * 4);
+        backend.read(*y3, 0, got3.data(), rows * 4);
+        for (uint32_t r = 0; r < rows; r++) {
+            double want = 0.0, magnitude = 0.0;
+            for (uint32_t b = 0; b < cols / 32; b++) {
+                int dot = 0;
+                for (uint32_t i = b * 32; i < b * 32 + 32; i++)
+                    dot += (int)w[(size_t)r * cols + i] * (int)xv[i];
+                const double term =
+                    (double)dot * scale_f32[(r * groups + b * 32 / group) % 4] * xs[b];
+                want += term;
+                magnitude += std::fabs(term);
+            }
+            // Absolute bound scaled by the sum of |block terms|, so a
+            // cancellation-heavy row cannot hide a wrong-scale bug behind a
+            // relative check, and the double-vs-float summation-order
+            // difference stays within it.
+            const float bound = (float)(magnitude * 1e-5 + 1e-3);
+            const auto ok = [&](float value) { return std::fabs(value - (float)want) <= bound; };
+            if (!ok(got[r]) || !ok(got2[r]) || !ok(got3[r])) {
+                fprintf(stderr, "%s wide cols=%u row %u: got %.7g pair %.7g/%.7g want %.7g\n",
+                        q27::dtype_name(dtype), cols, r, got[r], got2[r], got3[r], (float)want);
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+int test_mixed_pair(q27::MetalBackend& backend) {
+    constexpr int cols=128; std::vector<float> x(cols); for(int i=0;i<cols;i++) x[i]=(i%13-6)/7.0f;
+    std::vector<uint8_t> q4(cols/2,0x99); std::vector<int8_t> q8(cols,2);
+    std::vector<uint16_t> s4={0x3c00,0x3c00},s8={0x3c00};
+    q27::Tensor a; a.name="mixed-q4"; a.dtype=q27::DType::Q4_G64; a.shape={1,cols};
+    a.data=q4.data(); a.data_size=q4.size(); a.scales=(const uint8_t*)s4.data(); a.scales_size=s4.size()*2;
+    q27::Tensor b; b.name="mixed-q8"; b.dtype=q27::DType::Q8_G128; b.shape={1,cols};
+    b.data=(const uint8_t*)q8.data(); b.data_size=q8.size(); b.scales=(const uint8_t*)s8.data(); b.scales_size=s8.size()*2;
+    auto aw=backend.upload(a); auto bw=backend.upload(b); auto xb=backend.allocate(cols*4);
+    auto ao=backend.allocate(4); auto bo=backend.allocate(4); auto ar=backend.allocate(4); auto br=backend.allocate(4);
+    auto quant=backend.allocate_quantized(cols); backend.write(*xb,0,x.data(),cols*4);
+    backend.begin_commands(); backend.quantize(*xb,quant); backend.matvec_quantized(aw,quant,*ar); backend.matvec_quantized(bw,quant,*br); backend.end_commands();
+    backend.matvec_quantized_pair(aw,*ao,bw,*bo,quant);
+    float expected_a,expected_b,got_a,got_b; backend.read(*ar,0,&expected_a,4); backend.read(*br,0,&expected_b,4);
+    backend.read(*ao,0,&got_a,4); backend.read(*bo,0,&got_b,4);
+    if(got_a!=expected_a || got_b!=expected_b) { fprintf(stderr,"mixed quantized pair fallback mismatch\n"); return 1; }
+    return 0;
+}
+
+} // namespace
+
+int main() {
+    try {
+        q27::MetalBackend backend;
+        printf("Metal device: %s\n", backend.name().c_str());
+        printf("working set %.1f GiB, max buffer %.1f GiB, threadgroup memory %.1f KiB\n",
+               backend.recommended_working_set_size() / 1073741824.0,
+               backend.max_buffer_length() / 1073741824.0,
+               backend.max_threadgroup_memory_length() / 1024.0);
+        if (test_mmap_upload(backend) || test_dispatch_validation(backend) ||
+            test_f32(backend) || test_f16(backend) ||
+            test_q8(backend) || test_q4(backend) || test_t2(backend) ||
+            test_quantized_wide(backend, q27::DType::Q4_G64) ||
+            test_quantized_wide(backend, q27::DType::Q8_G128) ||
+            test_quantized_wide(backend, q27::DType::T2_G128) ||
+            test_t2_wide(backend) ||
+            test_f16_pair_wide(backend) ||
+            test_mixed_pair(backend) ||
+            (backend.supports_quantized_matmul() &&
+             (test_matmul_tiles(backend,q27::DType::Q4_G64) || test_matmul_tiles(backend,q27::DType::Q8_G128) ||
+              test_matmul_tiles(backend,q27::DType::T2_G128))))
+            return 1;
+        puts("Metal matvec: OK");
+        return 0;
+    } catch (const std::exception& error) {
+        fprintf(stderr, "%s\n", error.what());
+        return 1;
+    }
+}

--- a/src/metal/test_metal.cpp
+++ b/src/metal/test_metal.cpp
@@ -1,6 +1,7 @@
 #include "metal_backend.h"
 
 #include <cmath>
+#include <cstdlib>
 #include <cstdio>
 #include <exception>
 #include <string>
@@ -73,6 +74,14 @@ int test_mmap_upload(q27::MetalBackend& backend) {
                 backend.copy(*device_x, 0, *weight.data, weight.data_offset, sizeof(replacement));
             }))
             return 1;
+        // The shared mmap buffer extends beyond this tensor. Inflating the
+        // matrix shape must still fail at the tensor's logical boundary.
+        weight.rows = 4;
+        auto oversized_y = backend.allocate(4 * sizeof(float));
+        bool rejected = false;
+        try { backend.matvec(weight, *device_x, *oversized_y); }
+        catch (const std::runtime_error&) { rejected = true; }
+        if (!rejected) { fprintf(stderr, "mmap tensor overread was not rejected\n"); return 1; }
         return 0;
     } catch (...) {
         unlink(path);
@@ -106,6 +115,45 @@ int test_dispatch_validation(q27::MetalBackend& backend) {
     auto bad_weight=backend.upload(bad_group); auto bad_x=backend.allocate(32*4),bad_y=backend.allocate(4);
     rejected=false; try { backend.matvec(bad_weight,*bad_x,*bad_y); } catch(const std::runtime_error&) { rejected=true; }
     if(!rejected) { fprintf(stderr,"invalid quantization group was not rejected\n"); return 1; }
+
+    auto concat_a=backend.allocate(4),concat_b=backend.allocate(4),concat_out=backend.allocate(4);
+    rejected=false;
+    try { backend.concat(*concat_a,UINT32_MAX,*concat_b,1,*concat_out); }
+    catch(const std::runtime_error&) { rejected=true; }
+    if(!rejected) { fprintf(stderr,"concat element overflow was not rejected\n"); return 1; }
+
+    auto tiny=backend.allocate(4);
+    q27::BackendTensor huge;
+    huge.dtype=q27::DType::F16; huge.data=tiny;
+    huge.rows=UINT32_MAX; huge.cols=UINT32_MAX;
+    rejected=false;
+    try { backend.matvec(huge,*tiny,*tiny); }
+    catch(const std::runtime_error& error) {
+        rejected=std::string(error.what()).find("size overflow")!=std::string::npos;
+    }
+    if(!rejected) { fprintf(stderr,"matvec size overflow was not rejected\n"); return 1; }
+    rejected=false;
+    try { backend.matvec_pair(huge,*tiny,huge,*tiny,*tiny); }
+    catch(const std::runtime_error& error) {
+        rejected=std::string(error.what()).find("size overflow")!=std::string::npos;
+    }
+    if(!rejected) { fprintf(stderr,"fused matvec size overflow was not rejected\n"); return 1; }
+    rejected=false;
+    try { backend.matvec_f16_pair_rows(huge,*tiny,huge,*tiny,*tiny,1); }
+    catch(const std::runtime_error& error) {
+        rejected=std::string(error.what()).find("size overflow")!=std::string::npos;
+    }
+    if(!rejected) { fprintf(stderr,"chunked matvec size overflow was not rejected\n"); return 1; }
+
+    const uint32_t batch_write=0x12345678;
+    rejected=false;
+    backend.begin_commands();
+    try { backend.write(*tiny,0,&batch_write,sizeof(batch_write)); }
+    catch(const std::runtime_error& error) {
+        rejected=std::string(error.what()).find("cannot CPU-write during command batch")!=std::string::npos;
+    }
+    backend.abort_commands();
+    if(!rejected) { fprintf(stderr,"CPU write during command batch was not rejected\n"); return 1; }
 
     // Aborting a failed explicit batch must leave the backend reusable.
     std::vector<float> x={1,2,3,4}; auto xb=backend.allocate(16),yb=backend.allocate(16);
@@ -647,6 +695,46 @@ int test_mixed_pair(q27::MetalBackend& backend) {
     return 0;
 }
 
+int test_profiled_batch_atomicity() {
+    if(setenv("Q27_METAL_PROFILE","1",1)!=0) return 1;
+    int failure=0;
+    try {
+        q27::MetalBackend backend;
+        auto src=backend.allocate(4),dst=backend.allocate(4);
+        bool nested_rejected=false;
+        backend.begin_commands();
+        try { backend.begin_commands(); }
+        catch(const std::runtime_error& error) {
+            nested_rejected=std::string(error.what()).find("command batch already active")!=std::string::npos;
+        }
+        backend.abort_commands();
+        if(!nested_rejected) { fprintf(stderr,"profiled nested batch was not rejected\n"); failure=1; }
+        const uint32_t value=0x12345678; uint32_t got=0;
+        backend.write(*src,0,&value,sizeof(value)); backend.write(*dst,0,&got,sizeof(got));
+        bool rejected=false;
+        backend.begin_commands();
+        try {
+            for(uint32_t i=0;i<4096;i++) backend.copy(*src,0,*dst,0,sizeof(value));
+        } catch(const std::runtime_error& error) {
+            rejected=std::string(error.what()).find("profiled command batch exceeds operation limit")!=std::string::npos;
+        }
+        backend.abort_commands();
+        if(!rejected) {
+            fprintf(stderr,"profiled oversized batch was not rejected\n"); failure=1;
+        } else {
+            backend.read(*dst,0,&got,sizeof(got));
+            if(got!=0) { fprintf(stderr,"rejected profiled batch committed partial work\n"); failure=1; }
+            backend.copy(*src,0,*dst,0,sizeof(value)); backend.read(*dst,0,&got,sizeof(got));
+            if(got!=value) { fprintf(stderr,"backend was not reusable after profiled batch rejection\n"); failure=1; }
+        }
+    } catch(...) {
+        unsetenv("Q27_METAL_PROFILE");
+        throw;
+    }
+    unsetenv("Q27_METAL_PROFILE");
+    return failure;
+}
+
 } // namespace
 
 int main() {
@@ -670,6 +758,7 @@ int main() {
              (test_matmul_tiles(backend,q27::DType::Q4_G64) || test_matmul_tiles(backend,q27::DType::Q8_G128) ||
               test_matmul_tiles(backend,q27::DType::T2_G128))))
             return 1;
+        if (test_profiled_batch_atomicity()) return 1;
         puts("Metal matvec: OK");
         return 0;
     } catch (const std::exception& error) {

--- a/src/metal/test_metal_ops.cpp
+++ b/src/metal/test_metal_ops.cpp
@@ -1,0 +1,976 @@
+#include "metal_backend.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <exception>
+#include <numeric>
+#include <vector>
+
+namespace {
+
+bool near(float a, float b, float tol = 3e-4f) {
+    return std::fabs(a - b) <= tol * std::max(1.0f, std::fabs(b));
+}
+
+q27::BackendTensor upload_f32(q27::MetalBackend& backend, const std::vector<float>& values,
+                              std::vector<uint64_t> shape) {
+    q27::Tensor tensor;
+    tensor.name = "test-f32";
+    tensor.dtype = q27::DType::F32;
+    tensor.shape = std::move(shape);
+    tensor.data = reinterpret_cast<const uint8_t*>(values.data());
+    tensor.data_size = values.size() * sizeof(float);
+    return backend.upload(tensor);
+}
+
+std::shared_ptr<q27::BackendBuffer> upload_buffer(q27::MetalBackend& backend,
+                                                  const std::vector<float>& values) {
+    auto result = backend.allocate(values.size() * sizeof(float));
+    backend.write(*result, 0, values.data(), values.size() * sizeof(float));
+    return result;
+}
+
+std::vector<float> read_f32(q27::MetalBackend& backend, const q27::BackendBuffer& buffer,
+                            size_t n) {
+    std::vector<float> result(n);
+    backend.read(buffer, 0, result.data(), n * sizeof(float));
+    return result;
+}
+
+int test_primitives(q27::MetalBackend& backend) {
+    int failures = 0;
+    auto fail = [&](const char* name, size_t i, float got, float want) {
+        fprintf(stderr, "%s[%zu]: got %.8g want %.8g\n", name, i, got, want);
+        failures++;
+    };
+
+    // Q8 embedding.
+    std::vector<int8_t> ew(2 * 128);
+    for (size_t i = 0; i < ew.size(); i++) ew[i] = (int8_t)((int)(i % 21) - 10);
+    std::vector<uint16_t> es = {0x3c00, 0x3800};
+    q27::Tensor et;
+    et.name = "embedding"; et.dtype = q27::DType::Q8_G128; et.shape = {2, 128};
+    et.data = reinterpret_cast<const uint8_t*>(ew.data()); et.data_size = ew.size();
+    et.scales = reinterpret_cast<const uint8_t*>(es.data()); et.scales_size = es.size() * 2;
+    auto embedding = backend.upload(et);
+    auto embed_out = backend.allocate(128 * 4);
+    backend.embedding_q8(embedding, 1, *embed_out);
+    auto embedded = read_f32(backend, *embed_out, 128);
+    for (size_t i = 0; i < embedded.size(); i++) {
+        float want = ew[128 + i] * 0.5f;
+        if (!near(embedded[i], want)) { fail("embedding", i, embedded[i], want); break; }
+    }
+
+    // RMSNorm.
+    std::vector<float> x = {1, -2, 3, -4, 0.5f};
+    std::vector<float> w = {1, 0.5f, -1, 2, 3};
+    auto xb = upload_buffer(backend, x); auto out = backend.allocate(x.size() * 4);
+    auto wt = upload_f32(backend, w, {w.size()});
+    backend.rmsnorm(*xb, wt, *out, (uint32_t)x.size(), 1e-6f);
+    auto got = read_f32(backend, *out, x.size());
+    float sum = std::inner_product(x.begin(), x.end(), x.begin(), 0.0f);
+    float inv = 1.0f / std::sqrt(sum / x.size() + 1e-6f);
+    for (size_t i = 0; i < x.size(); i++) if (!near(got[i], x[i] * inv * w[i])) fail("rmsnorm", i, got[i], x[i] * inv * w[i]);
+
+    // Fused RMSNorm + group-32 quantization must match the two-dispatch path.
+    std::vector<float> fx(32),fw(32,1.0f); for(size_t i=0;i<fx.size();i++) fx[i]=(float)((int)i-15)/7;
+    auto fxb=upload_buffer(backend,fx); auto fwt=upload_f32(backend,fw,{32});
+    auto normal=backend.allocate(32*4),fused=backend.allocate(32*4);
+    auto nq=backend.allocate_quantized(32),fq=backend.allocate_quantized(32);
+    backend.begin_commands(); backend.rmsnorm(*fxb,fwt,*normal,32,1e-6f); backend.quantize(*normal,nq); backend.end_commands();
+    backend.rmsnorm_quantized(*fxb,fwt,*fused,32,1e-6f,fq);
+    auto normal_f=read_f32(backend,*normal,32),fused_f=read_f32(backend,*fused,32);
+    std::vector<int8_t> normal_q(32),fused_q(32); float normal_s=0,fused_s=0;
+    backend.read(*nq.values,0,normal_q.data(),32); backend.read(*fq.values,0,fused_q.data(),32);
+    backend.read(*nq.scales,0,&normal_s,4); backend.read(*fq.scales,0,&fused_s,4);
+    for(size_t i=0;i<32;i++) if(normal_f[i]!=fused_f[i] || normal_q[i]!=fused_q[i]) fail("fused rms",i,fused_f[i],normal_f[i]);
+    if(normal_s!=fused_s) fail("fused rms scale",0,fused_s,normal_s);
+
+    // Per-head RMSNorm with a stride, then contiguous L2 normalization.
+    std::vector<float> heads = {1,2,3,4,99,99, -1,2,-3,4,88,88};
+    std::vector<float> hw = {1,0.5f,2,-1};
+    auto hb = upload_buffer(backend, heads); auto hwt = upload_f32(backend, hw, {4});
+    backend.rmsnorm_heads(*hb, hwt, 2, 4, 6, 1e-6f);
+    auto hg = read_f32(backend, *hb, heads.size());
+    for (uint32_t h = 0; h < 2; h++) {
+        float ss = 0; for (uint32_t d=0; d<4; d++) ss += heads[h*6+d]*heads[h*6+d];
+        float ri = 1/std::sqrt(ss/4+1e-6f);
+        for(uint32_t d=0;d<4;d++) if(!near(hg[h*6+d],heads[h*6+d]*ri*hw[d])) fail("head rms",h*6+d,hg[h*6+d],heads[h*6+d]*ri*hw[d]);
+    }
+    std::vector<float> l2 = {3,4,0,0, 1,2,2,1};
+    auto l2b=upload_buffer(backend,l2); backend.l2norm_heads(*l2b,2,4,1e-6f); auto l2g=read_f32(backend,*l2b,8);
+    for(uint32_t h=0;h<2;h++){float ss=0;for(uint32_t d=0;d<4;d++)ss+=l2[h*4+d]*l2[h*4+d];float li=1/std::max(std::sqrt(ss),1e-6f);for(uint32_t d=0;d<4;d++)if(!near(l2g[h*4+d],l2[h*4+d]*li))fail("l2",h*4+d,l2g[h*4+d],l2[h*4+d]*li);}
+
+    // Elementwise sequence in one command buffer.
+    std::vector<float> gate={-2,-1,0,1,2}, up={1,2,3,4,5}, residual={.1f,.2f,.3f,.4f,.5f};
+    auto gb=upload_buffer(backend,gate), ub=upload_buffer(backend,up), rb=upload_buffer(backend,residual); auto eb=backend.allocate(20);
+    backend.begin_commands(); backend.silu_mul(*gb,*ub,*eb,5); backend.add_inplace(*eb,*rb,5); backend.end_commands();
+    auto eg=read_f32(backend,*eb,5); for(size_t i=0;i<5;i++){float want=gate[i]/(1+std::exp(-gate[i]))*up[i]+residual[i];if(!near(eg[i],want))fail("elementwise",i,eg[i],want);}
+
+    // Device-side state copy with non-zero offsets (used by prefix snapshots).
+    std::vector<float> copy_src={1,2,3,4,5},copy_zero(7,0);
+    auto cs=upload_buffer(backend,copy_src),cd=upload_buffer(backend,copy_zero);
+    backend.copy(*cs,4,*cd,8,3*sizeof(float)); auto copied=read_f32(backend,*cd,copy_zero.size());
+    for(size_t i=0;i<3;i++) if(copied[i+2]!=copy_src[i+1]) fail("copy",i,copied[i+2],copy_src[i+1]);
+
+    // Sigmoid gate.
+    std::vector<float> values={1,2,3,4}, qg={0,0,1,-1, 2,-2,0.5f,-0.5f};
+    auto vb=upload_buffer(backend,values), qgb=upload_buffer(backend,qg); backend.sigmoid_gate_mul(*vb,*qgb,2,2); auto vg=read_f32(backend,*vb,4);
+    for(size_t i=0;i<4;i++){uint32_t h=i/2,d=i%2;float gv=qg[h*4+2+d];float want=values[i]/(1+std::exp(-gv));if(!near(vg[i],want))fail("sigmoid gate",i,vg[i],want);}
+
+    // Partial NeoX RoPE.
+    std::vector<float> rope={1,2,3,4,5,6,7,8}; auto ropeb=upload_buffer(backend,rope);
+    backend.rope_neox(*ropeb,1,8,4,8,3,10000.0f); auto rg=read_f32(backend,*ropeb,8);
+    for(uint32_t d=0;d<2;d++){float theta=3*std::pow(10000.0f,-2.0f*d/4.0f);float c=std::cos(theta),s=std::sin(theta);float a=rope[d],b=rope[d+2];if(!near(rg[d],a*c-b*s))fail("rope",d,rg[d],a*c-b*s);if(!near(rg[d+2],a*s+b*c))fail("rope",d+2,rg[d+2],a*s+b*c);}
+
+    // Stable lower-index tie break.
+    std::vector<float> logits={-1,7,3,7,2}; auto lb=upload_buffer(backend,logits); auto ib=backend.allocate(4); backend.argmax(*lb,5,*ib); uint32_t index=99; backend.read(*ib,0,&index,4); if(index!=1){fprintf(stderr,"argmax: got %u want 1\n",index);failures++;}
+
+    return failures;
+}
+
+int test_attention(q27::MetalBackend& backend) {
+    constexpr uint32_t seq=3,qh=2,kvh=1,dim=4,stride=8;
+    auto kc=backend.allocate(seq*kvh*dim*2), vc=backend.allocate(seq*kvh*dim*2);
+    const std::vector<std::vector<float>> keys={{1,0,0,0},{0,1,0,0},{1,1,0,0}};
+    const std::vector<std::vector<float>> vals={{1,2,3,4},{2,0,1,3},{4,3,2,1}};
+    for(uint32_t p=0;p<seq;p++){auto k=upload_buffer(backend,keys[p]),v=upload_buffer(backend,vals[p]);backend.kv_store(*k,*v,*kc,*vc,p,kvh,dim,q27::KvFormat::F16);}
+    std::vector<float> q={1,.5f,0,0, 9,9,9,9, 0,1,0,0, 8,8,8,8}; auto qb=upload_buffer(backend,q);
+    auto out=backend.allocate(qh*dim*4);
+    backend.attention(*qb,stride,*kc,*vc,*out,seq,qh,kvh,dim,0.5f,q27::KvFormat::F16,nullptr); auto got=read_f32(backend,*out,qh*dim);
+    int failures=0;
+    for(uint32_t h=0;h<qh;h++){std::vector<float>s(seq);float mx=-1e30f;for(uint32_t p=0;p<seq;p++){s[p]=0;for(uint32_t d=0;d<dim;d++)s[p]+=q[h*stride+d]*keys[p][d];s[p]*=.5f;mx=std::max(mx,s[p]);}float den=0;for(float&v:s){v=std::exp(v-mx);den+=v;}for(float&v:s)v/=den;for(uint32_t d=0;d<dim;d++){float want=0;for(uint32_t p=0;p<seq;p++)want+=s[p]*vals[p][d];if(!near(got[h*dim+d],want,8e-4f)){fprintf(stderr,"attention[%u,%u] got %.8g want %.8g\n",h,d,got[h*dim+d],want);failures++;}}}
+    return failures;
+}
+
+int test_unsupported_kv_formats(q27::MetalBackend& backend) {
+    constexpr uint32_t qh = 2, kvh = 1, dim = 256;
+    std::vector<float> kv(dim), q(qh * dim);
+    auto k = upload_buffer(backend, kv), v = upload_buffer(backend, kv);
+    auto query = upload_buffer(backend, q);
+    auto kc = backend.allocate(dim * 2), vc = backend.allocate(dim * 2);
+    auto out = backend.allocate(qh * dim * 4);
+    int failures = 0;
+    auto expect_unsupported = [&](const char* operation, auto&& call) {
+        try {
+            call();
+            fprintf(stderr, "%s accepted an unsupported KV format\n", operation);
+            failures++;
+        } catch (const std::runtime_error& error) {
+            if (std::string(error.what()).find("unsupported KV format") == std::string::npos) {
+                fprintf(stderr, "%s rejected for the wrong reason: %s\n", operation, error.what());
+                failures++;
+            }
+        }
+    };
+    const q27::KvFormat unsupported[] = {
+        q27::KvFormat::FP8_E4M3,
+        q27::KvFormat::TURBO3V,
+        q27::KvFormat::TURBO5K,
+        static_cast<q27::KvFormat>(0xff),
+    };
+    for (q27::KvFormat format : unsupported) {
+        expect_unsupported("kv_store", [&] {
+            backend.kv_store(*k, *v, *kc, *vc, 0, kvh, dim, format);
+        });
+        expect_unsupported("attention", [&] {
+            backend.attention(*query, dim, *kc, *vc, *out, 1, qh, kvh, dim,
+                              1.0f / 16.0f, format, nullptr);
+        });
+        expect_unsupported("kv_store_rows", [&] {
+            backend.kv_store_rows(*k, *v, *kc, *vc, 0, kvh, dim, 1, format);
+        });
+        expect_unsupported("attention_causal", [&] {
+            backend.attention_causal(*query, dim, qh * dim, *kc, *vc, *out,
+                                     1, qh, kvh, dim, 1, 1.0f / 16.0f,
+                                     format, nullptr);
+        });
+    }
+    for (q27::KvFormat format : {q27::KvFormat::F16, q27::KvFormat::TURBO3}) {
+        try {
+            backend.attention_causal(*query, dim, qh * dim, *kc, *vc, *out,
+                                     UINT32_MAX, qh, kvh, dim, 2, 1.0f / 16.0f,
+                                     format, nullptr);
+            fprintf(stderr, "attention_causal accepted an overflowing sequence length\n");
+            failures++;
+        } catch (const std::runtime_error& error) {
+            if (std::string(error.what()).find("sequence length overflow") == std::string::npos) {
+                fprintf(stderr, "attention_causal overflow rejected for the wrong reason: %s\n",
+                        error.what());
+                failures++;
+            }
+        }
+    }
+    return failures;
+}
+
+// Production-shape gate for the online-softmax decode kernel: 24:4 GQA at
+// head_dim 256 with sequence lengths that exercise unequal simdgroup stripes
+// (133), empty stripes (5), and running-max updates (scores swing sign and
+// magnitude across positions). The tiny test above cannot reach any of that.
+int test_attention_production_shape(q27::MetalBackend& backend) {
+    int failures = 0;
+    uint32_t lcg = 12345;
+    auto uniform = [&]() { lcg = lcg * 1664525u + 1013904223u; return (float)(lcg >> 8) / 8388608.0f - 1.0f; };
+    for (uint32_t seq : {5u, 133u}) {
+        constexpr uint32_t qh = 24, kvh = 4, dim = 256, stride = 2 * dim;
+        const float scale = 1.0f / 16.0f;
+        std::vector<std::vector<float>> keys(seq), vals(seq);
+        auto kc = backend.allocate((uint64_t)seq * kvh * dim * 2);
+        auto vc = backend.allocate((uint64_t)seq * kvh * dim * 2);
+        for (uint32_t p = 0; p < seq; p++) {
+            keys[p].resize(kvh * dim); vals[p].resize(kvh * dim);
+            // Alternate key magnitudes so the running maximum keeps moving.
+            const float magnitude = (p % 3 == 0) ? 2.5f : 0.4f;
+            for (auto& value : keys[p]) value = uniform() * magnitude;
+            for (auto& value : vals[p]) value = uniform() * 3.0f;
+            auto kb = upload_buffer(backend, keys[p]), vb = upload_buffer(backend, vals[p]);
+            backend.kv_store(*kb, *vb, *kc, *vc, p, kvh, dim, q27::KvFormat::F16);
+        }
+        // Half-precision K/V for the CPU reference, matching what the cache holds.
+        auto as_half = [](float v) { return (float)(_Float16)v; };
+        std::vector<float> q((uint64_t)qh * stride);
+        for (auto& value : q) value = uniform() * 1.5f;
+        auto qb = upload_buffer(backend, q);
+        auto out = backend.allocate((uint64_t)qh * dim * 4);
+        backend.attention(*qb, stride, *kc, *vc, *out, seq, qh, kvh, dim, scale,
+                          q27::KvFormat::F16, nullptr);
+        auto got = read_f32(backend, *out, (uint64_t)qh * dim);
+        for (uint32_t h = 0; h < qh; h++) {
+            const uint32_t kh = h / (qh / kvh);
+            std::vector<float> s(seq);
+            float mx = -1e30f;
+            for (uint32_t p = 0; p < seq; p++) {
+                s[p] = 0;
+                for (uint32_t d = 0; d < dim; d++) s[p] += q[h * stride + d] * as_half(keys[p][kh * dim + d]);
+                s[p] *= scale;
+                mx = std::max(mx, s[p]);
+            }
+            float den = 0;
+            for (float& value : s) { value = std::exp(value - mx); den += value; }
+            for (float& value : s) value /= den;
+            for (uint32_t d = 0; d < dim; d++) {
+                float want = 0;
+                for (uint32_t p = 0; p < seq; p++) want += s[p] * as_half(vals[p][kh * dim + d]);
+                if (!near(got[h * dim + d], want, 2e-3f)) {
+                    fprintf(stderr, "attention prod seq=%u [%u,%u] got %.8g want %.8g\n",
+                            seq, h, d, got[h * dim + d], want);
+                    failures++;
+                }
+            }
+        }
+    }
+    return failures;
+}
+
+int test_turbo3(q27::MetalBackend& backend) {
+    constexpr uint32_t seq=3,qh=2,kvh=1,dim=256,stride=256;
+    int failures=0;
+
+    // The signed randomized Hadamard transform must invert independently for
+    // both 128-element groups in every head.
+    std::vector<float> original(qh*dim);
+    for(size_t i=0;i<original.size();i++) original[i]=std::sin(float(i)*.071f)+.1f*std::cos(float(i)*.013f);
+    auto roundtrip=upload_buffer(backend,original);
+    backend.begin_commands(); backend.turbo_wht(*roundtrip,qh,stride,false); backend.turbo_wht(*roundtrip,qh,stride,true); backend.end_commands();
+    auto restored=read_f32(backend,*roundtrip,original.size());
+    for(size_t i=0;i<original.size();i++) if(!near(restored[i],original[i],2e-5f)) {
+        fprintf(stderr,"turbo3 WHT roundtrip[%zu] got %.8g want %.8g\n",i,restored[i],original[i]); failures++; break;
+    }
+
+    auto k16=backend.allocate((uint64_t)seq*kvh*dim*2), v16=backend.allocate((uint64_t)seq*kvh*dim*2);
+    auto kt3=backend.allocate((uint64_t)seq*kvh*2*50), vt3=backend.allocate((uint64_t)seq*kvh*2*50);
+    // Zero maps to centroid index 4: low two bits are all zero and every
+    // separately packed high bit is one. This catches leakage of bit 2 into
+    // the neighboring 2-bit fields.
+    std::vector<float> zeros(dim,0); auto zerob=upload_buffer(backend,zeros);
+    backend.kv_store(*zerob,*zerob,*kt3,*vt3,0,kvh,dim,q27::KvFormat::TURBO3);
+    std::vector<uint8_t> zero_block(50); backend.read(*kt3,0,zero_block.data(),zero_block.size());
+    for(size_t i=2;i<34;i++) if(zero_block[i]!=0) { fprintf(stderr,"turbo3 low-bit packing[%zu]=%u\n",i,zero_block[i]); failures++; break; }
+    for(size_t i=34;i<50;i++) if(zero_block[i]!=255) { fprintf(stderr,"turbo3 high-bit packing[%zu]=%u\n",i,zero_block[i]); failures++; break; }
+    for(uint32_t p=0;p<seq;p++) {
+        std::vector<float> k(dim),v(dim);
+        for(uint32_t d=0;d<dim;d++) {
+            k[d]=.45f*std::sin(float(d+17*p)*.039f)+.08f*std::cos(float(d)*.11f);
+            v[d]=.6f*std::cos(float(d+9*p)*.027f)-.12f*std::sin(float(d)*.07f);
+        }
+        auto kb=upload_buffer(backend,k),vb=upload_buffer(backend,v);
+        backend.kv_store(*kb,*vb,*k16,*v16,p,kvh,dim,q27::KvFormat::F16);
+        backend.kv_store(*kb,*vb,*kt3,*vt3,p,kvh,dim,q27::KvFormat::TURBO3);
+    }
+    std::vector<float> q(qh*dim);
+    for(size_t i=0;i<q.size();i++) q[i]=.2f*std::sin(float(i)*.031f)+.1f*std::cos(float(i)*.053f);
+    auto qbase=upload_buffer(backend,q),qt3=upload_buffer(backend,q);
+    auto out16=backend.allocate((uint64_t)qh*dim*4),out3=backend.allocate((uint64_t)qh*dim*4);
+    backend.attention(*qbase,stride,*k16,*v16,*out16,seq,qh,kvh,dim,
+                      1/std::sqrt(float(dim)),q27::KvFormat::F16,nullptr);
+    backend.begin_commands();
+    backend.turbo_wht(*qt3,qh,stride,false);
+    backend.attention(*qt3,stride,*kt3,*vt3,*out3,seq,qh,kvh,dim,
+                      1/std::sqrt(float(dim)),q27::KvFormat::TURBO3,nullptr);
+    backend.turbo_wht(*out3,qh,dim,true);
+    backend.end_commands();
+    auto baseline=read_f32(backend,*out16,qh*dim),compressed=read_f32(backend,*out3,qh*dim);
+    double signal=0,error=0,dot=0,norm3=0;
+    for(size_t i=0;i<baseline.size();i++) { signal+=baseline[i]*baseline[i]; double e=compressed[i]-baseline[i]; error+=e*e; dot+=compressed[i]*baseline[i]; norm3+=compressed[i]*compressed[i]; }
+    const double nrmse=std::sqrt(error/std::max(signal,1e-30));
+    const double cosine=dot/std::sqrt(std::max(signal*norm3,1e-30));
+    printf("turbo3 synthetic attention: nrmse %.5f, cosine %.6f\n",nrmse,cosine);
+    // This intentionally measures the complete lossy K+V path, not just the
+    // reversible WHT. Keep the bound below the observed failure modes for a
+    // broken sign/group mapping while allowing the 3-bit codec's expected loss.
+    if(nrmse>.30 || cosine<.95) { fprintf(stderr,"turbo3 attention quality: nrmse %.5f cosine %.6f\n",nrmse,cosine); failures++; }
+    return failures;
+}
+
+// Production-shape gate for the online-softmax turbo3 decode kernel: 24:4
+// GQA at head_dim 256 with sequence lengths exercising empty simdgroup
+// stripes (5) and multi-stripe running-max updates (133, key magnitudes
+// alternate so the maximum keeps moving). The CPU reference dequantizes the
+// stored 50-byte blocks, so it checks the kernel's attention math exactly;
+// codec loss is the separate quality gate above.
+int test_turbo3_production_shape(q27::MetalBackend& backend) {
+    constexpr float centroids[8] = {
+        -0.190207f, -0.118786f, -0.066822f, -0.021663f,
+         0.021663f,  0.066822f,  0.118786f,  0.190207f };
+    auto dequant = [&](const uint8_t* block, uint32_t j) {
+        const uint32_t low = (block[2 + (j >> 2)] >> ((j & 3) * 2)) & 3;
+        const uint32_t high = (block[34 + (j >> 3)] >> (j & 7)) & 1;
+        _Float16 h; __builtin_memcpy(&h, block, 2);
+        return centroids[low | (high << 2)] * (float)h;
+    };
+    int failures = 0;
+    uint32_t lcg = 54321;
+    auto uniform = [&]() { lcg = lcg * 1664525u + 1013904223u; return (float)(lcg >> 8) / 8388608.0f - 1.0f; };
+    for (uint32_t seq : {5u, 133u}) {
+        constexpr uint32_t qh = 24, kvh = 4, dim = 256, stride = 2 * dim;
+        const float scale = 1.0f / 16.0f;
+        const uint64_t row_bytes = (uint64_t)kvh * 2 * 50;
+        auto kc = backend.allocate(seq * row_bytes);
+        auto vc = backend.allocate(seq * row_bytes);
+        for (uint32_t p = 0; p < seq; p++) {
+            std::vector<float> k(kvh * dim), v(kvh * dim);
+            const float magnitude = (p % 3 == 0) ? 2.5f : 0.4f;
+            for (auto& value : k) value = uniform() * magnitude;
+            for (auto& value : v) value = uniform() * 3.0f;
+            auto kb = upload_buffer(backend, k), vb = upload_buffer(backend, v);
+            backend.kv_store(*kb, *vb, *kc, *vc, p, kvh, dim, q27::KvFormat::TURBO3);
+        }
+        std::vector<uint8_t> k_blocks(seq * row_bytes), v_blocks(seq * row_bytes);
+        backend.read(*kc, 0, k_blocks.data(), k_blocks.size());
+        backend.read(*vc, 0, v_blocks.data(), v_blocks.size());
+        std::vector<float> q((uint64_t)qh * stride);
+        for (auto& value : q) value = uniform() * 1.5f;
+        auto qb = upload_buffer(backend, q);
+        backend.turbo_wht(*qb, qh, stride, false);
+        auto q_wht = read_f32(backend, *qb, q.size());
+        auto out = backend.allocate((uint64_t)qh * dim * 4);
+        backend.attention(*qb, stride, *kc, *vc, *out, seq, qh, kvh, dim, scale,
+                          q27::KvFormat::TURBO3, nullptr);
+        auto got = read_f32(backend, *out, (uint64_t)qh * dim);
+        for (uint32_t h = 0; h < qh; h++) {
+            const uint32_t kh = h / (qh / kvh);
+            std::vector<float> s(seq);
+            float mx = -1e30f;
+            for (uint32_t p = 0; p < seq; p++) {
+                s[p] = 0;
+                for (uint32_t d = 0; d < dim; d++) {
+                    const uint8_t* block =
+                        k_blocks.data() + ((uint64_t)p * kvh * 2 + kh * 2 + (d >> 7)) * 50;
+                    s[p] += q_wht[h * stride + d] * dequant(block, d & 127);
+                }
+                s[p] *= scale;
+                mx = std::max(mx, s[p]);
+            }
+            float den = 0;
+            for (float& value : s) { value = std::exp(value - mx); den += value; }
+            for (float& value : s) value /= den;
+            for (uint32_t d = 0; d < dim; d++) {
+                float want = 0;
+                for (uint32_t p = 0; p < seq; p++) {
+                    const uint8_t* block =
+                        v_blocks.data() + ((uint64_t)p * kvh * 2 + kh * 2 + (d >> 7)) * 50;
+                    want += s[p] * dequant(block, d & 127);
+                }
+                if (!near(got[h * dim + d], want, 2e-3f)) {
+                    fprintf(stderr, "turbo3 prod seq=%u [%u,%u] got %.8g want %.8g\n",
+                            seq, h, d, got[h * dim + d], want);
+                    failures++;
+                }
+            }
+        }
+    }
+    return failures;
+}
+
+int test_gdn(q27::MetalBackend& backend) {
+    int failures=0;
+    // Gates.
+    std::vector<float> alpha={-30.1f,.3f}, br={-1,2}, av={-.5f,-.25f}, dtv={.1f,-.2f};
+    auto ab=upload_buffer(backend,alpha), brb=upload_buffer(backend,br), go=backend.allocate(8), bo=backend.allocate(8);
+    auto at=upload_f32(backend,av,{2}), dtt=upload_f32(backend,dtv,{2}); backend.gdn_gates(*ab,*brb,at,dtt,*go,*bo,2);
+    auto gg=read_f32(backend,*go,2), bg=read_f32(backend,*bo,2); for(int i=0;i<2;i++){float z=alpha[i]+dtv[i],sp=z>20?z:std::log1p(std::exp(z)),gw=av[i]*sp,bw=1/(1+std::exp(-br[i]));if(!near(gg[i],gw)||!near(bg[i],bw)){fprintf(stderr,"gates[%d] mismatch\n",i);failures++;}}
+    const float tail_want=av[0]*std::log1p(std::exp(alpha[0]+dtv[0]));
+    if(std::fabs(gg[0]-tail_want)>std::fabs(tail_want)*1e-3f){fprintf(stderr,"gates negative-tail mismatch %.8g %.8g\n",gg[0],tail_want);failures++;}
+
+    // Convolution ring update.
+    constexpr uint32_t channels=7; std::vector<float> ring(channels*3),qkv(channels),cw(channels*4),conv_want(channels),ring_want(ring.size());
+    for(size_t i=0;i<ring.size();i++)ring[i]=(float)((int)i-5)*.03f;for(uint32_t i=0;i<channels;i++){qkv[i]=(int(i)-2)*.1f;for(int t=0;t<4;t++)cw[i*4+t]=.05f*(t+1);float z=ring[i]*cw[i*4]+ring[channels+i]*cw[i*4+1]+ring[2*channels+i]*cw[i*4+2]+qkv[i]*cw[i*4+3];conv_want[i]=z/(1+std::exp(-z));ring_want[i]=ring[channels+i];ring_want[channels+i]=ring[2*channels+i];ring_want[2*channels+i]=qkv[i];}
+    auto ringb=upload_buffer(backend,ring),qkvb=upload_buffer(backend,qkv),co=backend.allocate(channels*4);auto cwt=upload_f32(backend,cw,{channels,4});backend.conv_step(*ringb,*ringb,*qkvb,cwt,*co,channels);
+    auto cg=read_f32(backend,*co,channels),rr=read_f32(backend,*ringb,ring.size());for(size_t i=0;i<cg.size();i++)if(!near(cg[i],conv_want[i]))failures++;for(size_t i=0;i<rr.size();i++)if(!near(rr[i],ring_want[i]))failures++;
+
+    // Full 128x128 DeltaNet recurrence on three value heads.
+    constexpr uint32_t vh=3,qkh=16,hd=128; const size_t state_n=(size_t)vh*hd*hd,conv_n=(qkh*2+vh)*hd;
+    std::vector<float> state(state_n), cv(conv_n), decay={-.04f,-.02f,-.06f}, beta={.3f,.7f,.5f};
+    for(size_t i=0;i<state.size();i++)state[i]=(int(i%17)-8)*.0005f;for(size_t i=0;i<cv.size();i++)cv[i]=(int(i%23)-11)*.01f;
+    std::vector<float> state_want(state_n), out_want(vh*hd);
+    for(uint32_t h=0;h<vh;h++){uint32_t qk=h%qkh;float de=std::exp(decay[h]);for(uint32_t j=0;j<hd;j++){float pred=0;for(uint32_t i=0;i<hd;i++)pred+=cv[2048+qk*hd+i]*(state[((size_t)h*hd+i)*hd+j]*de);float dv=beta[h]*(cv[4096+h*hd+j]-pred),ov=0;for(uint32_t i=0;i<hd;i++){float sv=state[((size_t)h*hd+i)*hd+j]*de+cv[2048+qk*hd+i]*dv;state_want[((size_t)h*hd+i)*hd+j]=sv;ov+=cv[qk*hd+i]/std::sqrt(128.0f)*sv;}out_want[h*hd+j]=ov;}}
+    auto sb=upload_buffer(backend,state), cvb=upload_buffer(backend,cv), db=upload_buffer(backend,decay), betab=upload_buffer(backend,beta), dout=backend.allocate(vh*hd*4);
+    backend.delta_step(*sb,*sb,*cvb,*db,*betab,*dout,vh,qkh,hd);auto sg=read_f32(backend,*sb,state_n),og=read_f32(backend,*dout,vh*hd);
+    for(size_t i=0;i<sg.size();i++)if(!near(sg[i],state_want[i],2e-3f)){fprintf(stderr,"delta state[%zu] mismatch %.8g %.8g\n",i,sg[i],state_want[i]);failures++;break;}
+    for(size_t i=0;i<og.size();i++)if(!near(og[i],out_want[i],2e-3f)){fprintf(stderr,"delta out[%zu] mismatch %.8g %.8g\n",i,og[i],out_want[i]);failures++;break;}
+
+    std::vector<float> nw(hd,1.1f), gate(vh*hd);for(size_t i=0;i<gate.size();i++)gate[i]=(int(i%13)-6)*.1f;
+    auto nwt=upload_f32(backend,nw,{hd}); auto gateb=upload_buffer(backend,gate); auto normout=backend.allocate(vh*hd*4);
+    backend.gated_norm_gdn(*dout,nwt,*gateb,*normout,vh,hd,1e-6f);auto ng=read_f32(backend,*normout,vh*hd);
+    for(uint32_t h=0;h<vh;h++){float ss=0;for(uint32_t d=0;d<hd;d++)ss+=out_want[h*hd+d]*out_want[h*hd+d];float ni=1/std::sqrt(ss/hd+1e-6f);for(uint32_t d=0;d<hd;d++){size_t i=h*hd+d;float want=out_want[i]*ni*nw[d]*(gate[i]/(1+std::exp(-gate[i])));if(!near(ng[i],want,2e-3f)){fprintf(stderr,"gated norm[%zu] mismatch\n",i);failures++;break;}}}
+    return failures;
+}
+
+uint16_t to_half(float value) {
+    _Float16 h = (_Float16)value;
+    uint16_t bits; __builtin_memcpy(&bits, &h, sizeof(bits));
+    return bits;
+}
+
+// Every chunked layer-major operation must reproduce the token-serial path
+// it replaces: the serial kernels are the validated reference.
+int test_chunked(q27::MetalBackend& backend) {
+    int failures = 0;
+    constexpr uint32_t T = 3;
+    auto fail = [&](const char* name, size_t i, float got, float want) {
+        fprintf(stderr, "chunked %s[%zu]: got %.8g want %.8g\n", name, i, got, want);
+        failures++;
+    };
+    auto row_view = [&](const q27::BackendBuffer& src, size_t row, size_t floats) {
+        auto tmp = backend.allocate(floats * 4);
+        backend.copy(src, row * floats * 4, *tmp, 0, floats * 4);
+        return tmp;
+    };
+
+    // Chunked Q8 embedding.
+    {
+        constexpr uint32_t vocab = 4, cols = 128;
+        std::vector<int8_t> ew(vocab * cols);
+        for (size_t i = 0; i < ew.size(); i++) ew[i] = (int8_t)((int)(i % 29) - 14);
+        std::vector<uint16_t> es = {0x3c00, 0x3800, 0x4000, 0x3400};
+        q27::Tensor et; et.name="embedding"; et.dtype=q27::DType::Q8_G128; et.shape={vocab,cols};
+        et.data=(const uint8_t*)ew.data(); et.data_size=ew.size();
+        et.scales=(const uint8_t*)es.data(); et.scales_size=es.size()*2;
+        auto weight = backend.upload(et);
+        const uint32_t tokens[T] = {2, 0, 3};
+        auto chunk = backend.allocate((uint64_t)T * cols * 4);
+        backend.embedding_q8_rows(weight, tokens, T, *chunk);
+        auto serial = backend.allocate(cols * 4);
+        for (uint32_t t = 0; t < T; t++) {
+            backend.embedding_q8(weight, tokens[t], *serial);
+            auto got = read_f32(backend, *chunk, (size_t)T * cols);
+            auto want = read_f32(backend, *serial, cols);
+            for (uint32_t i = 0; i < cols; i++)
+                if (got[t * cols + i] != want[i]) { fail("embedding", t * cols + i, got[t*cols+i], want[i]); break; }
+        }
+    }
+
+    // Chunked fused RMSNorm + quantization.
+    {
+        constexpr uint32_t n = 64;
+        std::vector<float> x(T * n), w(n);
+        for (size_t i = 0; i < x.size(); i++) x[i] = std::sin(float(i) * .37f) * (1.0f + float(i % 5));
+        for (size_t i = 0; i < n; i++) w[i] = 0.5f + float(i % 3);
+        auto xb = upload_buffer(backend, x); auto wt = upload_f32(backend, w, {n});
+        auto chunk_out = backend.allocate((uint64_t)T * n * 4);
+        auto chunk_q = backend.allocate_quantized(T * n);
+        backend.rmsnorm_rows_quantized(*xb, wt, *chunk_out, n, T, 1e-6f, chunk_q);
+        std::vector<int8_t> chunk_values(T * n); std::vector<float> chunk_scales(T * n / 32);
+        backend.read(*chunk_q.values, 0, chunk_values.data(), chunk_values.size());
+        backend.read(*chunk_q.scales, 0, chunk_scales.data(), chunk_scales.size() * 4);
+        auto chunk_f = read_f32(backend, *chunk_out, (size_t)T * n);
+        auto serial_out = backend.allocate(n * 4); auto serial_q = backend.allocate_quantized(n);
+        for (uint32_t t = 0; t < T; t++) {
+            auto row = row_view(*xb, t, n);
+            backend.rmsnorm_quantized(*row, wt, *serial_out, n, 1e-6f, serial_q);
+            auto want_f = read_f32(backend, *serial_out, n);
+            std::vector<int8_t> want_values(n); std::vector<float> want_scales(n / 32);
+            backend.read(*serial_q.values, 0, want_values.data(), n);
+            backend.read(*serial_q.scales, 0, want_scales.data(), want_scales.size() * 4);
+            for (uint32_t i = 0; i < n; i++)
+                if (chunk_f[t*n+i] != want_f[i] || chunk_values[t*n+i] != want_values[i])
+                    { fail("rmsnorm rows", t*n+i, chunk_f[t*n+i], want_f[i]); break; }
+            for (uint32_t b = 0; b < n / 32; b++)
+                if (chunk_scales[t*(n/32)+b] != want_scales[b]) { fail("rmsnorm rows scale", t*(n/32)+b, chunk_scales[t*(n/32)+b], want_scales[b]); break; }
+        }
+    }
+
+    // Chunked F16 projection pair.
+    {
+        constexpr uint32_t rows_a = 5, rows_b = 3, cols = 32;
+        std::vector<uint16_t> wa(rows_a * cols), wb(rows_b * cols);
+        for (size_t i = 0; i < wa.size(); i++) wa[i] = to_half(((int)(i % 11) - 5) * 0.25f);
+        for (size_t i = 0; i < wb.size(); i++) wb[i] = to_half(((int)(i % 9) - 4) * 0.5f);
+        q27::Tensor ta; ta.name="pair-a"; ta.dtype=q27::DType::F16; ta.shape={rows_a,cols};
+        ta.data=(const uint8_t*)wa.data(); ta.data_size=wa.size()*2;
+        q27::Tensor tb; tb.name="pair-b"; tb.dtype=q27::DType::F16; tb.shape={rows_b,cols};
+        tb.data=(const uint8_t*)wb.data(); tb.data_size=wb.size()*2;
+        auto weight_a = backend.upload(ta); auto weight_b = backend.upload(tb);
+        std::vector<float> x(T * cols);
+        for (size_t i = 0; i < x.size(); i++) x[i] = std::cos(float(i) * .21f);
+        auto xb = upload_buffer(backend, x);
+        auto chunk_a = backend.allocate((uint64_t)T * rows_a * 4);
+        auto chunk_b = backend.allocate((uint64_t)T * rows_b * 4);
+        backend.matvec_f16_pair_rows(weight_a, *chunk_a, weight_b, *chunk_b, *xb, T);
+        auto got_a = read_f32(backend, *chunk_a, (size_t)T * rows_a);
+        auto got_b = read_f32(backend, *chunk_b, (size_t)T * rows_b);
+        auto serial_a = backend.allocate(rows_a * 4); auto serial_b = backend.allocate(rows_b * 4);
+        for (uint32_t t = 0; t < T; t++) {
+            auto row = row_view(*xb, t, cols);
+            backend.matvec_pair(weight_a, *serial_a, weight_b, *serial_b, *row);
+            auto want_a = read_f32(backend, *serial_a, rows_a);
+            auto want_b = read_f32(backend, *serial_b, rows_b);
+            for (uint32_t i = 0; i < rows_a; i++)
+                if (got_a[t*rows_a+i] != want_a[i]) { fail("pair rows A", t*rows_a+i, got_a[t*rows_a+i], want_a[i]); break; }
+            for (uint32_t i = 0; i < rows_b; i++)
+                if (got_b[t*rows_b+i] != want_b[i]) { fail("pair rows B", t*rows_b+i, got_b[t*rows_b+i], want_b[i]); break; }
+        }
+    }
+
+    // Chunked GDN gates.
+    {
+        constexpr uint32_t heads = 4;
+        std::vector<float> alpha(T * heads), braw(T * heads), av(heads), dtv(heads);
+        for (size_t i = 0; i < alpha.size(); i++) { alpha[i] = std::sin(float(i)) * 2; braw[i] = std::cos(float(i)); }
+        for (size_t i = 0; i < heads; i++) { av[i] = -0.1f - 0.2f * float(i); dtv[i] = 0.3f - 0.1f * float(i); }
+        alpha[0] = -30.0f - dtv[0];
+        auto ab = upload_buffer(backend, alpha); auto bb = upload_buffer(backend, braw);
+        auto at = upload_f32(backend, av, {heads}); auto dtt = upload_f32(backend, dtv, {heads});
+        auto cgo = backend.allocate((uint64_t)T * heads * 4); auto cbo = backend.allocate((uint64_t)T * heads * 4);
+        backend.gdn_gates_rows(*ab, *bb, at, dtt, *cgo, *cbo, heads, T);
+        auto got_g = read_f32(backend, *cgo, T * heads); auto got_b = read_f32(backend, *cbo, T * heads);
+        const float tail_want = av[0] * std::log1p(std::exp(-30.0f));
+        if (std::fabs(got_g[0] - tail_want) > std::fabs(tail_want) * 1e-3f)
+            { fprintf(stderr, "gates rows negative-tail mismatch %.8g %.8g\n", got_g[0], tail_want); failures++; }
+        auto sgo = backend.allocate(heads * 4); auto sbo = backend.allocate(heads * 4);
+        for (uint32_t t = 0; t < T; t++) {
+            auto arow = row_view(*ab, t, heads); auto brow = row_view(*bb, t, heads);
+            backend.gdn_gates(*arow, *brow, at, dtt, *sgo, *sbo, heads);
+            auto want_g = read_f32(backend, *sgo, heads); auto want_b = read_f32(backend, *sbo, heads);
+            for (uint32_t i = 0; i < heads; i++)
+                if (got_g[t*heads+i] != want_g[i] || got_b[t*heads+i] != want_b[i])
+                    { fail("gates rows", t*heads+i, got_g[t*heads+i], want_g[i]); break; }
+        }
+    }
+
+    // Chunked convolution ring: one dispatch must match T serial steps and
+    // leave the identical ring state.
+    {
+        constexpr uint32_t channels = 7;
+        std::vector<float> ring(channels * 3), qkv(T * channels), cw(channels * 4);
+        for (size_t i = 0; i < ring.size(); i++) ring[i] = std::sin(float(i) * .61f);
+        for (size_t i = 0; i < qkv.size(); i++) qkv[i] = std::cos(float(i) * .43f);
+        for (size_t i = 0; i < cw.size(); i++) cw[i] = 0.05f * float((int)(i % 9) - 4);
+        auto cwt = upload_f32(backend, cw, {channels, 4});
+        auto ring_serial = upload_buffer(backend, ring); auto ring_chunk = upload_buffer(backend, ring);
+        auto qkvb = upload_buffer(backend, qkv);
+        auto chunk_out = backend.allocate((uint64_t)T * channels * 4);
+        backend.conv_chunk(*ring_chunk, *ring_chunk, *qkvb, cwt, *chunk_out, channels, T);
+        auto got = read_f32(backend, *chunk_out, (size_t)T * channels);
+        auto serial_out = backend.allocate(channels * 4);
+        for (uint32_t t = 0; t < T; t++) {
+            auto row = row_view(*qkvb, t, channels);
+            backend.conv_step(*ring_serial, *ring_serial, *row, cwt, *serial_out, channels);
+            auto want = read_f32(backend, *serial_out, channels);
+            for (uint32_t i = 0; i < channels; i++)
+                if (got[t*channels+i] != want[i]) { fail("conv chunk", t*channels+i, got[t*channels+i], want[i]); break; }
+        }
+        auto ring_a = read_f32(backend, *ring_serial, ring.size());
+        auto ring_b = read_f32(backend, *ring_chunk, ring.size());
+        for (size_t i = 0; i < ring.size(); i++)
+            if (ring_a[i] != ring_b[i]) { fail("conv chunk ring", i, ring_b[i], ring_a[i]); break; }
+    }
+
+    // Chunked DeltaNet recurrence: register-resident chunk state must match
+    // T serial device round trips.
+    {
+        constexpr uint32_t vh = 3, qkh = 16, hd = 128;
+        const size_t state_n = (size_t)vh * hd * hd, conv_row = (qkh * 2 + vh) * hd;
+        std::vector<float> state(state_n), cv(T * conv_row), g(T * vh), beta(T * vh);
+        for (size_t i = 0; i < state.size(); i++) state[i] = (int(i % 17) - 8) * .0005f;
+        for (size_t i = 0; i < cv.size(); i++) cv[i] = (int(i % 23) - 11) * .01f;
+        for (size_t i = 0; i < g.size(); i++) g[i] = -.01f - .002f * float(i % 7);
+        for (size_t i = 0; i < beta.size(); i++) beta[i] = .2f + .05f * float(i % 9);
+        auto state_serial = upload_buffer(backend, state); auto state_chunk = upload_buffer(backend, state);
+        auto cvb = upload_buffer(backend, cv); auto gb = upload_buffer(backend, g); auto betab = upload_buffer(backend, beta);
+        auto chunk_out = backend.allocate((uint64_t)T * vh * hd * 4);
+        backend.delta_chunk(*state_chunk, *state_chunk, *cvb, *gb, *betab, *chunk_out, vh, qkh, hd, T);
+        auto got = read_f32(backend, *chunk_out, (size_t)T * vh * hd);
+        auto serial_out = backend.allocate((uint64_t)vh * hd * 4);
+        for (uint32_t t = 0; t < T; t++) {
+            auto cv_row = row_view(*cvb, t, conv_row);
+            auto g_row = row_view(*gb, t, vh); auto beta_row = row_view(*betab, t, vh);
+            backend.delta_step(*state_serial, *state_serial, *cv_row, *g_row, *beta_row, *serial_out, vh, qkh, hd);
+            auto want = read_f32(backend, *serial_out, (size_t)vh * hd);
+            for (uint32_t i = 0; i < vh * hd; i++)
+                if (!near(got[t*vh*hd+i], want[i], 1e-5f)) { fail("delta chunk", t*vh*hd+i, got[t*vh*hd+i], want[i]); break; }
+        }
+        auto sa = read_f32(backend, *state_serial, state_n);
+        auto sb = read_f32(backend, *state_chunk, state_n);
+        for (size_t i = 0; i < state_n; i++)
+            if (!near(sa[i], sb[i], 1e-5f)) { fail("delta chunk state", i, sb[i], sa[i]); break; }
+    }
+
+    // MTP verification state discipline: a chunk writing state to a discard
+    // slot must leave live state bit-untouched with identical outputs, and
+    // replaying a K-token prefix afterwards (the acceptance path) must
+    // bit-match a directly committed K-token chunk. This is the partial
+    // acceptance contract that replaced the checkpoint/restore/re-encode.
+    {
+        constexpr uint32_t channels = 7, K = 2;
+        static_assert(K < T, "replay must cover a strict prefix");
+        std::vector<float> ring(channels * 3), qkv(T * channels), cw(channels * 4);
+        for (size_t i = 0; i < ring.size(); i++) ring[i] = std::cos(float(i) * .29f);
+        for (size_t i = 0; i < qkv.size(); i++) qkv[i] = std::sin(float(i) * .53f);
+        for (size_t i = 0; i < cw.size(); i++) cw[i] = 0.04f * float((int)(i % 7) - 3);
+        auto cwt = upload_f32(backend, cw, {channels, 4});
+        auto ring_live = upload_buffer(backend, ring);
+        auto ring_ref = upload_buffer(backend, ring);
+        auto ring_discard = backend.allocate((uint64_t)channels * 3 * 4);
+        auto qkvb = upload_buffer(backend, qkv);
+        auto out_full = backend.allocate((uint64_t)T * channels * 4);
+        auto out_prefix = backend.allocate((uint64_t)K * channels * 4);
+        auto out_replay = backend.allocate((uint64_t)K * channels * 4);
+        backend.conv_chunk(*ring_live, *ring_discard, *qkvb, cwt, *out_full, channels, T);
+        auto untouched = read_f32(backend, *ring_live, ring.size());
+        for (size_t i = 0; i < ring.size(); i++)
+            if (untouched[i] != ring[i]) { fail("conv discard ring", i, untouched[i], ring[i]); break; }
+        backend.conv_chunk(*ring_ref, *ring_ref, *qkvb, cwt, *out_prefix, channels, K);
+        backend.conv_chunk(*ring_live, *ring_live, *qkvb, cwt, *out_replay, channels, K);
+        auto want_ring = read_f32(backend, *ring_ref, ring.size());
+        auto got_ring = read_f32(backend, *ring_live, ring.size());
+        for (size_t i = 0; i < ring.size(); i++)
+            if (got_ring[i] != want_ring[i]) { fail("conv replay ring", i, got_ring[i], want_ring[i]); break; }
+        auto full = read_f32(backend, *out_full, (size_t)T * channels);
+        auto prefix = read_f32(backend, *out_prefix, (size_t)K * channels);
+        auto replay = read_f32(backend, *out_replay, (size_t)K * channels);
+        for (size_t i = 0; i < (size_t)K * channels; i++) {
+            if (full[i] != prefix[i]) { fail("conv prefix invariance", i, full[i], prefix[i]); break; }
+            if (replay[i] != prefix[i]) { fail("conv replay out", i, replay[i], prefix[i]); break; }
+        }
+    }
+    {
+        constexpr uint32_t vh = 3, qkh = 16, hd = 128, K = 2;
+        static_assert(K < T, "replay must cover a strict prefix");
+        const size_t state_n = (size_t)vh * hd * hd, conv_row = (qkh * 2 + vh) * hd;
+        std::vector<float> state(state_n), cv(T * conv_row), g(T * vh), beta(T * vh);
+        for (size_t i = 0; i < state.size(); i++) state[i] = (int(i % 13) - 6) * .0007f;
+        for (size_t i = 0; i < cv.size(); i++) cv[i] = (int(i % 19) - 9) * .012f;
+        for (size_t i = 0; i < g.size(); i++) g[i] = -.02f - .003f * float(i % 5);
+        for (size_t i = 0; i < beta.size(); i++) beta[i] = .15f + .04f * float(i % 7);
+        auto state_live = upload_buffer(backend, state);
+        auto state_ref = upload_buffer(backend, state);
+        auto state_discard = backend.allocate(state_n * 4);
+        auto cvb = upload_buffer(backend, cv);
+        auto gb = upload_buffer(backend, g); auto betab = upload_buffer(backend, beta);
+        auto out_full = backend.allocate((uint64_t)T * vh * hd * 4);
+        auto out_prefix = backend.allocate((uint64_t)K * vh * hd * 4);
+        auto out_replay = backend.allocate((uint64_t)K * vh * hd * 4);
+        backend.delta_chunk(*state_live, *state_discard, *cvb, *gb, *betab, *out_full, vh, qkh, hd, T);
+        auto untouched = read_f32(backend, *state_live, state_n);
+        for (size_t i = 0; i < state_n; i++)
+            if (untouched[i] != state[i]) { fail("delta discard state", i, untouched[i], state[i]); break; }
+        backend.delta_chunk(*state_ref, *state_ref, *cvb, *gb, *betab, *out_prefix, vh, qkh, hd, K);
+        backend.delta_chunk(*state_live, *state_live, *cvb, *gb, *betab, *out_replay, vh, qkh, hd, K);
+        auto want_state = read_f32(backend, *state_ref, state_n);
+        auto got_state = read_f32(backend, *state_live, state_n);
+        for (size_t i = 0; i < state_n; i++)
+            if (got_state[i] != want_state[i]) { fail("delta replay state", i, got_state[i], want_state[i]); break; }
+        auto full = read_f32(backend, *out_full, (size_t)T * vh * hd);
+        auto prefix = read_f32(backend, *out_prefix, (size_t)K * vh * hd);
+        auto replay = read_f32(backend, *out_replay, (size_t)K * vh * hd);
+        for (size_t i = 0; i < (size_t)K * vh * hd; i++) {
+            if (full[i] != prefix[i]) { fail("delta prefix invariance", i, full[i], prefix[i]); break; }
+            if (replay[i] != prefix[i]) { fail("delta replay out", i, replay[i], prefix[i]); break; }
+        }
+    }
+
+    // Chunked strided L2 norm (row stride exceeds the normalized span).
+    {
+        constexpr uint32_t heads = 2, hd = 4, row_stride = 12;
+        std::vector<float> x(T * row_stride);
+        for (size_t i = 0; i < x.size(); i++) x[i] = std::sin(float(i) * .83f) + .2f;
+        auto chunk = upload_buffer(backend, x);
+        backend.l2norm_rows(*chunk, heads, hd, row_stride, T, 1e-6f);
+        auto got = read_f32(backend, *chunk, x.size());
+        for (uint32_t t = 0; t < T; t++) {
+            std::vector<float> row(x.begin() + t * row_stride, x.begin() + t * row_stride + heads * hd);
+            auto serial = upload_buffer(backend, row);
+            backend.l2norm_heads(*serial, heads, hd, 1e-6f);
+            auto want = read_f32(backend, *serial, row.size());
+            for (uint32_t i = 0; i < heads * hd; i++)
+                if (got[t*row_stride+i] != want[i]) { fail("l2 rows", t*row_stride+i, got[t*row_stride+i], want[i]); break; }
+            for (uint32_t i = heads * hd; i < row_stride; i++)
+                if (got[t*row_stride+i] != x[t*row_stride+i]) { fail("l2 rows tail", t*row_stride+i, got[t*row_stride+i], x[t*row_stride+i]); break; }
+        }
+    }
+
+    // Chunked RoPE with per-token positions.
+    {
+        constexpr uint32_t heads = 2, hd = 8, n_rot = 4, stride = 8, row_stride = 16, base = 3;
+        std::vector<float> x(T * row_stride);
+        for (size_t i = 0; i < x.size(); i++) x[i] = std::cos(float(i) * .29f) * 2;
+        auto chunk = upload_buffer(backend, x);
+        backend.rope_neox_rows(*chunk, heads, hd, n_rot, stride, row_stride, base, T, 10000.0f);
+        auto got = read_f32(backend, *chunk, x.size());
+        for (uint32_t t = 0; t < T; t++) {
+            std::vector<float> row(x.begin() + t * row_stride, x.begin() + (t + 1) * row_stride);
+            auto serial = upload_buffer(backend, row);
+            backend.rope_neox(*serial, heads, hd, n_rot, stride, base + t, 10000.0f);
+            auto want = read_f32(backend, *serial, row.size());
+            for (uint32_t i = 0; i < row_stride; i++)
+                if (got[t*row_stride+i] != want[i]) { fail("rope rows", t*row_stride+i, got[t*row_stride+i], want[i]); break; }
+        }
+    }
+
+    // Chunked sigmoid gating.
+    {
+        constexpr uint32_t heads = 2, hd = 2;
+        std::vector<float> values(T * heads * hd), qg(T * heads * hd * 2);
+        for (size_t i = 0; i < values.size(); i++) values[i] = float(i % 7) - 3;
+        for (size_t i = 0; i < qg.size(); i++) qg[i] = std::sin(float(i) * 1.1f) * 2;
+        auto chunk = upload_buffer(backend, values); auto qgb = upload_buffer(backend, qg);
+        backend.sigmoid_gate_mul_rows(*chunk, *qgb, heads, hd, T);
+        auto got = read_f32(backend, *chunk, values.size());
+        for (uint32_t t = 0; t < T; t++) {
+            std::vector<float> row(values.begin() + t * heads * hd, values.begin() + (t + 1) * heads * hd);
+            std::vector<float> qg_row(qg.begin() + t * heads * hd * 2, qg.begin() + (t + 1) * heads * hd * 2);
+            auto serial = upload_buffer(backend, row); auto serial_qg = upload_buffer(backend, qg_row);
+            backend.sigmoid_gate_mul(*serial, *serial_qg, heads, hd);
+            auto want = read_f32(backend, *serial, row.size());
+            for (uint32_t i = 0; i < heads * hd; i++)
+                if (got[t*heads*hd+i] != want[i]) { fail("sigmoid rows", t*heads*hd+i, got[t*heads*hd+i], want[i]); break; }
+        }
+    }
+
+    // Chunked per-lane argmax, including the lower-index tie break.
+    {
+        constexpr uint32_t n = 300;
+        std::vector<float> logits(T * n);
+        for (size_t i = 0; i < logits.size(); i++) logits[i] = std::sin(float(i) * .7f) * 5;
+        logits[0 * n + 37] = 100; logits[1 * n + 4] = 100; logits[1 * n + 250] = 100;
+        auto lb = upload_buffer(backend, logits);
+        auto rows_out = backend.allocate(T * 4);
+        backend.argmax_rows(*lb, n, T, *rows_out);
+        std::vector<uint32_t> got(T); backend.read(*rows_out, 0, got.data(), T * 4);
+        auto serial_out = backend.allocate(4);
+        for (uint32_t t = 0; t < T; t++) {
+            auto row = row_view(*lb, t, n);
+            backend.argmax(*row, n, *serial_out);
+            uint32_t want = 0; backend.read(*serial_out, 0, &want, 4);
+            if (got[t] != want) fail("argmax rows", t, (float)got[t], (float)want);
+        }
+    }
+
+    // Teacher-forced NLL rows: logsumexp - target logit, including a wide
+    // vocab-like width so the 256-thread reduction walks multiple strides.
+    {
+        constexpr uint32_t n = 2048, rows = 13;
+        std::vector<float> logits(rows * n);
+        std::vector<uint32_t> targets(rows);
+        for (uint32_t t = 0; t < rows; t++) {
+            for (uint32_t v = 0; v < n; v++)
+                logits[t * n + v] = std::sin(float(t * 17 + v) * 0.11f) * 3.0f;
+            targets[t] = 100 + t * 37;
+            logits[t * n + targets[t]] += 2.5f;  // make the target distinctive
+        }
+        auto lb = upload_buffer(backend, logits);
+        auto tb = backend.allocate(rows * 4);
+        backend.write(*tb, 0, targets.data(), rows * 4);
+        auto nb = backend.allocate(rows * 4);
+        backend.nll_rows(*lb, *tb, *nb, n, rows);
+        std::vector<float> got(rows);
+        backend.read(*nb, 0, got.data(), rows * 4);
+        for (uint32_t t = 0; t < rows; t++) {
+            double mx = -1e300;
+            for (uint32_t v = 0; v < n; v++) mx = std::max(mx, (double)logits[t * n + v]);
+            double se = 0.0;
+            for (uint32_t v = 0; v < n; v++) se += std::exp((double)logits[t * n + v] - mx);
+            const float want = (float)(std::log(se) + mx - (double)logits[t * n + targets[t]]);
+            if (std::fabs(got[t] - want) > 1e-4f)
+                fail("nll rows", t, got[t], want);
+        }
+        targets[1] = n;
+        backend.write(*tb, 0, targets.data(), rows * 4);
+        backend.nll_rows(*lb, *tb, *nb, n, rows);
+        backend.read(*nb, 0, got.data(), rows * 4);
+        if (!std::isinf(got[1]) || got[1] < 0.0f)
+            { fprintf(stderr, "nll rows accepted out-of-range target: %.8g\n", got[1]); failures++; }
+    }
+
+    // Chunked FP16 KV append + causal attention over a warm cache.
+    {
+        constexpr uint32_t qh = 2, kvh = 1, dim = 4, stride = 8, row = kvh * dim, warm = 2;
+        auto kc = backend.allocate((uint64_t)(warm + T) * row * 2);
+        auto vc = backend.allocate((uint64_t)(warm + T) * row * 2);
+        for (uint32_t p = 0; p < warm; p++) {
+            std::vector<float> k(row), v(row);
+            for (uint32_t d = 0; d < row; d++) { k[d] = std::sin(float(p * row + d)); v[d] = std::cos(float(p * row + d)); }
+            auto kb = upload_buffer(backend, k); auto vb = upload_buffer(backend, v);
+            backend.kv_store(*kb, *vb, *kc, *vc, p, kvh, dim, q27::KvFormat::F16);
+        }
+        std::vector<float> knew(T * row), vnew(T * row), q(T * qh * stride);
+        for (size_t i = 0; i < knew.size(); i++) { knew[i] = std::sin(float(i) * .53f); vnew[i] = std::cos(float(i) * .31f); }
+        for (size_t i = 0; i < q.size(); i++) q[i] = std::sin(float(i) * .77f);
+        auto knb = upload_buffer(backend, knew); auto vnb = upload_buffer(backend, vnew);
+        backend.kv_store_rows(*knb, *vnb, *kc, *vc, warm, kvh, dim, T,
+                              q27::KvFormat::F16);
+        auto qb = upload_buffer(backend, q);
+        auto chunk_out = backend.allocate((uint64_t)T * qh * dim * 4);
+        backend.attention_causal(*qb, stride, qh * stride, *kc, *vc, *chunk_out,
+                                 warm + 1, qh, kvh, dim, T, 0.5f,
+                                 q27::KvFormat::F16, nullptr);
+        auto got = read_f32(backend, *chunk_out, (size_t)T * qh * dim);
+        auto serial_out = backend.allocate((uint64_t)qh * dim * 4);
+        for (uint32_t t = 0; t < T; t++) {
+            auto q_row = row_view(*qb, t, qh * stride);
+            backend.attention(*q_row, stride, *kc, *vc, *serial_out,
+                              warm + 1 + t, qh, kvh, dim, 0.5f,
+                              q27::KvFormat::F16, nullptr);
+            auto want = read_f32(backend, *serial_out, (size_t)qh * dim);
+            for (uint32_t i = 0; i < qh * dim; i++)
+                if (!near(got[t*qh*dim+i], want[i], 1e-5f)) { fail("causal attention", t*qh*dim+i, got[t*qh*dim+i], want[i]); break; }
+        }
+    }
+
+    // Production-shape chunk-causal attention (24:4 GQA, head_dim 256). The
+    // online-softmax chunk kernel mirrors the serial decode kernel exactly,
+    // so the comparison is bit-exact. warm=2 leaves most simdgroup stripes
+    // empty for the first chunk tokens; warm=130 exercises multi-stripe
+    // running-max updates at the decode gate's seq length (133).
+    for (uint32_t warm : {2u, 130u}) {
+        constexpr uint32_t qh = 24, kvh = 4, dim = 256, stride = 512, row = kvh * dim;
+        auto kc = backend.allocate((uint64_t)(warm + T) * row * 2);
+        auto vc = backend.allocate((uint64_t)(warm + T) * row * 2);
+        for (uint32_t p = 0; p < warm; p++) {
+            std::vector<float> k(row), v(row);
+            for (uint32_t d = 0; d < row; d++) {
+                k[d] = std::sin(float(p * 37 + d) * .021f) * (1.0f + float(p % 5));
+                v[d] = std::cos(float(p * 53 + d) * .013f);
+            }
+            auto kb = upload_buffer(backend, k); auto vb = upload_buffer(backend, v);
+            backend.kv_store(*kb, *vb, *kc, *vc, p, kvh, dim, q27::KvFormat::F16);
+        }
+        std::vector<float> knew(T * row), vnew(T * row), q(T * qh * stride);
+        for (size_t i = 0; i < knew.size(); i++) {
+            knew[i] = std::sin(float(i) * .0047f) * (1.0f + float(i % 7));
+            vnew[i] = std::cos(float(i) * .0031f);
+        }
+        for (size_t i = 0; i < q.size(); i++) q[i] = std::sin(float(i) * .0077f);
+        auto knb = upload_buffer(backend, knew); auto vnb = upload_buffer(backend, vnew);
+        backend.kv_store_rows(*knb, *vnb, *kc, *vc, warm, kvh, dim, T,
+                              q27::KvFormat::F16);
+        auto qb = upload_buffer(backend, q);
+        auto chunk_out = backend.allocate((uint64_t)T * qh * dim * 4);
+        backend.attention_causal(*qb, stride, qh * stride, *kc, *vc, *chunk_out,
+                                 warm + 1, qh, kvh, dim, T, 0.0625f,
+                                 q27::KvFormat::F16, nullptr);
+        auto got = read_f32(backend, *chunk_out, (size_t)T * qh * dim);
+        auto serial_out = backend.allocate((uint64_t)qh * dim * 4);
+        for (uint32_t t = 0; t < T; t++) {
+            auto q_row = row_view(*qb, t, qh * stride);
+            backend.attention(*q_row, stride, *kc, *vc, *serial_out,
+                              warm + 1 + t, qh, kvh, dim, 0.0625f,
+                              q27::KvFormat::F16, nullptr);
+            auto want = read_f32(backend, *serial_out, (size_t)qh * dim);
+            for (uint32_t i = 0; i < qh * dim; i++)
+                if (got[t*qh*dim+i] != want[i]) { fail("causal attention wide", t*qh*dim+i, got[t*qh*dim+i], want[i]); break; }
+        }
+    }
+
+    // Chunked turbo3 KV append + causal attention.
+    {
+        constexpr uint32_t qh = 2, kvh = 1, dim = 256, stride = 256, warm = 2;
+        const uint64_t row_bytes = (uint64_t)kvh * 2 * 50;
+        auto kc = backend.allocate((warm + T) * row_bytes);
+        auto vc = backend.allocate((warm + T) * row_bytes);
+        auto kc_ref = backend.allocate((warm + T) * row_bytes);
+        auto vc_ref = backend.allocate((warm + T) * row_bytes);
+        for (uint32_t p = 0; p < warm; p++) {
+            std::vector<float> k(kvh * dim), v(kvh * dim);
+            for (uint32_t d = 0; d < kvh * dim; d++) { k[d] = std::sin(float(p * 331 + d) * .05f); v[d] = std::cos(float(p * 173 + d) * .07f); }
+            auto kb = upload_buffer(backend, k); auto vb = upload_buffer(backend, v);
+            backend.kv_store(*kb, *vb, *kc, *vc, p, kvh, dim, q27::KvFormat::TURBO3);
+            backend.kv_store(*kb, *vb, *kc_ref, *vc_ref, p, kvh, dim, q27::KvFormat::TURBO3);
+        }
+        std::vector<float> knew(T * kvh * dim), vnew(T * kvh * dim), q(T * qh * stride);
+        for (size_t i = 0; i < knew.size(); i++) { knew[i] = std::sin(float(i) * .011f); vnew[i] = std::cos(float(i) * .017f); }
+        for (size_t i = 0; i < q.size(); i++) q[i] = std::sin(float(i) * .013f);
+        auto knb = upload_buffer(backend, knew); auto vnb = upload_buffer(backend, vnew);
+        backend.kv_store_rows(*knb, *vnb, *kc, *vc, warm, kvh, dim, T,
+                              q27::KvFormat::TURBO3);
+        for (uint32_t t = 0; t < T; t++) {
+            auto k_row = row_view(*knb, t, kvh * dim); auto v_row = row_view(*vnb, t, kvh * dim);
+            backend.kv_store(*k_row, *v_row, *kc_ref, *vc_ref, warm + t,
+                             kvh, dim, q27::KvFormat::TURBO3);
+        }
+        std::vector<uint8_t> cache_a((warm + T) * row_bytes), cache_b(cache_a.size());
+        backend.read(*kc, 0, cache_a.data(), cache_a.size());
+        backend.read(*kc_ref, 0, cache_b.data(), cache_b.size());
+        for (size_t i = 0; i < cache_a.size(); i++)
+            if (cache_a[i] != cache_b[i]) { fail("turbo3 store rows K", i, cache_a[i], cache_b[i]); break; }
+        backend.read(*vc, 0, cache_a.data(), cache_a.size());
+        backend.read(*vc_ref, 0, cache_b.data(), cache_b.size());
+        for (size_t i = 0; i < cache_a.size(); i++)
+            if (cache_a[i] != cache_b[i]) { fail("turbo3 store rows V", i, cache_a[i], cache_b[i]); break; }
+
+        auto qb = upload_buffer(backend, q);
+        backend.turbo_wht(*qb, T * qh, stride, false);
+        auto chunk_out = backend.allocate((uint64_t)T * qh * dim * 4);
+        backend.attention_causal(*qb, stride, qh * stride, *kc, *vc, *chunk_out,
+                                 warm + 1, qh, kvh, dim, T, 1.0f / std::sqrt(float(dim)),
+                                 q27::KvFormat::TURBO3, nullptr);
+        auto got = read_f32(backend, *chunk_out, (size_t)T * qh * dim);
+        auto serial_out = backend.allocate((uint64_t)qh * dim * 4);
+        for (uint32_t t = 0; t < T; t++) {
+            auto q_row = row_view(*qb, t, qh * stride);
+            backend.attention(*q_row, stride, *kc, *vc, *serial_out,
+                              warm + 1 + t, qh, kvh, dim, 1.0f / std::sqrt(float(dim)),
+                              q27::KvFormat::TURBO3, nullptr);
+            auto want = read_f32(backend, *serial_out, (size_t)qh * dim);
+            // The chunk kernel mirrors the decode kernel's online-softmax
+            // structure exactly, so the comparison is bit-exact.
+            for (uint32_t i = 0; i < qh * dim; i++)
+                if (got[t*qh*dim+i] != want[i]) { fail("turbo3 causal", t*qh*dim+i, got[t*qh*dim+i], want[i]); break; }
+        }
+    }
+
+    return failures;
+}
+
+} // namespace
+
+int main() {
+    try {
+        q27::MetalBackend backend;
+        int failures = test_primitives(backend) + test_attention(backend) +
+                       test_unsupported_kv_formats(backend) +
+                       test_attention_production_shape(backend) +
+                       test_turbo3(backend) + test_turbo3_production_shape(backend) +
+                       test_gdn(backend) + test_chunked(backend);
+        if (failures) { fprintf(stderr, "Metal ops: %d failure(s)\n", failures); return 1; }
+        puts("Metal decode primitives, FP16/turbo3 attention, GDN, and chunked prefill ops: OK");
+        return 0;
+    } catch (const std::exception& error) {
+        fprintf(stderr, "%s\n", error.what());
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Add a standalone Apple Metal implementation of the merged `ComputeBackend` seam.

- F32/F16, Q8, Q4, and T2 projection primitives
- quantized activation and small-N matrix paths
- embeddings, normalization, RoPE, argmax, concatenation, and gating
- F16 and TURBO3 KV storage/attention, including chunk-causal execution
- GDN/DeltaNet decode and chunked primitives
- mmap-backed model views, command batching, optional per-dispatch profiling, and buffer/range hardening

This is the backend-only cut. It intentionally does not add the Metal engine or CLI yet, so the dependency boundary remains reviewable and the existing CUDA executable is unchanged.

## Verification

Run on Apple M4 against current `master`:

```text
make -B test-metal-backend
Metal matvec: OK
Metal decode primitives, FP16/turbo3 attention, GDN, and chunked prefill ops: OK
```

The same target also passes at the first commit in the two-commit stack, so both commits are independently buildable.