### PR TITLE
metal: add q4s CLI and canonical gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NVCCFLAGS ?= -O2 -std=c++17 -gencode arch=compute_86,code=sm_86 \
              -gencode arch=compute_89,code=sm_89 \
              -gencode arch=compute_120,code=sm_120 -Xcompiler -Wall
 
-.PHONY: all clean test-inspect test-metal-backend metal-engine test-metal-contracts
+.PHONY: all clean test-inspect test-metal-backend metal-engine test-metal-contracts test-metal test-metal-canonical
 all: build/inspect build/test_sampling build/test_kernels build/test_argmax_tie build/q27 build/q27-server build/test_tokenizer build/test_stream_split build/test_depthctl build/test_toolconstrain
 
 build/q27: src/engine.cu src/engine.cuh src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp \
@@ -179,6 +179,27 @@ test-metal-contracts: build/test_metal_engine_contracts
 
 metal-engine: build/metal-engine.o
 
+build/q27-metal: src/metal/metal_cli.cpp src/metal/metal_engine.cpp \
+                 src/metal/metal_backend.mm src/metal/metal_engine.h \
+                 src/metal/metal_backend.h src/metal/q27_kernels.metal \
+                 src/backend.h src/loader.cpp src/loader.h src/tokenizer.cpp \
+                 src/tokenizer.h src/sampling.h src/suffixdraft.h | build
+	$(CXX) $(METALFLAGS) src/metal/metal_cli.cpp src/metal/metal_engine.cpp \
+	       src/metal/metal_backend.mm src/loader.cpp src/tokenizer.cpp \
+	       $(METALLIBS) -o $@
+
+test-metal: test-metal-backend build/q27-metal
+	@test -n "$(MODEL)" || { echo "set MODEL=...q4s.q27" >&2; exit 2; }
+	@test -n "$(TOKENIZER)" || { echo "set TOKENIZER=...tok" >&2; exit 2; }
+	./build/q27-metal "$(MODEL)" "$(TOKENIZER)" --validate-only
+	./build/q27-metal "$(MODEL)" "$(TOKENIZER)" --tokens 760,6511,314,9338,369 \
+	       -n 2 --ctx 16 --mtp 4 --dump-token-ids build/metal-smoke.ids
+
+test-metal-canonical: build/q27-metal
+	@test -n "$(MODEL)" || { echo "set MODEL=...q4s.q27" >&2; exit 2; }
+	@test -n "$(TOKENIZER)" || { echo "set TOKENIZER=...tok" >&2; exit 2; }
+	tools/metal_canonical_gate.sh "$(MODEL)" "$(TOKENIZER)"
+
 test-metal-backend: build/test-metal-backend build/test-metal-ops
 	./build/test-metal-backend
 	./build/test-metal-ops
@@ -189,4 +210,10 @@ metal-engine:
 	@echo "metal-engine requires macOS" >&2; exit 1
 test-metal-contracts:
 	@echo "test-metal-contracts requires macOS" >&2; exit 1
+
+test-metal:
+	@echo "test-metal requires macOS" >&2; exit 1
+
+test-metal-canonical:
+	@echo "test-metal-canonical requires macOS" >&2; exit 1
 endif

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ build/q27-metal: src/metal/metal_cli.cpp src/metal/metal_engine.cpp \
                  src/metal/metal_backend.mm src/metal/metal_engine.h \
                  src/metal/metal_backend.h src/metal/q27_kernels.metal \
                  src/backend.h src/loader.cpp src/loader.h src/tokenizer.cpp \
-                 src/tokenizer.h src/sampling.h src/suffixdraft.h | build
+                 src/tokenizer.h src/sampling.h src/suffixdraft.h third_party/json.hpp | build
 	$(CXX) $(METALFLAGS) src/metal/metal_cli.cpp src/metal/metal_engine.cpp \
 	       src/metal/metal_backend.mm src/loader.cpp src/tokenizer.cpp \
 	       $(METALLIBS) -o $@

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,10 @@ build/q27-metal: src/metal/metal_cli.cpp src/metal/metal_engine.cpp \
 test-metal: test-metal-backend build/q27-metal
 	@test -n "$(MODEL)" || { echo "set MODEL=...q4s.q27" >&2; exit 2; }
 	@test -n "$(TOKENIZER)" || { echo "set TOKENIZER=...tok" >&2; exit 2; }
+	@if ./build/q27-metal "$(MODEL)" "$(TOKENIZER)" --tokens 760 --prompt "" >/dev/null 2>&1; then \
+		echo "Metal CLI accepted --tokens with an empty --prompt" >&2; exit 1; fi
+	@if ./build/q27-metal "$(MODEL)" "$(TOKENIZER)" --tokens "" --prompt test >/dev/null 2>&1; then \
+		echo "Metal CLI accepted an empty --tokens with --prompt" >&2; exit 1; fi
 	./build/q27-metal "$(MODEL)" "$(TOKENIZER)" --validate-only
 	./build/q27-metal "$(MODEL)" "$(TOKENIZER)" --tokens 760,6511,314,9338,369 \
 	       -n 2 --ctx 16 --mtp 4 --dump-token-ids build/metal-smoke.ids

--- a/src/metal/metal_cli.cpp
+++ b/src/metal/metal_cli.cpp
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
     if (argc < 3) {
         fprintf(stderr,
                 "usage: %s model.q27 tokenizer.tok [--validate-only | --tokens id,id,... | --prompt text] "
-                "[-n count] [--ctx count] [--mtp width] [--prefill chunk|serial] "
+                "[-n count] [--ctx count] [--mtp width] [--kv fp16|turbo3] [--prefill chunk|serial] "
                 "[--temperature T --top-p P --top-k K --seed S] [--dump-token-ids file]\n",
                 argv[0]);
         return 1;
@@ -87,7 +87,7 @@ int main(int argc, char** argv) {
         std::string token_list, prompt_text, dump_token_ids;
         uint32_t count = 1, context = 128, mtp_width = 0;
         q27::SamplingParams sampling;
-        bool validate_only = false, serial_prefill = false;
+        bool validate_only = false, serial_prefill = false, turbo3_kv = false;
 
         for (int i = 3; i < argc; i++) {
             const std::string arg = argv[i];
@@ -97,6 +97,11 @@ int main(int argc, char** argv) {
             else if (arg == "-n" && i + 1 < argc) count = parse_u32(argv[++i], "-n");
             else if (arg == "--ctx" && i + 1 < argc) context = parse_u32(argv[++i], "--ctx");
             else if (arg == "--mtp" && i + 1 < argc) mtp_width = parse_u32(argv[++i], "--mtp");
+            else if (arg == "--kv" && i + 1 < argc) {
+                const std::string mode = argv[++i];
+                if (mode == "turbo3") turbo3_kv = true;
+                else if (mode != "fp16") throw std::runtime_error("--kv must be fp16 or turbo3");
+            }
             else if (arg == "--prefill" && i + 1 < argc) {
                 const std::string mode = argv[++i];
                 if (mode == "serial") serial_prefill = true;
@@ -147,7 +152,7 @@ int main(int argc, char** argv) {
             if (token >= q27::MetalEngine::vocabulary_size())
                 throw std::runtime_error("prompt token id is outside the model vocabulary");
 
-        q27::MetalEngine engine(model_path, context);
+        q27::MetalEngine engine(model_path, context, turbo3_kv);
         if (serial_prefill) engine.set_chunked_prefill(false);
         const auto loaded = std::chrono::steady_clock::now();
         fprintf(stderr, "Metal q4s model ready on %s in %.2f s\n", engine.backend().name().c_str(),

--- a/src/metal/metal_cli.cpp
+++ b/src/metal/metal_cli.cpp
@@ -1,0 +1,185 @@
+#include "metal_engine.h"
+#include "../tokenizer.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+uint32_t parse_u32(const std::string& text, const char* option) {
+    if (text.empty() || text[0] == '-')
+        throw std::runtime_error(std::string("invalid ") + option + ": " + text);
+    size_t consumed = 0;
+    unsigned long long value = 0;
+    try { value = std::stoull(text, &consumed, 10); }
+    catch (...) { throw std::runtime_error(std::string("invalid ") + option + ": " + text); }
+    if (consumed != text.size() || value > UINT32_MAX)
+        throw std::runtime_error(std::string("invalid ") + option + ": " + text);
+    return static_cast<uint32_t>(value);
+}
+
+uint64_t parse_u64(const std::string& text, const char* option) {
+    if (text.empty() || text[0] == '-')
+        throw std::runtime_error(std::string("invalid ") + option + ": " + text);
+    size_t consumed = 0;
+    unsigned long long value = 0;
+    try { value = std::stoull(text, &consumed, 10); }
+    catch (...) { throw std::runtime_error(std::string("invalid ") + option + ": " + text); }
+    if (consumed != text.size())
+        throw std::runtime_error(std::string("invalid ") + option + ": " + text);
+    return value;
+}
+
+float parse_float(const std::string& text, const char* option) {
+    size_t consumed = 0;
+    float value = 0;
+    try { value = std::stof(text, &consumed); }
+    catch (...) { throw std::runtime_error(std::string("invalid ") + option + ": " + text); }
+    if (consumed != text.size())
+        throw std::runtime_error(std::string("invalid ") + option + ": " + text);
+    return value;
+}
+
+std::vector<uint32_t> parse_tokens(const std::string& text) {
+    std::vector<uint32_t> result;
+    std::stringstream input(text);
+    std::string item;
+    while (std::getline(input, item, ',')) {
+        if (item.empty()) throw std::runtime_error("empty token id");
+        result.push_back(parse_u32(item, "token id"));
+    }
+    if (result.empty()) throw std::runtime_error("--tokens requires at least one token id");
+    return result;
+}
+
+void write_token_ids(const std::string& path, const std::vector<uint32_t>& tokens) {
+    FILE* file = fopen(path.c_str(), "w");
+    if (!file) throw std::runtime_error("cannot open --dump-token-ids output: " + path);
+    bool ok = true;
+    for (size_t i = 0; i < tokens.size(); i++) {
+        if (fprintf(file, "%s%u", i ? " " : "", tokens[i]) < 0) { ok = false; break; }
+    }
+    if (ok && fprintf(file, "\n") < 0) ok = false;
+    if (fclose(file) != 0) ok = false;
+    if (!ok) throw std::runtime_error("cannot write --dump-token-ids output: " + path);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        fprintf(stderr,
+                "usage: %s model.q27 tokenizer.tok [--validate-only | --tokens id,id,... | --prompt text] "
+                "[-n count] [--ctx count] [--mtp width] [--prefill chunk|serial] "
+                "[--temperature T --top-p P --top-k K --seed S] [--dump-token-ids file]\n",
+                argv[0]);
+        return 1;
+    }
+
+    try {
+        const std::string model_path = argv[1];
+        const std::string tokenizer_path = argv[2];
+        std::string token_list, prompt_text, dump_token_ids;
+        uint32_t count = 1, context = 128, mtp_width = 0;
+        q27::SamplingParams sampling;
+        bool validate_only = false, serial_prefill = false;
+
+        for (int i = 3; i < argc; i++) {
+            const std::string arg = argv[i];
+            if (arg == "--tokens" && i + 1 < argc) token_list = argv[++i];
+            else if (arg == "--prompt" && i + 1 < argc) prompt_text = argv[++i];
+            else if (arg == "--validate-only") validate_only = true;
+            else if (arg == "-n" && i + 1 < argc) count = parse_u32(argv[++i], "-n");
+            else if (arg == "--ctx" && i + 1 < argc) context = parse_u32(argv[++i], "--ctx");
+            else if (arg == "--mtp" && i + 1 < argc) mtp_width = parse_u32(argv[++i], "--mtp");
+            else if (arg == "--prefill" && i + 1 < argc) {
+                const std::string mode = argv[++i];
+                if (mode == "serial") serial_prefill = true;
+                else if (mode != "chunk") throw std::runtime_error("--prefill must be chunk or serial");
+            }
+            else if (arg == "--temperature" && i + 1 < argc)
+                sampling.temperature = parse_float(argv[++i], "--temperature");
+            else if (arg == "--top-p" && i + 1 < argc)
+                sampling.top_p = parse_float(argv[++i], "--top-p");
+            else if (arg == "--top-k" && i + 1 < argc)
+                sampling.top_k = parse_u32(argv[++i], "--top-k");
+            else if (arg == "--seed" && i + 1 < argc)
+                sampling.seed = parse_u64(argv[++i], "--seed");
+            else if (arg == "--dump-token-ids" && i + 1 < argc) dump_token_ids = argv[++i];
+            else throw std::runtime_error("unknown/incomplete argument: " + arg);
+        }
+
+        q27::validate_sampling(sampling);
+        if (!token_list.empty() && !prompt_text.empty())
+            throw std::runtime_error("--tokens and --prompt are mutually exclusive");
+        if (sampling.temperature > 0 && mtp_width)
+            throw std::runtime_error("sampling cannot be combined with --mtp");
+        if (validate_only) {
+            if (!token_list.empty() || !prompt_text.empty() || mtp_width ||
+                sampling.temperature > 0 || !dump_token_ids.empty())
+                throw std::runtime_error("--validate-only cannot be combined with generation options");
+        } else {
+            if (token_list.empty() && prompt_text.empty())
+                throw std::runtime_error("--tokens or --prompt is required");
+            if (!count) throw std::runtime_error("-n must be greater than zero");
+        }
+
+        const auto start = std::chrono::steady_clock::now();
+        q27::Tokenizer tokenizer(tokenizer_path);
+        if (tokenizer.vocab_size() != q27::MetalEngine::vocabulary_size())
+            throw std::runtime_error("tokenizer/model vocabulary mismatch");
+
+        std::vector<uint32_t> prompt;
+        if (!token_list.empty()) prompt = parse_tokens(token_list);
+        else if (!prompt_text.empty()) {
+            for (int token : tokenizer.encode(prompt_text)) {
+                if (token < 0) throw std::runtime_error("tokenizer returned a negative id");
+                prompt.push_back(static_cast<uint32_t>(token));
+            }
+            if (prompt.empty()) throw std::runtime_error("--prompt encoded to no tokens");
+        }
+        for (uint32_t token : prompt)
+            if (token >= q27::MetalEngine::vocabulary_size())
+                throw std::runtime_error("prompt token id is outside the model vocabulary");
+
+        q27::MetalEngine engine(model_path, context);
+        if (serial_prefill) engine.set_chunked_prefill(false);
+        const auto loaded = std::chrono::steady_clock::now();
+        fprintf(stderr, "Metal q4s model ready on %s in %.2f s\n", engine.backend().name().c_str(),
+                std::chrono::duration<double>(loaded - start).count());
+        if (validate_only) {
+            puts("q4s artifacts and Metal architecture: OK");
+            return 0;
+        }
+
+        std::vector<uint32_t> generated = sampling.temperature > 0
+            ? engine.generate_sampled(prompt, count, sampling)
+            : mtp_width ? engine.generate_mtp(prompt, count, mtp_width)
+                        : engine.generate(prompt, count);
+        if (!dump_token_ids.empty()) write_token_ids(dump_token_ids, generated);
+
+        const auto finished = std::chrono::steady_clock::now();
+        std::vector<int> ids(generated.begin(), generated.end());
+        printf("generated:%s\n", tokenizer.decode(ids).c_str());
+        const double elapsed = std::chrono::duration<double>(finished - loaded).count();
+        fprintf(stderr, "%zu tokens in %.2f s (%.2f tok/s), position %u\n",
+                generated.size(), elapsed, generated.size() / elapsed, engine.position());
+        if (mtp_width) {
+            const auto spec = engine.last_spec_stats();
+            fprintf(stderr, "speculation: %llu rounds, %llu drafts, %llu accepted (%.1f%%)\n",
+                    static_cast<unsigned long long>(spec.rounds),
+                    static_cast<unsigned long long>(spec.drafted),
+                    static_cast<unsigned long long>(spec.accepted),
+                    spec.drafted ? 100.0 * spec.accepted / spec.drafted : 0.0);
+        }
+        return 0;
+    } catch (const std::exception& error) {
+        fprintf(stderr, "%s\n", error.what());
+        return 1;
+    }
+}

--- a/src/metal/metal_cli.cpp
+++ b/src/metal/metal_cli.cpp
@@ -88,11 +88,18 @@ int main(int argc, char** argv) {
         uint32_t count = 1, context = 128, mtp_width = 0;
         q27::SamplingParams sampling;
         bool validate_only = false, serial_prefill = false, turbo3_kv = false;
+        bool token_list_supplied = false, prompt_supplied = false;
 
         for (int i = 3; i < argc; i++) {
             const std::string arg = argv[i];
-            if (arg == "--tokens" && i + 1 < argc) token_list = argv[++i];
-            else if (arg == "--prompt" && i + 1 < argc) prompt_text = argv[++i];
+            if (arg == "--tokens" && i + 1 < argc) {
+                token_list = argv[++i];
+                token_list_supplied = true;
+            }
+            else if (arg == "--prompt" && i + 1 < argc) {
+                prompt_text = argv[++i];
+                prompt_supplied = true;
+            }
             else if (arg == "--validate-only") validate_only = true;
             else if (arg == "-n" && i + 1 < argc) count = parse_u32(argv[++i], "-n");
             else if (arg == "--ctx" && i + 1 < argc) context = parse_u32(argv[++i], "--ctx");
@@ -120,16 +127,16 @@ int main(int argc, char** argv) {
         }
 
         q27::validate_sampling(sampling);
-        if (!token_list.empty() && !prompt_text.empty())
+        if (token_list_supplied && prompt_supplied)
             throw std::runtime_error("--tokens and --prompt are mutually exclusive");
         if (sampling.temperature > 0 && mtp_width)
             throw std::runtime_error("sampling cannot be combined with --mtp");
         if (validate_only) {
-            if (!token_list.empty() || !prompt_text.empty() || mtp_width ||
+            if (token_list_supplied || prompt_supplied || mtp_width ||
                 sampling.temperature > 0 || !dump_token_ids.empty())
                 throw std::runtime_error("--validate-only cannot be combined with generation options");
         } else {
-            if (token_list.empty() && prompt_text.empty())
+            if (!token_list_supplied && !prompt_supplied)
                 throw std::runtime_error("--tokens or --prompt is required");
             if (!count) throw std::runtime_error("-n must be greater than zero");
         }
@@ -140,8 +147,8 @@ int main(int argc, char** argv) {
             throw std::runtime_error("tokenizer/model vocabulary mismatch");
 
         std::vector<uint32_t> prompt;
-        if (!token_list.empty()) prompt = parse_tokens(token_list);
-        else if (!prompt_text.empty()) {
+        if (token_list_supplied) prompt = parse_tokens(token_list);
+        else if (prompt_supplied) {
             for (int token : tokenizer.encode(prompt_text)) {
                 if (token < 0) throw std::runtime_error("tokenizer returned a negative id");
                 prompt.push_back(static_cast<uint32_t>(token));

--- a/tools/canonical_md5.sh
+++ b/tools/canonical_md5.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Return the published canonical digest for one exact architecture/tier pair.
+# CUDA entries hash the `generated:` line used by sampling_gate.sh. Metal
+# entries hash the space-delimited token-id line emitted by --dump-token-ids.
+canonical_md5_for() {
+  local arch="$1" tier="$2"
+
+  case "$arch" in
+    sm120|sm_120|blackwell|5090) arch=sm120 ;;
+    sm86|sm_86|ampere|3090|a40) arch=sm86 ;;
+    metal-m4|apple-m4|m4) arch=metal-m4 ;;
+  esac
+  case "$tier" in
+    default|vanilla|qwen36-27b-mtp) tier=default ;;
+    q4s|q4s-v1) tier=q4s ;;
+    q5f|q5f-v1) tier=q5f ;;
+    q6f|q6f-v1) tier=q6f ;;
+  esac
+
+  case "$arch:$tier" in
+    sm120:default) printf '%s\n' a2982c5197c627551b27d76a0a94b220 ;;
+    sm120:q4s)    printf '%s\n' f64e7c02252ca4c40cea62db662205e0 ;;
+    sm120:q5f)    printf '%s\n' 683f7f4450ca4c60837abdb603ee3237 ;;
+    sm120:q6f)    printf '%s\n' 2a4d22eafcde63e962bf2408605fe502 ;;
+    sm86:default) printf '%s\n' 6894254e3b1a184ee3802771ddd59c2b ;;
+    metal-m4:q4s) printf '%s\n' 44310e1228cdd963f47ad8a2debb17d0 ;;
+    *) return 1 ;;
+  esac
+}

--- a/tools/canonical_md5.sh
+++ b/tools/canonical_md5.sh
@@ -18,6 +18,12 @@ canonical_md5_for() {
     q6f|q6f-v1) tier=q6f ;;
   esac
 
+  # sm86:default was derived on an RTX 3090 (82 SMs) and independently matched
+  # the A40 result (84 SMs) byte-for-byte, establishing SM-count independence
+  # within sm_86. A non-Blackwell `6894254e...` result therefore reproduces its
+  # own architecture's canonical rather than failing to reproduce Blackwell.
+  # Unlisted pairs require a same-device upstream/candidate differential.
+
   case "$arch:$tier" in
     sm120:default) printf '%s\n' a2982c5197c627551b27d76a0a94b220 ;;
     sm120:q4s)    printf '%s\n' f64e7c02252ca4c40cea62db662205e0 ;;

--- a/tools/canonical_md5.sh
+++ b/tools/canonical_md5.sh
@@ -23,6 +23,9 @@ canonical_md5_for() {
   # within sm_86. A non-Blackwell `6894254e...` result therefore reproduces its
   # own architecture's canonical rather than failing to reproduce Blackwell.
   # Unlisted pairs require a same-device upstream/candidate differential.
+  # metal-m4:q4s was derived on a base Apple M4 and independently matched on a
+  # 24 GB Apple M4 Pro byte-for-byte using the same q4s artifact (artifact MD5
+  # 7e5454e0c0ded717136ad3e42634ba25), establishing the shared family canonical.
 
   case "$arch:$tier" in
     sm120:default) printf '%s\n' a2982c5197c627551b27d76a0a94b220 ;;

--- a/tools/canonical_md5.sh
+++ b/tools/canonical_md5.sh
@@ -24,7 +24,7 @@ canonical_md5_for() {
     sm120:q5f)    printf '%s\n' 683f7f4450ca4c60837abdb603ee3237 ;;
     sm120:q6f)    printf '%s\n' 2a4d22eafcde63e962bf2408605fe502 ;;
     sm86:default) printf '%s\n' 6894254e3b1a184ee3802771ddd59c2b ;;
-    metal-m4:q4s) printf '%s\n' 44310e1228cdd963f47ad8a2debb17d0 ;;
+    metal-m4:q4s) printf '%s\n' 3a82b01053311807cc8bbaacdd8dcec7 ;;
     *) return 1 ;;
   esac
 }

--- a/tools/metal_canonical_gate.sh
+++ b/tools/metal_canonical_gate.sh
@@ -23,7 +23,7 @@ if [[ -z "${CANON_ARCH:-}" ]]; then
   fi
   chip="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || true)"
   case "$chip" in
-    "Apple M4") CANON_ARCH=metal-m4 ;;
+    "Apple M4"|"Apple M4 Pro") CANON_ARCH=metal-m4 ;;
     *)
       echo "no auto-selected Metal canonical for chip '$chip'; set CANON_ARCH after deriving one" >&2
       exit 2

--- a/tools/metal_canonical_gate.sh
+++ b/tools/metal_canonical_gate.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL="${1:-${MODEL:-}}"
+TOKENIZER="${2:-${TOKENIZER:-}}"
+BIN="$(dirname "$0")/../build/q27-metal"
+CANON_TIER="${CANON_TIER:-q4s}"
+CANON_IDS="760,6511,314,9338,369"
+
+if [[ -z "$MODEL" || -z "$TOKENIZER" ]]; then
+  echo "usage: $0 model-q4s.q27 tokenizer.tok" >&2
+  exit 2
+fi
+if [[ ! -x "$BIN" ]]; then
+  echo "missing $BIN; run make build/q27-metal" >&2
+  exit 2
+fi
+
+if [[ -z "${CANON_ARCH:-}" ]]; then
+  if [[ "$(uname -s)" != Darwin ]]; then
+    echo "CANON_ARCH is required outside macOS" >&2
+    exit 2
+  fi
+  chip="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || true)"
+  case "$chip" in
+    "Apple M4") CANON_ARCH=metal-m4 ;;
+    *)
+      echo "no auto-selected Metal canonical for chip '$chip'; set CANON_ARCH after deriving one" >&2
+      exit 2
+      ;;
+  esac
+fi
+
+if [[ -z "${CANON_MD5:-}" ]]; then
+  # shellcheck source=canonical_md5.sh
+  source "$(dirname "$0")/canonical_md5.sh"
+  if ! CANON_MD5="$(canonical_md5_for "$CANON_ARCH" "$CANON_TIER")"; then
+    echo "no published canonical for architecture=$CANON_ARCH tier=$CANON_TIER" >&2
+    echo "derive it with a same-device differential before publishing a digest" >&2
+    exit 2
+  fi
+fi
+
+hash_file() {
+  if command -v md5sum >/dev/null 2>&1; then
+    md5sum "$1" | cut -d' ' -f1
+  elif command -v md5 >/dev/null 2>&1; then
+    md5 -q "$1"
+  else
+    echo "md5 or md5sum is required" >&2
+    return 2
+  fi
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "== gate 1: $CANON_ARCH/$CANON_TIER 128-token canonical"
+"$BIN" "$MODEL" "$TOKENIZER" --tokens "$CANON_IDS" -n 128 --ctx 256 --mtp 4 \
+  --dump-token-ids "$tmp/mtp.ids" >/dev/null
+md5="$(hash_file "$tmp/mtp.ids")"
+if [[ "$md5" != "$CANON_MD5" ]]; then
+  echo "FAIL canonical changed: got $md5 want $CANON_MD5" >&2
+  exit 1
+fi
+echo "  OK md5=$md5"
+
+echo "== gate 2: speculative prefix equals plain greedy"
+"$BIN" "$MODEL" "$TOKENIZER" --tokens "$CANON_IDS" -n 16 --ctx 64 \
+  --dump-token-ids "$tmp/plain.ids" >/dev/null
+read -r -a mtp_ids < "$tmp/mtp.ids"
+: > "$tmp/mtp-prefix.ids"
+for ((i=0; i<16; i++)); do
+  if ((i > 0)); then printf ' ' >> "$tmp/mtp-prefix.ids"; fi
+  printf '%s' "${mtp_ids[$i]}" >> "$tmp/mtp-prefix.ids"
+done
+printf '\n' >> "$tmp/mtp-prefix.ids"
+if ! cmp -s "$tmp/mtp-prefix.ids" "$tmp/plain.ids"; then
+  echo "FAIL MTP and plain greedy trajectories differ" >&2
+  exit 1
+fi
+echo "  OK first 16 token ids are byte-identical"
+
+echo "METAL CANONICAL GATES: ALL PASS"

--- a/tools/metal_canonical_gate.sh
+++ b/tools/metal_canonical_gate.sh
@@ -23,7 +23,7 @@ if [[ -z "${CANON_ARCH:-}" ]]; then
   fi
   chip="$(sysctl -n machdep.cpu.brand_string 2>/dev/null || true)"
   case "$chip" in
-    "Apple M4"|"Apple M4 Pro") CANON_ARCH=metal-m4 ;;
+    "Apple M4") CANON_ARCH=metal-m4 ;;
     *)
       echo "no auto-selected Metal canonical for chip '$chip'; set CANON_ARCH after deriving one" >&2
       exit 2

--- a/tools/sampling_gate.sh
+++ b/tools/sampling_gate.sh
@@ -33,30 +33,56 @@ gen() { # $1=outfile ; extra args after
   grep '^generated:' "$out"
 }
 
+valid_generated() {
+  local line="$1"
+  [[ "$line" == "generated: "* && -n "${line#generated: }" ]]
+}
+
 echo "== gate 1: greedy canonical md5 (bitwise -- greedy path must be untouched)"
-gen "$tmp/canon.out" -n 128 >/dev/null
-md5="$(grep '^generated:' "$tmp/canon.out" | md5sum | cut -d' ' -f1)"
-if [[ "$md5" == "$CANON_MD5" ]]; then echo "  OK  md5=$md5"
-else echo "  FAIL md5=$md5 want $CANON_MD5" >&2; fail=1; fi
+canon="$(gen "$tmp/canon.out" -n 128)"
+if ! valid_generated "$canon"; then
+  echo "  FAIL canonical run produced no generated trajectory" >&2
+  fail=1
+else
+  md5="$(printf '%s\n' "$canon" | md5sum | cut -d' ' -f1)"
+  if [[ "$md5" == "$CANON_MD5" ]]; then echo "  OK  md5=$md5"
+  else echo "  FAIL md5=$md5 want $CANON_MD5" >&2; fail=1; fi
+fi
 
 echo "== gate 2: sampled seeded identity (same seed -> identical stream)"
 a="$(gen "$tmp/s1.out" -n 48 --temp 0.85 --top-p 0.95 --seed 42)"
 b="$(gen "$tmp/s2.out" -n 48 --temp 0.85 --top-p 0.95 --seed 42)"
-if [[ "$a" == "$b" && -n "$a" ]]; then echo "  OK  (identical across runs)"
+if ! valid_generated "$a" || ! valid_generated "$b"; then
+  echo "  FAIL seeded run produced no generated trajectory" >&2
+  fail=1
+elif [[ "$a" == "$b" ]]; then echo "  OK  (identical across runs)"
 else echo "  FAIL seeded runs differ" >&2; fail=1; fi
 
 echo "== gate 3: seed varies + sampled != greedy (sanity)"
 c="$(gen "$tmp/s3.out" -n 48 --temp 0.85 --top-p 0.95 --seed 7)"
-g="$(grep '^generated:' "$tmp/canon.out" | head -c 400)"
-[[ "$a" != "$c" ]] && echo "  OK  seed 42 != seed 7" || { echo "  FAIL seeds gave identical output" >&2; fail=1; }
-[[ "$a" != "$g" ]] && echo "  OK  sampled != greedy" || { echo "  FAIL sampled == greedy" >&2; fail=1; }
+g="${canon:0:400}"
+if ! valid_generated "$a" || ! valid_generated "$c"; then
+  echo "  FAIL seed comparison produced no generated trajectory" >&2
+  fail=1
+elif [[ "$a" != "$c" ]]; then echo "  OK  seed 42 != seed 7"
+else echo "  FAIL seeds gave identical output" >&2; fail=1; fi
+if ! valid_generated "$a" || ! valid_generated "$g"; then
+  echo "  FAIL sampled/greedy comparison produced no generated trajectory" >&2
+  fail=1
+elif [[ "$a" != "$g" ]]; then echo "  OK  sampled != greedy"
+else echo "  FAIL sampled == greedy" >&2; fail=1; fi
 
 echo "== gate 4: spec==plain trajectories both valid (full chi-square is kernel-proven)"
 sp="$(gen "$tmp/spec.out" -n 48 --temp 0.85 --top-p 0.95 --seed 3)"
 pl="$(Q27_SAMPLE_PLAIN=1 gen "$tmp/plain.out" -n 48 --temp 0.85 --top-p 0.95 --seed 3)"
-ns="$(wc -w <<<"$sp")"; np="$(wc -w <<<"$pl")"   # word count includes the 'generated:' token
-if [[ "$ns" -ge 40 && "$np" -ge 40 ]]; then echo "  OK  spec=$((ns-1)) tok, plain=$((np-1)) tok (both produced; distributions match by kernel gate)"
-else echo "  FAIL a path under-produced (spec=$ns plain=$np words)" >&2; fail=1; fi
+if ! valid_generated "$sp" || ! valid_generated "$pl"; then
+  echo "  FAIL spec/plain run produced no generated trajectory" >&2
+  fail=1
+else
+  ns="$(wc -w <<<"$sp")"; np="$(wc -w <<<"$pl")"   # word count includes the 'generated:' token
+  if [[ "$ns" -ge 40 && "$np" -ge 40 ]]; then echo "  OK  spec=$((ns-1)) tok, plain=$((np-1)) tok (both produced; distributions match by kernel gate)"
+  else echo "  FAIL a path under-produced (spec=$ns plain=$np words)" >&2; fail=1; fi
+fi
 
 echo "== gate 5: acceptance-vs-temp (tokens/round should sag as T rises)"
 for T in 0.0 0.3 0.7 1.0 1.5; do

--- a/tools/sampling_gate.sh
+++ b/tools/sampling_gate.sh
@@ -8,40 +8,20 @@
 set -u
 MODEL="${1:-/mnt/ai/models/qwen36-27b-mtp/qwen36-27b-mtp.q27}"
 BIN="$(dirname "$0")/../build/q27"
-# baseline greedy canonical: vanilla qwen36-27b-mtp (benchmark standard
-# 2026-07-09); other tiers/fine-tunes override via CANON_MD5= env --
-#   q4s: f64e7c02252ca4c40cea62db662205e0
-#   q5f: 683f7f4450ca4c60837abdb603ee3237  (Q4-head + ffn_down, 5.30bpw)
-#   q6f: 2a4d22eafcde63e962bf2408605fe502  (Q4-head + ffn_down + ffn_gate, 6.11bpw)
-#   Qwopus: 4c4120c7...
-#
-# THE CANONICAL IS PER-ARCHITECTURE. sm_86 codegen/ULP differences fork the
-# tie-heavy trajectory exactly like a cross-build lottery, so the bitwise
-# contract holds WITHIN an arch, not across them (BUILDLOG 2026-07-09):
-#   sm_120 (5090):  a2982c5197c627551b27d76a0a94b220   <- the default below
-#   sm_86  (3090, A40, and other GA10x): 6894254e3b1a184ee3802771ddd59c2b
-#     ^ DERIVED LOCALLY 2026-08-05 on our own RTX 3090 with CANON_ARCH=sm86,
-#       matching the A40 value reported in issue #7 exactly. Two sm_86 parts
-#       with DIFFERENT SM counts (3090 82, A40 84) agree bit-for-bit, so the
-#       canonical is SM-count-independent within an architecture -- consistent
-#       with the CLI path taking fd2 at a fixed FD2_NS rather than any
-#       SM-count-derived split.
-# A non-Blackwell run that reports 6894254e has REPRODUCED its own canonical,
-# it has not failed to reproduce this one. tools/shortbench_suite.sh learned
-# this in 07-09 and grew BENCH_GPU=; this gate did not, and in 2026-08-04 that
-# omission cost an outside contributor on an A40 a full gate run (q27 issue #7)
-# because the comment above listed tier overrides and said nothing about arch.
-# CANON_ARCH=sm86 selects the Ampere value; CANON_MD5= still overrides outright.
-#
-# CONTRIBUTORS ON OTHER SILICON: if no canonical is published for your arch, the
-# correct gate is the SAME-DEVICE differential -- build unmodified upstream and
-# your candidate on the one box and require byte-identical `generated:` lines.
-# That is what per-arch means; it is not a weaker substitute.
-case "${CANON_ARCH:-}" in
-  sm86|ampere|3090|a40) CANON_DEFAULT=6894254e3b1a184ee3802771ddd59c2b ;;
-  *)                    CANON_DEFAULT=a2982c5197c627551b27d76a0a94b220 ;;
-esac
-CANON_MD5="${CANON_MD5:-$CANON_DEFAULT}"
+# Canonicals are keyed by BOTH architecture and artifact tier. A digest from
+# one GPU architecture or quantization tier must never silently gate another.
+# CANON_MD5 remains the explicit escape hatch for a locally derived canonical.
+CANON_ARCH="${CANON_ARCH:-sm120}"
+CANON_TIER="${CANON_TIER:-default}"
+if [[ -z "${CANON_MD5:-}" ]]; then
+  # shellcheck source=canonical_md5.sh
+  source "$(dirname "$0")/canonical_md5.sh"
+  if ! CANON_MD5="$(canonical_md5_for "$CANON_ARCH" "$CANON_TIER")"; then
+    echo "no published canonical for architecture=$CANON_ARCH tier=$CANON_TIER" >&2
+    echo "run a same-device upstream/candidate differential or set CANON_MD5 explicitly" >&2
+    exit 2
+  fi
+fi
 CANON_IDS="760,6511,314,9338,369"
 export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
 tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT


### PR DESCRIPTION
## Summary

Complete the final Metal core stage from #8 on top of merged PR #18:

- add a q4s Metal CLI with token-id or text prompts, validation-only mode, configurable context, MTP width, FP16/turbo3 KV, chunked/serial prefill, CPU sampling, and token-id dumps
- add Darwin-only `test-metal` and `test-metal-canonical` targets without changing `all`
- key published canonical digests by both architecture and artifact tier, preserving the existing CUDA digests, their measured provenance, and fail-closed behavior for unknown pairs
- add a Metal gate that pins the independently measured base-M4 and M4 Pro q4s trajectory, auto-selecting both under the measured `metal-m4:q4s` family canonical
- reject ambiguous `--tokens`/`--prompt` combinations even when either supplied value is empty
- distinguish missing `generated:` trajectories from actual canonical or seeded-output differences

This stage adds no server, shared HTTP/API surface, CUDA source/runtime change, benchmark/probe surface, or Bonsai-specific policy. The shared-tool changes are the architecture+tier canonical lookup and clearer failure classification in `tools/sampling_gate.sh`.

## Verification

Replayed and run on base Apple M4 from current merged `master` (`07e05905`) against `qwen36-27b-mtp-q4s.q27` (MD5 `7e5454e0c0ded717136ad3e42634ba25`):

- `make -B test-metal MODEL=... TOKENIZER=...` — backend/operator suites pass under `-Werror`; artifact validation passes; the CLI MTP smoke generates `Paris.` and its empty-value mutual-exclusion regressions reject before model loading
- `make -B test-metal-contracts MODEL=...` — `Metal q4s engine contracts: OK`
- `make -B test-metal-canonical MODEL=... TOKENIZER=...` — 128-token `metal-m4/q4s` MD5 `3a82b01053311807cc8bbaacdd8dcec7`; first 16 speculative/plain token IDs are byte-identical; `METAL CANONICAL GATES: ALL PASS`
- compiled the new CLI separately against unmodified upstream engine sources and the candidate tree on the same device; both 128-token ID files were byte-identical with MD5 `3a82b01053311807cc8bbaacdd8dcec7`
- smoke-tested turbo3 KV with MTP, serial prefill, and text-prompt sampling with `top_k=0`
- `make build/test_sampling && ./build/test_sampling` — `CPU sampling: PASS`
- shell syntax and known/unknown architecture-tier mapping checks pass
- hermetic sampling-gate checks distinguish an absent trajectory from differing seeded trajectories and preserve the successful gate path
- every commit builds `build/q27-metal` independently under the Metal `-Werror` flags
- `git diff --check upstream/master...HEAD` is clean

Independently derived by the maintainer on a 24 GB Apple M4 Pro at `5a80ce1`, using the same artifact bytes verified against `CHECKSUMS.md5`:

- the 128-token dump MD5 is `3a82b01053311807cc8bbaacdd8dcec7`, byte-identical to base M4
- forced `CANON_ARCH=metal-m4` reports `METAL CANONICAL GATES: ALL PASS`
- `make -B build/q27-metal` and `make -B test-metal-backend` pass under `-Werror`
- the real q4s artifact exercises `model upload path: per-tensor (mapping 14.40 GiB, max buffer 13.32 GiB)`, closing the previously unmeasured fallback path

At final tip `2aa95f1`, a full canonical run with an injected exact `Apple M4 Pro` brand string auto-selects `metal-m4:q4s`, reproduces MD5 `3a82b01053311807cc8bbaacdd8dcec7`, and reports both gate phases passing. Unknown Apple variants continue to fail closed.

The exact incremental delta is five files, +403/-46.

## Files (5)

- Makefile [MODIFIED] (+32 -1)
- src/metal/metal_cli.cpp [ADDED] (+197 -0)
- tools/canonical_md5.sh [ADDED] (+39 -0)
- tools/metal_canonical_gate.sh [ADDED] (+84 -0)
- tools/sampling_gate.sh [MODIFIED] (+51 -45)