### PR TITLE
metal: add q4s inference engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NVCCFLAGS ?= -O2 -std=c++17 -gencode arch=compute_86,code=sm_86 \
              -gencode arch=compute_89,code=sm_89 \
              -gencode arch=compute_120,code=sm_120 -Xcompiler -Wall
 
-.PHONY: all clean test-inspect test-metal-backend metal-engine
+.PHONY: all clean test-inspect test-metal-backend metal-engine test-metal-contracts
 all: build/inspect build/test_sampling build/test_kernels build/test_argmax_tie build/q27 build/q27-server build/test_tokenizer build/test_stream_split build/test_depthctl build/test_toolconstrain
 
 build/q27: src/engine.cu src/engine.cuh src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp \
@@ -163,6 +163,19 @@ build/metal-engine.o: src/metal/metal_engine.cpp src/metal/metal_engine.h \
                       src/sampling.h src/suffixdraft.h | build
 	$(CXX) $(METALFLAGS) -c src/metal/metal_engine.cpp -o $@
 
+build/test_metal_engine_contracts: src/metal/test_metal_engine_contracts.cpp \
+                                   src/metal/metal_engine.cpp src/metal/metal_engine.h \
+                                   src/metal/metal_backend.mm src/metal/metal_backend.h \
+                                   src/metal/q27_kernels.metal src/backend.h \
+                                   src/loader.cpp src/loader.h src/sampling.h src/suffixdraft.h | build
+	$(CXX) $(METALFLAGS) src/metal/test_metal_engine_contracts.cpp \
+	       src/metal/metal_engine.cpp src/metal/metal_backend.mm src/loader.cpp \
+	       $(METALLIBS) -o $@
+
+test-metal-contracts: build/test_metal_engine_contracts
+	@test -n "$(MODEL)" || { echo "set MODEL=...q4s.q27" >&2; exit 2; }
+	./build/test_metal_engine_contracts "$(MODEL)"
+
 metal-engine: build/metal-engine.o
 
 test-metal-backend: build/test-metal-backend build/test-metal-ops
@@ -173,4 +186,6 @@ test-metal-backend:
 	@echo "test-metal-backend requires macOS" >&2; exit 1
 metal-engine:
 	@echo "metal-engine requires macOS" >&2; exit 1
+test-metal-contracts:
+	@echo "test-metal-contracts requires macOS" >&2; exit 1
 endif

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NVCCFLAGS ?= -O2 -std=c++17 -gencode arch=compute_86,code=sm_86 \
              -gencode arch=compute_89,code=sm_89 \
              -gencode arch=compute_120,code=sm_120 -Xcompiler -Wall
 
-.PHONY: all clean test-inspect test-metal-backend
+.PHONY: all clean test-inspect test-metal-backend metal-engine
 all: build/inspect build/test_sampling build/test_kernels build/test_argmax_tie build/q27 build/q27-server build/test_tokenizer build/test_stream_split build/test_depthctl build/test_toolconstrain
 
 build/q27: src/engine.cu src/engine.cuh src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp \
@@ -158,10 +158,19 @@ build/test-metal-ops: src/metal/test_metal_ops.cpp src/metal/metal_backend.mm \
 	$(CXX) $(METALFLAGS) src/metal/test_metal_ops.cpp src/metal/metal_backend.mm \
 	       src/loader.cpp $(METALLIBS) -o $@
 
+build/metal-engine.o: src/metal/metal_engine.cpp src/metal/metal_engine.h \
+                      src/metal/metal_backend.h src/backend.h src/loader.h \
+                      src/sampling.h src/suffixdraft.h | build
+	$(CXX) $(METALFLAGS) -c src/metal/metal_engine.cpp -o $@
+
+metal-engine: build/metal-engine.o
+
 test-metal-backend: build/test-metal-backend build/test-metal-ops
 	./build/test-metal-backend
 	./build/test-metal-ops
 else
 test-metal-backend:
 	@echo "test-metal-backend requires macOS" >&2; exit 1
+metal-engine:
+	@echo "metal-engine requires macOS" >&2; exit 1
 endif

--- a/Makefile
+++ b/Makefile
@@ -160,14 +160,15 @@ build/test-metal-ops: src/metal/test_metal_ops.cpp src/metal/metal_backend.mm \
 
 build/metal-engine.o: src/metal/metal_engine.cpp src/metal/metal_engine.h \
                       src/metal/metal_backend.h src/backend.h src/loader.h \
-                      src/sampling.h src/suffixdraft.h | build
+                      src/sampling.h src/suffixdraft.h third_party/json.hpp | build
 	$(CXX) $(METALFLAGS) -c src/metal/metal_engine.cpp -o $@
 
 build/test_metal_engine_contracts: src/metal/test_metal_engine_contracts.cpp \
                                    src/metal/metal_engine.cpp src/metal/metal_engine.h \
                                    src/metal/metal_backend.mm src/metal/metal_backend.h \
                                    src/metal/q27_kernels.metal src/backend.h \
-                                   src/loader.cpp src/loader.h src/sampling.h src/suffixdraft.h | build
+                                   src/loader.cpp src/loader.h src/sampling.h src/suffixdraft.h \
+                                   third_party/json.hpp | build
 	$(CXX) $(METALFLAGS) src/metal/test_metal_engine_contracts.cpp \
 	       src/metal/metal_engine.cpp src/metal/metal_backend.mm src/loader.cpp \
 	       $(METALLIBS) -o $@

--- a/src/metal/metal_backend.h
+++ b/src/metal/metal_backend.h
@@ -143,6 +143,7 @@ class MetalBackend final : public ComputeBackend {
 
     uint64_t recommended_working_set_size() const;
     uint64_t max_buffer_length() const;
+    bool uses_per_tensor_upload(const Model& model) const;
     uint64_t max_threadgroup_memory_length() const;
     bool supports_quantized_matmul() const;
 

--- a/src/metal/metal_backend.mm
+++ b/src/metal/metal_backend.mm
@@ -666,7 +666,7 @@ BackendTensor MetalBackend::upload(const Model& model, const Tensor& tensor) {
         return offset;
     };
 
-    if (mapped_size <= (uint64_t)impl_->device.maxBufferLength) {
+    if (!uses_per_tensor_upload(model)) {
         BackendTensor result;
         result.dtype = tensor.dtype;
         result.rows = tensor.rows();
@@ -1835,6 +1835,17 @@ uint64_t MetalBackend::recommended_working_set_size() const {
 
 uint64_t MetalBackend::max_buffer_length() const {
     return (uint64_t)impl_->device.maxBufferLength;
+}
+
+bool MetalBackend::uses_per_tensor_upload(const Model& model) const {
+    if (!model.mapping_base() || !model.mapping_size())
+        throw std::runtime_error("q27 Metal: invalid model view");
+    const uint64_t page_size = (uint64_t)getpagesize();
+    const uint64_t logical_size = model.mapping_size();
+    if (logical_size > UINT64_MAX - (page_size - 1))
+        throw std::runtime_error("q27 Metal: model mapping size overflow");
+    const uint64_t mapped_size = (logical_size + page_size - 1) / page_size * page_size;
+    return mapped_size > max_buffer_length();
 }
 
 bool MetalBackend::supports_quantized_matmul() const {

--- a/src/metal/metal_engine.cpp
+++ b/src/metal/metal_engine.cpp
@@ -13,9 +13,6 @@
 namespace q27 {
 namespace {
 
-bool is_matrix_dtype(DType dtype) {
-    return dtype == DType::Q4_G64 || dtype == DType::Q8_G128;
-}
 
 class CommandBatch {
   public:
@@ -44,6 +41,7 @@ struct MetalEngine::Snapshot {
     };
     const MetalEngine* owner = nullptr;
     uint32_t position = 0;
+    bool logits_resident = false;
     std::vector<StoredLayer> layers;
     std::shared_ptr<BackendBuffer> mtp_k_cache, mtp_v_cache, hidden, logits;
 };
@@ -116,9 +114,9 @@ void MetalEngine::validate_architecture() const {
         if (!tensor || tensor->dtype != dtype || tensor->shape != std::vector<uint64_t>(shape))
             throw std::runtime_error("q27 Metal: required tensor mismatch: " + name);
     };
-    auto matrix = [&](const std::string& name, uint64_t rows, uint64_t cols) {
+    auto matrix = [&](const std::string& name, DType dtype, uint64_t rows, uint64_t cols) {
         const Tensor* tensor = model_.find(name);
-        if (!tensor || !is_matrix_dtype(tensor->dtype) || tensor->shape != std::vector<uint64_t>{rows, cols})
+        if (!tensor || tensor->dtype != dtype || tensor->shape != std::vector<uint64_t>{rows, cols})
             throw std::runtime_error("q27 Metal: required matrix mismatch: " + name);
     };
 
@@ -131,44 +129,44 @@ void MetalEngine::validate_architecture() const {
         const std::string p = "blk." + std::to_string(layer) + ".";
         require(p + "attn_norm.weight", DType::F32, {N_EMBD});
         require(p + "post_attention_norm.weight", DType::F32, {N_EMBD});
-        matrix(p + "ffn_gate.weight", N_FFN, N_EMBD);
-        matrix(p + "ffn_up.weight", N_FFN, N_EMBD);
-        matrix(p + "ffn_down.weight", N_EMBD, N_FFN);
+        matrix(p + "ffn_gate.weight", DType::Q4_G64, N_FFN, N_EMBD);
+        matrix(p + "ffn_up.weight", DType::Q4_G64, N_FFN, N_EMBD);
+        matrix(p + "ffn_down.weight", DType::Q4_G64, N_EMBD, N_FFN);
         if (attention_layer(layer)) {
-            matrix(p + "attn_q.weight", 2 * N_HEAD * HEAD_DIM, N_EMBD);
-            matrix(p + "attn_k.weight", N_KV * HEAD_DIM, N_EMBD);
-            matrix(p + "attn_v.weight", N_KV * HEAD_DIM, N_EMBD);
-            matrix(p + "attn_output.weight", N_EMBD, N_HEAD * HEAD_DIM);
+            matrix(p + "attn_q.weight", DType::Q4_G64, 2 * N_HEAD * HEAD_DIM, N_EMBD);
+            matrix(p + "attn_k.weight", DType::Q8_G128, N_KV * HEAD_DIM, N_EMBD);
+            matrix(p + "attn_v.weight", DType::Q8_G128, N_KV * HEAD_DIM, N_EMBD);
+            matrix(p + "attn_output.weight", DType::Q4_G64, N_EMBD, N_HEAD * HEAD_DIM);
             require(p + "attn_q_norm.weight", DType::F32, {HEAD_DIM});
             require(p + "attn_k_norm.weight", DType::F32, {HEAD_DIM});
         } else {
-            matrix(p + "attn_qkv.weight", GDN_CH, N_EMBD);
-            matrix(p + "attn_gate.weight", GDN_V, N_EMBD);
+            matrix(p + "attn_qkv.weight", DType::Q4_G64, GDN_CH, N_EMBD);
+            matrix(p + "attn_gate.weight", DType::Q4_G64, GDN_V, N_EMBD);
             require(p + "ssm_alpha.weight", DType::F16, {GDN_HEADS, N_EMBD});
             require(p + "ssm_beta.weight", DType::F16, {GDN_HEADS, N_EMBD});
             require(p + "ssm_a", DType::F32, {GDN_HEADS});
             require(p + "ssm_dt.bias", DType::F32, {GDN_HEADS});
             require(p + "ssm_conv1d.weight", DType::F32, {GDN_CH, 4});
             require(p + "ssm_norm.weight", DType::F32, {GDN_DIM});
-            matrix(p + "ssm_out.weight", N_EMBD, GDN_V);
+            matrix(p + "ssm_out.weight", DType::Q4_G64, N_EMBD, GDN_V);
         }
     }
     const std::string p = "blk.64.";
     require(p + "nextn.enorm.weight", DType::F32, {N_EMBD});
     require(p + "nextn.hnorm.weight", DType::F32, {N_EMBD});
     require(p + "nextn.shared_head_norm.weight", DType::F32, {N_EMBD});
-    matrix(p + "nextn.eh_proj.weight", N_EMBD, 2 * N_EMBD);
+    matrix(p + "nextn.eh_proj.weight", DType::Q8_G128, N_EMBD, 2 * N_EMBD);
     require(p + "attn_norm.weight", DType::F32, {N_EMBD});
     require(p + "post_attention_norm.weight", DType::F32, {N_EMBD});
     require(p + "attn_q_norm.weight", DType::F32, {HEAD_DIM});
     require(p + "attn_k_norm.weight", DType::F32, {HEAD_DIM});
-    matrix(p + "attn_q.weight", 2 * N_HEAD * HEAD_DIM, N_EMBD);
-    matrix(p + "attn_k.weight", N_KV * HEAD_DIM, N_EMBD);
-    matrix(p + "attn_v.weight", N_KV * HEAD_DIM, N_EMBD);
-    matrix(p + "attn_output.weight", N_EMBD, N_HEAD * HEAD_DIM);
-    matrix(p + "ffn_gate.weight", N_FFN, N_EMBD);
-    matrix(p + "ffn_up.weight", N_FFN, N_EMBD);
-    matrix(p + "ffn_down.weight", N_EMBD, N_FFN);
+    matrix(p + "attn_q.weight", DType::Q8_G128, 2 * N_HEAD * HEAD_DIM, N_EMBD);
+    matrix(p + "attn_k.weight", DType::Q8_G128, N_KV * HEAD_DIM, N_EMBD);
+    matrix(p + "attn_v.weight", DType::Q8_G128, N_KV * HEAD_DIM, N_EMBD);
+    matrix(p + "attn_output.weight", DType::Q8_G128, N_EMBD, N_HEAD * HEAD_DIM);
+    matrix(p + "ffn_gate.weight", DType::Q8_G128, N_FFN, N_EMBD);
+    matrix(p + "ffn_up.weight", DType::Q8_G128, N_FFN, N_EMBD);
+    matrix(p + "ffn_down.weight", DType::Q8_G128, N_EMBD, N_FFN);
 }
 
 MetalEngine::MetalEngine(const std::string& model_path, uint32_t context, bool turbo3_kv)
@@ -284,6 +282,7 @@ void MetalEngine::set_chunked_prefill(bool enabled) {
 
 void MetalEngine::reset() {
     position_ = 0;
+    logits_resident_ = false;
     for (LayerState& layer : layers_) {
         if (layer.recurrent) backend_.zero(*layer.recurrent);
         if (layer.ring) backend_.zero(*layer.ring);
@@ -296,6 +295,7 @@ std::shared_ptr<MetalEngine::Snapshot> MetalEngine::capture_state() {
     backend_.synchronize();
     auto snapshot = std::make_shared<Snapshot>();
     snapshot->owner = this; snapshot->position = position_; snapshot->layers.resize(N_LAYER);
+    snapshot->logits_resident = logits_resident_;
     const uint64_t cache_row = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
                                           : (uint64_t)N_KV * HEAD_DIM * 2;
     const uint64_t active_cache = (uint64_t)position_ * cache_row;
@@ -336,6 +336,7 @@ void MetalEngine::restore_state(const Snapshot& snapshot) {
     if(snapshot.logits) backend_.copy(*snapshot.logits,0,*logits_,0,logits_->size());
     batch.finish();
     position_=snapshot.position;
+    logits_resident_=snapshot.logits_resident;
 }
 
 // Serial-decode projection dispatch: T2 weights route to the float-activation
@@ -569,9 +570,11 @@ void MetalEngine::gdn_replay(uint32_t count) {
 uint32_t MetalEngine::step(uint32_t token) {
     if (token >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
     if (position_ >= max_context_) throw std::runtime_error("q27 Metal: context exhausted");
+    logits_resident_ = false;
     CommandBatch batch(backend_);
     encode_token(token, true);
     batch.finish();
+    logits_resident_ = true;
     uint32_t next = 0;
     backend_.read(*token_out_, 0, &next, sizeof(next));
     return next;
@@ -604,6 +607,7 @@ uint32_t MetalEngine::prefill(const std::vector<uint32_t>& prompt, bool warm_mtp
         throw std::runtime_error("q27 Metal: prompt exceeds context");
     for (uint32_t token : prompt)
         if (token >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
+    logits_resident_ = false;
     // Layer-major chunked ingestion. MTP warming needs each token's final
     // normalized hidden state, which the chunked path does not produce, so
     // MTP prompts stay on the token-serial path. The final prompt token is
@@ -634,6 +638,7 @@ uint32_t MetalEngine::prefill(const std::vector<uint32_t>& prompt, bool warm_mtp
         }
         batch.finish();
     }
+    logits_resident_ = true;
     uint32_t next = 0;
     backend_.read(*token_out_, 0, &next, sizeof(next));
     return next;
@@ -644,6 +649,8 @@ uint32_t MetalEngine::mtp_forward(const BackendBuffer& hidden, uint32_t token,
     if (!has_mtp_)
         throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
     if (position >= max_context_) throw std::runtime_error("q27 Metal: MTP context exhausted");
+    if (!logits_resident_)
+        throw std::runtime_error("q27 Metal: MTP pending token is stale for the current state");
     if (token >= VOCAB) throw std::runtime_error("q27 Metal: MTP token out of range");
     constexpr uint32_t layer = 64;
     CommandBatch batch(backend_);
@@ -788,6 +795,10 @@ uint32_t MetalEngine::stream_mtp_batched(uint32_t pending, uint32_t count, uint3
         if (encoded) {
             CommandBatch batch(backend_);
             gdn_replay(encoded);
+            // A fully accepted draft window advances beyond the final row
+            // written by mtp_forward; warm that consumed lane before the next round.
+            if (encoded == live)
+                mtp_warm(*hidden, lanes[encoded - 1], position_ + encoded - 1);
             backend_.copy(*cfinal_, (uint64_t)(encoded - 1) * N_EMBD * sizeof(float),
                           *x1_, 0, (uint64_t)N_EMBD * sizeof(float));
             backend_.copy(*clogits_, (uint64_t)(encoded - 1) * VOCAB * sizeof(float),
@@ -817,6 +828,8 @@ uint32_t MetalEngine::ingest_prompt(const std::vector<uint32_t>& tokens, bool wa
 }
 
 std::vector<float> MetalEngine::read_logits() {
+    if (!logits_resident_)
+        throw std::runtime_error("q27 Metal: logits are not resident for the current state");
     std::vector<float> result(VOCAB);
     backend_.synchronize();
     backend_.read(*logits_,0,result.data(),result.size()*sizeof(float));
@@ -887,6 +900,7 @@ std::vector<float> MetalEngine::teacher_force_nll(const std::vector<uint32_t>& t
             CommandBatch batch(backend_);
             encode_token(tokens[done], true);
             batch.finish();
+            logits_resident_ = true;
         }
         std::vector<float> logits = read_logits();
         result.push_back(nll_cpu(logits.data(), tokens[done + 1], VOCAB));
@@ -944,6 +958,8 @@ uint32_t MetalEngine::stream_from_pending(uint32_t pending, uint32_t count, uint
                                           StopCause& cause) {
     last_spec_stats_={};
     if (pending >= VOCAB) throw std::runtime_error("q27 Metal: pending token out of range");
+    if (count && !logits_resident_)
+        throw std::runtime_error("q27 Metal: pending token is stale for the current state");
     if (mtp_width && !has_mtp_)
         throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
     if (mtp_width && (mtp_width < 2 || mtp_width > 12))
@@ -971,6 +987,8 @@ std::vector<uint32_t> MetalEngine::generate_from_pending(uint32_t pending, uint3
                                                           uint32_t mtp_width) {
     last_spec_stats_={};
     if (pending >= VOCAB) throw std::runtime_error("q27 Metal: pending token out of range");
+    if (count && !logits_resident_)
+        throw std::runtime_error("q27 Metal: pending token is stale for the current state");
     if (mtp_width && !has_mtp_)
         throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
     if (mtp_width && (mtp_width < 2 || mtp_width > 12))

--- a/src/metal/metal_engine.cpp
+++ b/src/metal/metal_engine.cpp
@@ -1,0 +1,1067 @@
+#include "metal_engine.h"
+
+#include "../../third_party/json.hpp"
+#include "../suffixdraft.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+
+namespace q27 {
+namespace {
+
+bool is_matrix_dtype(DType dtype) {
+    return dtype == DType::Q4_G64 || dtype == DType::Q8_G128;
+}
+
+class CommandBatch {
+  public:
+    explicit CommandBatch(MetalBackend& backend) : backend_(backend) { backend_.begin_commands(); }
+    ~CommandBatch() { if (active_) backend_.abort_commands(); }
+    void finish() { backend_.end_commands(); active_ = false; }
+  private:
+    MetalBackend& backend_;
+    bool active_ = true;
+};
+
+// A shorter view over a chunk-capacity quantized activation, so partial
+// chunks quantize and multiply exactly `count` values without reallocating.
+BackendQuantized quantized_view(const BackendQuantized& full, uint32_t count) {
+    if (count > full.count) throw std::runtime_error("q27 Metal: quantized view exceeds capacity");
+    BackendQuantized view;
+    view.count = count; view.values = full.values; view.scales = full.scales;
+    return view;
+}
+
+} // namespace
+
+struct MetalEngine::Snapshot {
+    struct StoredLayer {
+        std::shared_ptr<BackendBuffer> recurrent, ring, k_cache, v_cache;
+    };
+    const MetalEngine* owner = nullptr;
+    uint32_t position = 0;
+    std::vector<StoredLayer> layers;
+    std::shared_ptr<BackendBuffer> mtp_k_cache, mtp_v_cache, hidden, logits;
+};
+
+std::shared_ptr<BackendBuffer> MetalEngine::alloc_f32(uint64_t count) {
+    return backend_.allocate(count * sizeof(float));
+}
+
+const BackendTensor& MetalEngine::weight(const std::string& name) const {
+    auto it = weights_.find(name);
+    if (it == weights_.end()) throw std::runtime_error("q27 Metal: weight is not mapped: " + name);
+    return it->second;
+}
+
+const BackendTensor& MetalEngine::layer_weight(uint32_t layer, const char* leaf) const {
+    return weight("blk." + std::to_string(layer) + "." + leaf);
+}
+
+void MetalEngine::validate_architecture() const {
+    nlohmann::json meta;
+    try { meta = nlohmann::json::parse(model_.meta_json); }
+    catch (const std::exception& e) { throw std::runtime_error(std::string("q27 Metal: invalid metadata JSON: ") + e.what()); }
+
+    auto exact = [&](const char* key, uint64_t expected) {
+        if (!meta.contains(key) || !meta[key].is_number_unsigned() || meta[key].get<uint64_t>() != expected)
+            throw std::runtime_error(std::string("q27 Metal: architecture mismatch: ") + key);
+    };
+    if (meta.value("general.architecture", std::string()) != "qwen35")
+        throw std::runtime_error("q27 Metal: expected qwen35 architecture");
+    if (meta.value("quant_policy", std::string()) != "q4s-v1" ||
+        !meta.value("q4_head", false))
+        throw std::runtime_error("q27 Metal: expected q4s-v1 artifact");
+    exact("qwen35.block_count", 65); exact("qwen35.embedding_length", N_EMBD);
+    exact("qwen35.feed_forward_length", N_FFN); exact("qwen35.attention.head_count", N_HEAD);
+    exact("qwen35.attention.head_count_kv", N_KV); exact("qwen35.attention.key_length", HEAD_DIM);
+    exact("qwen35.attention.value_length", HEAD_DIM); exact("qwen35.ssm.state_size", GDN_DIM);
+    exact("qwen35.ssm.group_count", GDN_QK_HEADS); exact("qwen35.ssm.inner_size", GDN_V);
+    exact("qwen35.context_length", 262144); exact("qwen35.rope.dimension_count", N_ROT);
+    exact("qwen35.ssm.conv_kernel", 4); exact("qwen35.ssm.time_step_rank", GDN_HEADS);
+    exact("qwen35.full_attention_interval", 4);
+    exact("qwen35.nextn_predict_layers", 1);
+    exact("group_q4", 64); exact("group_q8", 128);
+    if (meta.value("nibble_order", std::string()) != "even=low")
+        throw std::runtime_error("q27 Metal: incompatible Q4 nibble order");
+    auto exact_float = [&](const char* key, double expected, double tolerance) {
+        if (!meta.contains(key) || !meta[key].is_number() ||
+            std::fabs(meta[key].get<double>() - expected) > tolerance)
+            throw std::runtime_error(std::string("q27 Metal: architecture mismatch: ") + key);
+    };
+    exact_float("qwen35.rope.freq_base", FREQ_BASE, 0.0);
+    exact_float("qwen35.attention.layer_norm_rms_epsilon", EPS, 1e-12);
+    const std::vector<uint32_t> rope_sections{11,11,10,0};
+    if (!meta.contains("qwen35.rope.dimension_sections") ||
+        meta["qwen35.rope.dimension_sections"].get<std::vector<uint32_t>>() != rope_sections)
+        throw std::runtime_error("q27 Metal: architecture mismatch: rope dimension sections");
+
+    std::vector<uint32_t> expected_attention;
+    for (uint32_t i = 3; i < N_LAYER; i += 4) expected_attention.push_back(i);
+    const size_t expected_map = expected_attention.size() + 1;
+    if (!meta.contains("attn_layers") || meta["attn_layers"].size() != expected_map)
+        throw std::runtime_error("q27 Metal: invalid attention layer map");
+    for (size_t i = 0; i < expected_attention.size(); i++)
+        if (meta["attn_layers"][i].get<uint32_t>() != expected_attention[i])
+            throw std::runtime_error("q27 Metal: unexpected attention layer map");
+    if (meta["attn_layers"].back().get<uint32_t>() != 64)
+        throw std::runtime_error("q27 Metal: missing MTP attention layer");
+
+    auto require = [&](const std::string& name, DType dtype, std::initializer_list<uint64_t> shape) {
+        const Tensor* tensor = model_.find(name);
+        if (!tensor || tensor->dtype != dtype || tensor->shape != std::vector<uint64_t>(shape))
+            throw std::runtime_error("q27 Metal: required tensor mismatch: " + name);
+    };
+    auto matrix = [&](const std::string& name, uint64_t rows, uint64_t cols) {
+        const Tensor* tensor = model_.find(name);
+        if (!tensor || !is_matrix_dtype(tensor->dtype) || tensor->shape != std::vector<uint64_t>{rows, cols})
+            throw std::runtime_error("q27 Metal: required matrix mismatch: " + name);
+    };
+
+    require("token_embd.weight", DType::Q8_G128, {VOCAB, N_EMBD});
+    require("output.weight", DType::Q4_G64, {VOCAB, N_EMBD});
+    if (model_.find("output_q4.weight"))
+        throw std::runtime_error("q27 Metal: q4s artifact must not duplicate the output head");
+    require("output_norm.weight", DType::F32, {N_EMBD});
+    for (uint32_t layer = 0; layer < N_LAYER; layer++) {
+        const std::string p = "blk." + std::to_string(layer) + ".";
+        require(p + "attn_norm.weight", DType::F32, {N_EMBD});
+        require(p + "post_attention_norm.weight", DType::F32, {N_EMBD});
+        matrix(p + "ffn_gate.weight", N_FFN, N_EMBD);
+        matrix(p + "ffn_up.weight", N_FFN, N_EMBD);
+        matrix(p + "ffn_down.weight", N_EMBD, N_FFN);
+        if (attention_layer(layer)) {
+            matrix(p + "attn_q.weight", 2 * N_HEAD * HEAD_DIM, N_EMBD);
+            matrix(p + "attn_k.weight", N_KV * HEAD_DIM, N_EMBD);
+            matrix(p + "attn_v.weight", N_KV * HEAD_DIM, N_EMBD);
+            matrix(p + "attn_output.weight", N_EMBD, N_HEAD * HEAD_DIM);
+            require(p + "attn_q_norm.weight", DType::F32, {HEAD_DIM});
+            require(p + "attn_k_norm.weight", DType::F32, {HEAD_DIM});
+        } else {
+            matrix(p + "attn_qkv.weight", GDN_CH, N_EMBD);
+            matrix(p + "attn_gate.weight", GDN_V, N_EMBD);
+            require(p + "ssm_alpha.weight", DType::F16, {GDN_HEADS, N_EMBD});
+            require(p + "ssm_beta.weight", DType::F16, {GDN_HEADS, N_EMBD});
+            require(p + "ssm_a", DType::F32, {GDN_HEADS});
+            require(p + "ssm_dt.bias", DType::F32, {GDN_HEADS});
+            require(p + "ssm_conv1d.weight", DType::F32, {GDN_CH, 4});
+            require(p + "ssm_norm.weight", DType::F32, {GDN_DIM});
+            matrix(p + "ssm_out.weight", N_EMBD, GDN_V);
+        }
+    }
+    const std::string p = "blk.64.";
+    require(p + "nextn.enorm.weight", DType::F32, {N_EMBD});
+    require(p + "nextn.hnorm.weight", DType::F32, {N_EMBD});
+    require(p + "nextn.shared_head_norm.weight", DType::F32, {N_EMBD});
+    matrix(p + "nextn.eh_proj.weight", N_EMBD, 2 * N_EMBD);
+    require(p + "attn_norm.weight", DType::F32, {N_EMBD});
+    require(p + "post_attention_norm.weight", DType::F32, {N_EMBD});
+    require(p + "attn_q_norm.weight", DType::F32, {HEAD_DIM});
+    require(p + "attn_k_norm.weight", DType::F32, {HEAD_DIM});
+    matrix(p + "attn_q.weight", 2 * N_HEAD * HEAD_DIM, N_EMBD);
+    matrix(p + "attn_k.weight", N_KV * HEAD_DIM, N_EMBD);
+    matrix(p + "attn_v.weight", N_KV * HEAD_DIM, N_EMBD);
+    matrix(p + "attn_output.weight", N_EMBD, N_HEAD * HEAD_DIM);
+    matrix(p + "ffn_gate.weight", N_FFN, N_EMBD);
+    matrix(p + "ffn_up.weight", N_FFN, N_EMBD);
+    matrix(p + "ffn_down.weight", N_EMBD, N_FFN);
+}
+
+MetalEngine::MetalEngine(const std::string& model_path, uint32_t context, bool turbo3_kv)
+    : model_(Model::open(model_path)), max_context_(context), turbo3_kv_(turbo3_kv) {
+    if (!context || context > 262144) throw std::runtime_error("q27 Metal: context must be 1..262144");
+    validate_architecture();
+    has_mtp_ = model_.find("blk.64.attn_norm.weight") != nullptr;
+    const uint64_t cache_row_bytes = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
+                                                : (uint64_t)N_KV * HEAD_DIM * 2;
+    const uint64_t total_cache_bytes =
+        (16ull + (has_mtp_ ? 1 : 0)) * 2 * max_context_ * cache_row_bytes;
+    if (total_cache_bytes > backend_.recommended_working_set_size() / 2)
+        throw std::runtime_error("q27 Metal: requested KV cache is too large for this device; use --kv turbo3 or reduce --ctx");
+
+    const bool per_tensor_upload = backend_.uses_per_tensor_upload(model_);
+    constexpr double gibibyte = 1024.0 * 1024.0 * 1024.0;
+    std::fprintf(stderr,
+                 "q27 Metal: model upload path: %s (mapping %.2f GiB, max buffer %.2f GiB)\n",
+                 per_tensor_upload ? "per-tensor" : "whole-mapping",
+                 model_.mapping_size() / gibibyte,
+                 backend_.max_buffer_length() / gibibyte);
+
+    // All wrappers alias the mmap. No weight-sized copy is created.
+    weights_.reserve(model_.tensors.size());
+    for (const Tensor& tensor : model_.tensors)
+        weights_.emplace(tensor.name, backend_.upload(model_, tensor));
+
+    layers_.resize(N_LAYER);
+    for (uint32_t layer = 0; layer < N_LAYER; layer++) {
+        if (attention_layer(layer)) {
+            const uint64_t cache_bytes = (uint64_t)max_context_ * cache_row_bytes;
+            layers_[layer].k_cache = backend_.allocate(cache_bytes);
+            layers_[layer].v_cache = backend_.allocate(cache_bytes);
+        } else {
+            layers_[layer].recurrent = alloc_f32((uint64_t)GDN_HEADS * GDN_DIM * GDN_DIM);
+            layers_[layer].ring = alloc_f32((uint64_t)3 * GDN_CH);
+        }
+    }
+
+    h_ = alloc_f32(N_EMBD); x1_ = alloc_f32(N_EMBD); y_ = alloc_f32(N_EMBD);
+    qg_ = alloc_f32(2 * N_HEAD * HEAD_DIM); kbuf_ = alloc_f32(N_KV * HEAD_DIM);
+    vbuf_ = alloc_f32(N_KV * HEAD_DIM); attn_out_ = alloc_f32(N_HEAD * HEAD_DIM);
+    qkv_ = alloc_f32(GDN_CH); z_ = alloc_f32(GDN_V); alpha_ = alloc_f32(GDN_HEADS);
+    beta_raw_ = alloc_f32(GDN_HEADS); g_ = alloc_f32(GDN_HEADS); beta_ = alloc_f32(GDN_HEADS);
+    conv_out_ = alloc_f32(GDN_CH); delta_out_ = alloc_f32(GDN_V); gated_out_ = alloc_f32(GDN_V);
+    ffn_gate_ = alloc_f32(N_FFN); ffn_up_ = alloc_f32(N_FFN);
+    logits_ = alloc_f32(VOCAB); token_out_ = backend_.allocate(sizeof(uint32_t));
+    if (has_mtp_) {
+        mtp_embed_norm_ = alloc_f32(N_EMBD); mtp_hidden_norm_ = alloc_f32(N_EMBD);
+        mtp_concat_ = alloc_f32(2 * N_EMBD); mtp_x_ = alloc_f32(N_EMBD);
+        mtp_hidden_out_ = alloc_f32(N_EMBD);
+        const uint64_t mtp_cache_bytes = (uint64_t)max_context_ * cache_row_bytes;
+        mtp_k_cache_ = backend_.allocate(mtp_cache_bytes); mtp_v_cache_ = backend_.allocate(mtp_cache_bytes);
+    }
+    q5120_=backend_.allocate_quantized(N_EMBD); q6144_=backend_.allocate_quantized(GDN_V);
+    q10240_=backend_.allocate_quantized(GDN_CH); q17408_=backend_.allocate_quantized(N_FFN);
+
+    // Layer-major chunked prefill routes projections through the simdgroup
+    // GEMM, so it requires the same device family. The per-chunk activation
+    // buffers total a few MiB. Every attention kernel is online-softmax now,
+    // so no probability scratch exists on any path at any context length.
+    chunked_prefill_ = backend_.supports_quantized_matmul();
+    if (chunked_prefill_) {
+        ch_ = alloc_f32((uint64_t)CHUNK_MAX * N_EMBD);
+        cx1_ = alloc_f32((uint64_t)CHUNK_MAX * N_EMBD);
+        cy_ = alloc_f32((uint64_t)CHUNK_MAX * N_EMBD);
+        cqg_ = alloc_f32((uint64_t)CHUNK_MAX * 2 * N_HEAD * HEAD_DIM);
+        ckbuf_ = alloc_f32((uint64_t)CHUNK_MAX * N_KV * HEAD_DIM);
+        cvbuf_ = alloc_f32((uint64_t)CHUNK_MAX * N_KV * HEAD_DIM);
+        cattn_out_ = alloc_f32((uint64_t)CHUNK_MAX * N_HEAD * HEAD_DIM);
+        cqkv_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_CH);
+        cz_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_V);
+        calpha_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_HEADS);
+        cbeta_raw_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_HEADS);
+        cg_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_HEADS);
+        cbeta_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_HEADS);
+        cconv_out_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_CH);
+        cdelta_out_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_V);
+        cgated_out_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_V);
+        cffn_gate_ = alloc_f32((uint64_t)CHUNK_MAX * N_FFN);
+        cffn_up_ = alloc_f32((uint64_t)CHUNK_MAX * N_FFN);
+        cq5120_ = backend_.allocate_quantized(CHUNK_MAX * N_EMBD);
+        cq6144_ = backend_.allocate_quantized(CHUNK_MAX * GDN_V);
+        cq17408_ = backend_.allocate_quantized(CHUNK_MAX * N_FFN);
+        cfinal_ = alloc_f32((uint64_t)CHUNK_MAX * N_EMBD);
+        clogits_ = alloc_f32((uint64_t)CHUNK_MAX * VOCAB);
+        cpred_ = backend_.allocate((uint64_t)CHUNK_MAX * sizeof(uint32_t));
+        ctargets_ = backend_.allocate((uint64_t)CHUNK_MAX * sizeof(uint32_t));
+        cnll_ = alloc_f32(CHUNK_MAX);
+        // Batched MTP verification parks each GDN layer's chunk inputs
+        // (~24 MiB total) so acceptance can replay the recurrence over the
+        // accepted prefix, and discards speculative state commits into two
+        // slots shared by every layer. All of it stays physically lazy until
+        // the first batched MTP round.
+        const uint32_t gdn_layers = N_LAYER - N_LAYER / 4;
+        park_qkv_.reserve(gdn_layers); park_g_.reserve(gdn_layers); park_beta_.reserve(gdn_layers);
+        for (uint32_t i = 0; i < gdn_layers; i++) {
+            park_qkv_.push_back(alloc_f32((uint64_t)CHUNK_MAX * GDN_CH));
+            park_g_.push_back(alloc_f32((uint64_t)CHUNK_MAX * GDN_HEADS));
+            park_beta_.push_back(alloc_f32((uint64_t)CHUNK_MAX * GDN_HEADS));
+        }
+        discard_recurrent_ = alloc_f32((uint64_t)GDN_HEADS * GDN_DIM * GDN_DIM);
+        discard_ring_ = alloc_f32((uint64_t)3 * GDN_CH);
+    }
+    reset();
+}
+
+void MetalEngine::set_chunked_prefill(bool enabled) {
+    if (enabled && !ch_)
+        throw std::runtime_error("q27 Metal: chunked prefill requires quantized matmul support");
+    chunked_prefill_ = enabled;
+}
+
+void MetalEngine::reset() {
+    position_ = 0;
+    for (LayerState& layer : layers_) {
+        if (layer.recurrent) backend_.zero(*layer.recurrent);
+        if (layer.ring) backend_.zero(*layer.ring);
+        // KV rows are written before they become visible through position_;
+        // clearing the full reserved context would make long-context reset O(ctx).
+    }
+}
+
+std::shared_ptr<MetalEngine::Snapshot> MetalEngine::capture_state() {
+    backend_.synchronize();
+    auto snapshot = std::make_shared<Snapshot>();
+    snapshot->owner = this; snapshot->position = position_; snapshot->layers.resize(N_LAYER);
+    const uint64_t cache_row = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
+                                          : (uint64_t)N_KV * HEAD_DIM * 2;
+    const uint64_t active_cache = (uint64_t)position_ * cache_row;
+    CommandBatch batch(backend_);
+    for (uint32_t i=0;i<N_LAYER;i++) {
+        const LayerState& source=layers_[i]; auto& dest=snapshot->layers[i];
+        if(source.recurrent) { dest.recurrent=backend_.allocate(source.recurrent->size()); backend_.copy(*source.recurrent,0,*dest.recurrent,0,source.recurrent->size()); }
+        if(source.ring) { dest.ring=backend_.allocate(source.ring->size()); backend_.copy(*source.ring,0,*dest.ring,0,source.ring->size()); }
+        if(source.k_cache && active_cache) { dest.k_cache=backend_.allocate(active_cache); dest.v_cache=backend_.allocate(active_cache); backend_.copy(*source.k_cache,0,*dest.k_cache,0,active_cache); backend_.copy(*source.v_cache,0,*dest.v_cache,0,active_cache); }
+    }
+    if(active_cache && mtp_k_cache_) {
+        snapshot->mtp_k_cache=backend_.allocate(active_cache); snapshot->mtp_v_cache=backend_.allocate(active_cache);
+        backend_.copy(*mtp_k_cache_,0,*snapshot->mtp_k_cache,0,active_cache);
+        backend_.copy(*mtp_v_cache_,0,*snapshot->mtp_v_cache,0,active_cache);
+    }
+    snapshot->hidden=backend_.allocate(x1_->size()); backend_.copy(*x1_,0,*snapshot->hidden,0,x1_->size());
+    snapshot->logits=backend_.allocate(logits_->size()); backend_.copy(*logits_,0,*snapshot->logits,0,logits_->size());
+    batch.finish();
+    return snapshot;
+}
+
+void MetalEngine::restore_state(const Snapshot& snapshot) {
+    if(snapshot.owner!=this || snapshot.layers.size()!=N_LAYER || snapshot.position>max_context_)
+        throw std::runtime_error("q27 Metal: incompatible state snapshot");
+    backend_.synchronize();
+    const uint64_t cache_row = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
+                                          : (uint64_t)N_KV * HEAD_DIM * 2;
+    const uint64_t active_cache=(uint64_t)snapshot.position*cache_row;
+    CommandBatch batch(backend_);
+    for(uint32_t i=0;i<N_LAYER;i++) {
+        const auto& source=snapshot.layers[i]; LayerState& dest=layers_[i];
+        if(source.recurrent) backend_.copy(*source.recurrent,0,*dest.recurrent,0,source.recurrent->size());
+        if(source.ring) backend_.copy(*source.ring,0,*dest.ring,0,source.ring->size());
+        if(source.k_cache) { backend_.copy(*source.k_cache,0,*dest.k_cache,0,active_cache); backend_.copy(*source.v_cache,0,*dest.v_cache,0,active_cache); }
+    }
+    if(snapshot.mtp_k_cache) { backend_.copy(*snapshot.mtp_k_cache,0,*mtp_k_cache_,0,active_cache); backend_.copy(*snapshot.mtp_v_cache,0,*mtp_v_cache_,0,active_cache); }
+    backend_.copy(*snapshot.hidden,0,*x1_,0,x1_->size());
+    if(snapshot.logits) backend_.copy(*snapshot.logits,0,*logits_,0,logits_->size());
+    batch.finish();
+    position_=snapshot.position;
+}
+
+// Serial-decode projection dispatch: T2 weights route to the float-activation
+// select-form GEMV (exact ternary math, no activation quantization — see the
+// ternary-tier plan, Phase 2); Q4/Q8 keep the packed-dot quantized path. Both
+// operand sets are always live at the call sites: the fused rmsnorm/quantize
+// kernels produce the float output and the int8 copy together.
+void MetalEngine::project(const BackendTensor& w, const BackendBuffer& x_float,
+                          const BackendQuantized& xq, BackendBuffer& out) {
+    if (w.dtype == DType::T2_G128) backend_.matvec(w, x_float, out);
+    else backend_.matvec_quantized(w, xq, out);
+}
+
+void MetalEngine::project_pair(const BackendTensor& a, BackendBuffer& a_out,
+                               const BackendTensor& b, BackendBuffer& b_out,
+                               const BackendBuffer& x_float, const BackendQuantized& xq) {
+    if (a.dtype == DType::T2_G128 || b.dtype == DType::T2_G128) {
+        project(a, x_float, xq, a_out);
+        project(b, x_float, xq, b_out);
+    } else {
+        backend_.matvec_quantized_pair(a, a_out, b, b_out, xq);
+    }
+}
+
+void MetalEngine::gdn_block(uint32_t layer) {
+    project_pair(layer_weight(layer,"attn_qkv.weight"),*qkv_,
+                 layer_weight(layer,"attn_gate.weight"),*z_,*x1_,q5120_);
+    backend_.matvec_pair(layer_weight(layer,"ssm_alpha.weight"),*alpha_,
+                         layer_weight(layer,"ssm_beta.weight"),*beta_raw_,*x1_);
+    backend_.gdn_gates(*alpha_, *beta_raw_, layer_weight(layer, "ssm_a"),
+                       layer_weight(layer, "ssm_dt.bias"), *g_, *beta_, GDN_HEADS);
+    LayerState& state = layers_[layer];
+    backend_.conv_step(*state.ring, *state.ring, *qkv_,
+                       layer_weight(layer, "ssm_conv1d.weight"), *conv_out_, GDN_CH);
+    backend_.l2norm_heads(*conv_out_, 2 * GDN_QK_HEADS, GDN_DIM, EPS);
+    backend_.delta_step(*state.recurrent, *state.recurrent, *conv_out_, *g_, *beta_,
+                        *delta_out_, GDN_HEADS, GDN_QK_HEADS, GDN_DIM);
+    backend_.gated_norm_gdn(*delta_out_, layer_weight(layer, "ssm_norm.weight"), *z_,
+                            *gated_out_, GDN_HEADS, GDN_DIM, EPS);
+    const BackendTensor& ssm_out_w = layer_weight(layer, "ssm_out.weight");
+    if (ssm_out_w.dtype != DType::T2_G128) backend_.quantize(*gated_out_, q6144_);
+    project(ssm_out_w, *gated_out_, q6144_, *y_);
+}
+
+void MetalEngine::attention_block(uint32_t layer) {
+    project(layer_weight(layer, "attn_q.weight"), *x1_, q5120_, *qg_);
+    backend_.rmsnorm_heads(*qg_, layer_weight(layer, "attn_q_norm.weight"),
+                           N_HEAD, HEAD_DIM, 2 * HEAD_DIM, EPS);
+    project_pair(layer_weight(layer,"attn_k.weight"),*kbuf_,
+                 layer_weight(layer,"attn_v.weight"),*vbuf_,*x1_,q5120_);
+    backend_.rmsnorm_heads(*kbuf_, layer_weight(layer, "attn_k_norm.weight"),
+                           N_KV, HEAD_DIM, HEAD_DIM, EPS);
+    backend_.rope_neox(*qg_, N_HEAD, HEAD_DIM, N_ROT, 2 * HEAD_DIM, position_, FREQ_BASE);
+    backend_.rope_neox(*kbuf_, N_KV, HEAD_DIM, N_ROT, HEAD_DIM, position_, FREQ_BASE);
+    LayerState& state = layers_[layer];
+    const KvFormat format = turbo3_kv_ ? KvFormat::TURBO3 : KvFormat::F16;
+    if (turbo3_kv_) backend_.turbo_wht(*qg_, N_HEAD, 2 * HEAD_DIM, false);
+    backend_.kv_store(*kbuf_, *vbuf_, *state.k_cache, *state.v_cache,
+                      position_, N_KV, HEAD_DIM, format);
+    backend_.attention(*qg_, 2 * HEAD_DIM, *state.k_cache, *state.v_cache,
+                       *attn_out_, position_ + 1, N_HEAD, N_KV, HEAD_DIM,
+                       1.0f / std::sqrt((float)HEAD_DIM), format, nullptr);
+    if (turbo3_kv_) backend_.turbo_wht(*attn_out_, N_HEAD, HEAD_DIM, true);
+    backend_.sigmoid_gate_mul(*attn_out_, *qg_, N_HEAD, HEAD_DIM);
+    const BackendTensor& attn_out_w = layer_weight(layer, "attn_output.weight");
+    if (attn_out_w.dtype != DType::T2_G128) backend_.quantize(*attn_out_, q6144_);
+    project(attn_out_w, *attn_out_, q6144_, *y_);
+}
+
+void MetalEngine::ffn(uint32_t layer) {
+    project_pair(layer_weight(layer,"ffn_gate.weight"),*ffn_gate_,
+                 layer_weight(layer,"ffn_up.weight"),*ffn_up_,*x1_,q5120_);
+    backend_.silu_mul(*ffn_gate_, *ffn_up_, *ffn_gate_, N_FFN);
+    const BackendTensor& ffn_down_w = layer_weight(layer, "ffn_down.weight");
+    if (ffn_down_w.dtype != DType::T2_G128) backend_.quantize(*ffn_gate_, q17408_);
+    project(ffn_down_w, *ffn_gate_, q17408_, *y_);
+}
+
+void MetalEngine::encode_token(uint32_t token, bool produce_logits) {
+    if (token >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
+    if (position_ >= max_context_) throw std::runtime_error("q27 Metal: context exhausted");
+    backend_.embedding_q8(weight("token_embd.weight"), token, *h_);
+    for (uint32_t layer = 0; layer < N_LAYER; layer++) {
+        backend_.rmsnorm_quantized(*h_,layer_weight(layer,"attn_norm.weight"),*x1_,N_EMBD,EPS,q5120_);
+        if (attention_layer(layer)) attention_block(layer); else gdn_block(layer);
+        backend_.add_inplace(*h_, *y_, N_EMBD);
+        backend_.rmsnorm_quantized(*h_,layer_weight(layer,"post_attention_norm.weight"),*x1_,N_EMBD,EPS,q5120_);
+        ffn(layer);
+        backend_.add_inplace(*h_, *y_, N_EMBD);
+    }
+    if(produce_logits)
+        backend_.rmsnorm_quantized(*h_,weight("output_norm.weight"),*x1_,N_EMBD,EPS,q5120_);
+    else
+        backend_.rmsnorm(*h_,weight("output_norm.weight"),*x1_,N_EMBD,EPS);
+    if (produce_logits) {
+        project(weight("output.weight"), *x1_, q5120_, *logits_);
+        backend_.argmax(*logits_, VOCAB, *token_out_);
+    }
+    position_++;
+}
+
+void MetalEngine::gdn_chunk(uint32_t layer, uint32_t count, bool verify) {
+    BackendQuantized x5 = quantized_view(cq5120_, count * N_EMBD);
+    backend_.matmul_quantized(layer_weight(layer, "attn_qkv.weight"), x5, count, *cqkv_);
+    backend_.matmul_quantized(layer_weight(layer, "attn_gate.weight"), x5, count, *cz_);
+    // Official tier: fused F16 pair-rows kernel. Ternary tier: alpha/beta are
+    // T2 matrices; the T2 chunk GEMM writes the same [token][row] layout.
+    const BackendTensor& alpha_w = layer_weight(layer, "ssm_alpha.weight");
+    const BackendTensor& beta_w = layer_weight(layer, "ssm_beta.weight");
+    if (alpha_w.dtype == DType::T2_G128) {
+        backend_.matmul_quantized(alpha_w, x5, count, *calpha_);
+        backend_.matmul_quantized(beta_w, x5, count, *cbeta_raw_);
+    } else {
+        backend_.matvec_f16_pair_rows(alpha_w, *calpha_, beta_w, *cbeta_raw_, *cx1_, count);
+    }
+    backend_.gdn_gates_rows(*calpha_, *cbeta_raw_, layer_weight(layer, "ssm_a"),
+                            layer_weight(layer, "ssm_dt.bias"), *cg_, *cbeta_, GDN_HEADS, count);
+    LayerState& state = layers_[layer];
+    // Verification parks the recurrence inputs and discards the speculative
+    // state commit; gdn_replay later commits real state for the accepted
+    // prefix from the parked copies — bit-identical inputs, no re-encode.
+    if (verify) {
+        const uint32_t slot = gdn_slot(layer);
+        backend_.copy(*cqkv_, 0, *park_qkv_[slot], 0, (uint64_t)count * GDN_CH * sizeof(float));
+        backend_.copy(*cg_, 0, *park_g_[slot], 0, (uint64_t)count * GDN_HEADS * sizeof(float));
+        backend_.copy(*cbeta_, 0, *park_beta_[slot], 0, (uint64_t)count * GDN_HEADS * sizeof(float));
+    }
+    BackendBuffer& ring_dst = verify ? *discard_ring_ : *state.ring;
+    BackendBuffer& recurrent_dst = verify ? *discard_recurrent_ : *state.recurrent;
+    backend_.conv_chunk(*state.ring, ring_dst, *cqkv_, layer_weight(layer, "ssm_conv1d.weight"),
+                        *cconv_out_, GDN_CH, count);
+    backend_.l2norm_rows(*cconv_out_, 2 * GDN_QK_HEADS, GDN_DIM, GDN_CH, count, EPS);
+    backend_.delta_chunk(*state.recurrent, recurrent_dst, *cconv_out_, *cg_, *cbeta_, *cdelta_out_,
+                         GDN_HEADS, GDN_QK_HEADS, GDN_DIM, count);
+    // Token rows are contiguous, so the per-head gated norm batches by
+    // flattening the chunk into count*GDN_HEADS heads.
+    backend_.gated_norm_gdn(*cdelta_out_, layer_weight(layer, "ssm_norm.weight"), *cz_,
+                            *cgated_out_, count * GDN_HEADS, GDN_DIM, EPS);
+    BackendQuantized x6 = quantized_view(cq6144_, count * GDN_V);
+    backend_.quantize(*cgated_out_, x6);
+    backend_.matmul_quantized(layer_weight(layer, "ssm_out.weight"), x6, count, *cy_);
+}
+
+void MetalEngine::attention_chunk(uint32_t layer, uint32_t count) {
+    BackendQuantized x5 = quantized_view(cq5120_, count * N_EMBD);
+    backend_.matmul_quantized(layer_weight(layer, "attn_q.weight"), x5, count, *cqg_);
+    backend_.rmsnorm_heads(*cqg_, layer_weight(layer, "attn_q_norm.weight"),
+                           count * N_HEAD, HEAD_DIM, 2 * HEAD_DIM, EPS);
+    backend_.matmul_quantized(layer_weight(layer, "attn_k.weight"), x5, count, *ckbuf_);
+    backend_.matmul_quantized(layer_weight(layer, "attn_v.weight"), x5, count, *cvbuf_);
+    backend_.rmsnorm_heads(*ckbuf_, layer_weight(layer, "attn_k_norm.weight"),
+                           count * N_KV, HEAD_DIM, HEAD_DIM, EPS);
+    backend_.rope_neox_rows(*cqg_, N_HEAD, HEAD_DIM, N_ROT, 2 * HEAD_DIM,
+                            2 * N_HEAD * HEAD_DIM, position_, count, FREQ_BASE);
+    backend_.rope_neox_rows(*ckbuf_, N_KV, HEAD_DIM, N_ROT, HEAD_DIM,
+                            N_KV * HEAD_DIM, position_, count, FREQ_BASE);
+    LayerState& state = layers_[layer];
+    const float scale = 1.0f / std::sqrt((float)HEAD_DIM);
+    const KvFormat format = turbo3_kv_ ? KvFormat::TURBO3 : KvFormat::F16;
+    if (turbo3_kv_) backend_.turbo_wht(*cqg_, count * N_HEAD, 2 * HEAD_DIM, false);
+    backend_.kv_store_rows(*ckbuf_, *cvbuf_, *state.k_cache, *state.v_cache,
+                           position_, N_KV, HEAD_DIM, count, format);
+    backend_.attention_causal(*cqg_, 2 * HEAD_DIM, 2 * N_HEAD * HEAD_DIM,
+                              *state.k_cache, *state.v_cache, *cattn_out_,
+                              position_ + 1, N_HEAD, N_KV, HEAD_DIM, count,
+                              scale, format, nullptr);
+    if (turbo3_kv_)
+        backend_.turbo_wht(*cattn_out_, count * N_HEAD, HEAD_DIM, true);
+    backend_.sigmoid_gate_mul_rows(*cattn_out_, *cqg_, N_HEAD, HEAD_DIM, count);
+    BackendQuantized x6 = quantized_view(cq6144_, count * N_HEAD * HEAD_DIM);
+    backend_.quantize(*cattn_out_, x6);
+    backend_.matmul_quantized(layer_weight(layer, "attn_output.weight"), x6, count, *cy_);
+}
+
+void MetalEngine::ffn_chunk(uint32_t layer, uint32_t count) {
+    BackendQuantized x5 = quantized_view(cq5120_, count * N_EMBD);
+    backend_.matmul_quantized(layer_weight(layer, "ffn_gate.weight"), x5, count, *cffn_gate_);
+    backend_.matmul_quantized(layer_weight(layer, "ffn_up.weight"), x5, count, *cffn_up_);
+    backend_.silu_mul(*cffn_gate_, *cffn_up_, *cffn_gate_, count * N_FFN);
+    BackendQuantized x17 = quantized_view(cq17408_, count * N_FFN);
+    backend_.quantize(*cffn_gate_, x17);
+    backend_.matmul_quantized(layer_weight(layer, "ffn_down.weight"), x17, count, *cy_);
+}
+
+void MetalEngine::chunk_forward(const uint32_t* tokens, uint32_t count, bool verify) {
+    if (!ch_) throw std::runtime_error("q27 Metal: chunked prefill is unavailable");
+    if (!count || count > CHUNK_MAX) throw std::runtime_error("q27 Metal: invalid chunk size");
+    if ((uint64_t)position_ + count > max_context_)
+        throw std::runtime_error("q27 Metal: context exhausted");
+    for (uint32_t i = 0; i < count; i++)
+        if (tokens[i] >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
+    backend_.embedding_q8_rows(weight("token_embd.weight"), tokens, count, *ch_);
+    BackendQuantized x5 = quantized_view(cq5120_, count * N_EMBD);
+    for (uint32_t layer = 0; layer < N_LAYER; layer++) {
+        backend_.rmsnorm_rows_quantized(*ch_, layer_weight(layer, "attn_norm.weight"),
+                                        *cx1_, N_EMBD, count, EPS, x5);
+        if (attention_layer(layer)) attention_chunk(layer, count); else gdn_chunk(layer, count, verify);
+        backend_.add_inplace(*ch_, *cy_, count * N_EMBD);
+        backend_.rmsnorm_rows_quantized(*ch_, layer_weight(layer, "post_attention_norm.weight"),
+                                        *cx1_, N_EMBD, count, EPS, x5);
+        ffn_chunk(layer, count);
+        backend_.add_inplace(*ch_, *cy_, count * N_EMBD);
+    }
+}
+
+void MetalEngine::encode_chunk(const uint32_t* tokens, uint32_t count) {
+    chunk_forward(tokens, count);
+    position_ += count;
+}
+
+// Commits GDN state (recurrent + convolution ring) for the first `count`
+// verified lanes by replaying only the conv/DeltaNet recurrence from the
+// inputs parked during the verify chunk. Both chunk kernels are sequential
+// in-kernel, so the replayed state is bit-identical to the state the verify
+// chunk would have committed after `count` lanes — the full-stack commit
+// re-encode this replaces streamed every weight a second time (~0.9 s).
+void MetalEngine::gdn_replay(uint32_t count) {
+    for (uint32_t layer = 0; layer < N_LAYER; layer++) {
+        if (attention_layer(layer)) continue;
+        LayerState& state = layers_[layer];
+        const uint32_t slot = gdn_slot(layer);
+        backend_.conv_chunk(*state.ring, *state.ring, *park_qkv_[slot],
+                            layer_weight(layer, "ssm_conv1d.weight"), *cconv_out_, GDN_CH, count);
+        backend_.l2norm_rows(*cconv_out_, 2 * GDN_QK_HEADS, GDN_DIM, GDN_CH, count, EPS);
+        backend_.delta_chunk(*state.recurrent, *state.recurrent, *cconv_out_,
+                             *park_g_[slot], *park_beta_[slot], *cdelta_out_,
+                             GDN_HEADS, GDN_QK_HEADS, GDN_DIM, count);
+    }
+}
+
+uint32_t MetalEngine::step(uint32_t token) {
+    if (token >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
+    if (position_ >= max_context_) throw std::runtime_error("q27 Metal: context exhausted");
+    CommandBatch batch(backend_);
+    encode_token(token, true);
+    batch.finish();
+    uint32_t next = 0;
+    backend_.read(*token_out_, 0, &next, sizeof(next));
+    return next;
+}
+
+void MetalEngine::mtp_warm(const BackendBuffer& hidden, uint32_t token, uint32_t position) {
+    if (!has_mtp_)
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
+    constexpr uint32_t layer = 64;
+    backend_.embedding_q8(weight("token_embd.weight"), token, *h_);
+    backend_.rmsnorm(*h_, layer_weight(layer, "nextn.enorm.weight"), *mtp_embed_norm_, N_EMBD, EPS);
+    backend_.rmsnorm(hidden, layer_weight(layer, "nextn.hnorm.weight"), *mtp_hidden_norm_, N_EMBD, EPS);
+    backend_.concat(*mtp_embed_norm_, N_EMBD, *mtp_hidden_norm_, N_EMBD, *mtp_concat_);
+    backend_.quantize(*mtp_concat_, q10240_);
+    backend_.matvec_quantized(layer_weight(layer, "nextn.eh_proj.weight"), q10240_, *mtp_x_);
+    backend_.rmsnorm_quantized(*mtp_x_,layer_weight(layer,"attn_norm.weight"),*x1_,N_EMBD,EPS,q5120_);
+    backend_.matvec_quantized_pair(layer_weight(layer,"attn_k.weight"),*kbuf_,
+                                   layer_weight(layer,"attn_v.weight"),*vbuf_,q5120_);
+    backend_.rmsnorm_heads(*kbuf_, layer_weight(layer, "attn_k_norm.weight"),
+                           N_KV, HEAD_DIM, HEAD_DIM, EPS);
+    backend_.rope_neox(*kbuf_, N_KV, HEAD_DIM, N_ROT, HEAD_DIM, position, FREQ_BASE);
+    backend_.kv_store(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_, position,
+                      N_KV, HEAD_DIM,
+                      turbo3_kv_ ? KvFormat::TURBO3 : KvFormat::F16);
+}
+
+uint32_t MetalEngine::prefill(const std::vector<uint32_t>& prompt, bool warm_mtp) {
+    if (prompt.empty()) throw std::runtime_error("q27 Metal: prompt is empty");
+    if ((uint64_t)position_ + prompt.size() > max_context_)
+        throw std::runtime_error("q27 Metal: prompt exceeds context");
+    for (uint32_t token : prompt)
+        if (token >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
+    // Layer-major chunked ingestion. MTP warming needs each token's final
+    // normalized hidden state, which the chunked path does not produce, so
+    // MTP prompts stay on the token-serial path. The final prompt token is
+    // always serial: it produces logits and leaves the last hidden state in
+    // x1_ for MTP drafting and prefix snapshots.
+    size_t serial_begin = 0;
+    if (chunked_prefill_ && !warm_mtp && prompt.size() >= 3) {
+        const size_t chunkable = prompt.size() - 1;
+        while (chunkable - serial_begin >= 2) {
+            const uint32_t count =
+                (uint32_t)std::min<size_t>(CHUNK_MAX, chunkable - serial_begin);
+            CommandBatch batch(backend_);
+            encode_chunk(prompt.data() + serial_begin, count);
+            batch.finish();
+            serial_begin += count;
+        }
+    }
+    // Bound encoder growth for long serial prompts: this avoids recording
+    // millions of dispatches into one command buffer.
+    constexpr size_t COMMAND_CHUNK=8;
+    for(size_t begin=serial_begin;begin<prompt.size();begin+=COMMAND_CHUNK) {
+        CommandBatch batch(backend_);
+        if(begin==serial_begin && warm_mtp && position_>0) mtp_warm(*x1_,prompt.front(),position_);
+        size_t end=std::min(prompt.size(),begin+COMMAND_CHUNK);
+        for(size_t i=begin;i<end;i++) {
+            encode_token(prompt[i],i+1==prompt.size());
+            if(warm_mtp && i+1<prompt.size()) mtp_warm(*x1_,prompt[i+1],position_);
+        }
+        batch.finish();
+    }
+    uint32_t next = 0;
+    backend_.read(*token_out_, 0, &next, sizeof(next));
+    return next;
+}
+
+uint32_t MetalEngine::mtp_forward(const BackendBuffer& hidden, uint32_t token,
+                                  uint32_t position) {
+    if (!has_mtp_)
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
+    if (position >= max_context_) throw std::runtime_error("q27 Metal: MTP context exhausted");
+    if (token >= VOCAB) throw std::runtime_error("q27 Metal: MTP token out of range");
+    constexpr uint32_t layer = 64;
+    CommandBatch batch(backend_);
+    backend_.embedding_q8(weight("token_embd.weight"), token, *h_);
+    backend_.rmsnorm(*h_, layer_weight(layer, "nextn.enorm.weight"), *mtp_embed_norm_, N_EMBD, EPS);
+    backend_.rmsnorm(hidden, layer_weight(layer, "nextn.hnorm.weight"), *mtp_hidden_norm_, N_EMBD, EPS);
+    backend_.concat(*mtp_embed_norm_, N_EMBD, *mtp_hidden_norm_, N_EMBD, *mtp_concat_);
+    backend_.quantize(*mtp_concat_, q10240_);
+    backend_.matvec_quantized(layer_weight(layer, "nextn.eh_proj.weight"), q10240_, *mtp_x_);
+
+    backend_.rmsnorm_quantized(*mtp_x_,layer_weight(layer,"attn_norm.weight"),*x1_,N_EMBD,EPS,q5120_);
+    backend_.matvec_quantized(layer_weight(layer, "attn_q.weight"), q5120_, *qg_);
+    backend_.rmsnorm_heads(*qg_, layer_weight(layer, "attn_q_norm.weight"),
+                           N_HEAD, HEAD_DIM, 2 * HEAD_DIM, EPS);
+    backend_.matvec_quantized_pair(layer_weight(layer,"attn_k.weight"),*kbuf_,
+                                   layer_weight(layer,"attn_v.weight"),*vbuf_,q5120_);
+    backend_.rmsnorm_heads(*kbuf_, layer_weight(layer, "attn_k_norm.weight"),
+                           N_KV, HEAD_DIM, HEAD_DIM, EPS);
+    backend_.rope_neox(*qg_, N_HEAD, HEAD_DIM, N_ROT, 2 * HEAD_DIM, position, FREQ_BASE);
+    backend_.rope_neox(*kbuf_, N_KV, HEAD_DIM, N_ROT, HEAD_DIM, position, FREQ_BASE);
+    const KvFormat format = turbo3_kv_ ? KvFormat::TURBO3 : KvFormat::F16;
+    if (turbo3_kv_) backend_.turbo_wht(*qg_, N_HEAD, 2 * HEAD_DIM, false);
+    backend_.kv_store(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_, position,
+                      N_KV, HEAD_DIM, format);
+    backend_.attention(*qg_, 2 * HEAD_DIM, *mtp_k_cache_, *mtp_v_cache_,
+                       *attn_out_, position + 1, N_HEAD, N_KV, HEAD_DIM,
+                       1.0f / std::sqrt((float)HEAD_DIM), format, nullptr);
+    if (turbo3_kv_) backend_.turbo_wht(*attn_out_, N_HEAD, HEAD_DIM, true);
+    backend_.sigmoid_gate_mul(*attn_out_, *qg_, N_HEAD, HEAD_DIM);
+    backend_.quantize(*attn_out_, q6144_);
+    backend_.matvec_quantized(layer_weight(layer, "attn_output.weight"), q6144_, *y_);
+    backend_.add_inplace(*mtp_x_, *y_, N_EMBD);
+
+    backend_.rmsnorm_quantized(*mtp_x_,layer_weight(layer,"post_attention_norm.weight"),*x1_,N_EMBD,EPS,q5120_);
+    backend_.matvec_quantized_pair(layer_weight(layer,"ffn_gate.weight"),*ffn_gate_,
+                                   layer_weight(layer,"ffn_up.weight"),*ffn_up_,q5120_);
+    backend_.silu_mul(*ffn_gate_, *ffn_up_, *ffn_gate_, N_FFN);
+    backend_.quantize(*ffn_gate_, q17408_);
+    backend_.matvec_quantized(layer_weight(layer, "ffn_down.weight"), q17408_, *y_);
+    backend_.add_inplace(*mtp_x_, *y_, N_EMBD);
+    backend_.rmsnorm(*mtp_x_, layer_weight(layer, "nextn.shared_head_norm.weight"),
+                     *mtp_hidden_out_, N_EMBD, EPS);
+    const BackendTensor& head = model_.find("output_q4.weight") ? weight("output_q4.weight")
+                                                                : weight("output.weight");
+    backend_.quantize(*mtp_hidden_out_, q5120_);
+    backend_.matvec_quantized(head, q5120_, *logits_);
+    backend_.argmax(*logits_, VOCAB, *token_out_);
+    batch.finish();
+    uint32_t result = 0; backend_.read(*token_out_, 0, &result, sizeof(result));
+    return result;
+}
+
+// One batched MTP round: draft serially through layer 64, then verify every
+// lane in a single state-free layer-major pass with a batched output head
+// and per-lane argmax — one CPU synchronization per round instead of one
+// per committed token. The verify chunk parks each GDN layer's recurrence
+// inputs and discards its speculative state commits; acceptance then
+// replays only the GDN recurrence over the accepted prefix (gdn_replay),
+// so no state checkpoint, restore, or full-stack commit re-encode exists.
+// KV rows written for rejected lanes stay invisible behind position_.
+// Committed tokens follow the exact serial-walk semantics, including never
+// encoding the final output token.
+std::vector<uint32_t> MetalEngine::generate_mtp_batched(uint32_t pending, uint32_t count,
+                                                        uint32_t width) {
+    // Vector convenience wrapper over the streaming core: a sink that never
+    // cancels and an EOS sentinel that never matches (tokens are < VOCAB <
+    // UINT32_MAX) reproduce the previous whole-completion behaviour exactly.
+    std::vector<uint32_t> output;
+    output.reserve(count);
+    StopCause cause;
+    stream_mtp_batched(pending, count, width, UINT32_MAX,
+                       [&](uint32_t token) { output.push_back(token); return true; }, cause);
+    return output;
+}
+
+uint32_t MetalEngine::stream_mtp_batched(uint32_t pending, uint32_t count, uint32_t width,
+                                         uint32_t eos, const TokenSink& sink, StopCause& cause) {
+    uint32_t emitted = 0;
+    cause = StopCause::MaxTokens;
+    // commit() streams one token through the sink, stopping on EOS or cancel.
+    // Returns 0 = continue, 1 = EOS reached, 2 = client cancelled.
+    auto commit = [&](uint32_t token) -> int {
+        if (token == eos) { cause = StopCause::Eos; return 1; }
+        if (!sink(token)) { cause = StopCause::Cancelled; return 2; }
+        emitted++;
+        return 0;
+    };
+    // Start narrow and let acceptance widen the window: committed tokens are
+    // width-invariant, and a wide first round pays for many serial drafts
+    // through a cold draft head before acceptance has been measured once.
+    uint32_t live_width = std::min(width, 4u);
+    while (emitted < count) {
+        if (emitted + 1 == count) { commit(pending); return emitted; }
+        const uint32_t remaining = (uint32_t)(count - emitted);
+        uint32_t live = std::min(live_width, remaining);
+        // The verify chunk stores a KV row for every lane, so it must stay
+        // inside the reserved context even before acceptance is known.
+        if ((uint64_t)position_ + live > max_context_)
+            live = (uint32_t)(max_context_ - position_);
+        if (live < 2) {
+            if (commit(pending)) return emitted;
+            if (emitted == count) return emitted;
+            pending = step(pending);
+            continue;
+        }
+        static const bool trace = getenv("Q27_MTP_TRACE") != nullptr;
+        auto clock = [] { return std::chrono::steady_clock::now(); };
+        auto since = [](std::chrono::steady_clock::time_point start) {
+            return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+        };
+        auto draft_start = clock();
+        std::vector<uint32_t> lanes(live);
+        lanes[0] = pending;
+        const BackendBuffer* hidden = x1_.get();
+        for (uint32_t lane = 1; lane < live; lane++) {
+            lanes[lane] = mtp_forward(*hidden, lanes[lane - 1], position_ + lane - 1);
+            hidden = mtp_hidden_out_.get();
+        }
+        last_spec_stats_.rounds++;
+        last_spec_stats_.drafted += live - 1;
+        auto verify_start = clock();
+        {
+            CommandBatch batch(backend_);
+            chunk_forward(lanes.data(), live, /*verify=*/true);
+            BackendQuantized x5 = quantized_view(cq5120_, live * N_EMBD);
+            backend_.rmsnorm_rows_quantized(*ch_, weight("output_norm.weight"), *cfinal_,
+                                            N_EMBD, live, EPS, x5);
+            backend_.matmul_quantized(weight("output.weight"), x5, live, *clogits_);
+            backend_.argmax_rows(*clogits_, VOCAB, live, *cpred_);
+            batch.finish();
+        }
+        std::vector<uint32_t> predictions(live);
+        backend_.read(*cpred_, 0, predictions.data(), live * sizeof(uint32_t));
+        uint32_t accepted = 0;
+        while (accepted + 1 < live && predictions[accepted] == lanes[accepted + 1]) accepted++;
+        uint32_t committed = std::min(accepted + 1, remaining);
+        // The final output token is pushed but never encoded, exactly like
+        // the serial walk, so snapshots and continuations stay compatible.
+        const uint32_t encoded = committed == remaining ? committed - 1 : committed;
+        last_spec_stats_.accepted += committed - 1;
+        auto commit_start = clock();
+        if (encoded) {
+            CommandBatch batch(backend_);
+            gdn_replay(encoded);
+            backend_.copy(*cfinal_, (uint64_t)(encoded - 1) * N_EMBD * sizeof(float),
+                          *x1_, 0, (uint64_t)N_EMBD * sizeof(float));
+            backend_.copy(*clogits_, (uint64_t)(encoded - 1) * VOCAB * sizeof(float),
+                          *logits_, 0, (uint64_t)VOCAB * sizeof(float));
+            batch.finish();
+        }
+        position_ += encoded;
+        if (trace)
+            fprintf(stderr, "mtp round: live %u accepted %u | draft %.2fs verify %.2fs commit %.2fs\n",
+                    live, accepted, std::chrono::duration<double>(verify_start - draft_start).count(),
+                    std::chrono::duration<double>(commit_start - verify_start).count(), since(commit_start));
+        for (uint32_t i = 0; i < committed; i++)
+            if (commit(lanes[i])) return emitted;
+        pending = predictions[committed - 1];
+        // Width adaptation is a pure performance control: committed tokens
+        // are width-invariant, matching the recorded 2/4/8/12 gate.
+        live_width = accepted + 1 == live ? std::min(width, live_width + 2)
+                                          : std::max(2u, accepted + 2);
+    }
+    return emitted;
+}
+
+uint32_t MetalEngine::ingest_prompt(const std::vector<uint32_t>& tokens, bool warm_mtp,
+                                    bool reset_first) {
+    if (reset_first) reset();
+    return prefill(tokens, warm_mtp);
+}
+
+std::vector<float> MetalEngine::read_logits() {
+    std::vector<float> result(VOCAB);
+    backend_.synchronize();
+    backend_.read(*logits_,0,result.data(),result.size()*sizeof(float));
+    return result;
+}
+
+std::vector<float> MetalEngine::teacher_force_nll(const std::vector<uint32_t>& tokens) {
+    if (tokens.size() < 2) throw std::runtime_error("q27 Metal: NLL needs at least two tokens");
+    if (tokens.size() - 1 > max_context_)
+        throw std::runtime_error("q27 Metal: NLL sequence exceeds context");
+    for (uint32_t token : tokens)
+        if (token >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
+    reset();
+    const uint32_t n_encode = (uint32_t)tokens.size() - 1;
+    std::vector<float> result;
+    result.reserve(n_encode);
+
+    auto nll_cpu = [](const float* logits, uint32_t target, uint32_t vocab) -> float {
+        double mx = -1e300;
+        for (uint32_t v = 0; v < vocab; v++) mx = std::max(mx, (double)logits[v]);
+        double se = 0.0;
+        for (uint32_t v = 0; v < vocab; v++) se += std::exp((double)logits[v] - mx);
+        return (float)(std::log(se) + mx - (double)logits[target]);
+    };
+
+    uint32_t done = 0;
+    // Prefer the layer-major chunk path: one command buffer per up-to-12
+    // tokens, batched output head, and a GPU logsumexp so only `count`
+    // floats cross back to the CPU per chunk.
+    if (chunked_prefill_ && n_encode >= 2) {
+        while (n_encode - done >= 2) {
+            const uint32_t count = std::min(CHUNK_MAX, n_encode - done);
+            std::vector<uint32_t> targets(count);
+            for (uint32_t r = 0; r < count; r++) targets[r] = tokens[done + r + 1];
+            // Host write before the command batch: targets are shared-memory
+            // and must be visible before the NLL kernel is encoded.
+            backend_.write(*ctargets_, 0, targets.data(), count * sizeof(uint32_t));
+            {
+                CommandBatch batch(backend_);
+                chunk_forward(tokens.data() + done, count);
+                BackendQuantized x5 = quantized_view(cq5120_, count * N_EMBD);
+                backend_.rmsnorm_rows_quantized(*ch_, weight("output_norm.weight"), *cfinal_,
+                                                N_EMBD, count, EPS, x5);
+                backend_.matmul_quantized(weight("output.weight"), x5, count, *clogits_);
+                backend_.nll_rows(*clogits_, *ctargets_, *cnll_, VOCAB, count);
+                batch.finish();
+            }
+            position_ += count;
+            std::vector<float> chunk_nll(count);
+            backend_.read(*cnll_, 0, chunk_nll.data(), count * sizeof(float));
+            result.insert(result.end(), chunk_nll.begin(), chunk_nll.end());
+            done += count;
+            if ((done / CHUNK_MAX) % 32 == 0)
+                fprintf(stderr, "  nll pos %u/%u\r", done, n_encode);
+            // Early readout: absolute PPL stabilizes long before a deep pass
+            // finishes; print the running mean so a long run yields its
+            // verdict in the first minutes and the tail only refines buckets.
+            if (done / 2048 != (done - count) / 2048) {
+                double sum = 0.0;
+                for (float v : result) sum += v;
+                fprintf(stderr, "  nll pos %u: running mean %.4f (ppl %.3f)\n",
+                        done, sum / result.size(), std::exp(sum / result.size()));
+            }
+        }
+    }
+    while (done < n_encode) {
+        {
+            CommandBatch batch(backend_);
+            encode_token(tokens[done], true);
+            batch.finish();
+        }
+        std::vector<float> logits = read_logits();
+        result.push_back(nll_cpu(logits.data(), tokens[done + 1], VOCAB));
+        done++;
+    }
+    if (n_encode >= CHUNK_MAX) fprintf(stderr, "\n");
+    return result;
+}
+
+std::vector<uint32_t> MetalEngine::generate_sampled_from_logits(uint32_t count,
+                                                                 const SamplingParams& params) {
+    validate_sampling(params); last_spec_stats_={};
+    if((uint64_t)position_+(count?count-1:0)>max_context_)
+        throw std::runtime_error("q27 Metal: generation exceeds context");
+    std::mt19937_64 random(params.seed); std::vector<uint32_t> output; output.reserve(count);
+    for(uint32_t i=0;i<count;i++) {
+        // top_k == 0 must stay on the complete logits vector; candidate over-sets
+        // intentionally reject that configuration because they omit vocabulary entries.
+        uint32_t token=sample_logits_cpu(read_logits(),params,random); output.push_back(token);
+        if(i+1<count) step(token);
+    }
+    return output;
+}
+
+std::vector<uint32_t> MetalEngine::generate_sampled(const std::vector<uint32_t>& prompt,
+                                                     uint32_t count,const SamplingParams& params) {
+    if(prompt.empty()) throw std::runtime_error("q27 Metal: prompt is empty");
+    if((uint64_t)prompt.size()+count>max_context_+1)
+        throw std::runtime_error("q27 Metal: prompt/generation exceeds context");
+    ingest_prompt(prompt,false,true);
+    return generate_sampled_from_logits(count,params);
+}
+
+uint32_t MetalEngine::stream_sampled_from_logits(uint32_t count, uint32_t eos,
+                                                 const SamplingParams& params,
+                                                 const TokenSink& sink, StopCause& cause) {
+    validate_sampling(params); last_spec_stats_={};
+    if((uint64_t)position_+(count?count-1:0)>max_context_)
+        throw std::runtime_error("q27 Metal: generation exceeds context");
+    std::mt19937_64 random(params.seed);
+    cause = StopCause::MaxTokens;
+    uint32_t emitted=0;
+    while(emitted<count) {
+        uint32_t token=sample_logits_cpu(read_logits(),params,random);
+        if(token==eos) { cause=StopCause::Eos; return emitted; }
+        if(!sink(token)) { cause=StopCause::Cancelled; return emitted; }
+        if(++emitted==count) return emitted;
+        step(token);
+    }
+    return emitted;
+}
+
+uint32_t MetalEngine::stream_from_pending(uint32_t pending, uint32_t count, uint32_t eos,
+                                          uint32_t mtp_width, const TokenSink& sink,
+                                          StopCause& cause) {
+    last_spec_stats_={};
+    if (pending >= VOCAB) throw std::runtime_error("q27 Metal: pending token out of range");
+    if (mtp_width && !has_mtp_)
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
+    if (mtp_width && (mtp_width < 2 || mtp_width > 12))
+        throw std::runtime_error("q27 Metal: MTP width must be 2..12");
+    if ((uint64_t)position_ + (count ? count - 1 : 0) > max_context_)
+        throw std::runtime_error("q27 Metal: generation exceeds context");
+    cause = StopCause::MaxTokens;
+    if (mtp_width && chunked_prefill_)
+        return stream_mtp_batched(pending, count, mtp_width, eos, sink, cause);
+    // Serial greedy walk: the pending token is emitted, then each step()
+    // yields the next. EOS stops without emitting it; the sink returning
+    // false is a client cancel (mirrors the CUDA engine's on_token contract).
+    uint32_t emitted=0;
+    uint32_t cur=pending;
+    while(emitted<count) {
+        if(cur==eos) { cause=StopCause::Eos; return emitted; }
+        if(!sink(cur)) { cause=StopCause::Cancelled; return emitted; }
+        if(++emitted==count) return emitted;
+        cur=step(cur);
+    }
+    return emitted;
+}
+
+std::vector<uint32_t> MetalEngine::generate_from_pending(uint32_t pending, uint32_t count,
+                                                          uint32_t mtp_width) {
+    last_spec_stats_={};
+    if (pending >= VOCAB) throw std::runtime_error("q27 Metal: pending token out of range");
+    if (mtp_width && !has_mtp_)
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
+    if (mtp_width && (mtp_width < 2 || mtp_width > 12))
+        throw std::runtime_error("q27 Metal: MTP width must be 2..12");
+    if ((uint64_t)position_ + (count ? count - 1 : 0) > max_context_)
+        throw std::runtime_error("q27 Metal: generation exceeds context");
+    if (mtp_width && chunked_prefill_)
+        return generate_mtp_batched(pending, count, mtp_width);
+    std::vector<uint32_t> output;
+    output.reserve(count);
+    if (!mtp_width) {
+        if (!count) return output;
+        output.push_back(pending);
+        for (uint32_t i=1;i<count;i++) { pending=step(pending); output.push_back(pending); }
+        return output;
+    }
+    while (output.size() < count) {
+        if (output.size() + 1 == count) { output.push_back(pending); break; }
+        const uint32_t live_width = std::min<uint32_t>(mtp_width, (uint32_t)(count - output.size()));
+        std::vector<uint32_t> drafts;
+        drafts.reserve(live_width - 1);
+        const BackendBuffer* hidden = x1_.get();
+        uint32_t draft_token = pending;
+        for (uint32_t lane = 1; lane < live_width; lane++) {
+            draft_token = mtp_forward(*hidden, draft_token, position_ + lane - 1);
+            drafts.push_back(draft_token);
+            hidden = mtp_hidden_out_.get();
+        }
+        last_spec_stats_.rounds++; last_spec_stats_.drafted+=drafts.size();
+        output.push_back(pending);
+        uint32_t prediction = step(pending);
+        for (uint32_t draft : drafts) {
+            if (prediction != draft) break;
+            last_spec_stats_.accepted++;
+            output.push_back(draft);
+            if (output.size() == count) return output;
+            prediction = step(draft);
+        }
+        pending = prediction;
+    }
+    return output;
+}
+
+std::vector<uint32_t> MetalEngine::generate(const std::vector<uint32_t>& prompt, uint32_t count) {
+    if (prompt.empty()) throw std::runtime_error("q27 Metal: prompt is empty");
+    if ((uint64_t)prompt.size() + count > max_context_ + 1)
+        throw std::runtime_error("q27 Metal: prompt/generation exceeds context");
+    uint32_t pending = ingest_prompt(prompt, false, true);
+    return generate_from_pending(pending, count);
+}
+
+std::vector<uint32_t> MetalEngine::generate_mtp(const std::vector<uint32_t>& prompt,
+                                                 uint32_t count, uint32_t width) {
+    if (prompt.empty()) throw std::runtime_error("q27 Metal: prompt is empty");
+    if (!has_mtp_)
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
+    if ((uint64_t)prompt.size() + count > max_context_ + 1)
+        throw std::runtime_error("q27 Metal: prompt/generation exceeds context");
+    uint32_t pending = ingest_prompt(prompt, true, true);
+    return generate_from_pending(pending, count, width);
+}
+
+std::vector<uint32_t> MetalEngine::generate_suffix(const std::vector<uint32_t>& prompt,
+                                                    uint32_t count, uint32_t width,
+                                                    uint32_t minimum_match) {
+    if(prompt.empty()) throw std::runtime_error("q27 Metal: prompt is empty");
+    if(width<2 || width>12) throw std::runtime_error("q27 Metal: suffix width must be 2..12");
+    if((uint64_t)prompt.size()+count>max_context_+1)
+        throw std::runtime_error("q27 Metal: prompt/generation exceeds context");
+    uint32_t pending=ingest_prompt(prompt,false,true); last_spec_stats_={};
+    std::vector<int> history(prompt.begin(),prompt.end()); SuffixDraft drafter; drafter.reset(history);
+    std::vector<uint32_t> output; output.reserve(count);
+    while(output.size()<count) {
+        if(output.size()+1==count) { output.push_back(pending); break; }
+        const uint32_t lanes=std::min<uint32_t>(width-1,(uint32_t)(count-output.size()-1));
+        std::vector<int> proposals(lanes);
+        int match=drafter.propose_with((int)pending,(int)lanes,proposals.data());
+        last_spec_stats_.rounds++;
+        if(match>=(int)minimum_match) last_spec_stats_.drafted+=proposals.size();
+        output.push_back(pending); drafter.append((int)pending);
+        uint32_t prediction=step(pending);
+        if(match>=(int)minimum_match) for(int proposal:proposals) {
+            if(prediction!=(uint32_t)proposal) break;
+            last_spec_stats_.accepted++;
+            output.push_back((uint32_t)proposal); drafter.append(proposal);
+            if(output.size()==count) return output;
+            prediction=step((uint32_t)proposal);
+        }
+        pending=prediction;
+    }
+    return output;
+}
+
+} // namespace q27

--- a/src/metal/metal_engine.cpp
+++ b/src/metal/metal_engine.cpp
@@ -786,11 +786,21 @@ uint32_t MetalEngine::stream_mtp_batched(uint32_t pending, uint32_t count, uint3
         backend_.read(*cpred_, 0, predictions.data(), live * sizeof(uint32_t));
         uint32_t accepted = 0;
         while (accepted + 1 < live && predictions[accepted] == lanes[accepted + 1]) accepted++;
-        uint32_t committed = std::min(accepted + 1, remaining);
-        // The final output token is pushed but never encoded, exactly like
-        // the serial walk, so snapshots and continuations stay compatible.
-        const uint32_t encoded = committed == remaining ? committed - 1 : committed;
-        last_spec_stats_.accepted += committed - 1;
+        const uint32_t offered = std::min(accepted + 1, remaining);
+        // Determine the externally committed prefix before mutating recurrent,
+        // KV, hidden, or logits state. EOS and a rejecting sink do not consume
+        // their token; prior delivered tokens still need encoding so state
+        // predicts the stopped token exactly as the serial walk does.
+        uint32_t delivered = 0;
+        int stop = 0;
+        while (delivered < offered) {
+            stop = commit(lanes[delivered]);
+            if (stop) break;
+            delivered++;
+        }
+        last_spec_stats_.accepted += delivered ? delivered - 1 : 0;
+        const bool exhausted = emitted == count;
+        const uint32_t encoded = exhausted ? delivered - 1 : delivered;
         auto commit_start = clock();
         if (encoded) {
             CommandBatch batch(backend_);
@@ -810,9 +820,8 @@ uint32_t MetalEngine::stream_mtp_batched(uint32_t pending, uint32_t count, uint3
             fprintf(stderr, "mtp round: live %u accepted %u | draft %.2fs verify %.2fs commit %.2fs\n",
                     live, accepted, std::chrono::duration<double>(verify_start - draft_start).count(),
                     std::chrono::duration<double>(commit_start - verify_start).count(), since(commit_start));
-        for (uint32_t i = 0; i < committed; i++)
-            if (commit(lanes[i])) return emitted;
-        pending = predictions[committed - 1];
+        if (stop || exhausted) return emitted;
+        pending = predictions[delivered - 1];
         // Width adaptation is a pure performance control: committed tokens
         // are width-invariant, matching the recorded 2/4/8/12 gate.
         live_width = accepted + 1 == live ? std::min(width, live_width + 2)

--- a/src/metal/metal_engine.cpp
+++ b/src/metal/metal_engine.cpp
@@ -3,6 +3,7 @@
 #include "../../third_party/json.hpp"
 #include "../suffixdraft.h"
 
+#include <array>
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -217,7 +218,7 @@ MetalEngine::MetalEngine(const std::string& model_path, uint32_t context, bool t
     if (has_mtp_) {
         mtp_embed_norm_ = alloc_f32(N_EMBD); mtp_hidden_norm_ = alloc_f32(N_EMBD);
         mtp_concat_ = alloc_f32(2 * N_EMBD); mtp_x_ = alloc_f32(N_EMBD);
-        mtp_hidden_out_ = alloc_f32(N_EMBD);
+        mtp_hidden_out_ = alloc_f32(N_EMBD); mtp_logits_ = alloc_f32(VOCAB);
         const uint64_t mtp_cache_bytes = (uint64_t)max_context_ * cache_row_bytes;
         mtp_k_cache_ = backend_.allocate(mtp_cache_bytes); mtp_v_cache_ = backend_.allocate(mtp_cache_bytes);
     }
@@ -288,6 +289,16 @@ void MetalEngine::reset() {
         if (layer.ring) backend_.zero(*layer.ring);
         // KV rows are written before they become visible through position_;
         // clearing the full reserved context would make long-context reset O(ctx).
+    }
+    // MTP attention includes row 0, but there is no predecessor hidden state
+    // from which to warm it. Keep that permanent sentinel deterministic while
+    // leaving the remaining O(context) cache rows write-before-visible.
+    if (mtp_k_cache_) {
+        std::array<uint8_t, N_KV * HEAD_DIM * sizeof(uint16_t)> zero_row{};
+        const uint64_t cache_row = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
+                                              : zero_row.size();
+        backend_.write(*mtp_k_cache_, 0, zero_row.data(), cache_row);
+        backend_.write(*mtp_v_cache_, 0, zero_row.data(), cache_row);
     }
 }
 
@@ -661,7 +672,8 @@ uint32_t MetalEngine::mtp_forward(const BackendBuffer& hidden, uint32_t token,
     backend_.quantize(*mtp_concat_, q10240_);
     backend_.matvec_quantized(layer_weight(layer, "nextn.eh_proj.weight"), q10240_, *mtp_x_);
 
-    backend_.rmsnorm_quantized(*mtp_x_,layer_weight(layer,"attn_norm.weight"),*x1_,N_EMBD,EPS,q5120_);
+    // Drafting may stop before any lane commits; keep resident x1_/logits_ intact.
+    backend_.rmsnorm_quantized(*mtp_x_,layer_weight(layer,"attn_norm.weight"),*h_,N_EMBD,EPS,q5120_);
     backend_.matvec_quantized(layer_weight(layer, "attn_q.weight"), q5120_, *qg_);
     backend_.rmsnorm_heads(*qg_, layer_weight(layer, "attn_q_norm.weight"),
                            N_HEAD, HEAD_DIM, 2 * HEAD_DIM, EPS);
@@ -684,7 +696,7 @@ uint32_t MetalEngine::mtp_forward(const BackendBuffer& hidden, uint32_t token,
     backend_.matvec_quantized(layer_weight(layer, "attn_output.weight"), q6144_, *y_);
     backend_.add_inplace(*mtp_x_, *y_, N_EMBD);
 
-    backend_.rmsnorm_quantized(*mtp_x_,layer_weight(layer,"post_attention_norm.weight"),*x1_,N_EMBD,EPS,q5120_);
+    backend_.rmsnorm_quantized(*mtp_x_,layer_weight(layer,"post_attention_norm.weight"),*h_,N_EMBD,EPS,q5120_);
     backend_.matvec_quantized_pair(layer_weight(layer,"ffn_gate.weight"),*ffn_gate_,
                                    layer_weight(layer,"ffn_up.weight"),*ffn_up_,q5120_);
     backend_.silu_mul(*ffn_gate_, *ffn_up_, *ffn_gate_, N_FFN);
@@ -696,8 +708,8 @@ uint32_t MetalEngine::mtp_forward(const BackendBuffer& hidden, uint32_t token,
     const BackendTensor& head = model_.find("output_q4.weight") ? weight("output_q4.weight")
                                                                 : weight("output.weight");
     backend_.quantize(*mtp_hidden_out_, q5120_);
-    backend_.matvec_quantized(head, q5120_, *logits_);
-    backend_.argmax(*logits_, VOCAB, *token_out_);
+    backend_.matvec_quantized(head, q5120_, *mtp_logits_);
+    backend_.argmax(*mtp_logits_, VOCAB, *token_out_);
     batch.finish();
     uint32_t result = 0; backend_.read(*token_out_, 0, &result, sizeof(result));
     return result;

--- a/src/metal/metal_engine.cpp
+++ b/src/metal/metal_engine.cpp
@@ -182,11 +182,11 @@ MetalEngine::MetalEngine(const std::string& model_path, uint32_t context, bool t
     if (total_cache_bytes > backend_.recommended_working_set_size() / 2)
         throw std::runtime_error("q27 Metal: requested KV cache is too large for this device; use --kv turbo3 or reduce --ctx");
 
-    const bool per_tensor_upload = backend_.uses_per_tensor_upload(model_);
+    per_tensor_upload_ = backend_.uses_per_tensor_upload(model_);
     constexpr double gibibyte = 1024.0 * 1024.0 * 1024.0;
     std::fprintf(stderr,
                  "q27 Metal: model upload path: %s (mapping %.2f GiB, max buffer %.2f GiB)\n",
-                 per_tensor_upload ? "per-tensor" : "whole-mapping",
+                 per_tensor_upload_ ? "per-tensor" : "whole-mapping",
                  model_.mapping_size() / gibibyte,
                  backend_.max_buffer_length() / gibibyte);
 

--- a/src/metal/metal_engine.h
+++ b/src/metal/metal_engine.h
@@ -97,6 +97,7 @@ class MetalEngine {
     uint32_t max_context_;
     bool turbo3_kv_;
     uint32_t position_ = 0;
+    bool logits_resident_ = false;
     SpecStats last_spec_stats_;
     std::unordered_map<std::string, BackendTensor> weights_;
     std::vector<LayerState> layers_;

--- a/src/metal/metal_engine.h
+++ b/src/metal/metal_engine.h
@@ -108,7 +108,7 @@ class MetalEngine {
     std::shared_ptr<BackendBuffer> delta_out_, gated_out_;
     std::shared_ptr<BackendBuffer> ffn_gate_, ffn_up_, logits_, token_out_;
     std::shared_ptr<BackendBuffer> mtp_embed_norm_, mtp_hidden_norm_, mtp_concat_;
-    std::shared_ptr<BackendBuffer> mtp_x_, mtp_hidden_out_, mtp_k_cache_, mtp_v_cache_;
+    std::shared_ptr<BackendBuffer> mtp_x_, mtp_hidden_out_, mtp_logits_, mtp_k_cache_, mtp_v_cache_;
     BackendQuantized q5120_, q6144_, q10240_, q17408_;
 
     // Layer-major chunked prefill state (CHUNK_MAX token rows per buffer).

--- a/src/metal/metal_engine.h
+++ b/src/metal/metal_engine.h
@@ -64,6 +64,7 @@ class MetalEngine {
     uint32_t position() const { return position_; }
     SpecStats last_spec_stats() const { return last_spec_stats_; }
     MetalBackend& backend() { return backend_; }
+    bool used_per_tensor_upload() const { return per_tensor_upload_; }
     bool chunked_prefill() const { return chunked_prefill_; }
     void set_chunked_prefill(bool enabled);
 
@@ -96,6 +97,7 @@ class MetalEngine {
     MetalBackend backend_;
     uint32_t max_context_;
     bool turbo3_kv_;
+    bool per_tensor_upload_ = false;
     uint32_t position_ = 0;
     bool logits_resident_ = false;
     SpecStats last_spec_stats_;

--- a/src/metal/metal_engine.h
+++ b/src/metal/metal_engine.h
@@ -1,0 +1,166 @@
+#pragma once
+
+#include "metal_backend.h"
+#include "../sampling.h"
+#include "../loader.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace q27 {
+
+class MetalEngine {
+  public:
+    struct Snapshot;
+    struct SpecStats { uint64_t rounds=0,drafted=0,accepted=0; };
+    explicit MetalEngine(const std::string& model_path, uint32_t context = 128,
+                         bool turbo3_kv = false);
+
+    void reset();
+    uint32_t step(uint32_t token);
+    std::vector<uint32_t> generate(const std::vector<uint32_t>& prompt, uint32_t count);
+    std::vector<uint32_t> generate_mtp(const std::vector<uint32_t>& prompt,
+                                       uint32_t count, uint32_t width);
+    std::vector<uint32_t> generate_suffix(const std::vector<uint32_t>& prompt,
+                                          uint32_t count, uint32_t width,
+                                          uint32_t minimum_match = 12);
+    uint32_t ingest_prompt(const std::vector<uint32_t>& tokens, bool warm_mtp,
+                           bool reset_first = true);
+    std::vector<uint32_t> generate_from_pending(uint32_t pending, uint32_t count,
+                                                uint32_t mtp_width = 0);
+    std::vector<float> read_logits();
+    // Teacher-forced NLL for tokens[0..N): returns N-1 values where
+    // result[i] = -log P(tokens[i+1] | tokens[0..i]). Uses layer-major
+    // chunked encode + batched output head when available.
+    std::vector<float> teacher_force_nll(const std::vector<uint32_t>& tokens);
+    std::vector<uint32_t> generate_sampled(const std::vector<uint32_t>& prompt,
+                                           uint32_t count,const SamplingParams& params);
+    std::vector<uint32_t> generate_sampled_from_logits(uint32_t count,
+                                                       const SamplingParams& params);
+
+    // Streaming generation. `sink(token)` is called for each committed,
+    // non-EOS token in order; return false from the sink to cancel (client
+    // disconnect). Generation stops at EOS (StopCause::Eos, the EOS token is
+    // not passed to the sink), when `count` tokens have been emitted
+    // (StopCause::MaxTokens), or when the sink returns false
+    // (StopCause::Cancelled). Returns the number of tokens passed to the sink.
+    // These mirror the CUDA server's generate(prompt, n_max, eos, on_token)
+    // contract so the two servers report finish_reason identically.
+    enum class StopCause { MaxTokens, Eos, Cancelled };
+    using TokenSink = std::function<bool(uint32_t)>;
+    uint32_t stream_from_pending(uint32_t pending, uint32_t count, uint32_t eos,
+                                 uint32_t mtp_width, const TokenSink& sink, StopCause& cause);
+    uint32_t stream_sampled_from_logits(uint32_t count, uint32_t eos,
+                                        const SamplingParams& params,
+                                        const TokenSink& sink, StopCause& cause);
+
+    std::shared_ptr<Snapshot> capture_state();
+    void restore_state(const Snapshot& snapshot);
+    static constexpr uint32_t vocabulary_size() { return 248320; }
+    uint32_t position() const { return position_; }
+    SpecStats last_spec_stats() const { return last_spec_stats_; }
+    MetalBackend& backend() { return backend_; }
+    bool chunked_prefill() const { return chunked_prefill_; }
+    void set_chunked_prefill(bool enabled);
+
+  private:
+    static constexpr uint32_t N_LAYER = 64;
+    static constexpr uint32_t N_EMBD = 5120;
+    static constexpr uint32_t N_FFN = 17408;
+    static constexpr uint32_t N_HEAD = 24;
+    static constexpr uint32_t N_KV = 4;
+    static constexpr uint32_t HEAD_DIM = 256;
+    static constexpr uint32_t N_ROT = 64;
+    static constexpr uint32_t GDN_CH = 10240;
+    static constexpr uint32_t GDN_V = 6144;
+    static constexpr uint32_t GDN_HEADS = 48;
+    static constexpr uint32_t GDN_QK_HEADS = 16;
+    static constexpr uint32_t GDN_DIM = 128;
+    static constexpr uint32_t VOCAB = 248320;
+    static constexpr uint32_t CHUNK_MAX = 12;
+    static constexpr float EPS = 1e-6f;
+    static constexpr float FREQ_BASE = 1e7f;
+
+    struct LayerState {
+        std::shared_ptr<BackendBuffer> recurrent;
+        std::shared_ptr<BackendBuffer> ring;
+        std::shared_ptr<BackendBuffer> k_cache;
+        std::shared_ptr<BackendBuffer> v_cache;
+    };
+
+    Model model_;
+    MetalBackend backend_;
+    uint32_t max_context_;
+    bool turbo3_kv_;
+    uint32_t position_ = 0;
+    SpecStats last_spec_stats_;
+    std::unordered_map<std::string, BackendTensor> weights_;
+    std::vector<LayerState> layers_;
+
+    std::shared_ptr<BackendBuffer> h_, x1_, y_;
+    std::shared_ptr<BackendBuffer> qg_, kbuf_, vbuf_, attn_out_;
+    std::shared_ptr<BackendBuffer> qkv_, z_, alpha_, beta_raw_, g_, beta_, conv_out_;
+    std::shared_ptr<BackendBuffer> delta_out_, gated_out_;
+    std::shared_ptr<BackendBuffer> ffn_gate_, ffn_up_, logits_, token_out_;
+    std::shared_ptr<BackendBuffer> mtp_embed_norm_, mtp_hidden_norm_, mtp_concat_;
+    std::shared_ptr<BackendBuffer> mtp_x_, mtp_hidden_out_, mtp_k_cache_, mtp_v_cache_;
+    BackendQuantized q5120_, q6144_, q10240_, q17408_;
+
+    // Layer-major chunked prefill state (CHUNK_MAX token rows per buffer).
+    bool chunked_prefill_ = false;
+    std::shared_ptr<BackendBuffer> ch_, cx1_, cy_;
+    std::shared_ptr<BackendBuffer> cqg_, ckbuf_, cvbuf_, cattn_out_;
+    std::shared_ptr<BackendBuffer> cqkv_, cz_, calpha_, cbeta_raw_, cg_, cbeta_, cconv_out_;
+    std::shared_ptr<BackendBuffer> cdelta_out_, cgated_out_, cffn_gate_, cffn_up_;
+    BackendQuantized cq5120_, cq6144_, cq17408_;
+
+    // Batched MTP verification: per-lane logits/predictions plus the parked
+    // GDN inputs and shared discard slots that make the verify chunk
+    // state-free — acceptance replays only the GDN recurrence over the
+    // accepted prefix, so no checkpoint, restore, or commit re-encode exists.
+    // ctargets_/cnll_ also serve teacher-forced NLL quality gates.
+    std::shared_ptr<BackendBuffer> cfinal_, clogits_, cpred_;
+    std::shared_ptr<BackendBuffer> ctargets_, cnll_;
+    std::vector<std::shared_ptr<BackendBuffer>> park_qkv_, park_g_, park_beta_;
+    std::shared_ptr<BackendBuffer> discard_recurrent_, discard_ring_;
+
+    // The q4s contract requires the MTP layer; retained as an explicit gate at
+    // call sites so missing state fails closed if construction ever changes.
+    bool has_mtp_ = true;
+
+    std::shared_ptr<BackendBuffer> alloc_f32(uint64_t count);
+    const BackendTensor& weight(const std::string& name) const;
+    const BackendTensor& layer_weight(uint32_t layer, const char* leaf) const;
+    static bool attention_layer(uint32_t layer) { return layer % 4 == 3; }
+
+    void validate_architecture() const;
+    void project(const BackendTensor& w, const BackendBuffer& x_float,
+                 const BackendQuantized& xq, BackendBuffer& out);
+    void project_pair(const BackendTensor& a, BackendBuffer& a_out,
+                      const BackendTensor& b, BackendBuffer& b_out,
+                      const BackendBuffer& x_float, const BackendQuantized& xq);
+    void gdn_block(uint32_t layer);
+    void attention_block(uint32_t layer);
+    void ffn(uint32_t layer);
+    void encode_token(uint32_t token, bool produce_logits);
+    void gdn_chunk(uint32_t layer, uint32_t count, bool verify);
+    void attention_chunk(uint32_t layer, uint32_t count);
+    void ffn_chunk(uint32_t layer, uint32_t count);
+    void chunk_forward(const uint32_t* tokens, uint32_t count, bool verify = false);
+    void encode_chunk(const uint32_t* tokens, uint32_t count);
+    static uint32_t gdn_slot(uint32_t layer) { return layer - (layer + 1) / 4; }
+    void gdn_replay(uint32_t count);
+    std::vector<uint32_t> generate_mtp_batched(uint32_t pending, uint32_t count,
+                                               uint32_t width);
+    uint32_t stream_mtp_batched(uint32_t pending, uint32_t count, uint32_t width,
+                                uint32_t eos, const TokenSink& sink, StopCause& cause);
+    uint32_t prefill(const std::vector<uint32_t>& prompt, bool warm_mtp);
+    void mtp_warm(const BackendBuffer& hidden, uint32_t token, uint32_t position);
+    uint32_t mtp_forward(const BackendBuffer& hidden, uint32_t token, uint32_t position);
+};
+
+} // namespace q27

--- a/src/metal/test_metal_engine_contracts.cpp
+++ b/src/metal/test_metal_engine_contracts.cpp
@@ -61,11 +61,23 @@ int main(int argc, char** argv) {
         }
 
         q27::MetalEngine::StopCause cause = q27::MetalEngine::StopCause::MaxTokens;
-        const uint32_t emitted = engine.stream_from_pending(
+        bool sink_called = false;
+        uint32_t emitted = engine.stream_from_pending(
+            pending, 2, pending, 2,
+            [&](uint32_t) { sink_called = true; return true; }, cause);
+        if (emitted != 0 || cause != q27::MetalEngine::StopCause::Eos ||
+            sink_called || engine.position() != 1) {
+            std::fprintf(stderr, "MTP EOS changed unconsumed engine state\n");
+            return 1;
+        }
+
+        cause = q27::MetalEngine::StopCause::MaxTokens;
+        emitted = engine.stream_from_pending(
             pending, 2, UINT32_MAX, 2,
             [](uint32_t) { return false; }, cause);
-        if (emitted != 0 || cause != q27::MetalEngine::StopCause::Cancelled) {
-            std::fprintf(stderr, "cancelled MTP stream did not report cancellation\n");
+        if (emitted != 0 || cause != q27::MetalEngine::StopCause::Cancelled ||
+            engine.position() != 1) {
+            std::fprintf(stderr, "cancelled MTP stream changed unconsumed engine state\n");
             return 1;
         }
 

--- a/src/metal/test_metal_engine_contracts.cpp
+++ b/src/metal/test_metal_engine_contracts.cpp
@@ -1,5 +1,6 @@
 #include "metal_engine.h"
 
+#include <cstring>
 #include <cstdio>
 #include <exception>
 #include <stdexcept>
@@ -23,6 +24,11 @@ bool rejects_pending(q27::MetalEngine& engine, uint32_t pending) {
     } catch (const std::runtime_error&) {
         return true;
     }
+}
+
+bool same_logits(const std::vector<float>& left, const std::vector<float>& right) {
+    return left.size() == right.size() &&
+           std::memcmp(left.data(), right.data(), left.size() * sizeof(float)) == 0;
 }
 
 } // namespace
@@ -60,24 +66,38 @@ int main(int argc, char** argv) {
             return 1;
         }
 
+        const std::vector<float> baseline_logits = engine.read_logits();
+        const std::vector<uint32_t> baseline_retry =
+            engine.generate_from_pending(pending, 2, 2);
+        engine.restore_state(*snapshot);
+
         q27::MetalEngine::StopCause cause = q27::MetalEngine::StopCause::MaxTokens;
         bool sink_called = false;
         uint32_t emitted = engine.stream_from_pending(
             pending, 2, pending, 2,
             [&](uint32_t) { sink_called = true; return true; }, cause);
-        if (emitted != 0 || cause != q27::MetalEngine::StopCause::Eos ||
-            sink_called || engine.position() != 1) {
-            std::fprintf(stderr, "MTP EOS changed unconsumed engine state\n");
+        if (emitted != 0 || cause != q27::MetalEngine::StopCause::Eos || sink_called ||
+            engine.position() != 1 || !same_logits(engine.read_logits(), baseline_logits)) {
+            std::fprintf(stderr, "MTP EOS changed unconsumed resident state\n");
             return 1;
         }
+        if (engine.generate_from_pending(pending, 2, 2) != baseline_retry) {
+            std::fprintf(stderr, "MTP EOS changed retry behavior\n");
+            return 1;
+        }
+        engine.restore_state(*snapshot);
 
         cause = q27::MetalEngine::StopCause::MaxTokens;
         emitted = engine.stream_from_pending(
             pending, 2, UINT32_MAX, 2,
             [](uint32_t) { return false; }, cause);
         if (emitted != 0 || cause != q27::MetalEngine::StopCause::Cancelled ||
-            engine.position() != 1) {
-            std::fprintf(stderr, "cancelled MTP stream changed unconsumed engine state\n");
+            engine.position() != 1 || !same_logits(engine.read_logits(), baseline_logits)) {
+            std::fprintf(stderr, "cancelled MTP stream changed unconsumed resident state\n");
+            return 1;
+        }
+        if (engine.generate_from_pending(pending, 2, 2) != baseline_retry) {
+            std::fprintf(stderr, "cancelled MTP stream changed retry behavior\n");
             return 1;
         }
 

--- a/src/metal/test_metal_engine_contracts.cpp
+++ b/src/metal/test_metal_engine_contracts.cpp
@@ -67,6 +67,13 @@ int main(int argc, char** argv) {
         }
 
         const std::vector<float> baseline_logits = engine.read_logits();
+        const std::vector<uint32_t> unlimited_sample = engine.generate_sampled_from_logits(
+            1, q27::SamplingParams{1.0f, 0.95f, 0, 17});
+        if (unlimited_sample.size() != 1 || engine.position() != 1 ||
+            !same_logits(engine.read_logits(), baseline_logits)) {
+            std::fprintf(stderr, "top_k=0 did not use the non-mutating full-logits path\n");
+            return 1;
+        }
         const std::vector<uint32_t> baseline_retry =
             engine.generate_from_pending(pending, 2, 2);
         engine.restore_state(*snapshot);

--- a/src/metal/test_metal_engine_contracts.cpp
+++ b/src/metal/test_metal_engine_contracts.cpp
@@ -1,0 +1,78 @@
+#include "metal_engine.h"
+
+#include <cstdio>
+#include <exception>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+bool rejects_logits(q27::MetalEngine& engine) {
+    try {
+        (void)engine.read_logits();
+        return false;
+    } catch (const std::runtime_error&) {
+        return true;
+    }
+}
+
+bool rejects_pending(q27::MetalEngine& engine, uint32_t pending) {
+    try {
+        (void)engine.generate_from_pending(pending, 1, 2);
+        return false;
+    } catch (const std::runtime_error&) {
+        return true;
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::fprintf(stderr, "usage: %s model.q27\n", argv[0]);
+        return 2;
+    }
+    try {
+        q27::MetalEngine engine(argv[1], 8);
+        if (!rejects_logits(engine)) {
+            std::fprintf(stderr, "fresh engine exposed non-resident logits\n");
+            return 1;
+        }
+
+        const uint32_t pending = engine.ingest_prompt({760}, false, true);
+        if (engine.position() != 1 ||
+            engine.read_logits().size() != q27::MetalEngine::vocabulary_size()) {
+            std::fprintf(stderr, "prompt ingestion did not publish current logits\n");
+            return 1;
+        }
+        auto snapshot = engine.capture_state();
+
+        engine.reset();
+        if (!rejects_logits(engine) || !rejects_pending(engine, pending)) {
+            std::fprintf(stderr, "reset did not invalidate logits and pending state\n");
+            return 1;
+        }
+
+        engine.restore_state(*snapshot);
+        if (engine.position() != 1 ||
+            engine.read_logits().size() != q27::MetalEngine::vocabulary_size()) {
+            std::fprintf(stderr, "snapshot restore did not restore logits residency\n");
+            return 1;
+        }
+
+        q27::MetalEngine::StopCause cause = q27::MetalEngine::StopCause::MaxTokens;
+        const uint32_t emitted = engine.stream_from_pending(
+            pending, 2, UINT32_MAX, 2,
+            [](uint32_t) { return false; }, cause);
+        if (emitted != 0 || cause != q27::MetalEngine::StopCause::Cancelled) {
+            std::fprintf(stderr, "cancelled MTP stream did not report cancellation\n");
+            return 1;
+        }
+
+        puts("Metal q4s engine contracts: OK");
+        return 0;
+    } catch (const std::exception& error) {
+        std::fprintf(stderr, "%s\n", error.what());
+        return 1;
+    }
+}

--- a/src/metal/test_metal_engine_contracts.cpp
+++ b/src/metal/test_metal_engine_contracts.cpp
@@ -3,8 +3,12 @@
 #include <cstring>
 #include <cstdio>
 #include <exception>
+#include <limits>
 #include <stdexcept>
 #include <vector>
+
+#include <sys/stat.h>
+#include <unistd.h>
 
 namespace {
 
@@ -31,6 +35,18 @@ bool same_logits(const std::vector<float>& left, const std::vector<float>& right
            std::memcmp(left.data(), right.data(), left.size() * sizeof(float)) == 0;
 }
 
+bool artifact_requires_per_tensor_upload(const char* path, uint64_t max_buffer_length) {
+    struct stat info {};
+    if (::stat(path, &info) != 0 || info.st_size <= 0)
+        throw std::runtime_error("could not read model artifact size");
+    const uint64_t logical_size = static_cast<uint64_t>(info.st_size);
+    const uint64_t page_size = static_cast<uint64_t>(::getpagesize());
+    if (logical_size > std::numeric_limits<uint64_t>::max() - (page_size - 1))
+        throw std::runtime_error("model artifact size overflow");
+    const uint64_t mapped_size = (logical_size + page_size - 1) / page_size * page_size;
+    return mapped_size > max_buffer_length;
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -40,6 +56,16 @@ int main(int argc, char** argv) {
     }
     try {
         q27::MetalEngine engine(argv[1], 8);
+        const bool expected_per_tensor = artifact_requires_per_tensor_upload(
+            argv[1], engine.backend().max_buffer_length());
+        if (engine.used_per_tensor_upload() != expected_per_tensor) {
+            std::fprintf(stderr,
+                         "model upload path did not match artifact size and device limit: "
+                         "expected %s, got %s\n",
+                         expected_per_tensor ? "per-tensor" : "whole-mapping",
+                         engine.used_per_tensor_upload() ? "per-tensor" : "whole-mapping");
+            return 1;
+        }
         if (!rejects_logits(engine)) {
             std::fprintf(stderr, "fresh engine exposed non-resident logits\n");
             return 1;


### PR DESCRIPTION
## Summary

Add the q4s-only Metal inference engine on top of the merged native backend:

- validate the qwen35/q4s metadata, tensor names, shapes, and dtypes before allocation
- support serial and chunked prefill, FP16 or turbo3 KV, greedy/MTP generation, sampled generation, teacher-forced NLL, snapshots, reset, and streaming stop semantics
- route every KV operation through the merged `KvFormat` backend seam
- derive and gate the actual model mmap upload path against artifact size and the device limit; the 15.46 GB q4s artifact records `per-tensor` on Apple M4 because it exceeds the 13.32 GiB single-buffer limit
- keep `top_k == 0` sampling on the complete logits vector and cover that fallback in the artifact-backed contract gate

This is the engine slice only. It adds no CLI, server, CUDA path, canonical digest, benchmark/probe surface, or Bonsai-specific policy. The Makefile additions remain Darwin-only and do not alter `all`.

## Verification

Run on Apple M4 against `qwen36-27b-mtp-q4s.q27` (MD5 `7e5454e0c0ded717136ad3e42634ba25`):

- `make -B test-metal-backend` — backend and operator suites pass under `-Werror`
- `make build/test_sampling && ./build/test_sampling` — `CPU sampling: PASS`
- `make -B test-metal-contracts MODEL=qwen36-27b-mtp-q4s.q27` — independently derives the required upload path from the artifact size and device limit, records `model upload path: per-tensor (mapping 14.40 GiB, max buffer 13.32 GiB)`, and reports `Metal q4s engine contracts: OK`
- each commit compiles independently under the Metal `-Werror` flags
- `git diff --check upstream/master...HEAD` is clean

The exact incremental delta from merged `master` is six files, +1,457/-2.

## Files (6)

- Makefile [MODIFIED] (+26 -1)
- src/metal/metal_backend.h [MODIFIED] (+1 -0)
- src/metal/metal_backend.mm [MODIFIED] (+12 -1)
- src/metal/metal_engine.cpp [ADDED] (+1106 -0)
- src/metal/metal_engine.h [ADDED] (+169 -0)
- src/metal/test_metal_engine_contracts.cpp [ADDED] (+143 -0)