### PR TITLE
serving: restore shared API and CUDA parity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ NVCCFLAGS ?= -O2 -std=c++17 -gencode arch=compute_86,code=sm_86 \
              -gencode arch=compute_89,code=sm_89 \
              -gencode arch=compute_120,code=sm_120 -Xcompiler -Wall
 
-.PHONY: all clean test-inspect test-metal-backend metal-engine test-metal-contracts test-metal test-metal-canonical
-all: build/inspect build/test_sampling build/test_kernels build/test_argmax_tie build/q27 build/q27-server build/test_tokenizer build/test_stream_split build/test_depthctl build/test_toolconstrain
+.PHONY: all clean test-inspect test-metal-backend metal-engine test-metal-contracts test-metal test-metal-canonical check-chat-extract check-responses-integration
+all: build/inspect build/test_sampling build/test_kernels build/test_argmax_tie build/q27 build/q27-server build/test_tokenizer build/test_stream_split build/test_openai_bridge build/test_chat_completions_integration build/test_depthctl build/test_toolconstrain
 
 build/q27: src/engine.cu src/engine.cuh src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp \
            src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/device_model.h src/loader.h src/cuda_common.h src/depthctl.h src/prefix_cache.h src/prefix_ram.h | build
@@ -30,11 +30,30 @@ test-inspect: build/inspect build/test_loader_contracts
 build/test_sampling: src/test_sampling.cpp src/sampling.h | build
 	$(CXX) $(CXXFLAGS) src/test_sampling.cpp -o $@
 
-build/test_tokenizer: src/test_tokenizer.cpp src/tokenizer.cpp src/tokenizer.h src/api_common.h src/stream_split.h src/toolgram.h | build
+build/test_tokenizer: src/test_tokenizer.cpp src/tokenizer.cpp src/tokenizer.h src/api_common.h src/stream_split.h src/markdown_lex.h src/toolgram.h | build
 	$(CXX) $(CXXFLAGS) -DQ27_TOKENIZER_TESTING src/test_tokenizer.cpp src/tokenizer.cpp -o $@
 
-build/test_stream_split: tools/test_stream_split.cpp src/stream_split.h | build
+build/test_stream_split: tools/test_stream_split.cpp src/stream_split.h src/markdown_lex.h | build
 	$(CXX) $(CXXFLAGS) -I src tools/test_stream_split.cpp -o $@
+
+build/test_openai_bridge: tools/test_openai_bridge.cpp src/api_common.h src/stream_split.h src/markdown_lex.h | build
+	$(CXX) $(CXXFLAGS) -I src tools/test_openai_bridge.cpp -o $@
+
+build/test_chat_completions_integration: tools/test_chat_completions_integration.cpp src/server.cu src/api_common.h src/toolconstrain.h src/toolgram.h src/stream_split.h src/markdown_lex.h src/tokenizer.h | build
+	$(CXX) $(CXXFLAGS) -I src tools/test_chat_completions_integration.cpp -o $@
+
+build/test_auth: tools/test_auth.cpp src/api_common.h | build
+	$(CXX) $(CXXFLAGS) -I src tools/test_auth.cpp -o $@
+
+build/test_auth_integration: tools/test_auth_integration.cpp src/api_common.h third_party/httplib.h | build
+	$(CXX) $(CXXFLAGS) -I src -I third_party -pthread tools/test_auth_integration.cpp -o $@
+
+check-chat-extract: tools/extract_check.sh src/server.cu tools/test_chat_completions_integration.cpp
+	./tools/extract_check.sh
+
+SERVER ?= build/q27-server
+check-responses-integration: $(SERVER) tools/test_responses_integration.py
+	python3 tools/test_responses_integration.py --server "$(SERVER)" --model "$(MODEL)" --tokenizer "$(TOKENIZER)"
 
 build/test_depthctl: tools/test_depthctl.cpp src/depthctl.h | build
 	$(CXX) $(CXXFLAGS) tools/test_depthctl.cpp -o $@
@@ -63,7 +82,7 @@ build/test_argmax_tie: tools/test_argmax_tie.cu src/blocks.cu src/blocks.cuh | b
 
 
 build/q27-server: src/server.cu src/engine.cuh src/conductor.h src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu \
-                  src/device_model.cu src/loader.cpp src/tokenizer.cpp src/api_common.h src/stream_split.h \
+                  src/device_model.cu src/loader.cpp src/tokenizer.cpp src/api_common.h src/stream_split.h src/markdown_lex.h \
                   src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/cuda_common.h src/toolgram.h \
                   src/depthctl.h src/toolconstrain.h src/tokenizer.h src/prefix_cache.h src/prefix_ram.h | build
 	$(NVCC) $(NVCCFLAGS) -Xcompiler -pthread src/server.cu src/blocks.cu src/prefill.cu src/kernels.cu \
@@ -108,7 +127,7 @@ build/turbo5_test: tools/turbo5_test.cu src/turbo5.cuh src/turbo3.cuh | build
 # graph zoo so the fixed stack fits beside the weights (the default W12
 # build OOMs at graph instantiation on 24GB). Same sources, own binary.
 build/q27-server-w8: src/server.cu src/engine.cuh src/conductor.h src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu \
-                     src/device_model.cu src/loader.cpp src/tokenizer.cpp src/api_common.h src/stream_split.h \
+                     src/device_model.cu src/loader.cpp src/tokenizer.cpp src/api_common.h src/stream_split.h src/markdown_lex.h \
                      src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/cuda_common.h src/toolgram.h \
                      src/depthctl.h src/toolconstrain.h src/tokenizer.h src/prefix_cache.h src/prefix_ram.h | build
 	$(NVCC) $(NVCCFLAGS) -DQ27_W_MAX=8 -Xcompiler -pthread src/server.cu src/blocks.cu src/prefill.cu src/kernels.cu \
@@ -133,7 +152,7 @@ build/fused_smoke: tools/fused_smoke.cu src/engine.cuh src/conductor.h src/prefi
 
 # w16 serving build (batch mode's natural target; was hand-built since part 10)
 build/q27-server-w16: src/server.cu src/engine.cuh src/conductor.h src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu \
-                      src/device_model.cu src/loader.cpp src/tokenizer.cpp src/api_common.h src/stream_split.h \
+                      src/device_model.cu src/loader.cpp src/tokenizer.cpp src/api_common.h src/stream_split.h src/markdown_lex.h \
                       src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/cuda_common.h src/toolgram.h \
                       src/depthctl.h src/toolconstrain.h src/tokenizer.h src/prefix_cache.h src/prefix_ram.h | build
 	$(NVCC) $(NVCCFLAGS) -DQ27_W_MAX=16 -Xcompiler -pthread src/server.cu src/blocks.cu src/prefill.cu src/kernels.cu \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NVCCFLAGS ?= -O2 -std=c++17 -gencode arch=compute_86,code=sm_86 \
              -gencode arch=compute_120,code=sm_120 -Xcompiler -Wall
 
 .PHONY: all clean test-inspect test-metal-backend metal-engine test-metal-contracts test-metal test-metal-canonical check-chat-extract check-responses-integration
-all: build/inspect build/test_sampling build/test_kernels build/test_argmax_tie build/q27 build/q27-server build/test_tokenizer build/test_stream_split build/test_openai_bridge build/test_chat_completions_integration build/test_depthctl build/test_toolconstrain
+all: build/inspect build/test_sampling build/test_kernels build/test_argmax_tie build/q27 build/q27-server build/test_tokenizer build/test_stream_split build/test_tool_drift build/test_tool_drift_corpus build/test_think_resolve build/test_openai_bridge build/test_chat_completions_integration build/test_depthctl build/test_toolconstrain
 
 build/q27: src/engine.cu src/engine.cuh src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp \
            src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/device_model.h src/loader.h src/cuda_common.h src/depthctl.h src/prefix_cache.h src/prefix_ram.h | build
@@ -41,6 +41,15 @@ build/test_openai_bridge: tools/test_openai_bridge.cpp src/api_common.h src/stre
 
 build/test_chat_completions_integration: tools/test_chat_completions_integration.cpp src/server.cu src/api_common.h src/toolconstrain.h src/toolgram.h src/stream_split.h src/markdown_lex.h src/tokenizer.h | build
 	$(CXX) $(CXXFLAGS) -I src tools/test_chat_completions_integration.cpp -o $@
+
+build/test_tool_drift: tools/test_tool_drift.cpp src/api_common.h src/stream_split.h src/markdown_lex.h | build
+	$(CXX) $(CXXFLAGS) -I src tools/test_tool_drift.cpp -o $@
+
+build/test_tool_drift_corpus: tools/test_tool_drift_corpus.cpp src/api_common.h src/stream_split.h src/markdown_lex.h | build
+	$(CXX) $(CXXFLAGS) -I src tools/test_tool_drift_corpus.cpp -o $@
+
+build/test_think_resolve: tools/test_think_resolve.cpp src/api_common.h src/stream_split.h src/markdown_lex.h | build
+	$(CXX) $(CXXFLAGS) -I src tools/test_think_resolve.cpp -o $@
 
 build/test_auth: tools/test_auth.cpp src/api_common.h | build
 	$(CXX) $(CXXFLAGS) -I src tools/test_auth.cpp -o $@

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -12,11 +12,14 @@
 #include <fstream>
 #include <limits>
 #include <mutex>
+#include <memory>
 #include <set>
 #include <string>
 #include <vector>
 
 #include "../third_party/json.hpp"
+#include "markdown_lex.h"
+
 #include "stream_split.h"
 
 namespace q27 {
@@ -59,6 +62,9 @@ inline std::string jstr(const json& b, const char* key,
     if (!b.is_object()) return dflt;
     const auto it = b.find(key);
     return (it != b.end() && it->is_string()) ? it->get<std::string>() : dflt;
+}
+inline std::string json_dump_replace(const json& value) {
+    return value.dump(-1,' ',false,json::error_handler_t::replace);
 }
 
 // Incremental UTF-8 boundary gate for streaming token pieces. BPE token
@@ -250,6 +256,15 @@ inline std::string tools_preamble(const json& tools) {
     return s;
 }
 
+inline std::string unavailable_tools_preamble(const json& tools) {
+    std::string s = "# Unavailable tools\n\nThe following tool declarations are included "
+                    "for request accounting only. They are not callable in this response:\n\n"
+                    "<unavailable_tools>";
+    for (const auto& tool : tools) s += "\n" + strip_ctrl(tool.dump());
+    s += "\n</unavailable_tools>";
+    return s;
+}
+
 // Build the full ChatML prompt string. If tools are present they are merged
 // into the (first) system message per the template's merged_system behavior.
 // think=false appends the empty think block (enable_thinking=false
@@ -265,7 +280,9 @@ inline std::string tools_preamble(const json& tools) {
 // split-invariance argument applies.
 inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools,
                                  bool think = true, size_t* stable_off = nullptr,
-                                 size_t* sys_off = nullptr) {
+                                 size_t* sys_off = nullptr,
+                                 const std::string& tool_instruction = {},
+                                 const json* unavailable_tools = nullptr) {
     std::string p;
     size_t start = 0;
     std::string sys;
@@ -279,12 +296,24 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
     // zero reasoning cost (real Claude Code always sends a system prompt, so
     // this never fires there). Q27_BARE=1 restores the no-default behavior.
     if (sys.empty() && !getenv("Q27_BARE")) sys = "You are a helpful assistant.";
-    if (tools.is_array() && !tools.empty()) {
-        p += "<|im_start|>system\n" + tools_preamble(tools);
-        if (!sys.empty()) p += "\n\n" + sys;
+    const bool has_tools=tools.is_array() && !tools.empty();
+    const bool has_unavailable=unavailable_tools && unavailable_tools->is_array() &&
+                               !unavailable_tools->empty();
+    if (has_tools || has_unavailable || !sys.empty() || !tool_instruction.empty()) {
+        p += "<|im_start|>system\n";
+        bool need_separator=false;
+        auto append_system_part=[&](const std::string& part) {
+            if (part.empty()) return;
+            if (need_separator) p += "\n\n";
+            p += part;
+            need_separator=true;
+        };
+        if (has_tools) append_system_part(tools_preamble(tools));
+        if (has_unavailable)
+            append_system_part(unavailable_tools_preamble(*unavailable_tools));
+        append_system_part(sys);
+        append_system_part(strip_ctrl(tool_instruction));
         p += "<|im_end|>\n";
-    } else if (!sys.empty()) {
-        p += "<|im_start|>system\n" + sys + "<|im_end|>\n";
     }
     if (sys_off) *sys_off = p.size();  // 0 when no system block was emitted
     for (size_t i = start; i < msgs.size(); i++)
@@ -556,6 +585,771 @@ struct ThinkBudgetState {
 // Anthropic error envelope, exactly the real API's shape: the SDK inside
 // Claude Code reads error.message from it, and CC's compact-vs-retry
 // decision substring-matches that message.
+// Minimal JSON structural context for mode-10 quote repair. A colon can
+// terminate a quoted OBJECT KEY, but inside a string VALUE it is ordinary
+// content (for example the raw shell fragment `echo "key": value`).
+struct JsonQuoteContext {
+    struct Frame { char kind; bool expect_key; };
+    std::vector<Frame> stack;
+    bool opening_string_is_key() const {
+        return !stack.empty() && stack.back().kind=='{' && stack.back().expect_key;
+    }
+    void structural(char c) {
+        if(c=='{') stack.push_back({'{',true});
+        else if(c=='[') stack.push_back({'[',false});
+        else if(c=='}') { if(!stack.empty() && stack.back().kind=='{') stack.pop_back(); }
+        else if(c==']') { if(!stack.empty() && stack.back().kind=='[') stack.pop_back(); }
+        else if(c==':' && !stack.empty() && stack.back().kind=='{') stack.back().expect_key=false;
+        else if(c==',' && !stack.empty() && stack.back().kind=='{') stack.back().expect_key=true;
+    }
+};
+
+inline std::string escape_json_interior(const std::string& s);
+
+inline void append_json_escaped_byte(std::string& out, unsigned char c) {
+    switch(c) {
+        case '"': out+="\\\""; return;
+        case '\\': out+="\\\\"; return;
+        case '\b': out+="\\b"; return;
+        case '\f': out+="\\f"; return;
+        case '\n': out+="\\n"; return;
+        case '\r': out+="\\r"; return;
+        case '\t': out+="\\t"; return;
+        default:
+            if(c<0x20) {
+                static constexpr char hex[]="0123456789abcdef";
+                out+="\\u00";
+                out+=hex[c>>4];
+                out+=hex[c&15];
+            } else out+=(char)c;
+    }
+}
+
+// Incremental tool-call argument streamer. Shares the
+// mode-5/10 drift semantics of JsonSanitizerStepper but deliberately keeps
+// its OWN loop: it is STREAMING (no full-call buffer for
+// quote_terminates_string lookahead) and adds mode-3 <content>-tag capture,
+// neither of which fits the stepper's buffer+index contract. Keep the
+// escape/repair RULES in lockstep with the stepper; mechanics differ.
+//
+// Feeds the splitter's TOOL-channel bytes as they decode; once the call head
+// parses ({"name": "X", "arguments": { — tolerating mode 9's missing
+// opening quote on the arguments key), object fields stream out sanitized.
+// A quoted `content` field is the one deliberate holdback: until its closing
+// bytes arrive, valid JSON is indistinguishable from mode 3's raw
+// `"content":"RAW</content>` drift. That value is released at finalization
+// if valid, or escaped when the tag appears; other fields remain incremental.
+// Heads that deviate (mode 6/7/8 shapes) or exceed the bound never stream:
+// raw bytes stay exact for the buffered recovery path. A streamed call whose
+// body ends unbalanced reaches the client unbalanced (production semantics —
+// the model's bytes are the model's bytes); repair applies only where bytes
+// have not already reached the wire.
+struct ToolCallStreamer {
+    enum State { HEAD, ARGS, DONE, INVALID_DONE, FALLBACK };
+    State state = HEAD;
+    std::string raw;      // entire body verbatim (fallback + logging)
+    std::string name;     // valid once opened
+    bool opened = false;  // head parsed; an opener chunk belongs on the wire
+
+    bool active() const { return !raw.empty(); }
+    bool invalid() const { return invalid_done_; }
+    void reset() { *this = ToolCallStreamer(); }
+
+    // Feed body bytes; returns the sanitized argument fragment to stream
+    // (often empty). *opened_now fires on the feed that completes the head.
+    std::string feed(const std::string& t, bool* opened_now) {
+        if (opened_now) *opened_now = false;
+        raw += t;
+        if (state == DONE || state == INVALID_DONE) { add_trail(t); return ""; }
+        if (state == FALLBACK) return "";
+        std::string out;
+        if (state == HEAD) {
+            head_ += t;
+            size_t consumed = 0;
+            int m = match_head(head_, name, consumed);
+            if (m == 0) {
+                if (head_.size() > 512) state = FALLBACK;
+                return "";
+            }
+            if (m < 0) { state = FALLBACK; return ""; }
+            state = ARGS;
+            opened = true;
+            if (opened_now) *opened_now = true;
+            std::string rest = head_.substr(consumed);
+            head_.clear();
+            scan(rest, out);
+            sanitized_ += out;
+            validate_done();
+            return out;
+        }
+        scan(t, out);
+        sanitized_ += out;
+        validate_done();
+        return out;
+    }
+
+    // Wrapper closed (or turn flushed). True = the args object completed
+    // cleanly (DONE). Mid-ARGS: resolves a pending quote per the EOF rule
+    // (terminator), appends the final bytes to *tail, returns false — the
+    // handler closes the call as-is. HEAD/FALLBACK: false, nothing streamed.
+    bool finalize(std::string* tail,bool allow_repair=true) {
+        if (state == DONE) return true;
+        if (!allow_repair) return false;
+        if (state == ARGS) {
+            if (defer_raw_tail_) {
+                const std::string pending = raw_tail_;
+                const bool array_value = !json_ctx_.stack.empty() &&
+                    json_ctx_.stack.back().kind == '[';
+                if (!raw_replay_work_) raw_replay_work_ = std::make_shared<size_t>(0);
+                bool have_fallback = false;
+                ToolCallStreamer fallback;
+                std::string fallback_output;
+                bool fallback_starts_call = false;
+                bool have_incomplete = false;
+                ToolCallStreamer incomplete;
+                std::string incomplete_output;
+                for (size_t terminal = pending.find("</content>");
+                     terminal != std::string::npos;
+                     terminal = pending.find("</content>", terminal + 1)) {
+                    size_t after = terminal + 10;
+                    while (after < pending.size() && is_ws(pending[after])) after++;
+                    bool structural = false;
+                    if (after == pending.size()) structural = true;
+                    else if (pending[after] == '}' || pending[after] == ']') structural = true;
+                    else if (pending[after] == ',') {
+                        size_t next = after + 1;
+                        while (next < pending.size() && is_ws(pending[next])) next++;
+                        if (array_value) {
+                            if (next < pending.size()) {
+                                const char n = pending[next];
+                                structural = n == '<' || n == '"' || n == '{' || n == '[' ||
+                                    n == '-' || (n >= '0' && n <= '9') || n == 't' ||
+                                    n == 'f' || n == 'n';
+                            }
+                        } else if (next < pending.size() && pending[next] == '"') {
+                            bool key_escape = false;
+                            size_t close = next + 1;
+                            for (; close < pending.size(); close++) {
+                                if (key_escape) { key_escape = false; continue; }
+                                if (pending[close] == '\\') { key_escape = true; continue; }
+                                if (pending[close] == '"') break;
+                            }
+                            size_t colon = close < pending.size() ? close + 1 : close;
+                            while (colon < pending.size() && is_ws(pending[colon])) colon++;
+                            structural = colon < pending.size() && pending[colon] == ':';
+                        }
+                    }
+                    if (!structural) continue;
+                    ToolCallStreamer replay = *this;
+                    constexpr size_t max_raw_replay_work = 4u * 1024u * 1024u;
+                    if (pending.size() > max_raw_replay_work -
+                        std::min(*raw_replay_work_, max_raw_replay_work)) break;
+                    *raw_replay_work_ += pending.size();
+                    replay.raw.clear();
+                    replay.defer_raw_tail_ = false;
+                    replay.raw_tail_.clear();
+                    replay.raw_tail_depth_ = raw_tail_depth_ + 1;
+                    replay.defer_raw_tails_enabled_ = replay.raw_tail_depth_ < 8;
+                    replay.tag_raw_ = false;
+                    const std::string escaped = escape_json_interior(pending.substr(0, terminal));
+                    replay.sanitized_ += escaped;
+                    std::string scanned;
+                    replay.scan("\"" + pending.substr(terminal + 10), scanned);
+                    replay.sanitized_ += scanned;
+                    replay.validate_done();
+                    std::string replay_tail;
+                    const bool complete = replay.finalize(&replay_tail);
+                    const size_t trail_begin = replay.trail_.find_first_not_of(" \t\r\n");
+                    bool clean_trail = trail_begin == std::string::npos;
+                    if (!clean_trail) {
+                        std::string remaining = replay.trail_.substr(trail_begin);
+                        clean_trail = true;
+                        int packed_count = 0;
+                        while (!remaining.empty() && packed_count++ < 64) {
+                            ToolCallStreamer packed;
+                            packed.raw_replay_work_ = raw_replay_work_;
+                            packed.raw_tail_depth_ = raw_tail_depth_ + 1;
+                            bool packed_opened = false;
+                            (void)packed.feed(remaining, &packed_opened);
+                            std::string packed_tail;
+                            if (!packed_opened || !packed.finalize(&packed_tail)) {
+                                clean_trail = false;
+                                break;
+                            }
+                            remaining = packed.trail_;
+                            const size_t next = remaining.find_first_not_of(" \t\r\n");
+                            if (next == std::string::npos) remaining.clear();
+                            else if (next > 0) remaining.erase(0, next);
+                        }
+                        if (!remaining.empty()) clean_trail = false;
+                    }
+                    if (complete && clean_trail) {
+                        *tail += escaped + scanned + replay_tail;
+                        state = replay.state;
+                        invalid_done_ = replay.invalid_done_;
+                        trail_ = std::move(replay.trail_);
+                        outer_seen_ = replay.outer_seen_;
+                        defer_raw_tail_ = false;
+                        raw_tail_.clear();
+                        return true;
+                    }
+                    if (complete && !have_fallback) {
+                        have_fallback = true;
+                        fallback = std::move(replay);
+                        fallback_output = escaped + scanned + replay_tail;
+                        const size_t fallback_begin = fallback.trail_.find_first_not_of(" \t\r\n");
+                        if (fallback_begin != std::string::npos) {
+                            std::string packed_name;
+                            size_t packed_args = 0;
+                            fallback_starts_call =
+                                match_head(fallback.trail_.substr(fallback_begin),
+                                           packed_name, packed_args) == 1;
+                        }
+                    }
+                    if (!complete && replay.state == ARGS && replay.trail_.empty()) {
+                        have_incomplete = true;
+                        incomplete = std::move(replay);
+                        incomplete_output = escaped + scanned + replay_tail;
+                    }
+                }
+                if (have_fallback && fallback_starts_call) {
+                    *tail += fallback_output;
+                    state = fallback.state;
+                    invalid_done_ = fallback.invalid_done_;
+                    trail_ = std::move(fallback.trail_);
+                    outer_seen_ = fallback.outer_seen_;
+                    defer_raw_tail_ = false;
+                    raw_tail_.clear();
+                    return true;
+                }
+                if (have_incomplete) {
+                    *tail += incomplete_output;
+                    state = incomplete.state;
+                    invalid_done_ = incomplete.invalid_done_;
+                    trail_ = std::move(incomplete.trail_);
+                    outer_seen_ = incomplete.outer_seen_;
+                    defer_raw_tail_ = false;
+                    raw_tail_.clear();
+                    return false;
+                }
+                if (have_fallback) {
+                    *tail += fallback_output;
+                    state = fallback.state;
+                    invalid_done_ = fallback.invalid_done_;
+                    trail_ = std::move(fallback.trail_);
+                    outer_seen_ = fallback.outer_seen_;
+                    defer_raw_tail_ = false;
+                    raw_tail_.clear();
+                    return true;
+                }
+                *tail += escape_json_interior(pending);
+                *tail += '"';
+                defer_raw_tail_ = false;
+                raw_tail_.clear();
+                tag_raw_ = false;
+                return false;
+            }
+            if (defer_content_) {
+                const std::string pending = deferred_;
+                const std::string complete_text = sanitized_ + pending;
+                auto balanced_end = [](const std::string& text) {
+                    int depth = 0;
+                    bool in_string = false, escaped = false, started = false;
+                    for (size_t i = 0; i < text.size(); i++) {
+                        const char c = text[i];
+                        if (escaped) { escaped = false; continue; }
+                        if (in_string) {
+                            if (c == '\\') escaped = true;
+                            else if (c == '"') in_string = false;
+                            continue;
+                        }
+                        if (c == '"') in_string = true;
+                        else if (c == '{') { depth++; started = true; }
+                        else if (c == '}' && started && --depth == 0) return i;
+                    }
+                    return std::string::npos;
+                };
+                const size_t exact_end = balanced_end(complete_text);
+                if (exact_end != std::string::npos && exact_end + 1 >= sanitized_.size()) {
+                    try {
+                        const json exact = json::parse(complete_text.substr(0, exact_end + 1));
+                        if (exact.is_object()) {
+                            const std::string emitted = complete_text.substr(
+                                sanitized_.size(), exact_end + 1 - sanitized_.size());
+                            *tail += emitted;
+                            sanitized_ += emitted;
+                            state = DONE;
+                            defer_content_ = false;
+                            deferred_.clear();
+                            add_trail(complete_text.substr(exact_end + 1));
+                            return true;
+                        }
+                    } catch (...) {}
+                }
+
+                auto prepare = [&](ToolCallStreamer& replay) {
+                    replay.defer_content_ = false;
+                    replay.deferred_.clear();
+                    replay.defer_content_keys_ = false;
+                };
+                auto finish = [&](ToolCallStreamer& replay, const std::string& bytes,
+                                  const std::string& prefix, std::string& emitted) {
+                    emitted = prefix;
+                    std::string scanned;
+                    replay.scan(bytes, scanned);
+                    replay.sanitized_ += scanned;
+                    replay.validate_done();
+                    emitted += scanned;
+                    std::string replay_tail;
+                    const bool complete = replay.finalize(&replay_tail);
+                    emitted += replay_tail;
+                    return complete;
+                };
+                auto adopt = [&](ToolCallStreamer& replay) {
+                    state = replay.state;
+                    invalid_done_ = replay.invalid_done_;
+                    trail_ = std::move(replay.trail_);
+                    outer_seen_ = replay.outer_seen_;
+                    defer_content_ = false;
+                    deferred_.clear();
+                };
+
+                // Find a provable closing quote for THIS content value. Raw
+                // controls and lone backslashes are tolerated for ownership,
+                // but unescaped inner quotes remain invalid; this distinguishes
+                // `a\nb", "body":...` from raw `{"a":"b"}</content>`.
+                const size_t any_tag = pending.find("</content>");
+                size_t tag = std::string::npos;
+                for (size_t search = any_tag; search != std::string::npos;
+                     search = pending.find("</content>", search + 1)) {
+                    size_t after = search + 10;
+                    while (after < pending.size() && is_ws(pending[after])) after++;
+                    if (after == pending.size() || pending[after] == ',' ||
+                        pending[after] == '}' || pending[after] == ']') {
+                        tag = search;
+                        break;
+                    }
+                }
+                size_t first_close_quote = std::string::npos;
+                if (any_tag != std::string::npos) {
+                    bool escaped = false;
+                    size_t quote = std::string::npos;
+                    char quote_delimiter = 0;
+                    for (size_t i = 0; i < pending.size(); i++) {
+                        if (escaped) { escaped = false; continue; }
+                        if (pending[i] == '\\') { escaped = true; continue; }
+                        if (pending[i] != '"') continue;
+                        size_t next = i + 1;
+                        while (next < pending.size() && is_ws(pending[next])) next++;
+                        if (next < pending.size() &&
+                            (pending[next] == ',' || pending[next] == '}' || pending[next] == ']')) {
+                            quote = i;
+                            quote_delimiter = pending[next];
+                            break;
+                        }
+                    }
+                    if (quote != std::string::npos) {
+                        if (quote_delimiter == ',') {
+                            ToolCallStreamer boundary = *this;
+                            prepare(boundary);
+                            boundary.recognize_tags_ = false;
+                            std::string first_part;
+                            boundary.scan(pending.substr(0, quote + 1), first_part);
+                            boundary.sanitized_ += first_part;
+                            boundary.validate_done();
+                            boundary.recognize_tags_ = true;
+                            std::string rest;
+                            const bool boundary_complete = finish(
+                                boundary, pending.substr(quote + 1), "", rest);
+                            const size_t trail_start = boundary.trail_.find_first_not_of(" \t\r\n");
+                            const bool packed = trail_start != std::string::npos &&
+                                boundary.trail_[trail_start] == '{';
+                            const bool stranded = boundary.trail_.find("</content>") !=
+                                std::string::npos && !packed;
+                            if (boundary_complete && !stranded) first_close_quote = quote;
+                        } else {
+                            std::vector<char> stack;
+                            bool in_string = false, prefix_escape = false;
+                            for (size_t i = 0; i + 1 < sanitized_.size(); i++) {
+                                const char c = sanitized_[i];
+                                if (prefix_escape) { prefix_escape = false; continue; }
+                                if (in_string) {
+                                    if (c == '\\') prefix_escape = true;
+                                    else if (c == '"') in_string = false;
+                                } else if (c == '"') in_string = true;
+                                else if (c == '{' || c == '[') stack.push_back(c);
+                                else if ((c == '}' || c == ']') && !stack.empty()) stack.pop_back();
+                            }
+                            std::string body;
+                            body.reserve(quote + 8);
+                            for (size_t i = 0; i < quote; i++) {
+                                const unsigned char c = (unsigned char)pending[i];
+                                if (c == '\\') {
+                                    if (i + 1 < quote) {
+                                        const char n = pending[i + 1];
+                                        if (n == '"' || n == '\\' || n == '/' || n == 'b' || n == 'f' ||
+                                            n == 'n' || n == 'r' || n == 't' || n == 'u') {
+                                            body += '\\'; body += n; i++; continue;
+                                        }
+                                    }
+                                    body += "\\\\";
+                                } else if (c == '\n') body += "\\n";
+                                else if (c == '\r') body += "\\r";
+                                else if (c == '\t') body += "\\t";
+                                else if (c < 0x20) {
+                                    char hex[8];
+                                    snprintf(hex, sizeof hex, "\\u%04x", c);
+                                    body += hex;
+                                } else body += (char)c;
+                            }
+                            std::string probe = sanitized_ + body + "\"";
+                            for (auto it = stack.rbegin(); it != stack.rend(); ++it)
+                                probe += *it == '{' ? '}' : ']';
+                            try {
+                                if (json::parse(probe).is_object()) first_close_quote = quote;
+                            } catch (...) {}
+                        }
+                    }
+                }
+                if (tag != std::string::npos && first_close_quote == std::string::npos) {
+                    ToolCallStreamer tagged = *this;
+                    prepare(tagged);
+                    const std::string escaped = escape_json_interior(pending.substr(0, tag));
+                    tagged.sanitized_ += escaped;
+                    std::string tagged_out;
+                    if (finish(tagged, "\"" + pending.substr(tag + 10), escaped, tagged_out)) {
+                        *tail += tagged_out;
+                        adopt(tagged);
+                        return true;
+                    }
+                }
+
+                // No sentinel reconstruction completed. Preserve the prior
+                // tolerant quote/control repair path without recursive
+                // content deferral or duplicate raw buffering.
+                ToolCallStreamer ordinary = *this;
+                prepare(ordinary);
+                std::string ordinary_out;
+                bool complete = false;
+                if (first_close_quote != std::string::npos) {
+                    ordinary.recognize_tags_ = false;
+                    std::string first_value;
+                    ordinary.scan(pending.substr(0, first_close_quote + 1), first_value);
+                    ordinary.sanitized_ += first_value;
+                    ordinary.validate_done();
+                    ordinary_out += first_value;
+                    ordinary.recognize_tags_ = true;
+                    std::string remainder;
+                    complete = finish(ordinary, pending.substr(first_close_quote + 1), "", remainder);
+                    ordinary_out += remainder;
+                } else {
+                    ordinary.recognize_tags_ = any_tag == std::string::npos || tag != std::string::npos;
+                    complete = finish(ordinary, pending, "", ordinary_out);
+                }
+                *tail += ordinary_out;
+                adopt(ordinary);
+                return complete;
+            }
+            if (!tag_.empty()) { *tail += tag_; tag_.clear(); }
+            if (pend_q_ || pend_tag_) {
+                *tail += '"';
+                *tail += pend_ws_;
+                pend_q_ = pend_tag_ = false;
+            }
+        }
+        return false;
+    }
+
+    // Bytes seen after the streamed call's arguments object closed. A
+    // wrapper can pack more than one call; these are NOT framing — the
+    // handler runs them through the bare-call recovery chain (review
+    // 2026-07-17: the DONE-state byte drop silently lost every call after
+    // the first, a regression vs the buffered path).
+    const std::string& trail() const { return trail_; }
+
+  private:
+    std::string head_;
+    std::string trail_;
+    std::string sanitized_;
+    bool invalid_done_ = false;
+    int depth_ = 0;
+    int raw_tail_depth_ = 0;
+    std::shared_ptr<size_t> raw_replay_work_;
+    bool in_str_ = false, esc_ = false, string_is_key_ = false;
+    bool tag_raw_ = false;   // <content> opened a raw value; escape until its close tag
+    bool defer_raw_tail_ = false;
+    std::string raw_tail_;
+    bool defer_raw_tails_enabled_ = true;
+    bool content_value_ = false;
+    std::string current_key_;
+    bool defer_content_keys_ = true;
+    bool next_content_value_ = false;
+    // A quoted `content` value is ambiguous until finalization can prefer a
+    // valid literal-tag interpretation over the malformed mode-3 sentinel.
+    bool defer_content_ = false;
+    std::string deferred_;
+    bool recognize_tags_ = true;
+    JsonQuoteContext json_ctx_;
+    bool pend_q_ = false;   // in-string quote awaiting one-byte lookahead
+    bool pend_tag_ = false; // full </content> matched, awaiting the same lookahead
+    bool outer_seen_ = false; // the call object's OWN closing } consumed from the trail
+    std::string pend_ws_;   // whitespace held behind the pending quote/tag
+    std::string tag_;       // partial <content>/</content> capture (mode 3)
+
+    // Post-DONE bytes: the head consumed the call object's opening { without
+    // counting it, so exactly one closing } after the args object is the
+    // call's own framing — swallow it once; everything else is trail.
+    void add_trail(const std::string& s) {
+        size_t k = 0;
+        if (!outer_seen_) {
+            while (k < s.size() && is_ws(s[k])) k++;
+            if (k == s.size()) return;      // only ws so far: keep waiting
+            outer_seen_ = true;
+            if (s[k] == '}') k++;
+        }
+        trail_ += s.substr(k);
+    }
+
+    static bool is_content_key(const std::string& raw) {
+        static constexpr char expected[] = "content";
+        size_t out = 0;
+        for (size_t i = 0; i < raw.size();) {
+            unsigned value = static_cast<unsigned char>(raw[i++]);
+            if (value == '\\') {
+                if (i == raw.size()) return false;
+                const char escape = raw[i++];
+                if (escape == 'u') {
+                    if (raw.size() - i < 4) return false;
+                    value = 0;
+                    for (int digit = 0; digit < 4; digit++) {
+                        const char h = raw[i++];
+                        unsigned nibble;
+                        if (h >= '0' && h <= '9') nibble = static_cast<unsigned>(h - '0');
+                        else if (h >= 'a' && h <= 'f') nibble = static_cast<unsigned>(h - 'a' + 10);
+                        else if (h >= 'A' && h <= 'F') nibble = static_cast<unsigned>(h - 'A' + 10);
+                        else return false;
+                        value = (value << 4) | nibble;
+                    }
+                } else {
+                    switch (escape) {
+                        case '"': value = '"'; break;
+                        case '\\': value = '\\'; break;
+                        case '/': value = '/'; break;
+                        case 'b': value = '\b'; break;
+                        case 'f': value = '\f'; break;
+                        case 'n': value = '\n'; break;
+                        case 'r': value = '\r'; break;
+                        case 't': value = '\t'; break;
+                        default: return false;
+                    }
+                }
+            }
+            if (out >= sizeof(expected) - 1 || value != static_cast<unsigned char>(expected[out]))
+                return false;
+            out++;
+        }
+        return out == sizeof(expected) - 1;
+    }
+
+    static bool is_ws(char c) { return c==' '||c=='\t'||c=='\r'||c=='\n'; }
+
+    void validate_done() {
+        if(state!=DONE) return;
+        try {
+            json parsed=json::parse(sanitized_);
+            if(!parsed.is_object()) throw std::runtime_error("tool arguments are not an object");
+        } catch(...) {
+            invalid_done_=true;
+            // The opener is already on wire, so this is not an ordinary
+            // buffered fallback. Preserve all later feeds as recovery trail
+            // for packed calls that start in a subsequent token.
+            state=INVALID_DONE;
+        }
+    }
+
+    void scan(const std::string& in, std::string& out) {
+        for (size_t i = 0; i < in.size() && state == ARGS; ) {
+            const char c = in[i];
+            if (defer_raw_tail_) {
+                raw_tail_ += c;
+                i++;
+                continue;
+            }
+            if (defer_content_) {
+                deferred_ += c;
+                i++;
+                continue;
+            }
+            if (!tag_.empty()) {
+                const char* want = in_str_ ? "</content>" : "<content>";
+                const size_t wl = in_str_ ? 10 : 9;
+                if (c == want[tag_.size()]) {
+                    tag_ += c; i++;
+                    if (tag_.size() == wl) {
+                        if (in_str_ && tag_raw_ && defer_raw_tails_enabled_) {
+                            defer_raw_tail_ = true;
+                            raw_tail_ = tag_;
+                            tag_.clear();
+                        } else {
+                            tag_.clear();
+                            if (in_str_) pend_tag_ = true;
+                            else {
+                                out += '"';
+                                in_str_ = true;
+                                string_is_key_ = false;
+                                tag_raw_ = true;
+                                content_value_ = false;
+                                next_content_value_ = false;
+                            }
+                        }
+                    }
+                    continue;
+                }
+                out += tag_;
+                tag_.clear();
+                continue;
+            }
+            if (pend_q_ || pend_tag_) {
+                if (is_ws(c)) { pend_ws_ += c; i++; continue; }
+                const bool terminates = string_is_key_ ? c == ':'
+                    : (c == ',' || c == '}' || c == ']');
+                if (terminates) {
+                    out += '"'; out += pend_ws_;
+                    in_str_ = false;
+                    content_value_ = false;
+                    tag_raw_ = false;
+                    if (string_is_key_)
+                        next_content_value_ = is_content_key(current_key_);
+                } else {
+                    out += pend_tag_ ? "</content>" : "\\\"";
+                    for (char w : pend_ws_)
+                        out += w=='\n' ? "\\n" : w=='\r' ? "\\r"
+                             : w=='\t' ? "\\t" : std::string(1, w);
+                }
+                pend_ws_.clear();
+                pend_q_ = pend_tag_ = false;
+            }
+            if (esc_) {
+                esc_ = false;
+                if (string_is_key_) current_key_ += c;
+                out += c; i++; continue;
+            }
+            if (in_str_) {
+                if (tag_raw_) {
+                    if (recognize_tags_ && c == '<') { tag_ += c; i++; continue; }
+                    append_json_escaped_byte(out,(unsigned char)c);
+                    i++;
+                    continue;
+                }
+                if (c == '\\') {
+                    if (string_is_key_) current_key_ += c;
+                    esc_ = true; out += c; i++; continue;
+                }
+                if (c == '"') { pend_q_ = true; i++; continue; }
+                if (recognize_tags_ && content_value_ && c == '<') { tag_ += c; i++; continue; }
+                if (string_is_key_) current_key_ += c;
+                append_json_escaped_byte(out,(unsigned char)c);
+                i++;
+                continue;
+            }
+            if (next_content_value_ && !is_ws(c) && c != ':' && c != '"' && c != '<')
+                next_content_value_ = false;
+            if (recognize_tags_ && c == '<') { tag_ += c; i++; continue; }
+            out += c; i++;
+            if (c == '"') {
+                string_is_key_ = json_ctx_.opening_string_is_key();
+                in_str_ = true;
+                if (string_is_key_) current_key_.clear();
+                else {
+                    content_value_ = next_content_value_;
+                    defer_content_ = defer_content_keys_ && content_value_;
+                    next_content_value_ = false;
+                    deferred_.clear();
+                }
+            } else {
+                json_ctx_.structural(c);
+                if (c == '{') depth_++;
+                else if (c == '}' && --depth_ == 0) {
+                    state = DONE;
+                    add_trail(in.substr(i));
+                }
+            }
+        }
+    }
+
+    // 1 = matched (name_out set, consumed = index OF the args '{'),
+    // 0 = undecided (need more bytes), -1 = not this shape (fallback).
+    static int match_head(const std::string& b, std::string& name_out,
+                          size_t& consumed) {
+        size_t i = 0;
+        auto skip = [&]() { while (i < b.size() && is_ws(b[i])) i++; return i < b.size(); };
+        auto lit = [&](const char* s) -> int {
+            for (size_t k = 0; s[k]; k++, i++) {
+                if (i >= b.size()) return 0;
+                if (b[i] != s[k]) return -1;
+            }
+            return 1;
+        };
+        int r;
+        if (!skip()) return 0;
+        if ((r = lit("{")) <= 0) return r;
+        if (!skip()) return 0;
+        if ((r = lit("\"name\"")) <= 0) return r;
+        if (!skip()) return 0;
+        if ((r = lit(":")) <= 0) return r;
+        if (!skip()) return 0;
+        if ((r = lit("\"")) <= 0) return r;
+        std::string nm;
+        for (;; i++) {
+            if (i >= b.size()) return 0;
+            if (b[i] == '\\') return -1;   // escaped names: buffered path
+            if (b[i] == '"') { i++; break; }
+            nm += b[i];
+        }
+        if (nm.empty()) return -1;
+        if (!skip()) return 0;
+        if ((r = lit(",")) <= 0) return r;
+        if (!skip()) return 0;
+        if (b[i] == '"') i++;              // mode-9: opening quote optional
+        if ((r = lit("arguments\"")) <= 0) return r;
+        if (!skip()) return 0;
+        if ((r = lit(":")) <= 0) return r;
+        if (!skip()) return 0;
+        if (b[i] != '{') return -1;        // non-object args: buffered path
+        name_out = nm;
+        consumed = i;
+        return 1;
+    }
+};
+
+// Experimental harness-prefix prewarming accepts only an initial request:
+// zero or more merged system messages followed by exactly one live user
+// message. Return the closed static prompt and optionally the complete
+// ordinary generation prompt. Token-level callers still verify that encoding
+// the former is an exact prefix of encoding the latter before any side effect.
+inline std::string initial_harness_prefix(const std::vector<Msg>& messages,
+                                          const json& tools, bool think,
+                                          std::string* full_prompt = nullptr,
+                                          const std::string& tool_instruction = {},
+                                          const json* unavailable_tools = nullptr) {
+    if (messages.empty() || messages.back().role != "user")
+        throw std::runtime_error(
+            "prewarm requires an initial request ending in one user message");
+    std::vector<Msg> prefix_messages(messages.begin(), messages.end() - 1);
+    for (const auto& message : prefix_messages)
+        if (message.role != "system")
+            throw std::runtime_error(
+                "prewarm accepts initial requests only (system plus final user)");
+    if (full_prompt) *full_prompt=chatml_prompt(
+        messages,tools,think,nullptr,nullptr,tool_instruction,unavailable_tools);
+    size_t stable_bytes = 0;
+    std::string prefix=chatml_prompt(
+        prefix_messages,tools,think,&stable_bytes,nullptr,tool_instruction,
+        unavailable_tools);
+    prefix.resize(stable_bytes);
+    return prefix;
+}
+
 inline std::string anthropic_error_json(const std::string& err_type,
                                         const std::string& message) {
     json e = {{"type", "error"},
@@ -577,13 +1371,19 @@ inline json anthropic_tools_json(const json& body) {
     json out = json::array();
     if (body.contains("tools") && body["tools"].is_array())
         for (auto& t : body["tools"]) {
-            if (!t.is_object() || !t.contains("name")) continue;
+            if (!t.is_object() || !t.contains("name") || !t["name"].is_string()) continue;
+            const std::string& name=t["name"].get_ref<const std::string&>();
+            if(name.empty()) continue;
+            const std::string description=
+                t.contains("description") && t["description"].is_string()
+                    ? t["description"].get<std::string>() : "";
+            const json parameters=
+                t.contains("input_schema") && t["input_schema"].is_object()
+                    ? t["input_schema"] : json::object();
             out.push_back({{"type", "function"},
-                           {"function", {{"name", t["name"]},
-                                         {"description", t.value("description", "")},
-                                         {"parameters", t.contains("input_schema")
-                                                            ? t["input_schema"]
-                                                            : json::object()}}}});
+                           {"function", {{"name", name},
+                                         {"description", description},
+                                         {"parameters", parameters}}}});
         }
     return out;
 }
@@ -660,14 +1460,19 @@ inline std::vector<Msg> anthropic_msgs(const json& body) {
 inline json openai_tools_json(const json& body) {
     json out = json::array();
     if (body.contains("tools") && body["tools"].is_array())
-        for (auto& t : body["tools"]) {
-            if (!t.is_object() || t.value("type", "") != "function") continue;
+        for (const auto& t : body["tools"]) {
+            if (!t.is_object() || !t.contains("type") || !t["type"].is_string() ||
+                t["type"] != "function") continue;
             if (!t.contains("function") || !t["function"].is_object()) continue;
             const json& fn = t["function"];
-            if (!fn.contains("name") || !fn["name"].is_string()) continue;
+            if (!fn.contains("name") || !fn["name"].is_string() ||
+                fn["name"].get_ref<const std::string&>().empty()) continue;
+            if (fn.contains("description") && !fn["description"].is_string()) continue;
+            if (fn.contains("parameters") && !fn["parameters"].is_object()) continue;
             out.push_back({{"type", "function"},
                            {"function", {{"name", fn["name"]},
-                                         {"description", fn.value("description", "")},
+                                         {"description", fn.contains("description")
+                                                             ? fn["description"] : json("")},
                                          {"parameters", fn.contains("parameters")
                                                             ? fn["parameters"]
                                                             : json::object()}}}});
@@ -735,19 +1540,58 @@ inline std::vector<Msg> openai_msgs(const json& body) {
     return msgs;
 }
 
-// tool_choice (OpenAI shape): "auto"/absent -> AUTO (unchanged behavior);
-// "none" -> NONE (tools stripped from the prompt entirely -- the model gets
-// no tool definitions and cannot call anything this turn); "required" or a
-// named {"type":"function","function":{"name":...}} -> FORCED. FORCED is a
-// soft force (prompt-injected <tool_call> opener + pre-seeded stream router,
-// see server.cu) -- it is NOT combined with --constrain-tools grammar
-// masking (documented limitation: the grammar's engage trigger scans
-// GENERATED text for the <tool_call> marker, which never appears in the
-// output when it was injected into the PROMPT instead).
+// tool_choice (OpenAI shape): "auto"/absent -> AUTO; "none" -> NONE;
+// "required", a named function, or allowed_tools mode:"required" -> FORCED.
+// allowed_tools mode:"auto" keeps AUTO while narrowing the eligible registry.
 struct ToolChoice {
     enum Mode { AUTO, NONE, FORCED } mode = AUTO;
-    std::string forced_name; // empty = any registered tool eligible
+    std::string forced_name; // non-empty only for a named function choice
+    std::vector<std::string> allowed_names; // empty = every declared tool
+    bool disable_parallel_tool_use = false;
+    bool invalid = false;
 };
+
+inline bool forced_tool_choice_missing_is_error(const ToolChoice& choice,
+                                                bool has_eligible_call,
+                                                bool generation_truncated) {
+    return choice.mode == ToolChoice::FORCED && !has_eligible_call &&
+           !generation_truncated;
+}
+
+inline const char* openai_tool_finish_reason(bool has_eligible_call,
+                                             bool final_tool_incomplete,
+                                             bool generation_truncated) {
+    if(has_eligible_call && !final_tool_incomplete) return "tool_calls";
+    return generation_truncated ? "length" : "stop";
+}
+
+inline const char* anthropic_tool_stop_reason(bool has_eligible_call,
+                                               bool final_tool_incomplete,
+                                               bool generation_truncated) {
+    if(has_eligible_call && !final_tool_incomplete) return "tool_use";
+    return generation_truncated ? "max_tokens" : "end_turn";
+}
+
+// OpenAI's top-level parallel_tool_calls=false has the same output
+// multiplicity contract as Anthropic's disable_parallel_tool_use=true.
+// Keep it on ToolChoice so wrapped, recovered, streaming, and non-streaming
+// calls all pass through one eligibility rule.
+inline void apply_openai_parallel_tool_calls(const json& body,ToolChoice& choice) {
+    if(!body.contains("parallel_tool_calls")) return;
+    if(!body["parallel_tool_calls"].is_boolean()) {
+        choice.invalid=true;
+        return;
+    }
+    choice.disable_parallel_tool_use=!body["parallel_tool_calls"].get<bool>();
+}
+
+template<class NameSet>
+inline bool tool_choice_allows_call(const ToolChoice& choice,const NameSet& allowed,
+                                    const std::string& name,size_t accepted_calls) {
+    return choice.mode != ToolChoice::NONE && allowed.count(name) &&
+        (choice.forced_name.empty() || name == choice.forced_name) &&
+        (!choice.disable_parallel_tool_use || accepted_calls == 0);
+}
 inline ToolChoice parse_tool_choice(const json& body) {
     ToolChoice tc;
     if (!body.contains("tool_choice")) return tc;
@@ -756,12 +1600,375 @@ inline ToolChoice parse_tool_choice(const json& body) {
         if (v == "none") tc.mode = ToolChoice::NONE;
         else if (v == "required") tc.mode = ToolChoice::FORCED;
         // "auto" or any other/unknown string: default AUTO
-    } else if (v.is_object() && v.value("type", "") == "function" && v.contains("function") &&
-               v["function"].is_object()) {
-        tc.mode = ToolChoice::FORCED;
-        tc.forced_name = v["function"].value("name", std::string());
+        return tc;
     }
+    if (v.is_null()) return tc;
+    if (!v.is_object() || !v.contains("type") || !v["type"].is_string()) {
+        tc.invalid = true;
+        return tc;
+    }
+    if (v["type"] == "function") {
+        if (!v.contains("function") || !v["function"].is_object() ||
+            !v["function"].contains("name") || !v["function"]["name"].is_string() ||
+            v["function"]["name"].get_ref<const std::string&>().empty()) {
+            tc.invalid = true;
+            return tc;
+        }
+        tc.mode = ToolChoice::FORCED;
+        tc.forced_name = v["function"]["name"].get<std::string>();
+        tc.allowed_names.push_back(tc.forced_name);
+        return tc;
+    }
+    if (v["type"] == "allowed_tools") {
+        if (!v.contains("allowed_tools") || !v["allowed_tools"].is_object()) {
+            tc.invalid = true;
+            return tc;
+        }
+        const json& allowed = v["allowed_tools"];
+        if (!allowed.contains("mode") || !allowed["mode"].is_string() ||
+            (allowed["mode"] != "auto" && allowed["mode"] != "required") ||
+            !allowed.contains("tools") || !allowed["tools"].is_array()) {
+            tc.invalid = true;
+            return tc;
+        }
+        tc.mode = allowed["mode"] == "required" ? ToolChoice::FORCED : ToolChoice::AUTO;
+        for (const auto& tool : allowed["tools"]) {
+            if (!tool.is_object() || !tool.contains("type") || !tool["type"].is_string() ||
+                tool["type"] != "function" || !tool.contains("function") ||
+                !tool["function"].is_object() || !tool["function"].contains("name") ||
+                !tool["function"]["name"].is_string() ||
+                tool["function"]["name"].get_ref<const std::string&>().empty()) {
+                tc.invalid = true;
+                return tc;
+            }
+            const std::string name=tool["function"]["name"].get<std::string>();
+            if (std::find(tc.allowed_names.begin(),tc.allowed_names.end(),name)==tc.allowed_names.end())
+                tc.allowed_names.push_back(name);
+        }
+        if (tc.allowed_names.empty()) tc.invalid = true;
+        return tc;
+    }
+    tc.invalid = true;
     return tc;
+}
+
+// Anthropic tool_choice: absent/auto -> AUTO, none -> NONE, any -> FORCED
+// across the declared registry, and tool{name} -> FORCED for that one tool.
+inline ToolChoice parse_anthropic_tool_choice(const json& body) {
+    ToolChoice tc;
+    if (!body.contains("tool_choice") || body["tool_choice"].is_null()) return tc;
+    const json& v = body["tool_choice"];
+    if (!v.is_object() || !v.contains("type") || !v["type"].is_string()) {
+        tc.invalid = true;
+        return tc;
+    }
+    if (v.contains("disable_parallel_tool_use")) {
+        if (!v["disable_parallel_tool_use"].is_boolean()) {
+            tc.invalid = true;
+            return tc;
+        }
+        tc.disable_parallel_tool_use = v["disable_parallel_tool_use"].get<bool>();
+    }
+    const std::string type = v["type"].get<std::string>();
+    if (type == "auto") return tc;
+    if (type == "none") {
+        tc.mode = ToolChoice::NONE;
+        return tc;
+    }
+    if (type == "any") {
+        tc.mode = ToolChoice::FORCED;
+        return tc;
+    }
+    if (type == "tool") {
+        if (!v.contains("name") || !v["name"].is_string() ||
+            v["name"].get_ref<const std::string&>().empty()) {
+            tc.invalid = true;
+            return tc;
+        }
+        tc.mode = ToolChoice::FORCED;
+        tc.forced_name = v["name"].get<std::string>();
+        tc.allowed_names.push_back(tc.forced_name);
+        return tc;
+    }
+    tc.invalid = true;
+    return tc;
+}
+
+// Anthropic's incompatibility is request-scoped: an explicit thinking block
+// cannot coexist with forced tool_choice. A server-side --think default is a
+// local fallback, so forced choice may override it when the request is silent.
+inline void validate_anthropic_tool_choice_thinking(
+        const ToolChoice& choice, const ThinkCfg& thinking) {
+    if (choice.mode == ToolChoice::FORCED && thinking.enabled && thinking.enabled_set)
+        throw std::invalid_argument(
+            "thinking.type: enabled is incompatible with forced tool_choice");
+}
+
+inline std::string anthropic_tool_choice_instruction(const ToolChoice& choice) {
+    if (choice.mode == ToolChoice::NONE)
+        return "Tool use is disabled for this response. Do not call any tool.";
+    if (choice.mode != ToolChoice::FORCED) return {};
+    if (choice.forced_name.empty())
+        return "You must call at least one of the available tools before ending the response.";
+    return "You must call only the tool named " + json(choice.forced_name).dump() +
+           " before ending the response.";
+}
+
+inline void validate_responses_tool_fields(const json& body) {
+    if(!body.contains("tools") || !body["tools"].is_array()) return;
+    for(const auto& tool:body["tools"]) {
+        if(!tool.is_object()) continue;
+        auto require_string=[&](const char* field) {
+            const auto it=tool.find(field);
+            if(it!=tool.end() && !it->is_string())
+                throw std::invalid_argument(
+                    std::string("tools[].")+field+" must be a string");
+        };
+        require_string("type");
+        const std::string type=jstr(tool,"type");
+        if(type=="function" || type=="custom") {
+            require_string("name");
+            require_string("description");
+        }
+    }
+}
+
+// Legacy Codex clients can advertise their locally executed shell capability
+// as the hosted Responses type `shell`, while still consuming ordinary
+// function_call items. Translate that compatibility form into the two
+// model-facing functions the client executes; true hosted execution remains
+// the client's responsibility, not this inference server's.
+inline json responses_shell_prompt_tools() {
+    return json::array({
+        {{"type","function"},{"function",{
+            {"name","exec_command"},
+            {"description","Runs a shell command and returns output or a session ID for ongoing interaction."},
+            {"parameters",{{"type","object"},{"properties",{
+                {"cmd",{{"type","string"},{"description","Shell command to execute."}}},
+                {"workdir",{{"type","string"},{"description","Working directory for the command."}}},
+                {"tty",{{"type","boolean"},{"description","Whether to allocate a PTY."}}},
+                {"yield_time_ms",{{"type","number"},{"description","Wait before yielding output."}}},
+                {"max_output_tokens",{{"type","number"},{"description","Output token budget."}}},
+                {"shell",{{"type","string"},{"description","Shell binary to launch."}}}
+            }},{"required",json::array({"cmd"})},{"additionalProperties",false}}}
+        }}},
+        {{"type","function"},{"function",{
+            {"name","write_stdin"},
+            {"description","Writes characters to an existing command session and returns recent output."},
+            {"parameters",{{"type","object"},{"properties",{
+                {"session_id",{{"type","number"},{"description","Identifier of the running command session."}}},
+                {"chars",{{"type","string"},{"description","Bytes to write; empty polls without writing."}}},
+                {"yield_time_ms",{{"type","number"},{"description","Wait before yielding output."}}},
+                {"max_output_tokens",{{"type","number"},{"description","Output token budget."}}}
+            }},{"required",json::array({"session_id"})},{"additionalProperties",false}}}
+        }}}
+    });
+}
+
+template<class NameSet>
+inline void add_responses_hosted_call_names(NameSet& names,
+                                            const std::string& hosted_type) {
+    if (hosted_type != "shell") return;
+    names.insert("exec_command");
+    names.insert("write_stdin");
+}
+
+inline bool responses_tool_names_ambiguous(
+    const std::set<std::string>& function_names,
+    const std::set<std::string>& custom_names,
+    const std::set<std::string>& hosted_tool_types) {
+    std::set<std::string> hosted_call_names;
+    for (const auto& type : hosted_tool_types)
+        add_responses_hosted_call_names(hosted_call_names, type);
+    for (const auto& name : function_names)
+        if (custom_names.count(name) || hosted_tool_types.count(name) ||
+            hosted_call_names.count(name))
+            return true;
+    for (const auto& name : custom_names)
+        if (hosted_tool_types.count(name) || hosted_call_names.count(name))
+            return true;
+    return false;
+}
+inline void validate_responses_tool_choice_declarations(
+    const json& body,
+    const std::set<std::string>& function_names,
+    const std::set<std::string>& custom_names,
+    const std::set<std::string>& hosted_tool_types) {
+    auto validate_tool = [&](const json& tool) {
+        if (!tool.is_object()) return;
+        const std::string type = jstr(tool, "type");
+        if (type == "function" || type == "custom") {
+            const std::string name = jstr(tool, "name");
+            if (name.empty()) return;
+            const bool declared = type == "function" ? function_names.count(name)
+                                                       : custom_names.count(name);
+            if (!declared)
+                throw std::runtime_error("tool_choice kind/name not present in tools");
+        } else if (!type.empty() && type != "allowed_tools" && type != "mcp" &&
+                   !hosted_tool_types.count(type)) {
+            throw std::runtime_error("tool_choice hosted type not present in tools");
+        }
+    };
+    if (!body.contains("tool_choice") || !body["tool_choice"].is_object()) return;
+    const json& source = body["tool_choice"];
+    if (jstr(source, "type") != "allowed_tools") {
+        validate_tool(source);
+        return;
+    }
+    const json* allowed = &source;
+    if (source.contains("allowed_tools") && source["allowed_tools"].is_object())
+        allowed = &source["allowed_tools"];
+    if (allowed->contains("tools") && (*allowed)["tools"].is_array())
+        for (const auto& tool : (*allowed)["tools"]) validate_tool(tool);
+}
+
+inline ToolChoice responses_registered_tool_choice(
+    const ToolChoice& choice, const std::set<std::string>& hosted_tool_types) {
+    ToolChoice registered = choice;
+    auto mapped_names = [](const std::string& type) {
+        std::set<std::string> names;
+        add_responses_hosted_call_names(names, type);
+        return names;
+    };
+    if (!registered.forced_name.empty() &&
+        hosted_tool_types.count(registered.forced_name)) {
+        auto mapped = mapped_names(registered.forced_name);
+        registered.forced_name.clear();
+        registered.allowed_names.assign(mapped.begin(), mapped.end());
+        if (registered.allowed_names.empty()) registered.mode = ToolChoice::NONE;
+    } else if (!registered.allowed_names.empty()) {
+        std::set<std::string> expanded;
+        for (const auto& name : registered.allowed_names) {
+            if (hosted_tool_types.count(name)) {
+                auto mapped = mapped_names(name);
+                expanded.insert(mapped.begin(), mapped.end());
+            } else {
+                expanded.insert(name);
+            }
+        }
+        registered.allowed_names.assign(expanded.begin(), expanded.end());
+        if (registered.allowed_names.empty()) registered.mode = ToolChoice::NONE;
+    }
+    return registered;
+}
+
+
+// Responses API names function/custom tools directly in object-form
+// tool_choice, unlike Chat Completions' nested `function.name` shape.
+// Normalize that wire form into ToolChoice so both APIs share selection and
+// output-validation semantics.
+inline ToolChoice parse_responses_tool_choice(const json& body) {
+    if (body.contains("tool_choice") && body["tool_choice"].is_string() &&
+        body["tool_choice"] != "auto" && body["tool_choice"] != "none" &&
+        body["tool_choice"] != "required") {
+        ToolChoice invalid;
+        invalid.invalid = true;
+        return invalid;
+    }
+    if (!body.contains("tool_choice") || !body["tool_choice"].is_object())
+        return parse_tool_choice(body);
+    json normalized = body;
+    const json& source = body["tool_choice"];
+    const std::string type = source.value("type", std::string());
+    if ((type == "function" || type == "custom") && source.contains("name")) {
+        normalized["tool_choice"] = {{"type","function"},
+                                     {"function",{{"name",source["name"]}}}};
+    } else if (type == "shell") {
+        normalized["tool_choice"] = {{"type","function"},
+                                     {"function",{{"name",type}}}};
+    } else if (type == "allowed_tools") {
+        json allowed;
+        if (source.contains("allowed_tools") && source["allowed_tools"].is_object())
+            allowed=source["allowed_tools"];
+        else {
+            if (source.contains("mode")) allowed["mode"]=source["mode"];
+            if (source.contains("tools")) allowed["tools"]=source["tools"];
+        }
+        bool skipped_unavailable=false;
+        if (allowed.contains("tools") && allowed["tools"].is_array()) {
+            json tools = json::array();
+            const bool optional=allowed.value("mode",std::string())=="auto";
+            for (const auto& tool : allowed["tools"]) {
+                const std::string tool_type = tool.is_object()
+                    ? tool.value("type",std::string()) : std::string();
+                if (tool.is_object() && tool.contains("name") &&
+                    (tool_type == "function" || tool_type == "custom"))
+                    tools.push_back({{"type","function"},
+                                     {"function",{{"name",tool["name"]}}}});
+                else if (tool_type == "shell")
+                    tools.push_back({{"type","function"},
+                                     {"function",{{"name",tool_type}}}});
+                else if(optional && !tool_type.empty())
+                    skipped_unavailable=true;
+                else tools.push_back(tool);
+            }
+            if(skipped_unavailable && tools.empty()) {
+                ToolChoice unavailable;
+                unavailable.mode=ToolChoice::NONE;
+                return unavailable;
+            }
+            allowed["tools"] = std::move(tools);
+        }
+        normalized["tool_choice"] = {{"type","allowed_tools"},
+                                     {"allowed_tools",std::move(allowed)}};
+    }
+    return parse_tool_choice(normalized);
+}
+
+inline bool openai_stream_includes_usage(const json& body) {
+    if (!jbool(body,"stream",false) || !body.contains("stream_options") ||
+        !body["stream_options"].is_object()) return false;
+    const json& options=body["stream_options"];
+    return options.contains("include_usage") && options["include_usage"].is_boolean() &&
+           options["include_usage"].get<bool>();
+}
+
+struct OpenAIToolSelection {
+    json tools=json::array();
+    std::vector<std::string> names;
+};
+
+// Normalize the declared registry once, then apply tool_choice's eligible
+// subset. Both backends use this helper so prompt injection, grammar names,
+// fallback parsing, and output validation all share the same registry.
+inline OpenAIToolSelection select_openai_tools(const json& body,const ToolChoice& choice) {
+    if (choice.invalid) throw std::runtime_error("invalid tool_choice or parallel_tool_calls");
+    OpenAIToolSelection selected;
+    if (choice.mode == ToolChoice::NONE) return selected;
+    selected.tools=openai_tools_json(body);
+    for (const auto& tool : selected.tools)
+        selected.names.push_back(tool["function"]["name"].get<std::string>());
+    if (!choice.allowed_names.empty()) {
+        const std::set<std::string> declared(selected.names.begin(),selected.names.end());
+        for (const auto& name : choice.allowed_names)
+            if (!declared.count(name))
+                throw std::runtime_error("tool_choice names a function not present in tools");
+        const std::set<std::string> allowed(choice.allowed_names.begin(),choice.allowed_names.end());
+        json filtered=json::array();
+        for (auto& tool : selected.tools)
+            if (allowed.count(tool["function"]["name"].get<std::string>()))
+                filtered.push_back(std::move(tool));
+        selected.tools=std::move(filtered);
+        selected.names=choice.allowed_names;
+    }
+    if (choice.mode == ToolChoice::FORCED && selected.names.empty())
+        throw std::runtime_error("tool_choice requires at least one valid function tool");
+    return selected;
+}
+
+// Anthropic counts every declaration even when tool_choice narrows eligibility.
+// The inactive block keeps that accounting while leaving only selected schemas
+// in the callable interface. This choice-specific system prompt is intentional:
+// Anthropic documents that changing tool_choice invalidates message-block cache
+// entries (tool definitions are a separate hosted cache boundary).
+inline json unselected_openai_tools(const json& all_tools,
+                                    const OpenAIToolSelection& selected) {
+    const std::set<std::string> active(selected.names.begin(),selected.names.end());
+    json unavailable=json::array();
+    for (const auto& tool : all_tools)
+        if (!active.count(tool["function"]["name"].get<std::string>()))
+            unavailable.push_back(tool);
+    return unavailable;
 }
 
 // Parsed model tool call. `ok` false if the JSON was malformed (raw kept).
@@ -770,7 +1977,51 @@ struct ToolCall {
     std::string name;
     json arguments;
     std::string raw;
+    size_t source_begin=std::string::npos;
+    size_t source_end=std::string::npos;
+    size_t rewritten_begin=std::string::npos;
+    size_t rewritten_end=std::string::npos;
 };
+
+template<class NameSet>
+inline bool tool_choice_allows_all_calls(const ToolChoice& choice,
+                                         const NameSet& allowed,
+                                         const std::vector<ToolCall>& calls,
+                                         size_t accepted_calls=0) {
+    if (calls.empty()) return false;
+    for (const auto& call : calls) {
+        if (!call.ok || !tool_choice_allows_call(
+                choice, allowed, call.name, accepted_calls))
+            return false;
+        accepted_calls++;
+    }
+    return true;
+}
+template<class NameSet>
+inline bool responses_tool_tail_after_bare_calls(
+    bool current_tool_tail, const std::string& text,
+    const std::vector<ToolCall>& calls, const ToolChoice& choice,
+    const NameSet& allowed, size_t accepted_calls=0) {
+    if (calls.empty())
+        return current_tool_tail &&
+               text.find_first_not_of(" \t\r\n") == std::string::npos;
+    bool tool_tail = false;
+    size_t tail_begin = 0;
+    for (const auto& call : calls) {
+        if (call.ok && tool_choice_allows_call(
+                           choice, allowed, call.name, accepted_calls)) {
+            tool_tail = true;
+            accepted_calls++;
+        } else {
+            tool_tail = false;
+        }
+        if (call.source_end != std::string::npos && call.source_end <= text.size())
+            tail_begin = call.source_end;
+    }
+    if (text.find_first_not_of(" \t\r\n", tail_begin) != std::string::npos)
+        tool_tail = false;
+    return tool_tail;
+}
 
 inline std::string escape_content_tags(const std::string& text);
 
@@ -796,8 +2047,11 @@ inline ToolCall parse_tool_call(const std::string& seg) {
             json j = json::parse(seg);
             tc.name = j.value("name", std::string());
             tc.arguments = j.contains("arguments") ? j["arguments"] : json::object();
-            if (tc.arguments.is_string()) {
-                fprintf(stderr, "[q27-strict] rejected double-encoded arguments (tool=%s)\n",
+            if (!tc.arguments.is_object()) {
+                fprintf(stderr,
+                        tc.arguments.is_string()
+                            ? "[q27-strict] rejected double-encoded arguments (tool=%s)\n"
+                            : "[q27-strict] rejected non-object arguments (tool=%s)\n",
                         tc.name.c_str());
                 tc.ok = false;
                 return tc;
@@ -817,7 +2071,7 @@ inline ToolCall parse_tool_call(const std::string& seg) {
         tc.arguments = j.contains("arguments") ? j["arguments"] : json::object();
         if (tc.arguments.is_string()) // some models double-encode
             tc.arguments = json::parse(tc.arguments.get<std::string>());
-        tc.ok = !tc.name.empty();
+        tc.ok = !tc.name.empty() && tc.arguments.is_object();
     } catch (...) { tc.ok = false; }
     return tc;
 }
@@ -827,6 +2081,412 @@ inline std::string strip_ws2(const std::string& s) {
     if (a == std::string::npos) return "";
     size_t b = s.find_last_not_of(" \t\r\n");
     return s.substr(a, b - a + 1);
+}
+
+// Streaming Responses must withhold a possible wrapper-less call until it is
+// classified, but arbitrary Markdown/JSON must keep flowing. Limit holdback
+// to object prefixes whose first key can identify a supported call shape.
+inline bool plausible_bare_tool_prefix_range(
+    const std::string& text,size_t begin,size_t end) {
+    end=std::min(end,text.size());
+    if(begin>=end || text[begin]!='{') return false;
+    size_t p=begin+1;
+    while(p<end && (text[p]==' ' || text[p]=='\t' ||
+                    text[p]=='\r' || text[p]=='\n')) p++;
+    if(p==end) return true;
+    static const char* keys[]={
+        "\"name\"","\"arguments\"","\"function\"",
+        "\"tool\"","\"tool_name\"","\"tool_call\""};
+    const size_t available=end-p;
+    for(const char* key:keys) {
+        const size_t key_size=std::char_traits<char>::length(key);
+        const size_t compared=std::min(available,key_size);
+        if(text.compare(p,compared,key,compared)==0) return true;
+    }
+    return false;
+}
+
+inline bool plausible_bare_tool_prefix(const std::string& text) {
+    return plausible_bare_tool_prefix_range(text,0,text.size());
+}
+
+
+inline void consume_bare_text_context(JsonStringLexState& string_state,
+                                      MarkdownFenceLexState& fence_state,
+                                      char ch) {
+    consume_display_text_context(string_state,fence_state,ch);
+}
+
+inline void consume_bare_text_context(JsonStringLexState& string_state,
+                                      MarkdownFenceLexState& fence_state,
+                                      const std::string& text,
+                                      size_t count=std::string::npos) {
+    consume_display_text_context(string_state,fence_state,text,count);
+}
+
+inline bool bare_markdown_context_is_displayed(
+    const std::string& text,size_t position,
+    MarkdownFenceLexState& fence_state,bool end_is_final) {
+    return markdown_context_is_displayed(
+        text,position,fence_state,end_is_final);
+}
+
+
+inline bool bare_context_is_executable(
+    const std::string& text,size_t position,
+    JsonStringLexState& string_state,MarkdownFenceLexState& fence_state,
+    bool end_is_final) {
+    if(position<text.size()) string_state.settle_pending(text[position]);
+    if(string_state.in_inert_container() ||
+       !display_text_context_is_executable(
+           text,position,string_state,fence_state,end_is_final)) return false;
+    string_state.discard_pending_containers();
+    return true;
+}
+
+inline bool bare_text_position_is_executable(
+    const std::string& text,size_t position,
+    JsonStringLexState string_state={},
+    MarkdownFenceLexState fence_state={},bool end_is_final=true) {
+    consume_bare_text_context(string_state,fence_state,text,position);
+    return bare_context_is_executable(
+        text,position,string_state,fence_state,end_is_final);
+}
+
+inline bool bare_position_is_displayed(const std::string& text,size_t position) {
+    JsonStringLexState string_state;
+    MarkdownFenceLexState fence_state;
+    consume_bare_text_context(string_state,fence_state,text,position);
+    return bare_markdown_context_is_displayed(
+        text,position,fence_state,/*end_is_final=*/true);
+}
+
+inline size_t bare_object_position(const std::string& text,
+                                   JsonStringLexState string_state={},
+                                   MarkdownFenceLexState fence_state={},
+                                   bool end_is_final=true) {
+    for(size_t i=0;i<text.size();i++) {
+        if(text[i]=='{' && bare_context_is_executable(
+               text,i,string_state,fence_state,end_is_final)) return i;
+        consume_bare_text_context(string_state,fence_state,text[i]);
+    }
+    return std::string::npos;
+}
+
+inline size_t bare_unresolved_inline_probe_start(
+    const std::string& text,JsonStringLexState string_state={},
+    MarkdownFenceLexState fence_state={}) {
+    consume_bare_text_context(string_state,fence_state,text);
+    fence_state.settle_before_non_backtick();
+    return fence_state.fence_length==0 && fence_state.inline_ticks!=0
+        ?0:std::string::npos;
+}
+
+// Return the byte after the first balanced top-level object, or npos while
+// the candidate is incomplete. Braces inside JSON strings do not count.
+struct IncrementalBareJsonEnd {
+    size_t cursor=0;
+    int depth=0;
+    bool in_string=false;
+    bool escaped=false;
+
+    void begin(bool dropped_opener,size_t start=0) {
+        cursor=start;
+        depth=dropped_opener?1:0;
+        // Mode 10 starts after a synthesized {"name":" prefix.
+        in_string=dropped_opener;
+        escaped=false;
+    }
+
+    size_t advance(const std::string& text) {
+        while(cursor<text.size()) {
+            const char ch=text[cursor++];
+            if(escaped) { escaped=false; continue; }
+            if(in_string) {
+                if(ch=='\\') escaped=true;
+                else if(ch=='"') in_string=false;
+                continue;
+            }
+            if(ch=='"') in_string=true;
+            else if(ch=='{') depth++;
+            else if(ch=='}') {
+                if(depth<=0) return std::string::npos;
+                if(--depth==0) return cursor;
+            }
+        }
+        return std::string::npos;
+    }
+};
+
+inline size_t balanced_json_object_prefix_end(const std::string& text) {
+    if(text.empty() || text[0]!='{') return std::string::npos;
+    IncrementalBareJsonEnd scan;
+    scan.begin(false);
+    return scan.advance(text);
+}
+
+template<class NameSet>
+inline size_t bare_mode10_signature_position(
+    const std::string& text,const NameSet& names,
+    JsonStringLexState string_state={},
+    MarkdownFenceLexState fence_state={},bool end_is_final=true) {
+    size_t first=std::string::npos;
+    for(const auto& name:names) {
+        if(name.empty()) continue;
+        const std::string signature=name+"\", \"";
+        for(size_t p=text.find(signature);p!=std::string::npos;
+            p=text.find(signature,p+1)) {
+            if(!bare_text_position_is_executable(
+                   text,p,string_state,fence_state,end_is_final)) continue;
+            first=std::min(first,p);
+            break;
+        }
+    }
+    return first;
+}
+
+// Start of the longest suffix that can still become a dropped-opener
+// signature. Quoted and fenced suffixes are ordinary displayed content.
+template<class NameSet>
+inline size_t bare_mode10_probe_start(
+    const std::string& text,const NameSet& names,
+    JsonStringLexState string_state={},
+    MarkdownFenceLexState fence_state={},bool end_is_final=true) {
+    size_t best=std::string::npos;
+    for(const auto& name:names) {
+        if(name.empty()) continue;
+        const std::string signature=name+"\", \"";
+        const size_t cap=std::min(text.size(),signature.size()-1);
+        for(size_t len=cap;len;--len) {
+            const size_t start=text.size()-len;
+            if(text.compare(start,len,signature,0,len)!=0) continue;
+            if(!bare_text_position_is_executable(
+                   text,start,string_state,fence_state,end_is_final)) break;
+            best=best==std::string::npos?start:std::min(best,start);
+            break;
+        }
+    }
+    return best;
+}
+
+template<class NameSet>
+inline bool bare_candidate_repair_eligible(
+    const std::string& text,const NameSet& names,bool mode10) {
+    // A mode-10 probe already contains a registered-name signature.  The
+    // balanced-object path is deferred only for the exact mode-11 shape;
+    // ordinary {"name":...} JSON must continue streaming immediately.
+    if(mode10) return true;
+    if(text.compare(0,7,"{\"name\"")!=0) return false;
+    const size_t colon=text.find(':',7);
+    if(colon==std::string::npos) return false;
+    size_t q1=colon+1;
+    while(q1<text.size() && (text[q1]==' ' || text[q1]=='\t' ||
+                             text[q1]=='\r' || text[q1]=='\n')) q1++;
+    if(q1==text.size() || text[q1]!='\"') return false;
+    const size_t q2=text.find('\"',q1+1);
+    if(q2==std::string::npos) return false;
+    const std::string name=text.substr(q1+1,q2-q1-1);
+    if(std::find(names.begin(),names.end(),name)==names.end()) return false;
+    const size_t arguments=text.find("\"arguments\"",q2+1);
+    if(arguments==std::string::npos) return false;
+    const size_t arguments_colon=text.find(':',arguments+11);
+    if(arguments_colon==std::string::npos) return false;
+    size_t object=arguments_colon+1;
+    while(object<text.size() && (text[object]==' ' || text[object]=='\t' ||
+                                 text[object]=='\r' || text[object]=='\n')) object++;
+    return object<text.size() && text[object]=='{';
+}
+
+// Streaming handlers cannot retract text after it reaches the wire. Hold only
+// plausible wrapper-less call prefixes, classify complete strict candidates,
+// and defer a balanced-but-malformed candidate until final tolerant recovery.
+// EmitCandidate receives a callback that preserves Markdown/string context for
+// visible bytes and reports parsing and policy acceptance separately.
+struct BareToolCandidateResult {
+    bool parsed=false;
+    bool accepted=false;
+    explicit operator bool() const { return parsed; }
+};
+
+struct BareToolTextHoldback {
+    std::string pending;
+    std::string probe;
+    std::string deferred;
+    std::string deferred_trailing;
+    bool deferred_mode10=false;
+    bool holding=false;
+    bool mode10=false;
+    bool input_final=false;
+    bool input_allow_repair=false;
+    bool ordinary_call_seen=false;
+    IncrementalBareJsonEnd scan;
+    JsonStringLexState string_state;
+    MarkdownFenceLexState fence_state;
+
+    template<class EmitText>
+    void emit_visible(const std::string& text,EmitText&& emit_text) {
+        consume_bare_text_context(string_state,fence_state,text);
+        if(!text.empty()) emit_text(text);
+    }
+
+    template<class EmitText,class EmitCandidate>
+    bool flush_candidate(bool allow_repair,EmitText&& emit_text,
+                         EmitCandidate&& emit_candidate,
+                         bool defer_failure=false) {
+        if(!holding) return false;
+        const bool candidate_mode10=mode10;
+        auto visible=[&](const std::string& text) {
+            emit_visible(text,emit_text);
+        };
+        const BareToolCandidateResult result=
+            emit_candidate(pending,allow_repair,visible);
+        if(!result.parsed) {
+            if(defer_failure) {
+                deferred=std::move(pending);
+                deferred_mode10=candidate_mode10;
+            } else visible(pending);
+        }
+        if(!candidate_mode10 && result.accepted) ordinary_call_seen=true;
+        pending.clear();
+        holding=false;
+        mode10=false;
+        string_state.reset();
+        return !result.parsed && defer_failure;
+    }
+
+    template<class NameSet,class EmitText,class EmitCandidate>
+    void route(const std::string& value,const NameSet& names,
+               EmitText&& emit_text,EmitCandidate&& emit_candidate) {
+        if(!deferred.empty()) {
+            deferred_trailing+=value;
+            return;
+        }
+        std::string remaining=std::move(probe);
+        probe.clear();
+        remaining+=value;
+        while(!remaining.empty()) {
+            if(holding) {
+                pending+=remaining;
+                remaining.clear();
+            } else {
+                const size_t object_pos=bare_object_position(
+                    remaining,string_state,fence_state,input_final);
+                const size_t mode10_pos=ordinary_call_seen?std::string::npos:
+                    bare_mode10_signature_position(
+                        remaining,names,string_state,fence_state,input_final);
+                const size_t opener=object_pos==std::string::npos?mode10_pos:
+                    mode10_pos==std::string::npos?object_pos:
+                    std::min(object_pos,mode10_pos);
+                if(opener==std::string::npos) {
+                    size_t keep=input_final || ordinary_call_seen?std::string::npos:
+                        bare_mode10_probe_start(
+                            remaining,names,string_state,fence_state,false);
+                    if(!input_final) {
+                        const size_t inline_keep=bare_unresolved_inline_probe_start(
+                            remaining,string_state,fence_state);
+                        if(inline_keep!=std::string::npos)
+                            keep=keep==std::string::npos?inline_keep:
+                                 std::min(keep,inline_keep);
+                    }
+                    if(keep==std::string::npos) emit_visible(remaining,emit_text);
+                    else {
+                        emit_visible(remaining.substr(0,keep),emit_text);
+                        probe=remaining.substr(keep);
+                    }
+                    return;
+                }
+                if(opener) emit_visible(remaining.substr(0,opener),emit_text);
+                pending=remaining.substr(opener);
+                holding=true;
+                mode10=mode10_pos==opener;
+                scan.begin(mode10);
+                remaining.clear();
+            }
+            if(!mode10 && !plausible_bare_tool_prefix(pending)) {
+                std::string retry=std::move(pending);
+                pending.clear();
+                holding=false;
+                emit_visible(retry.substr(0,1),emit_text);
+                remaining=retry.substr(1);
+                continue;
+            }
+            const size_t end=scan.advance(pending);
+            if(end==std::string::npos) return;
+            std::string trailing=pending.substr(end);
+            pending.resize(end);
+            const bool defer_failure=!input_final &&
+                bare_candidate_repair_eligible(pending,names,mode10);
+            if(flush_candidate(input_final && input_allow_repair,
+                               emit_text,emit_candidate,defer_failure)) {
+                deferred_trailing=std::move(trailing);
+                return;
+            }
+            remaining=std::move(trailing);
+        }
+    }
+
+    template<class NameSet,class EmitText,class EmitCandidate>
+    void finish(bool allow_repair,const NameSet& names,
+                EmitText&& emit_text,EmitCandidate&& emit_candidate) {
+        if(!probe.empty()) {
+            input_final=true;
+            input_allow_repair=allow_repair;
+            std::string final_probe=std::move(probe);
+            probe.clear();
+            route(final_probe,names,emit_text,emit_candidate);
+            input_final=false;
+            input_allow_repair=false;
+        }
+        std::string trailing;
+        if(!deferred.empty()) {
+            pending=std::move(deferred);
+            trailing=std::move(deferred_trailing);
+            holding=true;
+            mode10=deferred_mode10;
+            deferred_mode10=false;
+            flush_candidate(allow_repair,emit_text,emit_candidate);
+        }
+        if(!trailing.empty()) {
+            input_final=true;
+            input_allow_repair=allow_repair;
+            route(trailing,names,emit_text,emit_candidate);
+            input_final=false;
+            input_allow_repair=false;
+        }
+        flush_candidate(allow_repair,emit_text,emit_candidate);
+    }
+
+    void reset_context() {
+        string_state.reset();
+        fence_state.reset();
+        ordinary_call_seen=false;
+    }
+};
+
+template<class EmitText,class EmitCall>
+inline size_t route_bare_tool_sequence(
+    const std::string& source,const std::vector<ToolCall>& calls,
+    EmitText&& emit_text,EmitCall&& emit_call) {
+    size_t cursor=0;
+    for(const auto& call:calls) {
+        if(call.source_begin<cursor || call.source_end<call.source_begin ||
+           call.source_end>source.size()) {
+            emit_text(source);
+            return 0;
+        }
+        cursor=call.source_end;
+    }
+    cursor=0;
+    size_t emitted=0;
+    for(const auto& call:calls) {
+        emit_text(source.substr(cursor,call.source_begin-cursor));
+        cursor=call.source_end;
+        if(emit_call(call)) emitted++;
+        else emit_text(source.substr(
+            call.source_begin,call.source_end-call.source_begin));
+    }
+    emit_text(source.substr(cursor));
+    return emitted;
 }
 
 // Fallback for models that drop the <tool_call> wrapper and emit the call
@@ -841,16 +2501,7 @@ inline std::string strip_ws2(const std::string& s) {
 // strings so the call parses. Returns the input unchanged if no tag pair.
 inline std::string escape_json_interior(const std::string& s) {
     std::string esc;
-    for (char c : s) {
-        switch (c) {
-            case '"': esc += "\\\""; break;
-            case '\\': esc += "\\\\"; break;
-            case '\n': esc += "\\n"; break;
-            case '\r': esc += "\\r"; break;
-            case '\t': esc += "\\t"; break;
-            default: esc += c;
-        }
-    }
+    for (unsigned char c : s) append_json_escaped_byte(esc,c);
     return esc;
 }
 
@@ -1031,7 +2682,18 @@ inline void scan_namedropped(const std::string& text, const json* tools,
                              std::vector<ToolCall>& out, size_t* first) {
     if (!tools) return;
     size_t p = 0;
+    JsonStringLexState string_state;
+    MarkdownFenceLexState fence_state;
+    size_t context_cursor=0;
     while ((p = text.find("{\"name\":", p)) != std::string::npos) {
+        for(size_t cursor=context_cursor;cursor<p;cursor++)
+            consume_bare_text_context(string_state,fence_state,text[cursor]);
+        context_cursor=p;
+        if(!bare_context_is_executable(
+               text,p,string_state,fence_state,/*end_is_final=*/true)) {
+            p+=8;
+            continue;
+        }
         size_t q = p + 8;
         while (q < text.size() && (text[q]==' '||text[q]=='\t'||text[q]=='\r'||text[q]=='\n')) q++;
         if (q >= text.size() || text[q] != '{') { p += 8; continue; }
@@ -1060,6 +2722,9 @@ inline void scan_namedropped(const std::string& text, const json* tools,
                 std::string nm = infer_tool_name_unwrapped(*tools, args);
                 if (!nm.empty()) {
                     ToolCall tc; tc.ok = true; tc.name = nm; tc.arguments = std::move(args);
+                    tc.raw=text.substr(p,e-p+1);
+                    tc.rewritten_begin=p;
+                    tc.rewritten_end=e+1;
                     if (*first == std::string::npos) *first = p;
                     out.push_back(std::move(tc));
                 }
@@ -1161,25 +2826,12 @@ inline std::string first_balanced_object(const std::string& s) {
     return "";
 }
 
-// True if `pos` sits inside an open ```...``` fenced code block (an odd number
-// of ``` precede it). A tool call the model INTENDS to emit is never markdown-
-// fenced; a call shown as an example, or echoed from an injected file/page, is.
-// We look ONLY before `pos`, so a write whose VALUE contains fences (its ``` are
-// after the call's opener) is not mistaken for a fenced call.
-inline bool inside_fence(const std::string& s, size_t pos) {
-    size_t f = 0, count = 0;
-    while ((f = s.find("```", f)) != std::string::npos && f < pos) {
-        count++;
-        f += 3;
-    }
-    return (count & 1) != 0;
-}
 
 inline bool recover_raw_value_call(const std::string& text, const json& tools,
                                    std::vector<ToolCall>& out) {
     size_t mo = text.rfind("{\"name\"");
     if (mo == std::string::npos) return false;
-    if (inside_fence(text, mo)) return false; // fenced example, not a real call
+    if (!bare_text_position_is_executable(text, mo)) return false;
     size_t colon = text.find(':', mo + 6);
     if (colon == std::string::npos) return false;
     size_t q1 = text.find('"', colon + 1);
@@ -1209,8 +2861,8 @@ inline bool recover_raw_value_call(const std::string& text, const json& tools,
     // parse the reconstructed object. The FIRST candidate that parses is the
     // real terminator -- inner quotes leave the tail as un-parseable raw code,
     // and a scalar arg after the value forces the correct earlier terminator
-    // (making that arg a valid sibling). Ordering-independent. The call must
-    // be at the end of the model output, which is the UN-RESCUED reality.
+    // (making that arg a valid sibling). Ordering-independent; map the
+    // reconstructed suffix back to the source so following prose is preserved.
     for (const auto& k : strkeys) {
         size_t kp = text.find("\"" + k + "\"", mo);
         if (kp == std::string::npos) continue;
@@ -1233,10 +2885,17 @@ inline bool recover_raw_value_call(const std::string& text, const json& tools,
             json args = obj.contains("arguments") && obj["arguments"].is_object()
                             ? obj["arguments"]
                             : json::object();
+            const size_t suffix_offset=(opener-mo)+body.size()+2;
+            if(recon.size()<suffix_offset) continue;
+            const size_t source_end=cand+1+(recon.size()-suffix_offset);
+            if(source_end>text.size()) continue;
             ToolCall tc;
             tc.ok = true;
             tc.name = nm;
+            tc.rewritten_begin=mo;
+            tc.rewritten_end=source_end;
             tc.arguments = std::move(args);
+            tc.raw=text.substr(mo,source_end-mo);
             fprintf(stderr, "[drift] mode-11 raw-value rescue: %s.%s (%zu bytes)\n", nm.c_str(),
                     k.c_str(), cand - opener - 1);
             out.push_back(std::move(tc));
@@ -1249,13 +2908,16 @@ inline bool recover_raw_value_call(const std::string& text, const json& tools,
 inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
                                                    std::string* prefix,
                                                    const json* tools = nullptr,
-                                                   bool allow_o10 = true) {
+                                                   bool allow_o10 = true,
+                                                   bool allow_eof_repair = true,
+                                                   std::string* remaining_text = nullptr) {
     std::vector<ToolCall> out;
     if (tool_strict()) {
         // strict-parser A/B: the wrapper-less recovery chain (drift modes 1-6)
         // is OFF. Log when the text plausibly contained an intended call so the
         // campaign can count suppressed rescues against the tolerant leg.
         if (prefix) *prefix = "";
+        if (remaining_text) *remaining_text = text_in;
         if (text_in.find("{\"name\"") != std::string::npos ||
             text_in.find("{\"tool_call\"") != std::string::npos ||
             text_in.find("</content>") != std::string::npos)
@@ -1264,18 +2926,70 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
         return out;
     }
     bool m2 = false, m5 = false, m6 = false, m8 = false; // drift-mode flags (exit-gate catalog)
+    struct SourceMappedText {
+        std::string value;
+        std::vector<size_t> boundaries;
+
+        explicit SourceMappedText(const std::string& source):value(source) {}
+
+        void ensure_boundaries() {
+            if(!boundaries.empty()) return;
+            boundaries.reserve(value.size()+1);
+            for(size_t i=0;i<=value.size();i++) boundaries.push_back(i);
+        }
+
+        size_t source_boundary(size_t position) const {
+            return boundaries.empty()?position:boundaries.at(position);
+        }
+
+        void insert(size_t position,const std::string& added) {
+            ensure_boundaries();
+            const size_t source=boundaries.at(position);
+            value.insert(position,added);
+            boundaries.insert(boundaries.begin()+position+1,added.size(),source);
+        }
+
+        void replace_with(const std::string& replacement) {
+            if(replacement==value) return;
+            ensure_boundaries();
+            size_t prefix=0;
+            while(prefix<value.size() && prefix<replacement.size() &&
+                  value[prefix]==replacement[prefix]) prefix++;
+            size_t old_suffix=value.size(),new_suffix=replacement.size();
+            while(old_suffix>prefix && new_suffix>prefix &&
+                  value[old_suffix-1]==replacement[new_suffix-1]) {
+                old_suffix--;
+                new_suffix--;
+            }
+            const size_t source_begin=boundaries[prefix];
+            const size_t source_end=boundaries[old_suffix];
+            std::vector<size_t> next;
+            next.reserve(replacement.size()+1);
+            next.insert(next.end(),boundaries.begin(),boundaries.begin()+prefix+1);
+            const size_t replacement_size=new_suffix-prefix;
+            if(replacement_size==0) next.back()=source_end;
+            else for(size_t i=0;i<replacement_size;i++)
+                next.push_back(i+1==replacement_size?source_end:source_begin);
+            next.insert(next.end(),boundaries.begin()+old_suffix+1,boundaries.end());
+            value=replacement;
+            boundaries=std::move(next);
+        }
+    };
+    SourceMappedText rewritten(text_in);
+    rewritten.replace_with(escape_content_tags(rewritten.value));
     // drift mode 9 (2026-07-11, codex-harnessed traffic): the model drops the
     // OPENING quote of the "arguments" key ({"name":"X",\narguments":{...}}).
     // "arguments" is the tool-call schema key, so quoting a bare `arguments":`
     // is unambiguous inside these segments. Applied before segmentation so
     // both the whole-object and truncated-tail parse paths see valid JSON.
-    auto fix_arg_quote = [](std::string s) {
+    auto fix_arg_quote = [](SourceMappedText& text) {
         size_t p = 0;
-        while ((p = s.find("arguments\"", p)) != std::string::npos) {
-            if (p == 0 || s[p - 1] != '"') { s.insert(p, "\""); p += 11; }
-            else p += 10;
+        while ((p = text.value.find("arguments\"", p)) != std::string::npos) {
+            if (p == 0 || text.value[p - 1] != '"') {
+                text.insert(p,"\"");
+                p += 11;
+            } else p += 10;
         }
-        return s;
     };
     // drift mode 12 (2026-07-19, club-3090 cli-40 agent): the model drops the
     // QUOTES around the tool-NAME value -- {"name": bash, "arguments": {...}}.
@@ -1284,20 +2998,22 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
     // name is quoted the object parses on the normal path. SAFE because we only
     // quote a bareword that EXACTLY matches a registered tool name -- prose,
     // non-tool JSON, null/numbers, and unknown names are left untouched.
-    auto fix_unquoted_name = [](std::string s, const json* tools) {
-        if (!tools || !tools->is_array()) return s;
+    auto fix_unquoted_name = [](SourceMappedText& text, const json* tools) {
+        if (!tools || !tools->is_array()) return;
         size_t p = 0;
-        while ((p = s.find("\"name\":", p)) != std::string::npos) {
+        while ((p = text.value.find("\"name\":", p)) != std::string::npos) {
             size_t c = p + 7;
-            while (c < s.size() && (s[c] == ' ' || s[c] == '\t' || s[c] == '\n' || s[c] == '\r'))
-                c++;
-            if (c < s.size() && s[c] != '"' &&
-                (isalpha((unsigned char)s[c]) || s[c] == '_')) {
+            while (c < text.value.size() &&
+                   (text.value[c] == ' ' || text.value[c] == '\t' ||
+                    text.value[c] == '\n' || text.value[c] == '\r')) c++;
+            if (c < text.value.size() && text.value[c] != '"' &&
+                (isalpha((unsigned char)text.value[c]) || text.value[c] == '_')) {
                 size_t e = c;
-                while (e < s.size() && (isalnum((unsigned char)s[e]) || s[e] == '_' ||
-                                        s[e] == '-' || s[e] == '.'))
-                    e++;
-                const std::string word = s.substr(c, e - c);
+                while (e < text.value.size() &&
+                       (isalnum((unsigned char)text.value[e]) ||
+                        text.value[e] == '_' || text.value[e] == '-' ||
+                        text.value[e] == '.')) e++;
+                const std::string word = text.value.substr(c, e - c);
                 bool match = false;
                 for (const auto& t : *tools)
                     if (t.contains("function") &&
@@ -1309,26 +3025,37 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
                     // Add the closing quote only if one isn't already there:
                     // {"name": bash,   -> both quotes; {"name": read"  (dropped
                     // OPENING quote, stray close) -> opening only (thunderdome).
-                    if (!(e < s.size() && s[e] == '"')) s.insert(e, "\"");
-                    s.insert(c, "\"");
+                    if (!(e < text.value.size() && text.value[e] == '"'))
+                        text.insert(e,"\"");
+                    text.insert(c,"\"");
                     p = e + 2;
                     continue;
                 }
             }
             p = c;
         }
-        return s;
     };
-    const std::string text =
-        fix_unquoted_name(fix_arg_quote(escape_content_tags(text_in)), tools);
+    fix_arg_quote(rewritten);
+    fix_unquoted_name(rewritten,tools);
+    const std::string& text=rewritten.value;
     const bool m3 = (text != text_in);              // mode 3: <content>-tagged value rewritten
     const bool m4 = text.find("{\"tool_call\":") != std::string::npos; // mode 4: JSON-keyed opener
     size_t first = std::string::npos;
     size_t i = text.find('{');
+    JsonStringLexState candidate_string_state;
+    MarkdownFenceLexState candidate_fence_state;
+    size_t candidate_context_cursor=0;
     while (i != std::string::npos) {
-        // A {...} sitting inside a ```fenced``` block is a displayed example /
-        // echoed injection, not a call the model is making -- don't recover it.
-        if (inside_fence(text, i)) {
+        // Displayed Markdown is an example or echoed input, not a call the
+        // model is making.  Malformed earlier call text must not poison a
+        // later executable candidate's independent recovery.
+        for(size_t cursor=candidate_context_cursor;cursor<i;cursor++)
+            consume_bare_text_context(
+                candidate_string_state,candidate_fence_state,text[cursor]);
+        candidate_context_cursor=i;
+        if(!bare_context_is_executable(
+               text,i,candidate_string_state,candidate_fence_state,
+               /*end_is_final=*/true)) {
             i = text.find('{', i + 1);
             continue;
         }
@@ -1355,6 +3082,7 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
             else if (ch == '}' && --depth == 0) { end = j; break; }
         }
         if (end == std::string::npos) {
+            if (!allow_eof_repair) break;
             // unbalanced to EOF: repair only a {"name" candidate (truncated
             // final call); otherwise keep scanning inner objects. `san` holds
             // the sanitized remainder (scan ran to EOF).
@@ -1411,6 +3139,9 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
             bool recovered_here = false;
             if (shaped) {
                 ToolCall tc = parse_tool_call(r);
+                tc.raw=text.substr(i);
+                tc.rewritten_begin=i;
+                tc.rewritten_end=text.size();
                 if (tc.ok) {
                     if (first == std::string::npos) first = i;
                     out.push_back(tc);
@@ -1426,11 +3157,14 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
             i = text.find('{', i + 1);
             continue;
         }
+        const std::string raw_seg=text.substr(i,end-i+1);
         const std::string& seg = san;
         bool shaped = false, m6cand = false, m8cand = false;
+        bool valid_json=false;
         json j6, j8;
         try {
             json j = json::parse(seg);
+            valid_json=true;
             shaped = j.is_object() && j.contains("name") && j.contains("arguments");
             if (!shaped && j.is_object() && j.contains("name") &&
                 j["name"].is_object() && !j.contains("arguments")) {
@@ -1441,6 +3175,9 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
         } catch (...) {}
         if (shaped) {
             ToolCall tc = parse_tool_call(seg);
+            tc.raw=raw_seg;
+            tc.rewritten_begin=i;
+            tc.rewritten_end=end+1;
             if (tc.ok) {
                 if (first == std::string::npos) first = i;
                 out.push_back(tc);
@@ -1455,6 +3192,9 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
             std::string nm = infer_tool_name_unwrapped(*tools, m6args);
             if (!nm.empty()) {
                 ToolCall tc; tc.ok = true; tc.name = nm; tc.arguments = std::move(m6args);
+                tc.raw=raw_seg;
+                tc.rewritten_begin=i;
+                tc.rewritten_end=end+1;
                 if (first == std::string::npos) first = i;
                 out.push_back(std::move(tc));
                 m6 = true;
@@ -1479,6 +3219,9 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
                     for (auto it = j8.begin(); it != j8.end(); ++it)
                         if (it.key() != "name") args[it.key()] = it.value();
                     ToolCall tc; tc.ok = true; tc.name = cand; tc.arguments = std::move(args);
+                    tc.raw=raw_seg;
+                    tc.rewritten_begin=i;
+                    tc.rewritten_end=end+1;
                     if (first == std::string::npos) first = i;
                     out.push_back(std::move(tc));
                     m8 = true;
@@ -1492,6 +3235,9 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
             json aa;
             if (resolve_aliased_call(*tools, j8, an, aa)) {
                 ToolCall tc; tc.ok = true; tc.name = std::move(an); tc.arguments = std::move(aa);
+                tc.raw=raw_seg;
+                tc.rewritten_begin=i;
+                tc.rewritten_end=end+1;
                 if (first == std::string::npos) first = i;
                 out.push_back(std::move(tc));
                 m8 = true;
@@ -1499,11 +3245,12 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
                 continue;
             }
         }
-        i = text.find('{', i + 1);
+        i = text.find('{', valid_json ? end + 1 : i + 1);
     }
     // Fallback: name-dropped mode-6 BATCH (the main scan can't segment it). Only when the
     // standard scan found nothing, so normal calls are never double-counted.
-    if (out.empty() && tools && text.find("{\"name\":") != std::string::npos) {
+    if (out.empty() && allow_eof_repair && tools &&
+        text.find("{\"name\":") != std::string::npos) {
         scan_namedropped(text, tools, out, &first);
         if (!out.empty()) m6 = true;
     }
@@ -1526,25 +3273,182 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
     // false in the recursion so a still-broken splice cannot loop). This is
     // the deterministic early-quit the n=3 seal caught: a missed first call
     // ends the agent turn with a leaked-JSON text response.
-    if (out.empty() && allow_o10 && tools && tools->is_array()) {
+    if (allow_o10 && tools && tools->is_array()) {
+        struct O10Candidate { size_t source,end; std::string name; };
+        std::vector<O10Candidate> candidates;
         for (const auto& t : *tools) {
-            std::string nm = t.contains("function")
-                                 ? t["function"].value("name", std::string())
-                                 : std::string();
-            if (nm.empty()) continue;
-            const std::string sig = nm + "\", \"";
-            size_t p = text.find(sig);
-            if (p == std::string::npos) continue;
-            if (p > 0 && text[p - 1] == '"') continue; // already `"name": "NAME"`
-            std::string synth = text.substr(0, p) + "{\"name\": \"" + text.substr(p);
-            if (synth.find('}') == std::string::npos) synth += "}";
-            std::string pre2;
-            auto rec = parse_bare_tool_calls(synth, &pre2, tools, /*allow_o10=*/false);
-            if (!rec.empty()) {
-                out = std::move(rec);
-                if (prefix) *prefix = pre2;
-                fprintf(stderr, "[drift] mode-10 dropped-opener rescue: %s\n", nm.c_str());
-                break;
+            const std::string nm=t.contains("function")
+                ?t["function"].value("name",std::string()):std::string();
+            if(nm.empty()) continue;
+            const std::string sig=nm+"\", \"";
+            for(size_t p=text.find(sig);p!=std::string::npos;p=text.find(sig,p+1)) {
+                // Quoted-string filtering runs after source-order sorting so
+                // an accepted dropped-opener call can restore lexical state
+                // before a later call in the same batch.
+                // Once the ordinary scanner has found a call, a matching
+                // signature after it is prose, not another executable item.
+                // Mode 10 only repairs dropped openers that precede the first
+                // already-classified call (or the whole turn when none exist).
+                if(first!=std::string::npos && p>=first) continue;
+                candidates.push_back({p,p+sig.size(),nm});
+            }
+        }
+        std::sort(candidates.begin(),candidates.end(),
+                  [](const O10Candidate& a,const O10Candidate& b) {
+                      if(a.source!=b.source) return a.source<b.source;
+                      return a.end>b.end; // same start: keep the longest name
+                  });
+        std::vector<O10Candidate> nonoverlapping;
+        for(auto& candidate:candidates)
+            if(nonoverlapping.empty() || candidate.source>=nonoverlapping.back().end)
+                nonoverlapping.push_back(std::move(candidate));
+        candidates=std::move(nonoverlapping);
+        JsonStringLexState lexical;
+        MarkdownFenceLexState fence;
+        size_t lexical_cursor=0,repaired_until=0,invalid_until=0;
+        const std::string mode10_opener="{\"name\": \"";
+        struct InvalidO10Context { size_t source,end; };
+        std::vector<InvalidO10Context> invalid_contexts;
+        constexpr size_t max_invalid_contexts=8;
+        auto add_invalid_context=[&](size_t source,size_t end) {
+            if(invalid_contexts.size()>=max_invalid_contexts) return false;
+            invalid_contexts.push_back({source,end});
+            return true;
+        };
+        std::vector<O10Candidate> safe_candidates;
+        auto consume_mode10_context=[&](size_t begin,size_t end) {
+            end=std::min(end,text.size());
+            for(size_t i=std::min(begin,end);i<end;i++)
+                consume_bare_text_context(lexical,fence,text[i]);
+        };
+        for(auto& candidate:candidates) {
+            if(candidate.source<repaired_until) continue;
+            if(candidate.source<invalid_until) {
+                const bool nested=std::any_of(
+                    invalid_contexts.begin(),invalid_contexts.end(),
+                    [&](const InvalidO10Context& context) {
+                        return candidate.source>context.source &&
+                               candidate.source<context.end;
+                    });
+                if(nested) continue;
+                lexical.reset();
+                fence.reset();
+                lexical_cursor=candidate.source;
+            } else if(lexical_cursor<invalid_until) {
+                lexical.reset();
+                fence.reset();
+                lexical_cursor=invalid_until;
+            }
+            consume_mode10_context(lexical_cursor,candidate.source);
+            lexical_cursor=candidate.source;
+            if(!bare_context_is_executable(
+                   text,candidate.source,lexical,fence,true)) continue;
+            IncrementalBareJsonEnd completion;
+            completion.begin(true,candidate.source);
+            const size_t call_end=completion.advance(text);
+            const size_t context_end=call_end==std::string::npos
+                ?text.size():call_end;
+            std::string probe=mode10_opener;
+            probe.append(text,candidate.source,context_end-candidate.source);
+            if(call_end==std::string::npos && allow_eof_repair) probe+='}';
+            if(call_end==std::string::npos && !allow_eof_repair) {
+                invalid_until=text.size();
+                if(!add_invalid_context(candidate.source,context_end)) break;
+                lexical.reset();
+                fence.reset();
+                lexical_cursor=candidate.end;
+                continue;
+            }
+            std::string probe_prefix,probe_remaining;
+            const auto parsed_candidate=parse_bare_tool_calls(
+                probe,&probe_prefix,tools,/*allow_o10=*/false,
+                allow_eof_repair,&probe_remaining);
+            const bool validated=std::any_of(
+                parsed_candidate.begin(),parsed_candidate.end(),
+                [&](const ToolCall& call) {
+                    return call.ok && call.name==candidate.name &&
+                           call.source_begin==0;
+                });
+            if(!validated) {
+                invalid_until=std::max(
+                    invalid_until,
+                    call_end==std::string::npos?text.size():call_end);
+                if(!add_invalid_context(candidate.source,context_end)) break;
+                lexical.reset();
+                fence.reset();
+                lexical_cursor=candidate.end;
+                continue;
+            }
+            safe_candidates.push_back(candidate);
+            repaired_until=call_end==std::string::npos?text.size():call_end;
+            lexical_cursor=repaired_until;
+            lexical.reset();
+            fence.reset();
+        }
+        candidates=std::move(safe_candidates);
+        if(!candidates.empty()) {
+            struct O10Insertion { size_t begin,end,source; };
+            // A validated candidate may follow malformed same-line call text
+            // with an unmatched quote. The synthetic newline is removed by
+            // source mapping and prevents that discarded prefix from poisoning
+            // the independently validated repaired object.
+            const std::string opener="\n{\"name\": \"";
+            std::vector<O10Insertion> insertions;
+            std::string synth;
+            size_t cursor=0;
+            for(const auto& candidate:candidates) {
+                synth.append(text,cursor,candidate.source-cursor);
+                const size_t begin=synth.size();
+                synth+=opener;
+                insertions.push_back({begin,synth.size(),candidate.source});
+                cursor=candidate.source;
+            }
+            synth.append(text,cursor,std::string::npos);
+            if(synth.find('}')==std::string::npos && allow_eof_repair) {
+                const size_t begin=synth.size();
+                synth+='}';
+                insertions.push_back({begin,synth.size(),text.size()});
+            }
+            std::string pre2,rec_remaining;
+            auto rec=parse_bare_tool_calls(synth,&pre2,tools,
+                                           /*allow_o10=*/false,allow_eof_repair,
+                                           &rec_remaining);
+            if(!rec.empty()) {
+                auto source_boundary=[&](size_t boundary) {
+                    size_t removed=0;
+                    for(const auto& insertion:insertions) {
+                        if(boundary<=insertion.begin) break;
+                        if(boundary<=insertion.end) return insertion.source;
+                        removed+=insertion.end-insertion.begin;
+                    }
+                    return boundary-removed;
+                };
+                bool mapped=true;
+                for(auto& call:rec) {
+                    if(call.source_begin==std::string::npos ||
+                       call.source_end==std::string::npos) {
+                        mapped=false;
+                        break;
+                    }
+                    const size_t begin=source_boundary(call.source_begin);
+                    const size_t end=source_boundary(call.source_end);
+                    if(end<begin || end>text.size()) {
+                        mapped=false;
+                        break;
+                    }
+                    call.source_begin=begin;
+                    call.source_end=end;
+                    call.rewritten_begin=begin;
+                    call.rewritten_end=end;
+                    call.raw=text.substr(begin,end-begin);
+                }
+                if(mapped) {
+                    out=std::move(rec);
+                    first=out.front().source_begin;
+                    if(prefix) *prefix=strip_ws2(text.substr(0,first));
+                    fprintf(stderr,"[drift] mode-10 dropped-opener rescue: %s (%zu calls)\n",
+                            candidates.front().name.c_str(),out.size());
+                }
             }
         }
     }
@@ -1552,10 +3456,51 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
     // Last resort -- runs only when everything above failed. Sets the prefix
     // to the text before the call object so a preamble ("Let me write...")
     // still streams as text.
-    if (out.empty() && tools && tools->is_array() &&
-        recover_raw_value_call(text, *tools, out) && prefix) {
+    if (out.empty() && allow_eof_repair && tools && tools->is_array() &&
+        recover_raw_value_call(text, *tools, out)) {
         size_t mo = text.rfind("{\"name\"");
-        *prefix = mo != std::string::npos ? strip_ws2(text.substr(0, mo)) : std::string();
+        const std::string before = mo != std::string::npos
+            ? strip_ws2(text.substr(0, mo)) : std::string();
+        if (prefix) *prefix = before;
+        if (remaining_text) *remaining_text = before;
+    }
+    bool exact_source_spans=true;
+    size_t source_cursor=0;
+    for(auto& call:out) {
+        if(call.rewritten_begin==std::string::npos ||
+           call.rewritten_end==std::string::npos ||
+           call.rewritten_begin>call.rewritten_end ||
+           call.rewritten_end>rewritten.value.size()) {
+            exact_source_spans=false;
+            break;
+        }
+        const size_t begin=rewritten.source_boundary(call.rewritten_begin);
+        const size_t end=rewritten.source_boundary(call.rewritten_end);
+        if(begin<source_cursor || end<begin || end>text_in.size()) {
+            exact_source_spans=false;
+            break;
+        }
+        call.source_begin=begin;
+        call.source_end=end;
+        call.raw=text_in.substr(begin,end-begin);
+        source_cursor=end;
+    }
+    if(!exact_source_spans) out.clear();
+    if(remaining_text) {
+        if(out.empty()) {
+            *remaining_text=text_in;
+        } else {
+            std::string remainder;
+            remainder.reserve(text_in.size());
+            source_cursor=0;
+            for(const auto& call:out) {
+                remainder.append(text_in,source_cursor,
+                                 call.source_begin-source_cursor);
+                source_cursor=call.source_end;
+            }
+            remainder.append(text_in,source_cursor,std::string::npos);
+            *remaining_text=std::move(remainder);
+        }
     }
     // Drift catalog (exit gate, docs/sampling-exit-gate.md): tag which tool-format
     // drift mode(s) the fallback chain rescued, or flag an intended call it could
@@ -1595,6 +3540,131 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
     return out;
 }
 
+struct OrderedToolPart {
+    enum class Kind { Text, Call };
+    Kind kind=Kind::Text;
+    size_t text_begin=0;
+    size_t text_end=0;
+    size_t call_index=0;
+};
+
+struct OrderedToolOutput {
+    std::string text;
+    std::string reasoning;
+    std::vector<ToolCall> calls;
+    std::vector<OrderedToolPart> parts;
+    size_t recovered = 0;
+
+    void append_visible_text(const std::string& raw) {
+        if(raw.empty()) return;
+        const size_t begin=text.size();
+        text+=raw;
+        if(!parts.empty() && parts.back().kind==OrderedToolPart::Kind::Text &&
+           parts.back().text_end==begin) {
+            parts.back().text_end=text.size();
+            return;
+        }
+        OrderedToolPart part;
+        part.kind=OrderedToolPart::Kind::Text;
+        part.text_begin=begin;
+        part.text_end=text.size();
+        parts.push_back(part);
+    }
+
+    void append_tool_call(ToolCall call) {
+        OrderedToolPart part;
+        part.kind=OrderedToolPart::Kind::Call;
+        part.call_index=calls.size();
+        calls.push_back(std::move(call));
+        parts.push_back(part);
+    }
+};
+
+inline std::string take_unclosed_final_tool_segment(
+    std::vector<std::pair<StreamSplitter::Chan,std::string>>& segments,
+    bool wrapper_incomplete) {
+    if(!wrapper_incomplete || segments.empty() ||
+       segments.back().first!=StreamSplitter::TOOL) return {};
+    std::string raw=std::move(segments.back().second);
+    segments.pop_back();
+    return raw;
+}
+
+// Resolve generated text and wrapped calls in generation order. This matters
+// when parallel calls are disabled: a bare call emitted before a later wrapped
+// call must win, and rejected or malformed bytes must remain visible as text.
+template<class Eligible>
+inline OrderedToolOutput resolve_ordered_tool_segments(
+
+    const std::vector<std::pair<StreamSplitter::Chan,std::string>>& segments,
+    const json* tools,bool allow_eof_repair,Eligible eligible) {
+    OrderedToolOutput out;
+    auto append_text=[&](const std::string& raw,bool repair_eof) {
+        if(!tools) { out.append_visible_text(raw); return; }
+        if(raw.empty()) return;
+        std::string pre,residual;
+        auto calls=parse_bare_tool_calls(raw,&pre,tools,true,
+                                         repair_eof,&residual);
+        if(calls.empty()) { out.append_visible_text(raw); return; }
+        size_t cursor=0;
+        for(auto& call:calls) {
+            out.append_visible_text(raw.substr(cursor,call.source_begin-cursor));
+            cursor=call.source_end;
+            if(eligible(call.name,out.calls.size())) {
+                out.recovered++;
+                out.append_tool_call(std::move(call));
+            } else {
+                out.append_visible_text(raw.substr(
+                    call.source_begin,call.source_end-call.source_begin));
+            }
+        }
+        out.append_visible_text(raw.substr(cursor));
+    };
+    std::string pending_text;
+    auto flush_pending_text=[&](bool final_segment) {
+        if(pending_text.empty()) return;
+        append_text(pending_text,final_segment && allow_eof_repair);
+        pending_text.clear();
+    };
+    for(const auto& segment:segments) {
+        if(segment.first==StreamSplitter::TEXT) {
+            pending_text+=segment.second;
+            continue;
+        }
+        flush_pending_text(false);
+        if(segment.first==StreamSplitter::THINK) {
+            out.reasoning+=segment.second;
+            continue;
+        }
+        ToolCall call=parse_tool_call(strip_ws2(segment.second));
+        if(call.ok && eligible(call.name,out.calls.size()))
+            out.append_tool_call(std::move(call));
+        else out.append_visible_text(call.raw);
+    }
+    flush_pending_text(true);
+    return out;
+}
+
+template<class ToolBlock>
+inline size_t append_anthropic_ordered_content(
+    json& content,const OrderedToolOutput& out,ToolBlock tool_block) {
+    size_t emitted=0;
+    size_t call_number=0;
+    for(const auto& part:out.parts) {
+        if(part.kind==OrderedToolPart::Kind::Call) {
+            content.push_back(tool_block(out.calls.at(part.call_index),call_number++));
+            emitted++;
+            continue;
+        }
+        if(part.text_begin>=part.text_end) continue;
+        content.push_back({{"type","text"},
+                           {"text",out.text.substr(
+                               part.text_begin,part.text_end-part.text_begin)}});
+        emitted++;
+    }
+    return emitted;
+}
+
 // Single-call convenience wrapper (first recovered call). suffix retained for
 // callers that trim trailing junk; multi-call callers use the vector form.
 inline ToolCall parse_bare_tool_call(const std::string& text_in, std::string* prefix,
@@ -1613,7 +3683,7 @@ inline ToolCall parse_bare_tool_call(const std::string& text_in, std::string* pr
 
 inline json openai_tool_call_json(const std::string& id, const ToolCall& c) {
     return {{"id", id}, {"type", "function"},
-            {"function", {{"name", c.name}, {"arguments", c.arguments.dump()}}}};
+            {"function", {{"name", c.name}, {"arguments", json_dump_replace(c.arguments)}}}};
 }
 
 // Non-streaming choices[0].message. content is null ONLY when there is at
@@ -1670,10 +3740,26 @@ struct ResponsesTerminalState {
     const char* event;
 };
 inline ResponsesTerminalState responses_terminal_state(
+    bool limit_reached) {
+    return {limit_reached, limit_reached ? "incomplete" : "completed",
+            limit_reached ? "response.incomplete" : "response.completed"};
+}
+inline ResponsesTerminalState responses_terminal_state(
     int produced, int limit, bool budget_truncated) {
-    const bool incomplete = produced >= limit || budget_truncated;
-    return {incomplete, incomplete ? "incomplete" : "completed",
-            incomplete ? "response.incomplete" : "response.completed"};
+    return responses_terminal_state(produced >= limit || budget_truncated);
+}
+
+inline bool unfinished_tool_wrapper(
+    int produced,int limit,bool budget_truncated,
+    StreamSplitter::Chan final_channel) {
+    return (produced>=limit || budget_truncated) &&
+           final_channel==StreamSplitter::TOOL;
+}
+
+inline std::string take_responses_output_text(std::string& text) {
+    std::string output=std::move(text);
+    text.clear();
+    return output;
 }
 
 // One streamed tool_calls[] delta entry. Whole-shot (id+name+full arguments
@@ -1686,7 +3772,7 @@ inline json openai_tool_call_delta(int index, const std::string& id, const ToolC
                                          {"id", id},
                                          {"type", "function"},
                                          {"function", {{"name", c.name},
-                                                       {"arguments", c.arguments.dump()}}}}})}};
+                                                       {"arguments", json_dump_replace(c.arguments)}}}}})}};
 }
 
 // ---- API key authentication -----------------------------------------------
@@ -1724,10 +3810,21 @@ inline bool secure_compare(const std::string& a, const std::string& b) {
 inline std::string extract_api_key(const std::string& authorization_header,
                                    const std::string& x_api_key_header) {
     if (!x_api_key_header.empty()) return x_api_key_header;
-    static const std::string prefix = "Bearer ";
-    if (authorization_header.size() > prefix.size() &&
-        authorization_header.compare(0, prefix.size(), prefix) == 0)
-        return authorization_header.substr(prefix.size());
+    static constexpr char bearer[]="bearer";
+    constexpr size_t scheme_size=sizeof(bearer)-1;
+    if(authorization_header.size()<=scheme_size) return "";
+    for(size_t i=0;i<scheme_size;i++) {
+        char ch=authorization_header[i];
+        if(ch>='A' && ch<='Z') ch=(char)(ch-'A'+'a');
+        if(ch!=bearer[i]) return "";
+    }
+    size_t token=scheme_size;
+    if(authorization_header[token]!=' ' && authorization_header[token]!='\t')
+        return "";
+    while(token<authorization_header.size() &&
+          (authorization_header[token]==' ' || authorization_header[token]=='\t'))
+        token++;
+    if(token<authorization_header.size()) return authorization_header.substr(token);
     return "";
 }
 

--- a/src/markdown_lex.h
+++ b/src/markdown_lex.h
@@ -1,0 +1,771 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+
+namespace q27 {
+
+struct JsonStringLexState {
+    bool in_string=false;
+    bool escaped=false;
+    // Active containers use their opener. A top-level undecided opener uses
+    // 'o'/'a' until the first non-space byte proves it is JSON-like.
+    std::string containers;
+    size_t active_containers=0;
+
+    void reset_string() { in_string=false; escaped=false; }
+    void reset() {
+        reset_string();
+        containers.clear();
+        active_containers=0;
+    }
+    bool in_inert_container() const {
+        return active_containers!=0;
+    }
+    bool has_pending_container() const {
+        return active_containers==0 && !containers.empty();
+    }
+    void discard_pending_containers() {
+        if(active_containers==0) containers.clear();
+    }
+
+    bool settle_pending(char ch) {
+        if(!has_pending_container()) return false;
+        if(ch==' ' || ch=='\t' || ch=='\r' || ch=='\n') return true;
+        const char pending=containers.back();
+        const bool object=pending=='o';
+        const bool empty_close=(object && ch=='}') || (!object && ch==']');
+        if(empty_close) {
+            containers.pop_back();
+            return true;
+        }
+        const bool json_start=object
+            ? ch=='"'
+            : ch=='"' || ch=='{' || ch=='[' || ch=='-' ||
+              (ch>='0' && ch<='9') || ch=='t' || ch=='f' || ch=='n';
+        if(json_start) {
+            containers.back()=object?'{':'[';
+            active_containers++;
+        } else {
+            containers.pop_back();
+        }
+        return false;
+    }
+
+    void consume(char ch) {
+        if(escaped) { escaped=false; return; }
+        if(in_string) {
+            if(ch=='\\') escaped=true;
+            else if(ch=='"') in_string=false;
+            return;
+        }
+        if(settle_pending(ch)) return;
+        if(ch=='"') {
+            in_string=true;
+            return;
+        }
+        if(ch=='{' || ch=='[') {
+            if(active_containers)
+                containers.push_back(ch),active_containers++;
+            else containers.push_back(ch=='{'?'o':'a');
+            return;
+        }
+        if(ch=='}' || ch==']') {
+            if(containers.empty()) return;
+            const char expected=ch=='}'?'{':'[';
+            if(containers.back()!=expected) {
+                // Keep a malformed fragment inert until a closer reaches an
+                // actual ancestor boundary. An unrelated closer changes no
+                // state; a matching ancestor closes it and discards invalid
+                // inner frames so later top-level calls remain executable.
+                const size_t match=containers.find_last_of(expected);
+                if(match==std::string::npos) return;
+                const size_t closed=containers.size()-match;
+                containers.resize(match);
+                active_containers=closed<active_containers
+                    ? active_containers-closed : 0;
+                return;
+            }
+            containers.pop_back();
+            active_containers--;
+        }
+    }
+
+    void consume(const std::string& text,size_t count=std::string::npos) {
+        const size_t end=std::min(count,text.size());
+        for(size_t i=0;i<end;i++) consume(text[i]);
+    }
+    void consume_range(const std::string& text,size_t begin,size_t end) {
+        end=std::min(end,text.size());
+        for(size_t i=std::min(begin,end);i<end;i++) consume(text[i]);
+    }
+};
+
+struct MarkdownFenceLexState {
+    struct PrefixInfo {
+        bool valid=false;
+        size_t quote_depth=0;
+        size_t list_depth=0;
+        size_t indent_total=0;
+        size_t max_indent_gap=0;
+        size_t list_indent=0;
+    };
+
+    size_t fence_length=0;
+    size_t inline_ticks=0;
+    size_t run_length=0;
+    char fence_marker=0;
+    char run_marker=0;
+    bool run_can_close=false;
+    bool closing_candidate=false;
+    bool opener_pending=false;
+    bool fence_opener_line=false;
+    std::string line_before;
+    std::string run_prefix;
+    std::string fence_prefix;
+    size_t list_continuation_indent=0;
+    size_t html_container_depth=0;
+    std::string html_container_name;
+    bool html_comment=false;
+    bool html_cdata=false;
+    size_t html_comment_open_progress=0;
+    size_t html_cdata_open_progress=0;
+    size_t html_comment_close_dashes=0;
+    size_t html_cdata_close_brackets=0;
+    bool html_tag_open=false;
+    bool html_tag_closing=false;
+    bool html_tag_name_done=false;
+    bool html_tag_declaration=false;
+    char html_tag_quote=0;
+    char html_tag_last_nonspace=0;
+    std::string html_tag_name;
+    size_t link_destination_depth=0;
+    char link_destination_quote=0;
+    bool link_destination_angle=false;
+    bool link_destination_escaped=false;
+    bool reference_definition=false;
+
+    static char ascii_lower(char ch) {
+        return ch>='A' && ch<='Z' ? char(ch-'A'+'a') : ch;
+    }
+    static bool html_name_start(char ch) {
+        ch=ascii_lower(ch);
+        return ch>='a' && ch<='z';
+    }
+    static bool html_name_char(char ch) {
+        ch=ascii_lower(ch);
+        return (ch>='a' && ch<='z') || (ch>='0' && ch<='9') ||
+               ch=='-' || ch==':' || ch=='_';
+    }
+    static bool html_void_name(const std::string& name) {
+        static const char* names[]={
+            "area","base","basefont","bgsound","br","col","embed","frame",
+            "hr","img","input","keygen","link","meta","param","source",
+            "track","wbr"
+        };
+        for(const char* candidate:names) if(name==candidate) return true;
+        return false;
+    }
+    bool displayed_html() const {
+        return html_comment || html_cdata || html_container_depth!=0 ||
+               html_tag_open;
+    }
+
+    static bool line_break(char ch) { return ch=='\n' || ch=='\r'; }
+    static bool line_space(char ch) { return ch==' ' || ch=='\t'; }
+    static bool marker(char ch) { return ch=='`' || ch=='~'; }
+    static bool marker_is_escaped(const std::string& line) {
+        size_t slashes=0;
+        for(size_t i=line.size();i>0 && line[i-1]=='\\';i--) slashes++;
+        return (slashes&1)!=0;
+    }
+
+    static bool char_is_escaped(const std::string& text,size_t position) {
+        size_t slashes=0;
+        while(position>0 && text[--position]=='\\') slashes++;
+        return (slashes&1)!=0;
+    }
+    static bool link_label_before_destination(const std::string& line) {
+        if(line.empty() || line.back()!=']' ||
+           char_is_escaped(line,line.size()-1)) return false;
+        size_t depth=1;
+        for(size_t i=line.size()-1;i>0;) {
+            --i;
+            if(char_is_escaped(line,i)) continue;
+            if(line[i]==']') depth++;
+            else if(line[i]=='[' && --depth==0) return true;
+        }
+        return false;
+    }
+    static bool reference_label_before_colon(const std::string& line) {
+        size_t i=0;
+        while(i<line.size() && i<4 && line[i]==' ') i++;
+        if(i>3 || i>=line.size() || line[i]!='[') return false;
+        bool content=false,escaped=false;
+        for(++i;i<line.size();i++) {
+            const char ch=line[i];
+            if(escaped) { escaped=false; content=true; continue; }
+            if(ch=='\\') { escaped=true; continue; }
+            if(ch=='[') return false;
+            if(ch==']') return content && i+1==line.size();
+            content=true;
+        }
+        return false;
+    }
+
+    bool displayed_markdown_metadata() const {
+        return link_destination_depth!=0 || reference_definition;
+    }
+
+    void reset_link_metadata() {
+        link_destination_depth=0;
+        link_destination_quote=0;
+        link_destination_angle=false;
+        link_destination_escaped=false;
+        reference_definition=false;
+    }
+
+    void consume_link_metadata(char ch) {
+        if(line_break(ch)) {
+            if(reference_definition) reset_link_metadata();
+            finish_line();
+            reset_line();
+            return;
+        }
+        line_before+=ch;
+        if(reference_definition) return;
+        if(link_destination_escaped) {
+            link_destination_escaped=false;
+            return;
+        }
+        if(ch=='\\') {
+            link_destination_escaped=true;
+            return;
+        }
+        if(link_destination_quote) {
+            if(ch==link_destination_quote) link_destination_quote=0;
+            return;
+        }
+        if(link_destination_angle) {
+            if(ch=='>') link_destination_angle=false;
+            return;
+        }
+        if(ch=='<' && link_destination_depth==1) {
+            link_destination_angle=true;
+        } else if(ch=='\'' || ch=='"') {
+            link_destination_quote=ch;
+        } else if(ch=='(') {
+            link_destination_depth++;
+        } else if(ch==')' && --link_destination_depth==0) {
+            link_destination_quote=0;
+            link_destination_angle=false;
+            link_destination_escaped=false;
+        }
+    }
+
+    static PrefixInfo parse_prefix(const std::string& prefix,
+                                   bool allow_content=false) {
+        PrefixInfo out;
+        size_t i=0;
+        for(;;) {
+            const size_t gap_begin=i;
+            while(i<prefix.size() && line_space(prefix[i])) i++;
+            const size_t gap=i-gap_begin;
+            out.indent_total+=gap;
+            out.max_indent_gap=std::max(out.max_indent_gap,gap);
+            if(i==prefix.size()) {
+                out.valid=true;
+                return out;
+            }
+            if(prefix[i]=='>') {
+                out.quote_depth++;
+                i++;
+                if(i<prefix.size() && line_space(prefix[i])) i++;
+                continue;
+            }
+            const size_t marker_begin=i;
+            if(prefix[i]=='-' || prefix[i]=='+' || prefix[i]=='*') {
+                i++;
+            } else {
+                size_t digits=0;
+                while(i<prefix.size() && prefix[i]>='0' && prefix[i]<='9' &&
+                      digits<9) {
+                    i++;
+                    digits++;
+                }
+                if(digits==0 || i>=prefix.size() ||
+                   (prefix[i]!='.' && prefix[i]!=')')) {
+                    out.valid=allow_content;
+                    return out;
+                }
+                i++;
+            }
+            if(i>=prefix.size() || !line_space(prefix[i])) {
+                out.valid=allow_content;
+                return out;
+            }
+            const size_t after_marker=i;
+            while(i<prefix.size() && line_space(prefix[i])) i++;
+            out.list_depth++;
+            out.list_indent+=gap+(after_marker-marker_begin)+(i-after_marker);
+        }
+    }
+
+    bool prefix_matches(const std::string& candidate) const {
+        const PrefixInfo opener=parse_prefix(fence_prefix);
+        const PrefixInfo closer=parse_prefix(candidate);
+        if(!opener.valid || !closer.valid) return candidate==fence_prefix;
+        if(opener.quote_depth!=closer.quote_depth) return false;
+        if(opener.list_depth) {
+            if(closer.list_depth) return false;
+            return closer.indent_total>=opener.list_indent &&
+                   closer.indent_total<=opener.list_indent+3;
+        }
+        if(opener.quote_depth==0 && opener.max_indent_gap>3)
+            return !closer.list_depth && closer.quote_depth==0 &&
+                   closer.indent_total==opener.indent_total;
+        return !closer.list_depth && opener.max_indent_gap<=3 &&
+               closer.max_indent_gap<=3;
+    }
+    bool line_matches_fence_container(const std::string& line) const {
+        const PrefixInfo opener=parse_prefix(fence_prefix);
+        if(!opener.valid || (!opener.quote_depth && !opener.list_depth))
+            return true;
+        const PrefixInfo current=parse_prefix(line,true);
+        if(!current.valid || current.quote_depth!=opener.quote_depth)
+            return false;
+        return !opener.list_depth || current.indent_total>=opener.list_indent;
+    }
+
+
+    static bool valid_opener_prefix(const std::string& prefix) {
+        const PrefixInfo info=parse_prefix(prefix);
+        return info.valid && (info.list_depth || info.quote_depth==0 ||
+            info.max_indent_gap<=3);
+    }
+
+    void reset_line() {
+        line_before.clear();
+        run_prefix.clear();
+        run_can_close=false;
+        closing_candidate=false;
+    }
+    bool indented_code_line() const {
+        size_t columns=0;
+        for(char ch:line_before) {
+            if(ch==' ') columns++;
+            else if(ch=='\t') columns+=4-(columns%4);
+            else break;
+            if(columns>=4) return true;
+        }
+        return false;
+    }
+    bool displayed_markdown_line() const {
+        const PrefixInfo info=parse_prefix(line_before,true);
+        if(info.quote_depth || info.list_depth) return true;
+        return list_continuation_indent!=0 &&
+            info.indent_total>=list_continuation_indent;
+    }
+
+    void finish_line() {
+        const PrefixInfo info=parse_prefix(line_before,true);
+        if(info.list_depth) {
+            list_continuation_indent=info.list_indent;
+            return;
+        }
+        bool blank=true;
+        for(char ch:line_before) {
+            if(!line_space(ch)) { blank=false; break; }
+        }
+        if(blank || (list_continuation_indent!=0 &&
+                     info.indent_total>=list_continuation_indent)) return;
+        list_continuation_indent=0;
+    }
+
+
+
+    void reset_html_tag() {
+        html_tag_quote=0;
+        html_tag_open=false;
+        html_tag_closing=false;
+        html_tag_name_done=false;
+        html_tag_declaration=false;
+        html_tag_last_nonspace=0;
+        html_comment_open_progress=0;
+        html_cdata_open_progress=0;
+        html_tag_name.clear();
+    }
+    void finish_html_tag() {
+        const bool container=!html_tag_declaration && !html_tag_name.empty() &&
+                             !html_void_name(html_tag_name);
+        if(container && html_tag_last_nonspace!='/') {
+            if(html_container_depth==0) {
+                if(!html_tag_closing) {
+                    html_container_name=html_tag_name;
+                    html_container_depth=1;
+                }
+            } else if(html_tag_name==html_container_name) {
+                if(html_tag_closing) {
+                    if(--html_container_depth==0) html_container_name.clear();
+                } else {
+                    html_container_depth++;
+                }
+            }
+        }
+        reset_html_tag();
+    }
+    void consume_html(char ch) {
+        if(html_comment) {
+            if(ch=='-') {
+                html_comment_close_dashes=std::min<size_t>(
+                    2,html_comment_close_dashes+1);
+            } else if(ch=='>' && html_comment_close_dashes==2) {
+                html_comment=false;
+                html_comment_close_dashes=0;
+            } else {
+                html_comment_close_dashes=0;
+            }
+            return;
+        }
+        if(html_cdata) {
+            if(ch==']') {
+                html_cdata_close_brackets=std::min<size_t>(
+                    2,html_cdata_close_brackets+1);
+            } else if(ch=='>' && html_cdata_close_brackets==2) {
+                html_cdata=false;
+                html_cdata_close_brackets=0;
+            } else {
+                html_cdata_close_brackets=0;
+            }
+            return;
+        }
+        if(!html_tag_open) {
+            if(ch=='<') {
+                reset_html_tag();
+                html_tag_open=true;
+                html_tag_last_nonspace='<';
+                html_comment_open_progress=1;
+                html_cdata_open_progress=1;
+            }
+            return;
+        }
+        bool special_prefix=false;
+        if(html_comment_open_progress) {
+            const bool matches=
+                (html_comment_open_progress==1 && ch=='!') ||
+                (html_comment_open_progress>=2 &&
+                 html_comment_open_progress<=3 && ch=='-');
+            if(matches) {
+                special_prefix=true;
+                html_comment_open_progress++;
+                if(html_comment_open_progress==4) {
+                    reset_html_tag();
+                    html_comment=true;
+                    html_comment_close_dashes=0;
+                    return;
+                }
+            } else {
+                html_comment_open_progress=0;
+            }
+        }
+        if(html_cdata_open_progress) {
+            static constexpr char opener[]="<![CDATA[";
+            if(html_cdata_open_progress<sizeof(opener)-1 &&
+               ch==opener[html_cdata_open_progress]) {
+                special_prefix=true;
+                html_cdata_open_progress++;
+                if(html_cdata_open_progress==sizeof(opener)-1) {
+                    reset_html_tag();
+                    html_cdata=true;
+                    html_cdata_close_brackets=0;
+                    return;
+                }
+            } else {
+                html_cdata_open_progress=0;
+            }
+        }
+        if(special_prefix) {
+            if(ch=='!') {
+                html_tag_declaration=true;
+                html_tag_name_done=true;
+            }
+            return;
+        }
+        if(html_tag_quote) {
+            if(ch==html_tag_quote) html_tag_quote=0;
+            return;
+        }
+        if((html_tag_name_done || !html_tag_name.empty()) &&
+           (ch=='\'' || ch=='"')) {
+            html_tag_name_done=true;
+            html_tag_quote=ch;
+            return;
+        }
+        if(ch=='>') {
+            finish_html_tag();
+            return;
+        }
+        if(ch=='\0') return;
+        if(!line_space(ch)) html_tag_last_nonspace=ch;
+        if(html_tag_name_done) return;
+        if(html_tag_name.empty()) {
+            if(ch=='/' && !html_tag_closing) {
+                html_tag_closing=true;
+                return;
+            }
+            if(ch=='!' || ch=='?') {
+                html_tag_declaration=true;
+                html_tag_name_done=true;
+                return;
+            }
+            if(!html_name_start(ch)) {
+                reset_html_tag();
+                if(ch=='<') {
+                    html_tag_open=true;
+                    html_tag_last_nonspace='<';
+                    html_comment_open_progress=1;
+                    html_cdata_open_progress=1;
+                }
+                return;
+            }
+            html_tag_name+=ascii_lower(ch);
+            return;
+        }
+        if(html_name_char(ch)) {
+            html_tag_name+=ascii_lower(ch);
+            return;
+        }
+        html_tag_name_done=true;
+    }
+
+    void reset() {
+        fence_length=0;
+        inline_ticks=0;
+        run_length=0;
+        fence_marker=0;
+        run_marker=0;
+        opener_pending=false;
+        fence_opener_line=false;
+        fence_prefix.clear();
+        list_continuation_indent=0;
+        html_container_depth=0;
+        html_container_name.clear();
+        html_comment=false;
+        html_cdata=false;
+        html_comment_close_dashes=0;
+        html_cdata_close_brackets=0;
+        reset_link_metadata();
+        reset_html_tag();
+
+        reset_line();
+    }
+
+    void settle_run(char following) {
+        const bool closes=fence_length!=0 && run_can_close &&
+            run_marker==fence_marker && run_length>=fence_length;
+        if(fence_length==0) {
+            if(inline_ticks==0 && run_length>=3 &&
+               valid_opener_prefix(run_prefix)) {
+                fence_length=run_length;
+                fence_marker=run_marker;
+                fence_prefix=run_prefix;
+                opener_pending=run_marker=='`';
+                fence_opener_line=true;
+            } else if(run_marker=='`') {
+                if(inline_ticks==0) inline_ticks=run_length;
+                else if(run_length==inline_ticks) inline_ticks=0;
+            }
+        }
+        run_length=0;
+        run_marker=0;
+        run_prefix.clear();
+        run_can_close=false;
+        if(closes) {
+            if(line_break(following)) {
+                fence_length=0;
+                fence_marker=0;
+                opener_pending=false;
+                fence_opener_line=false;
+                fence_prefix.clear();
+            } else if(line_space(following)) {
+                closing_candidate=true;
+            }
+        }
+    }
+
+    void leave_closed_container(char ch) {
+        if(fence_length==0 || fence_opener_line || line_break(ch)) return;
+        std::string candidate=line_before;
+        candidate+=ch;
+        if(parse_prefix(candidate).valid ||
+           line_matches_fence_container(candidate)) return;
+        fence_length=0;
+        fence_marker=0;
+        opener_pending=false;
+        fence_opener_line=false;
+        fence_prefix.clear();
+    }
+
+    void consume(char ch) {
+        leave_closed_container(ch);
+        if(displayed_markdown_metadata()) {
+            consume_link_metadata(ch);
+            return;
+        }
+        if(marker(ch) && run_length && ch==run_marker) {
+            run_length++;
+            line_before+=ch;
+            return;
+        }
+        if(run_length) settle_run(ch);
+        if(opener_pending && ch=='`') {
+            inline_ticks=fence_length;
+            fence_length=0;
+            fence_marker=0;
+            fence_prefix.clear();
+            opener_pending=false;
+        }
+        if(fence_length==0 && inline_ticks==0) {
+            const bool html_before=displayed_html();
+            consume_html(ch);
+            if(html_before || displayed_html()) {
+                if(line_break(ch)) {
+                    finish_line();
+                    reset_line();
+                } else {
+                    line_before+=ch;
+                }
+                return;
+            }
+        }
+        if(marker(ch) && !marker_is_escaped(line_before)) {
+            if(closing_candidate) closing_candidate=false;
+            run_marker=ch;
+            run_prefix=line_before;
+            run_can_close=fence_length!=0 && ch==fence_marker &&
+                prefix_matches(run_prefix);
+            run_length=1;
+            line_before+=ch;
+            return;
+        }
+
+        if(fence_length==0 && inline_ticks==0 && ch=='(' &&
+           link_label_before_destination(line_before)) {
+            link_destination_depth=1;
+            line_before+=ch;
+            return;
+        }
+        if(fence_length==0 && inline_ticks==0 && ch==':' &&
+           reference_label_before_colon(line_before)) {
+            reference_definition=true;
+            line_before+=ch;
+            return;
+        }
+        if(closing_candidate) {
+            if(line_break(ch)) {
+                fence_length=0;
+                fence_marker=0;
+                fence_prefix.clear();
+                opener_pending=false;
+                fence_opener_line=false;
+            } else if(!line_space(ch)) {
+                closing_candidate=false;
+            }
+        }
+        if(line_break(ch)) {
+            opener_pending=false;
+            fence_opener_line=false;
+            finish_line();
+            reset_line();
+            return;
+        }
+        line_before+=ch;
+    }
+
+    void consume(const std::string& text,size_t count=std::string::npos) {
+        const size_t end=std::min(count,text.size());
+        for(size_t i=0;i<end;i++) consume(text[i]);
+    }
+
+    void settle_before_non_backtick() {
+        if(run_length) settle_run('\0');
+        if(closing_candidate) closing_candidate=false;
+    }
+
+    bool outside_before_non_backtick() {
+        settle_before_non_backtick();
+        return fence_length==0 && inline_ticks==0;
+    }
+};
+
+inline bool markdown_inline_closer_after(
+    const std::string& text,size_t position,MarkdownFenceLexState state) {
+    for(size_t i=position;i<text.size();i++) {
+        const size_t before=state.inline_ticks;
+        state.consume(text[i]);
+        if(before!=0 && state.inline_ticks==0) return true;
+    }
+    const size_t before=state.inline_ticks;
+    state.settle_before_non_backtick();
+    return before!=0 && state.inline_ticks==0;
+}
+
+inline bool markdown_context_is_displayed(
+    const std::string& text,size_t position,
+    MarkdownFenceLexState& state,bool end_is_final) {
+    state.settle_before_non_backtick();
+    if(position<text.size()) state.leave_closed_container(text[position]);
+    if(state.displayed_html() || state.displayed_markdown_metadata()) return true;
+    if(state.fence_length!=0) return true;
+    if(state.indented_code_line()) return true;
+    if(state.displayed_markdown_line()) return true;
+    if(state.inline_ticks==0) return false;
+    if(markdown_inline_closer_after(text,position,state)) return true;
+    return !end_is_final;
+}
+
+inline void consume_display_text_context(JsonStringLexState& string_state,
+                                         MarkdownFenceLexState& fence_state,
+                                         char ch) {
+    const bool markdown_before=fence_state.fence_length!=0 ||
+        fence_state.inline_ticks!=0 ||
+        fence_state.displayed_markdown_metadata();
+    if(markdown_before || fence_state.run_length) {
+        fence_state.consume(ch);
+        if(fence_state.fence_length!=0 || fence_state.inline_ticks!=0 ||
+           fence_state.displayed_markdown_metadata()) {
+            string_state.reset_string();
+            return;
+        }
+        string_state.consume(ch);
+        return;
+    }
+    const bool was_in_string=string_state.in_string;
+    string_state.consume(ch);
+    const char markdown_ch=MarkdownFenceLexState::line_break(ch)
+        ?ch:(was_in_string || string_state.in_string?'\0':ch);
+    fence_state.consume(markdown_ch);
+    if(fence_state.fence_length!=0 || fence_state.inline_ticks!=0 ||
+       fence_state.displayed_markdown_metadata())
+        string_state.reset_string();
+}
+
+inline void consume_display_text_context(JsonStringLexState& string_state,
+                                         MarkdownFenceLexState& fence_state,
+                                         const std::string& text,
+                                         size_t count=std::string::npos) {
+    const size_t end=std::min(count,text.size());
+    for(size_t i=0;i<end;i++)
+        consume_display_text_context(string_state,fence_state,text[i]);
+}
+
+inline bool display_text_context_is_executable(
+    const std::string& text,size_t position,
+    JsonStringLexState& string_state,MarkdownFenceLexState& fence_state,
+    bool end_is_final) {
+    return !string_state.in_string && !markdown_context_is_displayed(
+        text,position,fence_state,end_is_final);
+}
+
+} // namespace q27

--- a/src/markdown_lex.h
+++ b/src/markdown_lex.h
@@ -717,6 +717,10 @@ inline bool markdown_context_is_displayed(
     state.settle_before_non_backtick();
     if(position<text.size()) state.leave_closed_container(text[position]);
     if(state.displayed_html() || state.displayed_markdown_metadata()) return true;
+    // An unterminated fence stays displayed through the end of the response.
+    // Unlike malformed JSON with an actual ancestor closer, it provides no
+    // trustworthy boundary after which a marker is executable; decaying at the
+    // marker itself would let truncated fenced or retrieved content call tools.
     if(state.fence_length!=0) return true;
     if(state.indented_code_line()) return true;
     if(state.displayed_markdown_line()) return true;

--- a/src/server.cu
+++ b/src/server.cu
@@ -41,7 +41,7 @@ using q27::StreamSplitter;
 // split characters intact; this is the backstop for everything else.
 // File-scope on purpose -- helpers with explicit capture lists use it too.
 static std::string jdump(const json& j) {
-    return j.dump(-1, ' ', false, json::error_handler_t::replace);
+    return q27::json_dump_replace(j);
 }
 
 // Sampling params (roadmap #2) shared across all 3 API shapes. temperature<=0
@@ -1426,17 +1426,21 @@ int main(int argc, char** argv) {
         q27::ToolChoice tchoice;
         std::vector<std::string> tool_names_v;
         if (routed_chat) {
-            tchoice = q27::parse_tool_choice(body);
-            tools = tchoice.mode == q27::ToolChoice::NONE ? json::array() : q27::openai_tools_json(body);
-            if (constrain_tools && tools.is_array())
-                for (auto& t : tools)
-                    if (t.contains("function") && t["function"].contains("name"))
-                        tool_names_v.push_back(t["function"]["name"].get<std::string>());
-            // named-forced tool_choice restricts the grammar to that one name;
-            // "required" (no name) leaves every registered tool eligible.
-            if (tchoice.mode == q27::ToolChoice::FORCED && !tchoice.forced_name.empty())
-                tool_names_v = {tchoice.forced_name};
+            try {
+                tchoice = q27::parse_tool_choice(body);
+                q27::apply_openai_parallel_tool_calls(body,tchoice);
+                q27::OpenAIToolSelection selected=q27::select_openai_tools(body,tchoice);
+                tools=std::move(selected.tools);
+                tool_names_v=std::move(selected.names);
+            } catch (const std::exception& e) {
+                res.status = 400;
+                res.set_content(json{{"error",{{"message",e.what()},
+                                                 {"type","invalid_request_error"}}}}.dump(),
+                                "application/json");
+                return;
+            }
         }
+        const std::set<std::string> allowed_tool_names(tool_names_v.begin(),tool_names_v.end());
         long rid = req_counter++;
         auto tk0 = std::chrono::steady_clock::now();
         std::vector<int> prompt;
@@ -1619,18 +1623,20 @@ int main(int argc, char** argv) {
             q27::ThinkBudgetState tb{think_budget};
             Engine::DecodeTask bt;
             q27::Utf8Gate ugate;
-            std::string think, text, tool_buf;
-            std::vector<q27::ToolCall> calls;
-            auto flush_tool = [&]() {
-                auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
-                tool_buf.clear();
-                if (c.ok) calls.push_back(std::move(c));
-                else text += c.raw; // stream parity: preserve generation order
-            };
+            std::vector<std::pair<StreamSplitter::Chan,std::string>> segments;
             auto route = [&](StreamSplitter::Chan ch, const std::string& t) {
-                if (ch == StreamSplitter::TOOL) { tool_buf += t; return; }
-                if (!tool_buf.empty()) flush_tool();
-                (ch == StreamSplitter::THINK ? think : text) += t;
+                if (ch == StreamSplitter::TOOL &&
+                    tchoice.mode == q27::ToolChoice::NONE)
+                    ch = StreamSplitter::TEXT;
+                if (t.empty()) {
+                    if (ch != StreamSplitter::TOOL && !segments.empty() &&
+                        segments.back().first == StreamSplitter::TOOL)
+                        segments.emplace_back(ch, std::string());
+                    return;
+                }
+                if (!segments.empty() && segments.back().first == ch)
+                    segments.back().second += t;
+                else segments.emplace_back(ch, t);
             };
             ToolConstrainer tc;
             tc.eng = &eng; tc.tok = &tok; tc.cache = &tool_mask_cache;
@@ -1697,29 +1703,39 @@ int main(int argc, char** argv) {
                 return;
             }
             for (auto& [ch, t] : sp.feed(ugate.flush())) route(ch, t);
+            const bool final_tool_incomplete=q27::unfinished_tool_wrapper(
+                n,n_max,bt.budget_truncated,sp.chan);
             for (auto& [ch, t] : sp.flush()) route(ch, t);
-            if (!tool_buf.empty()) flush_tool();
-
-            std::string tx = text;
-            if (tools.is_array() && !tools.empty()) {
-                // wrapper-less call recovery (see parse_bare_tool_calls)
-                std::string pre;
-                auto bcs = q27::parse_bare_tool_calls(tx, &pre, &tools);
-                if (!bcs.empty()) {
-                    fprintf(stderr,
-                            "[tool-fallback] %zu bare call(s) recovered (oai-nonstream)\n",
-                            bcs.size());
-                    tx = pre;
-                    for (auto& bc : bcs) calls.push_back(bc);
-                }
+            std::string unclosed_tool=q27::take_unclosed_final_tool_segment(
+                segments,final_tool_incomplete);
+            auto ordered = q27::resolve_ordered_tool_segments(
+                segments, tools.is_array() && !tools.empty() ? &tools : nullptr,
+                n < n_max && !bt.budget_truncated,
+                [&](const std::string& name, size_t accepted) {
+                    return q27::tool_choice_allows_call(
+                        tchoice, allowed_tool_names, name, accepted);
+                });
+            ordered.text+=unclosed_tool;
+            std::string tx = ordered.text;
+            std::vector<q27::ToolCall> eligible_calls = std::move(ordered.calls);
+            if (ordered.recovered)
+                fprintf(stderr,
+                        "[tool-fallback] %zu bare call(s) recovered (oai-nonstream)\n",
+                        ordered.recovered);
+            const bool any_call = !eligible_calls.empty();
+            if (q27::forced_tool_choice_missing_is_error(
+                    tchoice, any_call, n >= n_max || bt.budget_truncated)) {
+                res.status = 500;
+                res.set_content(json{{"error",{{"message","model produced no eligible tool call for forced tool_choice"},
+                                                 {"type","api_error"}}}}.dump(),
+                                "application/json");
+                return;
             }
-            bool any_call = false;
-            for (auto& c : calls)
-                if (c.ok) any_call = true;
-            json msg = q27::openai_chat_message_json(tx, calls, rid, think);
+            json msg = q27::openai_chat_message_json(
+                tx, eligible_calls, rid, ordered.reasoning);
             json choice = {{"index", 0},
-                          {"finish_reason", any_call ? "tool_calls" :
-                              ((n >= n_max || bt.budget_truncated) ? "length" : "stop")},
+                          {"finish_reason", q27::openai_tool_finish_reason(
+                              any_call,final_tool_incomplete,n>=n_max || bt.budget_truncated)},
                           {"message", msg}};
             json out = {{"id", "chatcmpl-q27-" + std::to_string(rid)}, {"object", obj},
                         {"created", created}, {"model", served_name},
@@ -1745,9 +1761,9 @@ int main(int argc, char** argv) {
             // handler's frame is dead (routing() and write_response() are
             // sibling calls in Server::process_request). `thinking` shipped as
             // a by-reference read of that dead frame from 2026-07-20 until the
-            // 07-24 audit -- benign only by stack-layout luck.
-            [&, samp, prompt, n_max, created, chat, obj, objd, rt, inc_usage, routed_chat,
-             tools, tool_names_v, tchoice, stable_len, has_tools, rid,
+            // fix; the bug was benign only by stack-layout luck.
+            [&, samp, prompt, n_max, created, chat, objd, rt, inc_usage, routed_chat,
+             tools, tool_names_v, allowed_tool_names, tchoice, stable_len, has_tools, rid,
              thinking, tcfg, sys_len, think_aware](size_t, httplib::DataSink& sink) {
                 Slot& sl = claim_slot(prompt,n_max,thinking,tcfg,think_aware);
                 auto sl_lease = slot_guard(sl);
@@ -1849,17 +1865,19 @@ int main(int argc, char** argv) {
                 bool alive = true; // cleared when a write fails (client disconnected)
                 int tool_idx = 0;
                 bool any_call = false;
-                std::string tool_buf, text_accum;
+                std::string tool_buf;
+                q27::BareToolTextHoldback bare_text;
                 bool forced_control_token = false;
-                auto emit_tool = [&]() {
-                    auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
-                    tool_buf.clear();
-                    if (!c.ok) { // malformed: surface as text so nothing is lost
-                        if (!send(q27::openai_stream_chunk(cid, objd, created, served_name,
-                                                           json{{"content", c.raw}})))
-                            alive = false;
-                        return;
-                    }
+                auto emit_text = [&](const std::string& t) {
+                    if (t.empty()) return;
+                    if (!send(q27::openai_stream_chunk(cid, objd, created, served_name,
+                                                       json{{"content", t}})))
+                        alive = false;
+                };
+                auto emit_call = [&](const q27::ToolCall& c) {
+                    if (!c.ok || !q27::tool_choice_allows_call(
+                        tchoice,allowed_tool_names,c.name,any_call?1u:0u))
+                        return false;
                     any_call = true;
                     std::string tid =
                         "call_q27_" + std::to_string(rid) + "_" + std::to_string(tool_idx);
@@ -1868,9 +1886,46 @@ int main(int argc, char** argv) {
                         q27::openai_tool_call_delta(tool_idx, tid, c)));
                     tool_idx++;
                     if (!ok) alive = false;
+                    return true;
+                };
+                auto classify_bare = [&](const std::string& source,bool allow_repair,
+                                         auto&& visible) {
+                    std::string pre,residual;
+                    auto bcs = q27::parse_bare_tool_calls(
+                        source,&pre,&tools,true,allow_repair,&residual);
+                    if (bcs.empty()) return q27::BareToolCandidateResult{};
+                    size_t cursor=0,recovered=0;
+                    for (const auto& bc : bcs) {
+                        visible(source.substr(cursor,bc.source_begin-cursor));
+                        cursor=bc.source_end;
+                        if (emit_call(bc)) recovered++;
+                        else visible(source.substr(
+                            bc.source_begin,bc.source_end-bc.source_begin));
+                    }
+                    visible(source.substr(cursor));
+                    if (recovered)
+                        fprintf(stderr,
+                                "[tool-fallback] %zu bare call(s) recovered (oai-stream)\n",
+                                recovered);
+                    return q27::BareToolCandidateResult{true,recovered!=0};
+                };
+                auto emit_tool = [&]() {
+                    auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
+                    tool_buf.clear();
+                    if (!c.ok) {
+                        if (!classify_bare(c.raw,true,emit_text)) emit_text(c.raw);
+                    } else if (!emit_call(c)) emit_text(c.raw);
                 };
                 auto emit_seg = [&](StreamSplitter::Chan ch, const std::string& t) {
-                    if (ch == StreamSplitter::TOOL) { tool_buf += t; return; }
+                    if (ch == StreamSplitter::TOOL) {
+                        if (tool_buf.empty()) {
+                            bare_text.finish(false,allowed_tool_names,
+                                             emit_text,classify_bare);
+                            bare_text.reset_context();
+                        }
+                        tool_buf += t;
+                        return;
+                    }
                     if (!tool_buf.empty()) emit_tool();
                     if (t.empty()) return;
                     // reasoning_content (no official OpenAI field for this;
@@ -1879,6 +1934,9 @@ int main(int argc, char** argv) {
                     // tags into `content` (the bug this whole path also
                     // happens to fix).
                     if (ch == StreamSplitter::THINK) {
+                        bare_text.finish(false,allowed_tool_names,
+                                         emit_text,classify_bare);
+                        bare_text.reset_context();
                         if (!send(q27::openai_stream_chunk(cid, objd, created, served_name,
                                                             q27::openai_reasoning_delta(t))))
                             alive = false;
@@ -1888,10 +1946,10 @@ int main(int argc, char** argv) {
                     // Preserve ordinary leading whitespace, including when
                     // thinking is disabled or the model closes naturally.
                     if (forced_control_token && q27::strip_ws2(t).empty()) return;
-                    text_accum += t;
-                    if (!send(q27::openai_stream_chunk(cid, objd, created, served_name,
-                                                       json{{"content", t}})))
-                        alive = false;
+                    if (has_tools)
+                        bare_text.route(t,allowed_tool_names,
+                                        emit_text,classify_bare);
+                    else emit_text(t);
                 };
                 eng.on_pending = [&](int id) { tc.on_pending(id); };
                 eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
@@ -1924,38 +1982,36 @@ int main(int argc, char** argv) {
                 eng.on_round_gap = nullptr;
                 req_log(rt, qw, eng, sl.id, tg_stats(tc) + bat_stats(bt));
                 for (auto& [ch, t] : sp.feed(ugate.flush())) emit_seg(ch, t);
+                const bool final_tool_incomplete=q27::unfinished_tool_wrapper(
+                    produced,nm,bt.budget_truncated,sp.chan);
                 for (auto& [ch, t] : sp.flush()) emit_seg(ch, t);
-                if (!tool_buf.empty()) emit_tool();
-                if (has_tools) {
-                    // wrapper-less call recovery: text already streamed as a
-                    // content delta (cosmetic); the tool_calls delta still fires
-                    std::string pre;
-                    auto bcs = q27::parse_bare_tool_calls(text_accum, &pre, &tools);
-                    if (!bcs.empty()) {
-                        fprintf(stderr,
-                                "[tool-fallback] %zu bare call(s) recovered (oai-stream)\n",
-                                bcs.size());
-                        any_call = true;
-                        for (auto& bc : bcs) {
-                            std::string tid = "call_q27_" + std::to_string(rid) + "_" +
-                                              std::to_string(tool_idx);
-                            bool ok = send(q27::openai_stream_chunk(
-                                cid, objd, created, served_name,
-                                q27::openai_tool_call_delta(tool_idx, tid, bc)));
-                            tool_idx++;
-                            if (!ok) alive = false;
-                        }
-                    }
+                if (!tool_buf.empty()) {
+                    if (final_tool_incomplete) {
+                        emit_text(tool_buf);
+                        tool_buf.clear();
+                    } else emit_tool();
                 }
+                if (!final_tool_incomplete)
+                    bare_text.finish(produced < nm && !bt.budget_truncated,
+                                     allowed_tool_names,emit_text,classify_bare);
                 // TODO(batch error surfacing): no standard OpenAI mid-stream
                 // error chunk exists (matches the plain-text leg's TODO
                 // above); end=error lands in the [req] line, [req-error]
                 // carries the what() (batch_generate logs it unconditionally
                 // when err_out is null, same as that leg's nullptr err_out).
+                if (q27::forced_tool_choice_missing_is_error(
+                        tchoice, any_call, produced >= nm || bt.budget_truncated)) {
+                    send(json{{"error",{{"message","model produced no eligible tool call for forced tool_choice"},
+                                         {"type","api_error"}}}});
+                    std::string done = "data: [DONE]\n\n";
+                    sink.write(done.data(), done.size());
+                    sink.done();
+                    return true;
+                }
                 {
-                    const char* fr = any_call ? "tool_calls"
-                                              : ((produced >= nm || bt.budget_truncated)
-                                                     ? "length" : "stop");
+                    const char* fr=q27::openai_tool_finish_reason(
+                        any_call,final_tool_incomplete,
+                        produced>=nm || bt.budget_truncated);
                     send(q27::openai_stream_chunk(cid, objd, created, served_name,
                                                   json::object(), fr));
                 }
@@ -1984,6 +2040,37 @@ int main(int argc, char** argv) {
                         "application/json");
     };
 
+    auto prepare_anthropic_prompt = [&](const json& body,
+                                         q27::ToolChoice& tchoice,
+                                         json& tools,
+                                         std::vector<std::string>& tool_names,
+                                         bool& thinking,
+                                         q27::ThinkCfg& tcfg,
+                                         size_t* stable_off,
+                                         size_t* sys_off) {
+        tchoice=q27::parse_anthropic_tool_choice(body);
+        json all_tools=q27::anthropic_tools_json(body);
+        json normalized={{"tools",all_tools}};
+        q27::OpenAIToolSelection selected=q27::select_openai_tools(normalized,tchoice);
+        const json unavailable=q27::unselected_openai_tools(all_tools,selected);
+        // Only eligible schemas enter the callable interface; the rest remain
+        // in a separately labelled accounting block.
+        tools=std::move(selected.tools);
+        tool_names=std::move(selected.names);
+        tcfg=q27::resolve_think_cfg(body,!no_think_srv,req_think,-1);
+        q27::validate_anthropic_tool_choice_thinking(tchoice,tcfg);
+        thinking=tcfg.enabled;
+        if(tchoice.mode==q27::ToolChoice::FORCED) {
+            thinking=false;
+            tcfg=q27::ThinkCfg{false,-1,false,true};
+        }
+        std::string rendered=q27::chatml_prompt(
+            q27::anthropic_msgs(body),tools,thinking,stable_off,sys_off,
+            q27::anthropic_tool_choice_instruction(tchoice),&unavailable);
+        if(tchoice.mode==q27::ToolChoice::FORCED) rendered+="<tool_call>\n";
+        return rendered;
+    };
+
     // Claude Code calls this before compaction decisions; a 404 here means
     // CC estimates context blind and only discovers overflow by erroring.
     // Count = exactly what /v1/messages would prefill for the same body
@@ -1998,9 +2085,19 @@ int main(int argc, char** argv) {
             anthropic_400(res, "messages: Field required");
             return;
         }
-        std::string rendered = q27::chatml_prompt(
-            q27::anthropic_msgs(body), q27::anthropic_tools_json(body),
-            q27::resolve_think(body, !no_think_srv, req_think));
+        q27::ToolChoice tchoice;
+        json tools;
+        std::vector<std::string> tool_names;
+        bool thinking=false;
+        q27::ThinkCfg tcfg;
+        std::string rendered;
+        try {
+            rendered=prepare_anthropic_prompt(
+                body,tchoice,tools,tool_names,thinking,tcfg,nullptr,nullptr);
+        } catch(const std::exception& e) {
+            anthropic_400(res,e.what());
+            return;
+        }
         json out = {{"input_tokens", (long)tok.encode(rendered).size()}};
         res.set_content(jdump(out), "application/json");
     });
@@ -2011,21 +2108,25 @@ int main(int argc, char** argv) {
         catch (...) { anthropic_400(res, "invalid JSON body"); return; }
         int n_max = (int)q27::jint(body, "max_tokens", 8192); // unified default (see /v1/chat/completions)
         bool stream = q27::jbool(body, "stream", false);
-        json tools = q27::anthropic_tools_json(body);
-        std::vector<std::string> tool_names_v;
-        if (constrain_tools && tools.is_array())
-            for (auto& t : tools)
-                if (t.contains("function") && t["function"].contains("name"))
-                    tool_names_v.push_back(t["function"]["name"].get<std::string>());
         auto tk0 = std::chrono::steady_clock::now();
-        size_t stable_off = 0;
-        int sys_len = 0; // P16b: system-block tokens (0 = none/feature off)
-        q27::ThinkCfg tcfg = q27::resolve_think_cfg(body, !no_think_srv, req_think, -1);
-        bool thinking = tcfg.enabled;
-        size_t sys_off = 0;
-        std::string rendered = q27::chatml_prompt(q27::anthropic_msgs(body), tools, thinking,
-                                                  &stable_off, &sys_off);
+        q27::ToolChoice tchoice;
+        json tools;
+        std::vector<std::string> tool_names_v;
+        bool thinking=false;
+        q27::ThinkCfg tcfg;
+        size_t stable_off=0, sys_off=0;
+        std::string rendered;
+        try {
+            rendered=prepare_anthropic_prompt(
+                body,tchoice,tools,tool_names_v,thinking,tcfg,&stable_off,&sys_off);
+        } catch(const std::exception& e) {
+            anthropic_400(res,e.what());
+            return;
+        }
         auto tk1 = std::chrono::steady_clock::now();
+        const std::set<std::string> allowed_tool_names(
+            tool_names_v.begin(),tool_names_v.end());
+        int sys_len = 0; // P16b: system-block tokens (0 = none/feature off)
         // P8: split-encode at the stable boundary. Both turns encode the
         // shared history with the same split (the boundary always abuts the
         // <|im_start|> special, so tokenization is split-invariant there),
@@ -2104,27 +2205,28 @@ int main(int argc, char** argv) {
             StreamSplitter sp;
             q27::ThinkBudgetState tb{think_budget};
             Engine::DecodeTask bt;
-            if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
+            if(tchoice.mode==q27::ToolChoice::FORCED) sp.chan=StreamSplitter::TOOL;
+            else if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected opener
             ReasoningBudgetObserver budget{tok, tb, eng, bt, think_close_ids, sp.chan};
             budget.start();
             q27::Utf8Gate ugate;
-            std::string think, text, tool_buf;
-            std::vector<q27::ToolCall> calls;
-            auto flush_tool = [&]() {
-                auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
-                tool_buf.clear();
-                if (c.ok) calls.push_back(std::move(c));
-                else text += c.raw; // stream parity: preserve generation order
-            };
+            std::vector<std::pair<StreamSplitter::Chan,std::string>> segments;
             auto route = [&](StreamSplitter::Chan ch, const std::string& t) {
-                if (ch == StreamSplitter::TOOL) { tool_buf += t; return; }
-                if (!tool_buf.empty()) flush_tool();
-                (ch == StreamSplitter::THINK ? think : text) += t;
+                if (t.empty()) {
+                    if (ch != StreamSplitter::TOOL && !segments.empty() &&
+                        segments.back().first == StreamSplitter::TOOL)
+                        segments.emplace_back(ch, std::string());
+                    return;
+                }
+                if (!segments.empty() && segments.back().first == ch)
+                    segments.back().second += t;
+                else segments.emplace_back(ch, t);
             };
             ToolConstrainer tc;
             tc.eng = &eng; tc.tok = &tok; tc.cache = &tool_mask_cache;
             tc.host2dev = &sl.tool_mask_host2dev;
-            tc.enabled = constrain_tools && eng.samp.inv_temp <= 0.f; // constrained+sampled is Phase 3
+            tc.enabled = constrain_tools && tchoice.mode!=q27::ToolChoice::FORCED &&
+                         eng.samp.inv_temp <= 0.f; // constrained+sampled is Phase 3
             tc.begin(tool_names_v);
             eng.on_pending = [&](int id) { tc.on_pending(id); };
             eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
@@ -2175,43 +2277,48 @@ int main(int argc, char** argv) {
                 return;
             }
             for (auto& [ch, t] : sp.feed(ugate.flush())) route(ch, t);
+            const bool final_tool_incomplete=q27::unfinished_tool_wrapper(
+                n,n_max,bt.budget_truncated,sp.chan);
             for (auto& [ch, t] : sp.flush()) route(ch, t);
-            if (!tool_buf.empty()) flush_tool();
-
+            std::string unclosed_tool=q27::take_unclosed_final_tool_segment(
+                segments,final_tool_incomplete);
+            auto ordered = q27::resolve_ordered_tool_segments(
+                segments, tools.is_array() && !tools.empty() ? &tools : nullptr,
+                n < n_max && !bt.budget_truncated,
+                [&](const std::string& name, size_t accepted) {
+                    return q27::tool_choice_allows_call(
+                        tchoice,allowed_tool_names,name,accepted);
+                });
+            ordered.append_visible_text(unclosed_tool);
             json content = json::array();
-            std::string th = think, tx = text;
+            std::string th = q27::strip_ws2(ordered.reasoning);
             if (!th.empty())
                 content.push_back({{"type", "thinking"}, {"thinking", th},
                                    {"signature", "q27-local"}});
-            bool any_call = false;
-            int ci = 0;
-            for (auto& c : calls) {
-                any_call = true;
-                (void)ci;
+            const bool any_call = !ordered.calls.empty();
+            if(q27::forced_tool_choice_missing_is_error(
+                    tchoice,any_call,n>=n_max || bt.budget_truncated)) {
+                res.status=500;
+                res.set_content(q27::anthropic_error_json(
+                    "api_error","model produced no eligible tool call for forced tool_choice"),
+                    "application/json");
+                return;
             }
-            if (tools.is_array() && !tools.empty()) {
-                // wrapper-less call recovery (see parse_bare_tool_calls)
-                std::string pre;
-                auto bcs = q27::parse_bare_tool_calls(tx, &pre, &tools);
-                if (!bcs.empty()) {
-                    fprintf(stderr, "[tool-fallback] %zu bare call(s) recovered (nonstream)\n",
-                            bcs.size());
-                    tx = pre;
-                    for (auto& bc : bcs) calls.push_back(bc);
-                    any_call = true;
-                }
-            }
-            if (!tx.empty() || (!any_call && th.empty()))
-                content.push_back({{"type", "text"}, {"text", tx}});
-            for (auto& c : calls)
-                if (c.ok)
-                    content.push_back({{"type", "tool_use"},
-                                       {"id", "toolu_q27_" + std::to_string(rid) + "_" +
-                                                  std::to_string(ci++)},
-                                       {"name", c.name}, {"input", c.arguments}});
-            const char* sr = any_call ? "tool_use"
-                                      : ((n >= n_max || bt.budget_truncated)
-                                             ? "max_tokens" : "end_turn");
+            if (ordered.recovered)
+                fprintf(stderr, "[tool-fallback] %zu bare call(s) recovered (nonstream)\n",
+                        ordered.recovered);
+            const size_t emitted=q27::append_anthropic_ordered_content(
+                content,ordered,[&](const q27::ToolCall& call,size_t call_number) {
+                    return json{{"type","tool_use"},
+                                {"id","toolu_q27_"+std::to_string(rid)+"_"+
+                                      std::to_string(call_number)},
+                                {"name",call.name},{"input",call.arguments}};
+                });
+            if(emitted==0 && !any_call && th.empty())
+                content.push_back({{"type","text"},{"text",""}});
+            const bool generation_truncated=n>=n_max || bt.budget_truncated;
+            const char* sr=q27::anthropic_tool_stop_reason(
+                any_call,final_tool_incomplete,generation_truncated);
             json out = {{"id", mid}, {"type", "message"}, {"role", "assistant"},
                         {"model", served_name}, {"content", content},
                         {"stop_reason", sr}, {"stop_sequence", nullptr},
@@ -2229,8 +2336,9 @@ int main(int argc, char** argv) {
         res.set_chunked_content_provider(
             "text/event-stream",
             // by-value or dangling: see the /v1/chat/completions twin
-            [&, samp, prompt, n_max, mid, rid, has_tools, tool_names_v, tools, stable_len, rt,
-             thinking, tcfg, sys_len](size_t, httplib::DataSink& sink) {
+            [&, samp, prompt, n_max, mid, rid, has_tools, tool_names_v,
+             allowed_tool_names, tchoice, tools, stable_len, rt, thinking, tcfg,
+             sys_len](size_t, httplib::DataSink& sink) {
                 Slot& sl = claim_slot(prompt, n_max, thinking, tcfg, true);
                 auto sl_lease = slot_guard(sl);
                 Engine& eng = *sl.eng;
@@ -2249,7 +2357,8 @@ int main(int argc, char** argv) {
                 ToolConstrainer tc;
                 tc.eng = &eng; tc.tok = &tok; tc.cache = &tool_mask_cache;
                 tc.host2dev = &sl.tool_mask_host2dev;
-                tc.enabled = constrain_tools && eng.samp.inv_temp <= 0.f; // constrained+sampled is Phase 3
+                tc.enabled = constrain_tools && tchoice.mode!=q27::ToolChoice::FORCED &&
+                             eng.samp.inv_temp <= 0.f; // constrained+sampled is Phase 3
                 tc.begin(tool_names_v);
                 int block_counter = 0, tool_counter = 0;
                 bool any_call = false;
@@ -2269,10 +2378,12 @@ int main(int argc, char** argv) {
                 StreamSplitter sp;
                 q27::ThinkBudgetState tb{think_budget};
                 Engine::DecodeTask bt;
-                if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
+                if(tchoice.mode==q27::ToolChoice::FORCED) sp.chan=StreamSplitter::TOOL;
+                else if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected opener
                 ReasoningBudgetObserver budget{tok, tb, eng, bt, think_close_ids, sp.chan};
                 budget.start();
-                std::string tool_buf, text_accum;
+                std::string tool_buf;
+                q27::BareToolTextHoldback bare_text;
                 q27::Utf8Gate ugate;
                 int idx = -1;       // open think/text block index, -1 = none
                 int chan_open = -1; // 0 text, 1 think
@@ -2297,17 +2408,18 @@ int main(int argc, char** argv) {
                         any = true;
                     }
                 };
-                auto emit_tool = [&]() {
-                    auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
-                    tool_buf.clear();
-                    if (!c.ok) { // malformed: surface as text so nothing is lost
-                        open_block(0);
-                        text_accum += c.raw;
-                        ev("content_block_delta", {{"type", "content_block_delta"}, {"index", idx},
-                            {"delta", {{"type", "text_delta"}, {"text", c.raw}}}});
-                        return;
-                    }
+                auto emit_text = [&](const std::string& t) {
+                    if (t.empty()) return;
+                    open_block(0);
+                    ev("content_block_delta", {{"type", "content_block_delta"}, {"index", idx},
+                        {"delta", {{"type", "text_delta"}, {"text", t}}}});
+                };
+                auto emit_call = [&](const q27::ToolCall& c) {
+                    if (!c.ok || !q27::tool_choice_allows_call(
+                            tchoice,allowed_tool_names,c.name,any_call?1u:0u))
+                        return false;
                     any_call = true;
+                    any = true;
                     close_block();
                     int ti = block_counter++;
                     std::string tid = "toolu_q27_" + std::to_string(rid) + "_" +
@@ -2321,24 +2433,63 @@ int main(int argc, char** argv) {
                         {"delta", {{"type", "input_json_delta"},
                                    {"partial_json", jdump(c.arguments)}}}});
                     ev("content_block_stop", {{"type", "content_block_stop"}, {"index", ti}});
+                    return true;
+                };
+                auto classify_bare = [&](const std::string& source,bool allow_repair,
+                                         auto&& visible) {
+                    std::string pre,residual;
+                    auto calls=q27::parse_bare_tool_calls(
+                        source,&pre,&tools,true,allow_repair,&residual);
+                    if (calls.empty()) return q27::BareToolCandidateResult{};
+                    size_t cursor=0,recovered=0;
+                    for (const auto& call:calls) {
+                        visible(source.substr(cursor,call.source_begin-cursor));
+                        cursor=call.source_end;
+                        if (emit_call(call)) recovered++;
+                        else visible(source.substr(
+                            call.source_begin,call.source_end-call.source_begin));
+                    }
+                    visible(source.substr(cursor));
+                    if(recovered)
+                        fprintf(stderr,"[tool-fallback] %zu bare call(s) recovered (stream)\n",
+                                recovered);
+                    return q27::BareToolCandidateResult{true,recovered!=0};
+                };
+                auto emit_tool = [&]() {
+                    auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
+                    tool_buf.clear();
+                    if (!c.ok) {
+                        if (!classify_bare(c.raw,true,emit_text)) emit_text(c.raw);
+                    } else if (!emit_call(c)) emit_text(c.raw);
                 };
                 bool forced_control_token = false;
                 auto emit_seg = [&](StreamSplitter::Chan ch, const std::string& t) {
-                    if (ch == StreamSplitter::TOOL) { tool_buf += t; return; }
+                    if (ch == StreamSplitter::TOOL) {
+                        if(tool_buf.empty()) {
+                            bare_text.finish(false,allowed_tool_names,
+                                             emit_text,classify_bare);
+                            bare_text.reset_context();
+                        }
+                        tool_buf += t;
+                        return;
+                    }
                     if (!tool_buf.empty()) emit_tool();
                     if (t.empty()) return;
-                    int chan = ch == StreamSplitter::THINK ? 1 : 0;
+                    const bool think = ch == StreamSplitter::THINK;
                     // Injected template whitespace is parser control; model
                     // whitespace, including after a natural close, is content.
-                    if (chan == 0 && forced_control_token && q27::strip_ws2(t).empty()) return;
-                    open_block(chan);
-                    if (chan == 0) text_accum += t;
-                    if (chan == 1)
+                    if (!think && forced_control_token && q27::strip_ws2(t).empty()) return;
+                    if (think) {
+                        bare_text.finish(false,allowed_tool_names,
+                                         emit_text,classify_bare);
+                        bare_text.reset_context();
+                        open_block(1);
                         ev("content_block_delta", {{"type", "content_block_delta"}, {"index", idx},
                             {"delta", {{"type", "thinking_delta"}, {"thinking", t}}}});
-                    else
-                        ev("content_block_delta", {{"type", "content_block_delta"}, {"index", idx},
-                            {"delta", {{"type", "text_delta"}, {"text", t}}}});
+                    } else if (has_tools) {
+                        bare_text.route(t,allowed_tool_names,
+                                        emit_text,classify_bare);
+                    } else emit_text(t);
                 };
                 eng.on_pending = [&](int id) { tc.on_pending(id); };
                 eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
@@ -2374,37 +2525,18 @@ int main(int argc, char** argv) {
                 eng.on_round_gap = nullptr;
                 req_log(rt, qw, eng, sl.id, tg_stats(tc) + bat_stats(bt));
                 for (auto& [ch, t] : sp.feed(ugate.flush())) emit_seg(ch, t);
+                const bool final_tool_incomplete=q27::unfinished_tool_wrapper(
+                    produced,nm,bt.budget_truncated,sp.chan);
                 for (auto& [ch, t] : sp.flush()) emit_seg(ch, t);
-                if (!tool_buf.empty()) emit_tool();
-                if (has_tools) {
-                    // wrapper-less call recovery: text already streamed as
-                    // text_delta (cosmetic); the tool_use blocks still fire
-                    std::string pre;
-                    auto bcs = q27::parse_bare_tool_calls(text_accum, &pre, &tools);
-                    if (!bcs.empty()) {
-                        fprintf(stderr, "[tool-fallback] %zu bare call(s) recovered (stream)\n",
-                                bcs.size());
-                        any_call = true;
-                        any = true;
-                        close_block();
-                        for (auto& bc : bcs) {
-                            int ti = block_counter++;
-                            std::string tid = "toolu_q27_" + std::to_string(rid) + "_" +
-                                              std::to_string(tool_counter++);
-                            ev("content_block_start",
-                               {{"type", "content_block_start"}, {"index", ti},
-                                {"content_block", {{"type", "tool_use"}, {"id", tid},
-                                                   {"name", bc.name},
-                                                   {"input", json::object()}}}});
-                            ev("content_block_delta",
-                               {{"type", "content_block_delta"}, {"index", ti},
-                                {"delta", {{"type", "input_json_delta"},
-                                           {"partial_json", jdump(bc.arguments)}}}});
-                            ev("content_block_stop",
-                               {{"type", "content_block_stop"}, {"index", ti}});
-                        }
-                    }
+                if (!tool_buf.empty()) {
+                    if (final_tool_incomplete) {
+                        emit_text(tool_buf);
+                        tool_buf.clear();
+                    } else emit_tool();
                 }
+                if(!final_tool_incomplete)
+                    bare_text.finish(produced<nm && !bt.budget_truncated,
+                                     allowed_tool_names,emit_text,classify_bare);
                 if (idx < 0 && !any) { // nothing at all: empty text block for validity
                     idx = block_counter++;
                     chan_open = 0;
@@ -2419,12 +2551,17 @@ int main(int argc, char** argv) {
                 // reading a silent early end_turn. message_delta/message_stop
                 // still follow: error-aware clients abort at the event,
                 // naive ones still get a well-formed stream.
-                if (!berr.empty())
+                const bool forced_tool_missing=q27::forced_tool_choice_missing_is_error(
+                    tchoice,any_call,produced>=nm || bt.budget_truncated);
+                if (!berr.empty() || forced_tool_missing)
                     ev("error", {{"type", "error"},
-                                 {"error", {{"type", "api_error"}, {"message", berr}}}});
-                const char* sr = any_call ? "tool_use"
-                                          : ((produced >= nm || bt.budget_truncated)
-                                                 ? "max_tokens" : "end_turn");
+                                 {"error", {{"type", "api_error"},
+                                    {"message", forced_tool_missing
+                                        ? "model produced no eligible tool call for forced tool_choice"
+                                        : berr}}}});
+                const char* sr=q27::anthropic_tool_stop_reason(
+                    any_call,final_tool_incomplete,
+                    produced>=nm || bt.budget_truncated);
                 ev("message_delta", {{"type", "message_delta"},
                                      {"delta", {{"stop_reason", sr}, {"stop_sequence", nullptr}}},
                                      {"usage", {{"output_tokens", produced},
@@ -2454,24 +2591,42 @@ int main(int argc, char** argv) {
         std::string resp_id = "resp_q27_" + std::to_string(rid);
 
         // tools: flat function entries pass through; `custom` freeform tools
-        // (apply_patch) are bridged to a one-string-param function; hosted tool
-        // types (web_search etc.) are skipped, never rejected.
+        // (apply_patch) are bridged to a one-string-param function. The legacy
+        // `shell` hosted form expands to the concrete client-executed functions;
+        // other hosted types remain client-side but still govern output eligibility.
         json tools = json::array();
         std::set<std::string> custom_names;
+        std::set<std::string> hosted_tool_types;
+        std::set<std::string> declared_tool_names;
+        std::set<std::string> function_names;
+        bool duplicate_tool_name = false;
+        try {
+            q27::validate_responses_tool_fields(body);
+        } catch(const std::exception& e) {
+            res.status=400;
+            res.set_content(json{{"error",{{"message",e.what()},
+                                             {"type","invalid_request_error"}}}}.dump(),
+                            "application/json");
+            return;
+        }
         if (body.contains("tools") && body["tools"].is_array())
             for (auto& t : body["tools"]) {
                 if (!t.is_object()) continue; // value() on a non-object throws 306
-                std::string ty = t.value("type", "");
+                std::string ty = q27::jstr(t, "type");
                 if (ty == "function") {
+                    std::string fn = q27::jstr(t, "name");
+                    if (!declared_tool_names.insert(fn).second) duplicate_tool_name = true;
+                    function_names.insert(fn);
                     tools.push_back({{"type", "function"},
-                                     {"function", {{"name", t.value("name", "")},
-                                                   {"description", t.value("description", "")},
+                                     {"function", {{"name", fn},
+                                                   {"description", q27::jstr(t, "description")},
                                                    {"parameters", t.contains("parameters")
                                                                       ? t["parameters"]
                                                                       : json::object()}}}});
                 } else if (ty == "custom") {
-                    std::string cn = t.value("name", "");
+                    std::string cn = q27::jstr(t, "name");
                     custom_names.insert(cn);
+                    if (!declared_tool_names.insert(cn).second) duplicate_tool_name = true;
                     json params = {{"type", "object"},
                                    {"properties",
                                     {{"input", {{"type", "string"},
@@ -2480,10 +2635,82 @@ int main(int argc, char** argv) {
                                    {"required", json::array({"input"})}};
                     tools.push_back({{"type", "function"},
                                      {"function", {{"name", cn},
-                                                   {"description", t.value("description", "")},
+                                                   {"description", q27::jstr(t, "description")},
                                                    {"parameters", params}}}});
+                } else if (!ty.empty()) {
+                    hosted_tool_types.insert(ty);
+                    if (ty == "shell")
+                        for (auto& shell_tool : q27::responses_shell_prompt_tools()) {
+                            const std::string name =
+                                shell_tool["function"]["name"].get<std::string>();
+                            if (!declared_tool_names.insert(name).second)
+                                duplicate_tool_name = true;
+                            tools.push_back(std::move(shell_tool));
+                        }
                 }
             }
+
+        q27::ToolChoice tchoice;
+        std::vector<std::string> tool_names_v;
+        std::set<std::string> allowed_hosted_names;
+        try {
+            if (duplicate_tool_name)
+                throw std::runtime_error("ambiguous duplicate Responses tool name");
+            if (q27::responses_tool_names_ambiguous(
+                    function_names, custom_names, hosted_tool_types))
+                throw std::runtime_error("ambiguous duplicate Responses tool name");
+            q27::validate_responses_tool_choice_declarations(
+                body, function_names, custom_names, hosted_tool_types);
+            json selection_body = body;
+            selection_body["tools"] = tools;
+            tchoice = q27::parse_responses_tool_choice(selection_body);
+            q27::apply_openai_parallel_tool_calls(body, tchoice);
+            if (tchoice.invalid)
+                throw std::runtime_error("invalid tool_choice or parallel_tool_calls");
+
+            q27::ToolChoice local_choice =
+                q27::responses_registered_tool_choice(tchoice, hosted_tool_types);
+            if (local_choice.mode == q27::ToolChoice::FORCED &&
+                local_choice.forced_name.empty() && local_choice.allowed_names.empty() &&
+                tools.empty() && !hosted_tool_types.empty())
+                local_choice.mode = q27::ToolChoice::NONE;
+            q27::OpenAIToolSelection selected =
+                q27::select_openai_tools(selection_body, local_choice);
+            tools = std::move(selected.tools);
+            tool_names_v = std::move(selected.names);
+
+            if (tchoice.mode != q27::ToolChoice::NONE) {
+                auto allow_hosted = [&](const std::string& type) {
+                    q27::add_responses_hosted_call_names(allowed_hosted_names, type);
+                };
+                if (!tchoice.forced_name.empty()) {
+                    if (hosted_tool_types.count(tchoice.forced_name))
+                        allow_hosted(tchoice.forced_name);
+                } else if (!tchoice.allowed_names.empty()) {
+                    for (const auto& name : tchoice.allowed_names)
+                        if (hosted_tool_types.count(name)) allow_hosted(name);
+                } else {
+                    for (const auto& type : hosted_tool_types) allow_hosted(type);
+                }
+            }
+            if (tchoice.mode == q27::ToolChoice::FORCED && tool_names_v.empty() &&
+                allowed_hosted_names.empty())
+                throw std::runtime_error("tool_choice requires at least one supported tool");
+            const std::set<std::string> selected_names(tool_names_v.begin(), tool_names_v.end());
+            for (auto it = custom_names.begin(); it != custom_names.end();)
+                if (!selected_names.count(*it)) it = custom_names.erase(it);
+                else ++it;
+        } catch (const std::exception& e) {
+            res.status = 400;
+            res.set_content(json{{"error",{{"message",e.what()},
+                                             {"type","invalid_request_error"}}}}.dump(),
+                            "application/json");
+            return;
+        }
+        std::set<std::string> eligible_call_names(tool_names_v.begin(), tool_names_v.end());
+        eligible_call_names.insert(allowed_hosted_names.begin(), allowed_hosted_names.end());
+        q27::ToolChoice response_choice =
+            q27::responses_registered_tool_choice(tchoice, hosted_tool_types);
 
         // input -> messages. instructions is the system prompt.
         std::vector<Msg> msgs;
@@ -2542,8 +2769,13 @@ int main(int argc, char** argv) {
         auto tk0 = std::chrono::steady_clock::now();
         q27::ThinkCfg tcfg = q27::resolve_think_cfg(body, !no_think_srv, req_think, -1);
         bool thinking = tcfg.enabled;
+        if (tchoice.mode == q27::ToolChoice::FORCED) {
+            thinking = false;
+            tcfg = q27::ThinkCfg{false, -1, false, true};
+        }
         size_t sys_off = 0;
-        const std::string rendered = q27::chatml_prompt(merged, tools, thinking, nullptr, &sys_off);
+        std::string rendered = q27::chatml_prompt(merged, tools, thinking, nullptr, &sys_off);
+        if (tchoice.mode == q27::ToolChoice::FORCED) rendered += "<tool_call>\n";
         std::vector<int> prompt = tok.encode(rendered);
         // P16b applies here even though P16a does not: this shape computes no
         // stable_off (so it never persists a stable entry), but a system+tools
@@ -2580,59 +2812,77 @@ int main(int argc, char** argv) {
         struct GenOut { json items = json::array(); int produced = 0; };
         auto make_item_cbs = [&](json& items, int& tool_counter,
                                  std::function<bool(const std::string&)> on_text_delta) {
-            // returns the segment router; caller finishes with finish()
+            (void)on_text_delta;
             struct Ctx {
                 std::string think, text, tool_buf;
+                int message_counter=0,reason_counter=0;
+                bool tool_tail=false;
             };
-            auto ctx = std::make_shared<Ctx>();
-            auto flush_think = [&items, ctx, rid]() {
-                std::string th = ctx->think;
+            auto ctx=std::make_shared<Ctx>();
+            auto flush_think=[&items,ctx,rid]() {
+                std::string th=q27::strip_ws2(ctx->think);
                 ctx->think.clear();
-                if (th.empty()) return json();
-                json r = {{"type", "reasoning"}, {"id", "rs_q27_" + std::to_string(rid)},
-                          {"summary", json::array({{{"type", "summary_text"}, {"text", th}}})},
-                          {"encrypted_content", nullptr}};
-                items.push_back(r);
-                return r;
+                if(th.empty()) return json();
+                ctx->tool_tail=false;
+                json item={{"type","reasoning"},
+                           {"id","rs_q27_"+std::to_string(rid)+"_"+
+                                 std::to_string(ctx->reason_counter++)},
+                           {"status","completed"},
+                           {"summary",json::array({{{"type","summary_text"},{"text",th}}})},
+                           {"encrypted_content",nullptr}};
+                items.push_back(item);
+                return item;
             };
-            auto flush_text = [&items, ctx, rid](bool incomplete=false) {
-                std::string tx = ctx->text;
-                ctx->text.clear();
-                if (tx.empty()) return json();
-                json m = {{"type", "message"}, {"id", "msg_q27_" + std::to_string(rid)},
-                          {"role", "assistant"}, {"status", incomplete ? "incomplete" : "completed"},
-                          {"content",
-                           json::array({{{"type", "output_text"}, {"text", tx},
-                                         {"annotations", json::array()}}})}};
-                items.push_back(m);
-                return m;
+            auto push_text=[&items,rid,ctx](const std::string& tx,bool incomplete=false) {
+                if(tx.empty()) return json();
+                ctx->tool_tail=false;
+                json item={{"type","message"},
+                           {"id","msg_q27_"+std::to_string(rid)+"_"+
+                                 std::to_string(ctx->message_counter++)},
+                           {"role","assistant"},
+                           {"status",incomplete?"incomplete":"completed"},
+                           {"content",json::array({{{"type","output_text"},{"text",tx},
+                                                    {"annotations",json::array()}}})}};
+                items.push_back(item);
+                return item;
             };
-            auto flush_tool = [&items, ctx, rid, &tool_counter, &custom_names](bool incomplete=false) {
-                auto c = q27::parse_tool_call(q27::strip_ws2(ctx->tool_buf));
-                ctx->tool_buf.clear();
-                std::string cid = "call_q27_" + std::to_string(rid) + "_" +
-                                  std::to_string(tool_counter++);
-                json it;
-                if (!c.ok) { // malformed call: surface as text so codex shows it
-                    it = {{"type", "message"}, {"role", "assistant"},
-                          {"status", incomplete ? "incomplete" : "completed"},
-                          {"content", json::array({{{"type", "output_text"}, {"text", c.raw},
-                                                    {"annotations", json::array()}}})}};
-                } else if (custom_names.count(c.name)) {
-                    std::string input = c.arguments.is_object() && c.arguments.contains("input") &&
-                                                c.arguments["input"].is_string()
-                                            ? c.arguments["input"].get<std::string>()
-                                            : jdump(c.arguments);
-                    it = {{"type", "custom_tool_call"}, {"call_id", cid}, {"name", c.name},
-                          {"input", input}};
+            auto flush_text=[ctx,push_text](bool incomplete=false) {
+                return push_text(q27::take_responses_output_text(ctx->text),incomplete);
+            };
+            auto emit_tool=[&items,rid,&tool_counter,&custom_names,
+                            &response_choice,&eligible_call_names,ctx,push_text](q27::ToolCall c) {
+                if(!c.ok || !q27::tool_choice_allows_call(
+                        response_choice,eligible_call_names,c.name,tool_counter))
+                    return push_text(c.raw);
+                const int call_index=tool_counter++;
+                const std::string cid="call_q27_"+std::to_string(rid)+"_"+
+                                      std::to_string(call_index);
+                const std::string iid="fc_q27_"+std::to_string(rid)+"_"+
+                                      std::to_string(call_index);
+                json item;
+                if(custom_names.count(c.name)) {
+                    std::string input=c.arguments.is_object() && c.arguments.contains("input") &&
+                                              c.arguments["input"].is_string()
+                                          ?c.arguments["input"].get<std::string>()
+                                          :jdump(c.arguments);
+                    item={{"type","custom_tool_call"},{"id",iid},{"call_id",cid},
+                          {"status","completed"},{"name",c.name},{"input",input}};
                 } else {
-                    it = {{"type", "function_call"}, {"call_id", cid}, {"name", c.name},
-                          {"arguments", jdump(c.arguments)}};
+                    item={{"type","function_call"},{"id",iid},{"call_id",cid},
+                          {"status","completed"},{"name",c.name},
+                          {"arguments",jdump(c.arguments)}};
                 }
-                items.push_back(it);
-                return it;
+                ctx->tool_tail=true;
+                items.push_back(item);
+                return item;
             };
-            return std::make_tuple(ctx, flush_think, flush_text, flush_tool);
+            auto flush_tool=[ctx,emit_tool]() {
+                auto c=q27::parse_tool_call(q27::strip_ws2(ctx->tool_buf));
+                ctx->tool_buf.clear();
+                return emit_tool(std::move(c));
+            };
+            return std::make_tuple(ctx,flush_think,flush_text,flush_tool,
+                                   emit_tool,push_text);
         };
 
         if (!stream) {
@@ -2658,10 +2908,54 @@ int main(int argc, char** argv) {
             auto& flush_think = std::get<1>(item_cbs);
             auto& flush_text = std::get<2>(item_cbs);
             auto& flush_tool = std::get<3>(item_cbs);
+            auto& emit_tool = std::get<4>(item_cbs);
+            auto& push_text = std::get<5>(item_cbs);
+            auto flush_recoverable_text=[&](bool allow_repair,bool incomplete) {
+                std::string source=q27::take_responses_output_text(ctx->text);
+                if(source.empty()) return;
+                std::string pre,residual;
+                auto calls=q27::parse_bare_tool_calls(source, &pre, tools.empty()?nullptr:&tools, true, allow_repair, &residual);
+                if(calls.empty()) {
+                    push_text(source,incomplete);
+                    return;
+                }
+                std::vector<bool> accepted(calls.size(),false);
+                size_t accepted_calls=tool_counter;
+                std::ptrdiff_t last_accepted=-1;
+                for(size_t i=0;i<calls.size();i++) {
+                    accepted[i]=calls[i].ok && q27::tool_choice_allows_call(
+                        response_choice,eligible_call_names,calls[i].name,
+                        accepted_calls);
+                    if(accepted[i]) {
+                        accepted_calls++;
+                        last_accepted=(std::ptrdiff_t)i;
+                    }
+                }
+                size_t cursor=0,recovered=0;
+                for(size_t i=0;i<calls.size();i++) {
+                    auto& call=calls[i];
+                    const bool segment_incomplete=incomplete &&
+                        last_accepted<(std::ptrdiff_t)i;
+                    push_text(source.substr(cursor,call.source_begin-cursor),
+                              segment_incomplete);
+                    cursor=call.source_end;
+                    if(accepted[i]) {
+                        emit_tool(std::move(call));
+                        recovered++;
+                    } else push_text(source.substr(call.source_begin,
+                                                   call.source_end-call.source_begin),
+                                     segment_incomplete);
+                }
+                push_text(source.substr(cursor),incomplete);
+                if(recovered)
+                    fprintf(stderr,"[tool-fallback] %zu bare call(s) recovered (resp nonstream)\n",
+                            recovered);
+            };
             StreamSplitter sp;
             q27::ThinkBudgetState tb{think_budget};
             Engine::DecodeTask bt;
-            if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
+            if (tchoice.mode == q27::ToolChoice::FORCED) sp.chan = StreamSplitter::TOOL;
+            else if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected opener
             ReasoningBudgetObserver budget{tok, tb, eng, bt, think_close_ids, sp.chan};
             budget.start();
             eng.on_round = [&](const int* em, int nr) {
@@ -2670,13 +2964,15 @@ int main(int argc, char** argv) {
             auto route = [&](StreamSplitter::Chan ch, const std::string& t) {
                 if (ch == StreamSplitter::TOOL) {
                     if (!ctx->think.empty()) flush_think();
-                    if (!ctx->text.empty()) flush_text();
+                    if (!ctx->text.empty()) flush_recoverable_text(false,false);
                     ctx->tool_buf += t;
                     return;
                 }
                 if (!ctx->tool_buf.empty()) flush_tool();
-                if (ch == StreamSplitter::THINK) ctx->think += t;
-                else {
+                if (ch == StreamSplitter::THINK) {
+                    if (!ctx->text.empty()) flush_recoverable_text(false,false);
+                    ctx->think += t;
+                } else {
                     if (!ctx->think.empty()) flush_think();
                     ctx->text += t;
                 }
@@ -2713,13 +3009,37 @@ int main(int argc, char** argv) {
                                 "application/json");
                 return;
             }
-            const auto terminal = q27::responses_terminal_state(
-                produced, n_max, bt.budget_truncated);
+            const bool token_limit_reached=produced>=n_max || bt.budget_truncated;
             for (auto& [ch, t] : sp.feed(ugate.flush())) route(ch, t);
+            const bool unfinished_tool_wrapper=q27::unfinished_tool_wrapper(
+                produced,n_max,bt.budget_truncated,sp.chan);
             for (auto& [ch, t] : sp.flush()) route(ch, t);
-            if (!ctx->tool_buf.empty()) flush_tool(terminal.incomplete);
+            if (!ctx->tool_buf.empty()) {
+                if (unfinished_tool_wrapper) {
+                    push_text(ctx->tool_buf,true);
+                    ctx->tool_buf.clear();
+                    ctx->tool_tail=false;
+                } else flush_tool();
+            }
             flush_think();
-            flush_text(terminal.incomplete);
+            const std::string& buffered_text=ctx->text;
+            std::string preview_prefix,preview_residual;
+            const bool allow_repair=!token_limit_reached;
+            const auto preview_calls=q27::parse_bare_tool_calls(buffered_text, &preview_prefix, tools.empty()?nullptr:&tools, true, allow_repair, &preview_residual);
+            const bool tool_tail=q27::responses_tool_tail_after_bare_calls(
+                ctx->tool_tail,buffered_text,preview_calls,response_choice,
+                eligible_call_names,tool_counter);
+            const bool limit_reached=token_limit_reached && !tool_tail;
+            const auto terminal=q27::responses_terminal_state(limit_reached);
+            flush_recoverable_text(allow_repair,terminal.incomplete);
+            if (q27::forced_tool_choice_missing_is_error(
+                    tchoice, tool_counter != 0, limit_reached)) {
+                res.status = 500;
+                res.set_content(json{{"error",{{"message","model produced no eligible tool call for forced tool_choice"},
+                                                 {"type","api_error"}}}}.dump(),
+                                "application/json");
+                return;
+            }
             const bool incomplete = terminal.incomplete;
             json out = {{"id", resp_id}, {"object", "response"},
                         {"status", incomplete ? "incomplete" : "completed"},
@@ -2741,7 +3061,8 @@ int main(int argc, char** argv) {
             "text/event-stream",
             // by-value or dangling: see the /v1/chat/completions twin
             [&, samp, prompt, n_max, resp_id, rid, custom_names, tools, rt,
-             thinking, tcfg, sys_len](size_t, httplib::DataSink& sink) {
+             thinking, tcfg, sys_len, tchoice, response_choice,
+             eligible_call_names](size_t, httplib::DataSink& sink) {
                 Slot& sl = claim_slot(prompt, n_max, thinking, tcfg, true);
                 auto sl_lease = slot_guard(sl);
                 Engine& eng = *sl.eng;
@@ -2770,113 +3091,331 @@ int main(int argc, char** argv) {
                     {"response", {{"id", resp_id}, {"object", "response"},
                                   {"status", "in_progress"}}}});
 
-                json items = json::array();
-                int tool_counter = 0;
-                std::set<std::string> cn = custom_names;
-                std::string think, text, tool_buf, text_accum;
-                int out_index = 0;
-                auto item_done = [&](const json& it) {
-                    ev({{"type", "response.output_item.done"}, {"output_index", out_index++},
-                        {"item", it}});
-                    items.push_back(it);
+                json items=json::array();
+                int tool_counter=0,out_index=0;
+                int message_counter=0,reason_counter=0;
+                bool output_tool_tail=false;
+                std::set<std::string> cn=custom_names;
+                std::string think,text,tool_buf,bare_pending,bare_probe,
+                    bare_deferred,bare_deferred_trailing,active_msg_id;
+                bool bare_holding=false,bare_mode10=false,bare_input_final=false;
+                bool bare_deferred_mode10=false,bare_ordinary_call_seen=false;
+
+                q27::IncrementalBareJsonEnd bare_scan;
+                q27::JsonStringLexState bare_text_lex;
+                q27::MarkdownFenceLexState bare_text_fence;
+                auto item_done=[&](const json& item) {
+                    ev({{"type","response.output_item.done"},{"output_index",out_index++},
+                        {"item",item}});
+                    items.push_back(item);
                 };
-                auto flush_think = [&]() {
-                    std::string th = think;
+                auto flush_think=[&]() {
+                    std::string th=q27::strip_ws2(think);
                     think.clear();
-                    if (th.empty()) return;
-                    item_done({{"type", "reasoning"}, {"id", "rs_q27_" + std::to_string(rid)},
-                               {"summary",
-                                json::array({{{"type", "summary_text"}, {"text", th}}})},
-                               {"encrypted_content", nullptr}});
+                    if(th.empty()) return;
+                    output_tool_tail=false;
+                    item_done({{"type","reasoning"},
+                               {"id","rs_q27_"+std::to_string(rid)+"_"+
+                                     std::to_string(reason_counter++)},
+                               {"status","completed"},
+                               {"summary",json::array({{{"type","summary_text"},{"text",th}}})},
+                               {"encrypted_content",nullptr}});
                 };
-                // codex 0.143 enforces the item lifecycle: an output_text.delta
-                // needs an already-OPEN item (else "OutputTextDelta without
-                // active item" and codex aborts the turn -- the T5/T8 failure).
-                // Open the message item + content part before the first delta;
-                // flush closes the full added->delta->done sequence. msg_index
-                // reserves the current out_index while streaming (only one item
-                // is ever open -- route flushes think/text before a tool).
-                const std::string msg_id = "msg_q27_" + std::to_string(rid);
-                int msg_index = -1;
-                auto open_text = [&]() {
-                    if (msg_index >= 0) return;
-                    msg_index = out_index;
-                    ev({{"type", "response.output_item.added"}, {"output_index", msg_index},
-                        {"item", {{"type", "message"}, {"id", msg_id}, {"role", "assistant"},
-                                  {"status", "in_progress"}, {"content", json::array()}}}});
-                    ev({{"type", "response.content_part.added"}, {"item_id", msg_id},
-                        {"output_index", msg_index}, {"content_index", 0},
-                        {"part", {{"type", "output_text"}, {"text", ""},
-                                  {"annotations", json::array()}}}});
+                int msg_index=-1;
+                auto open_text=[&]() {
+                    if(msg_index>=0) return;
+                    msg_index=out_index;
+                    active_msg_id="msg_q27_"+std::to_string(rid)+"_"+
+                                  std::to_string(message_counter++);
+                    ev({{"type","response.output_item.added"},{"output_index",msg_index},
+                        {"item",{{"type","message"},{"id",active_msg_id},
+                                  {"role","assistant"},{"status","in_progress"},
+                                  {"content",json::array()}}}});
+                    ev({{"type","response.content_part.added"},{"item_id",active_msg_id},
+                        {"output_index",msg_index},{"content_index",0},
+                        {"part",{{"type","output_text"},{"text",""},
+                                  {"annotations",json::array()}}}});
                 };
-                auto flush_text = [&](bool incomplete=false) {
-                    if (msg_index < 0) { text.clear(); return; }
-                    std::string tx = text;
-                    text.clear();
-                    ev({{"type", "response.output_text.done"}, {"item_id", msg_id},
-                        {"output_index", msg_index}, {"content_index", 0}, {"text", tx}});
-                    ev({{"type", "response.content_part.done"}, {"item_id", msg_id},
-                        {"output_index", msg_index}, {"content_index", 0},
-                        {"part", {{"type", "output_text"}, {"text", tx},
-                                  {"annotations", json::array()}}}});
-                    json it = {{"type", "message"}, {"id", msg_id}, {"role", "assistant"},
-                               {"status", incomplete ? "incomplete" : "completed"},
-                               {"content", json::array({{{"type", "output_text"}, {"text", tx},
-                                                         {"annotations", json::array()}}})}};
-                    ev({{"type", "response.output_item.done"}, {"output_index", msg_index},
-                        {"item", it}});
-                    items.push_back(it);
-                    out_index = msg_index + 1;
-                    msg_index = -1;
+                auto flush_text=[&](bool incomplete=false) {
+                    if(msg_index<0) { text.clear(); return; }
+                    std::string tx=q27::take_responses_output_text(text);
+                    ev({{"type","response.output_text.done"},{"item_id",active_msg_id},
+                        {"output_index",msg_index},{"content_index",0},{"text",tx}});
+                    ev({{"type","response.content_part.done"},{"item_id",active_msg_id},
+                        {"output_index",msg_index},{"content_index",0},
+                        {"part",{{"type","output_text"},{"text",tx},
+                                  {"annotations",json::array()}}}});
+                    json item={{"type","message"},{"id",active_msg_id},
+                               {"role","assistant"},
+                               {"status",incomplete?"incomplete":"completed"},
+                               {"content",json::array({{{"type","output_text"},{"text",tx},
+                                                        {"annotations",json::array()}}})}};
+                    ev({{"type","response.output_item.done"},{"output_index",msg_index},
+                        {"item",item}});
+                    items.push_back(item);
+                    out_index=msg_index+1;
+                    msg_index=-1;
+                    active_msg_id.clear();
                 };
-                auto flush_tool = [&](bool incomplete=false) {
-                    auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
-                    tool_buf.clear();
-                    std::string cid = "call_q27_" + std::to_string(rid) + "_" +
-                                      std::to_string(tool_counter++);
-                    if (!c.ok) {
-                        item_done({{"type", "message"}, {"role", "assistant"},
-                                   {"status", incomplete ? "incomplete" : "completed"},
-                                   {"content",
-                                    json::array({{{"type", "output_text"}, {"text", c.raw},
-                                                  {"annotations", json::array()}}})}});
-                    } else if (cn.count(c.name)) {
-                        std::string input =
-                            c.arguments.is_object() && c.arguments.contains("input") &&
-                                    c.arguments["input"].is_string()
-                                ? c.arguments["input"].get<std::string>()
-                                : jdump(c.arguments);
-                        item_done({{"type", "custom_tool_call"}, {"call_id", cid},
-                                   {"name", c.name}, {"input", input}});
+                auto append_text=[&](const std::string& value) {
+                    if(value.empty()) return;
+                    q27::consume_bare_text_context(
+                        bare_text_lex,bare_text_fence,value);
+                    if(value.find_first_not_of(" \t\r\n")!=std::string::npos)
+                        output_tool_tail=false;
+                    open_text();
+                    text+=value;
+                    ev({{"type","response.output_text.delta"},{"item_id",active_msg_id},
+                        {"output_index",msg_index},{"content_index",0},{"delta",value}});
+                };
+                auto emit_call=[&](q27::ToolCall call) {
+                    if(!call.ok || !q27::tool_choice_allows_call(
+                            response_choice,eligible_call_names,call.name,tool_counter))
+                        return false;
+                    const int call_index=tool_counter++;
+                    const std::string cid="call_q27_"+std::to_string(rid)+"_"+
+                                          std::to_string(call_index);
+                    const std::string iid="fc_q27_"+std::to_string(rid)+"_"+
+                                          std::to_string(call_index);
+                    json item;
+                    if(cn.count(call.name)) {
+                        std::string input=call.arguments.is_object() &&
+                                                  call.arguments.contains("input") &&
+                                                  call.arguments["input"].is_string()
+                                              ?call.arguments["input"].get<std::string>()
+                                              :jdump(call.arguments);
+                        item={{"type","custom_tool_call"},{"id",iid},{"call_id",cid},
+                              {"status","completed"},{"name",call.name},{"input",input}};
                     } else {
-                        item_done({{"type", "function_call"}, {"call_id", cid}, {"name", c.name},
-                                   {"arguments", jdump(c.arguments)}});
+                        item={{"type","function_call"},{"id",iid},{"call_id",cid},
+                              {"status","completed"},{"name",call.name},
+                              {"arguments",jdump(call.arguments)}};
                     }
+                    json added=item;
+                    added["status"]="in_progress";
+                    if(added["type"]=="function_call") added["arguments"]="";
+                    else added["input"]="";
+                    ev({{"type","response.output_item.added"},{"output_index",out_index},
+                        {"item",added}});
+                    if(item["type"]=="function_call")
+                        ev({{"type","response.function_call_arguments.done"},
+                            {"item_id",iid},{"output_index",out_index},
+                            {"name",call.name},{"arguments",item["arguments"]}});
+                    item_done(item);
+                    output_tool_tail=true;
+                    return true;
                 };
-                bool forced_control_token = false;
-                auto route = [&](StreamSplitter::Chan ch, const std::string& t) {
-                    if (ch == StreamSplitter::TOOL) {
-                        if (!think.empty()) flush_think();
-                        if (!text.empty()) flush_text();
-                        tool_buf += t;
+                auto flush_tool=[&]() {
+                    auto call=q27::parse_tool_call(q27::strip_ws2(tool_buf));
+                    tool_buf.clear();
+                    if(!emit_call(call)) append_text(call.raw);
+                };
+                auto emit_recovered=[&](const std::string& source,
+                                         std::vector<q27::ToolCall>& calls,
+                                         bool incomplete_item) {
+                    std::vector<bool> accepted(calls.size(),false);
+                    size_t accepted_calls=tool_counter;
+                    std::ptrdiff_t last_accepted=-1;
+                    for(size_t i=0;i<calls.size();i++) {
+                        accepted[i]=calls[i].ok && q27::tool_choice_allows_call(
+                            response_choice,eligible_call_names,calls[i].name,
+                            accepted_calls);
+                        if(accepted[i]) {
+                            accepted_calls++;
+                            last_accepted=(std::ptrdiff_t)i;
+                        }
+                    }
+                    size_t cursor=0,recovered=0;
+                    for(size_t i=0;i<calls.size();i++) {
+                        auto& call=calls[i];
+                        append_text(source.substr(cursor,call.source_begin-cursor));
+                        cursor=call.source_end;
+                        const bool segment_incomplete=incomplete_item &&
+                            last_accepted<(std::ptrdiff_t)i;
+                        if(accepted[i]) {
+                            if(msg_index>=0) flush_text(segment_incomplete);
+                            if(emit_call(call)) {
+                                recovered++;
+                                bare_text_lex.reset();
+                                bare_text_fence.reset();
+                            } else append_text(source.substr(
+                                call.source_begin,call.source_end-call.source_begin));
+                        } else append_text(source.substr(call.source_begin,
+                                                         call.source_end-call.source_begin));
+                    }
+                    append_text(source.substr(cursor));
+                    return recovered;
+                };
+                auto flush_bare=[&](bool allow_repair,bool incomplete_item=false,
+                                    bool defer_failure=false) {
+                    if(!bare_holding) return false;
+                    const bool candidate_mode10=bare_mode10;
+                    std::string pre,residual;
+                    auto calls=q27::parse_bare_tool_calls(bare_pending, &pre, tools.empty()?nullptr:&tools, true, allow_repair, &residual);
+                    size_t recovered=0;
+                    if(!calls.empty()) {
+                        recovered=emit_recovered(bare_pending,calls,incomplete_item);
+                        if(recovered)
+                            fprintf(stderr,"[tool-fallback] %zu bare call(s) recovered (resp)\n",
+                                    recovered);
+                    } else if(defer_failure) {
+                        bare_deferred=std::move(bare_pending);
+                        bare_deferred_mode10=candidate_mode10;
+                    } else append_text(bare_pending);
+                    if(!candidate_mode10 && recovered!=0)
+                        bare_ordinary_call_seen=true;
+                    bare_pending.clear();
+                    bare_holding=false;
+                    bare_mode10=false;
+                    // A balanced candidate is a JSON classification boundary.
+                    // Preserve any Markdown fence opened by emitted text.
+                    bare_text_lex.reset();
+                    return calls.empty() && defer_failure;
+                };
+                auto route_bare_text=[&](const std::string& value) {
+                    if(!bare_deferred.empty()) {
+                        bare_deferred_trailing+=value;
                         return;
                     }
-                    if (!tool_buf.empty()) flush_tool();
-                    if (t.empty()) return;
-                    if (ch == StreamSplitter::THINK) { think += t; return; }
-                    if (!think.empty()) flush_think();
-                    if (forced_control_token && q27::strip_ws2(t).empty()) return;
-                    open_text();
-                    text += t;
-                    text_accum += t; // survives flush_text for bare-call recovery
-                    ev({{"type", "response.output_text.delta"}, {"item_id", msg_id},
-                        {"output_index", msg_index}, {"content_index", 0}, {"delta", t}});
+
+                    std::string remaining=std::move(bare_probe);
+                    bare_probe.clear();
+                    remaining+=value;
+                    while(!remaining.empty()) {
+                        if(bare_holding) {
+                            bare_pending+=remaining;
+                            remaining.clear();
+                        } else {
+                            const size_t object_pos=q27::bare_object_position(
+                                remaining,bare_text_lex,bare_text_fence,
+                                bare_input_final);
+                            const size_t mode10_pos=bare_ordinary_call_seen
+                                ?std::string::npos
+                                :q27::bare_mode10_signature_position(
+                                    remaining,eligible_call_names,bare_text_lex,
+                                    bare_text_fence,bare_input_final);
+                            const size_t opener=object_pos==std::string::npos?mode10_pos:
+                                mode10_pos==std::string::npos?object_pos:
+                                std::min(object_pos,mode10_pos);
+                            if(opener==std::string::npos) {
+                                size_t keep=bare_input_final || bare_ordinary_call_seen
+                                    ?std::string::npos
+                                    :q27::bare_mode10_probe_start(
+                                        remaining,eligible_call_names,bare_text_lex,
+                                        bare_text_fence,false);
+                                if(!bare_input_final) {
+                                    const size_t inline_keep=
+                                        q27::bare_unresolved_inline_probe_start(
+                                            remaining,bare_text_lex,bare_text_fence);
+                                    if(inline_keep!=std::string::npos)
+                                        keep=keep==std::string::npos?inline_keep:
+                                             std::min(keep,inline_keep);
+                                }
+                                if(keep==std::string::npos) {
+                                    append_text(remaining);
+                                } else {
+                                    append_text(remaining.substr(0,keep));
+                                    bare_probe=remaining.substr(keep);
+                                }
+                                return;
+                            }
+                            if(opener) append_text(remaining.substr(0,opener));
+                            bare_pending=remaining.substr(opener);
+                            bare_holding=true;
+                            bare_mode10=mode10_pos==opener;
+                            bare_scan.begin(bare_mode10);
+                            remaining.clear();
+                        }
+                        if(!bare_mode10 &&
+                           !q27::plausible_bare_tool_prefix(bare_pending)) {
+                            std::string retry=std::move(bare_pending);
+                            bare_pending.clear();
+                            bare_holding=false;
+                            append_text(retry.substr(0,1));
+                            remaining=retry.substr(1);
+                            continue;
+                        }
+                        const size_t end=bare_scan.advance(bare_pending);
+                        if(end==std::string::npos) return;
+                        std::string trailing=bare_pending.substr(end);
+                        bare_pending.resize(end);
+                        const bool defer_failure=!bare_input_final &&
+                            q27::bare_candidate_repair_eligible(
+                                bare_pending,eligible_call_names,bare_mode10);
+                        if(flush_bare(false,false,defer_failure)) {
+                            bare_deferred_trailing=std::move(trailing);
+                            return;
+                        }
+                        remaining=std::move(trailing);
+
+                    }
+                };
+                auto finish_bare=[&](bool allow_repair,
+                                     bool incomplete_item=false) {
+                    if(!bare_probe.empty()) {
+                        bare_input_final=true;
+                        std::string final_probe=std::move(bare_probe);
+                        bare_probe.clear();
+                        route_bare_text(final_probe);
+                        bare_input_final=false;
+                    }
+                    std::string trailing;
+                    if(!bare_deferred.empty()) {
+                        bare_pending=std::move(bare_deferred);
+                        trailing=std::move(bare_deferred_trailing);
+                        bare_holding=true;
+                        bare_mode10=bare_deferred_mode10;
+                        bare_deferred_mode10=false;
+                        flush_bare(allow_repair,incomplete_item);
+                    }
+                    if(!trailing.empty()) {
+                        bare_input_final=true;
+                        route_bare_text(trailing);
+                        bare_input_final=false;
+                    }
+                    flush_bare(allow_repair,incomplete_item);
+                };
+
+                bool forced_control_token=false;
+                auto route=[&](StreamSplitter::Chan ch,const std::string& value) {
+                    if(ch==StreamSplitter::TOOL) {
+                        if(!think.empty()) flush_think();
+                        // The wrapper boundary conclusively ends the preceding
+                        // text segment. Classify complete bare calls without
+                        // repairing an unfinished one ahead of this wrapper.
+                        if(tool_buf.empty()) {
+                            finish_bare(false,false);
+                            if(msg_index>=0) flush_text(false);
+                            bare_text_lex.reset();
+                            bare_text_fence.reset();
+                            bare_ordinary_call_seen=false;
+
+                        }
+                        tool_buf+=value;
+                        return;
+                    }
+                    if(!tool_buf.empty()) flush_tool();
+                    if(value.empty()) return;
+                    if(ch==StreamSplitter::THINK) {
+                        finish_bare(false,false);
+                        if(msg_index>=0) flush_text(false);
+                        bare_text_lex.reset();
+                        bare_text_fence.reset();
+                        bare_ordinary_call_seen=false;
+
+                        think+=value;
+                        return;
+                    }
+                    if(!think.empty()) flush_think();
+                    if(forced_control_token && q27::strip_ws2(value).empty()) return;
+                    route_bare_text(value);
                 };
                 StreamSplitter sp;
                 q27::Utf8Gate ugate;
                 q27::ThinkBudgetState tb{think_budget};
                 Engine::DecodeTask bt;
-                if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected <think> opener -> start in THINK
+                if (tchoice.mode == q27::ToolChoice::FORCED) sp.chan = StreamSplitter::TOOL;
+                else if (thinking) sp.chan = StreamSplitter::THINK; // prompt-injected opener
                 ReasoningBudgetObserver budget{tok, tb, eng, bt, think_close_ids, sp.chan};
                 budget.start();
                 eng.on_round = [&](const int* em, int nr) {
@@ -2903,48 +3442,50 @@ int main(int argc, char** argv) {
                 eng.on_round = nullptr;
                 eng.on_round_gap = nullptr;
                 req_log(rt, qw, eng, sl.id, bat_stats(bt));
-                const auto terminal = q27::responses_terminal_state(
-                    produced, nm, bt.budget_truncated);
+                const bool token_limit_reached=produced>=nm || bt.budget_truncated;
                 for (auto& [ch, t] : sp.feed(ugate.flush())) route(ch, t);
+                const bool unfinished_tool_wrapper=q27::unfinished_tool_wrapper(
+                    produced,nm,bt.budget_truncated,sp.chan);
                 for (auto& [ch, t] : sp.flush()) route(ch, t);
-                if (!tool_buf.empty()) flush_tool(terminal.incomplete);
+                if (!tool_buf.empty()) {
+                    if (unfinished_tool_wrapper) {
+                        append_text(tool_buf);
+                        tool_buf.clear();
+                        output_tool_tail=false;
+                    } else flush_tool();
+                }
                 flush_think();
+                if(!bare_probe.empty()) {
+                    bare_input_final=true;
+                    std::string final_probe=std::move(bare_probe);
+                    bare_probe.clear();
+                    route_bare_text(final_probe);
+                    bare_input_final=false;
+                }
+                std::string pending;
+                if(bare_holding) pending=bare_pending;
+                else if(!bare_deferred.empty())
+                    pending=bare_deferred+bare_deferred_trailing;
+                std::string preview_prefix,preview_residual;
+                const bool allow_repair=!token_limit_reached;
+                const auto preview_calls=q27::parse_bare_tool_calls(pending, &preview_prefix, tools.empty()?nullptr:&tools, true, allow_repair, &preview_residual);
+                const bool tool_tail=q27::responses_tool_tail_after_bare_calls(
+                    output_tool_tail,pending,preview_calls,response_choice,
+                    eligible_call_names,tool_counter);
+
+                const bool limit_reached=token_limit_reached && !tool_tail;
+                const auto terminal=q27::responses_terminal_state(limit_reached);
+                finish_bare(allow_repair,terminal.incomplete);
                 flush_text(terminal.incomplete);
-                // wrapper-less call recovery (parity with the Anthropic path):
-                // the model sometimes emits a bare {"name":...,"arguments":...}
-                // as text, no <tool_call> wrapper -- it already streamed as an
-                // output_text item (cosmetic), but codex needs it as a
-                // function_call to execute. Emit the recovered calls as items
-                // after the text (T5 task-queue failed exactly here). UNLIKE
-                // the Anthropic path, recovery runs even with empty `tools`:
-                // codex registers its shell tool as a hosted type this handler
-                // skips (so `tools` is empty) yet the model still emits bare
-                // calls for it -- the parser only recovers well-shaped
-                // name+arguments JSON, which codex validates against its own
-                // tool set, so a spurious recovery is harmless.
-                {
-                    std::string pre;
-                    auto bcs = q27::parse_bare_tool_calls(text_accum, &pre,
-                                                          tools.empty() ? nullptr : &tools);
-                    if (!bcs.empty())
-                        fprintf(stderr, "[tool-fallback] %zu bare call(s) recovered (resp)\n",
-                                bcs.size());
-                    for (auto& bc : bcs) {
-                        std::string cid = "call_q27_" + std::to_string(rid) + "_" +
-                                          std::to_string(tool_counter++);
-                        if (cn.count(bc.name)) {
-                            std::string input =
-                                bc.arguments.is_object() && bc.arguments.contains("input") &&
-                                        bc.arguments["input"].is_string()
-                                    ? bc.arguments["input"].get<std::string>()
-                                    : jdump(bc.arguments);
-                            item_done({{"type", "custom_tool_call"}, {"call_id", cid},
-                                       {"name", bc.name}, {"input", input}});
-                        } else {
-                            item_done({{"type", "function_call"}, {"call_id", cid},
-                                       {"name", bc.name}, {"arguments", jdump(bc.arguments)}});
-                        }
-                    }
+                if (q27::forced_tool_choice_missing_is_error(
+                        tchoice, tool_counter != 0, limit_reached)) {
+                    json failed_response = {{"id", resp_id}, {"object", "response"},
+                                            {"status", "failed"}, {"output", items},
+                                            {"error", {{"code", "tool_choice_no_match"},
+                                                       {"message", "model produced no eligible tool call for forced tool_choice"}}}};
+                    ev({{"type", "response.failed"}, {"response", failed_response}});
+                    sink.done();
+                    return true;
                 }
 
                 json final_response = {{"id", resp_id}, {"object", "response"},

--- a/src/stream_split.h
+++ b/src/stream_split.h
@@ -17,6 +17,8 @@
 #include <utility>
 #include <vector>
 
+#include "markdown_lex.h"
+
 namespace q27 {
 
 struct StreamSplitter {
@@ -27,6 +29,8 @@ struct StreamSplitter {
     // been emitted since. The next structural opener may need an empty segment
     // to flush consumers' pending tool buffer.
     bool tool_boundary = false;
+    JsonStringLexState text_string_state;
+    MarkdownFenceLexState text_markdown_state;
 
     static constexpr const char* T_OPEN = "<think>";
     static constexpr const char* T_CLOSE = "</think>";
@@ -38,37 +42,40 @@ struct StreamSplitter {
         std::vector<std::pair<Chan, std::string>> out;
         for (;;) {
             if (chan == TEXT) {
-                // whichever of <think> open / <tool_call> open / a STRAY
-                // </tool_call> close comes first. A real </tool_call> follows an
-                // opener that already switched us to TOOL, so any </tool_call>
-                // seen in TEXT is stray (bare-call wrapper leftover, issue #4) --
-                // strip it, never emit it as visible content.
+                // Only markers in executable model text are structural.
+                // Markdown/HTML code, quotes, list examples, and JSON strings
+                // remain visible bytes; treating those as TOOL output would
+                // let echoed or retrieved documentation trigger a client call.
                 size_t pt = hold.find(T_OPEN), pc = hold.find(C_OPEN),
                        sc = hold.find(C_CLOSE);
                 size_t e = std::min(pt, std::min(pc, sc));
                 if (e != std::string::npos) {
+                    const char* marker=e==pt?T_OPEN:e==pc?C_OPEN:C_CLOSE;
+                    emit_text_head(out,e);
+                    if(e) tool_boundary=false;
+                    text_string_state.settle_pending(marker[0]);
+                    const bool structural=!text_string_state.in_inert_container() &&
+                        display_text_context_is_executable(
+                            hold,0,text_string_state,text_markdown_state,false);
+                    if(structural) text_string_state.discard_pending_containers();
+                    if (!structural) {
+                        emit_text_head(out,strlen(marker));
+                        tool_boundary=false;
+                        continue;
+                    }
                     if (e == pt) {
-                        if (pt > 0) {
-                            out.push_back({TEXT, hold.substr(0, pt)});
-                            tool_boundary = false;
-                        }
-                        hold.erase(0, pt + strlen(T_OPEN));
+                        hold.erase(0, strlen(T_OPEN));
                         chan = THINK;
                         continue;
                     }
                     if (e == pc) {
-                        if (pc == 0 && tool_boundary) out.push_back({TEXT, ""}); // adjacent-call boundary
+                        if (tool_boundary) out.push_back({TEXT, ""});
                         tool_boundary = false;
-                        if (pc > 0) out.push_back({TEXT, hold.substr(0, pc)});
-                        hold.erase(0, pc + strlen(C_OPEN));
+                        hold.erase(0, strlen(C_OPEN));
                         chan = TOOL;
                         continue;
                     }
-                    if (sc > 0) {
-                        out.push_back({TEXT, hold.substr(0, sc)});
-                        tool_boundary = false;
-                    }
-                    hold.erase(0, sc + strlen(C_CLOSE)); // strip stray close
+                    hold.erase(0, strlen(C_CLOSE)); // executable stray close
                     continue;
                 }
                 // hold back the longest suffix that prefixes any marker
@@ -100,14 +107,28 @@ struct StreamSplitter {
 
     std::vector<std::pair<Chan, std::string>> flush() {
         std::vector<std::pair<Chan, std::string>> out;
-        if (!hold.empty()) out.push_back({chan, hold});
-        else if (chan == THINK && tool_boundary) out.push_back({THINK, ""});
+        if (!hold.empty()) {
+            if (chan == TEXT)
+                consume_display_text_context(
+                    text_string_state,text_markdown_state,hold);
+            out.push_back({chan, hold});
+        } else if (chan == THINK && tool_boundary) out.push_back({THINK, ""});
         hold.clear();
         tool_boundary = false;
         return out;
     }
 
   private:
+    void emit_text_head(std::vector<std::pair<Chan, std::string>>& out,
+                        size_t count) {
+        if (!count) return;
+        std::string text=hold.substr(0,count);
+        consume_display_text_context(
+            text_string_state,text_markdown_state,text);
+        out.push_back({TEXT,std::move(text)});
+        hold.erase(0,count);
+    }
+
     size_t tail_keep(const char* marker) const {
         size_t mlen = strlen(marker);
         size_t maxk = std::min(hold.size(), mlen - 1);
@@ -116,12 +137,14 @@ struct StreamSplitter {
         return 0;
     }
     bool emit_head(std::vector<std::pair<Chan, std::string>>& out, size_t keep) {
-        if (hold.size() > keep) {
-            out.push_back({chan, hold.substr(0, hold.size() - keep)});
-            hold.erase(0, hold.size() - keep);
-            return true;
+        if (hold.size() <= keep) return false;
+        const size_t count=hold.size()-keep;
+        if (chan == TEXT) emit_text_head(out,count);
+        else {
+            out.push_back({chan, hold.substr(0,count)});
+            hold.erase(0,count);
         }
-        return false;
+        return true;
     }
 };
 

--- a/src/test_tokenizer.cpp
+++ b/src/test_tokenizer.cpp
@@ -233,17 +233,23 @@ static int anthropic_api_selftest() {
         json body = json::parse(R"({"tools":[
             {"name":"ls","description":"list","input_schema":{"type":"object"}},
             {"description":"nameless skipped"},
+            {"name":123},
+            {"name":"typed","description":123,"input_schema":"bad"},
             {"name":"noschema"}]})");
         json t = q27::anthropic_tools_json(body);
-        expect(t.is_array() && t.size() == 2, "nameless skipped");
-        expect(t.size() == 2 && t[0]["type"] == "function" &&
+        expect(t.is_array() && t.size() == 3, "malformed or nameless tools skipped");
+        expect(t.size() == 3 && t[0]["type"] == "function" &&
                    t[0]["function"]["name"] == "ls" &&
                    t[0]["function"]["description"] == "list" &&
                    t[0]["function"]["parameters"]["type"] == "object",
                "function shape");
-        expect(t.size() == 2 && t[1]["function"]["parameters"].is_object() &&
+        expect(t.size() == 3 && t[1]["function"]["parameters"].is_object() &&
                    t[1]["function"]["parameters"].empty() &&
                    t[1]["function"]["description"] == "",
+               "malformed optional fields default");
+        expect(t.size() == 3 && t[2]["function"]["parameters"].is_object() &&
+                   t[2]["function"]["parameters"].empty() &&
+                   t[2]["function"]["description"] == "",
                "schema/description defaults");
         expect(q27::anthropic_tools_json(json::object()).is_array(), "no tools -> empty array");
     }

--- a/tools/extract_check.sh
+++ b/tools/extract_check.sh
@@ -27,6 +27,7 @@ real = open('src/server.cu').read()
 fake = open('tools/test_chat_completions_integration.cpp').read()
 ok = True
 for marker, label in (('auto build_prompt = [&]', 'build_prompt'),
+                      ('auto prepare_anthropic_prompt = [&]', 'prepare_anthropic_prompt'),
                       ('auto handle = [&]', 'handle')):
     r, f = extract(real, marker), extract(fake, marker)
     if r != f:

--- a/tools/test_auth.cpp
+++ b/tools/test_auth.cpp
@@ -50,7 +50,9 @@ static void test_secure_compare_no_early_exit_timing_class() {
 static void test_extract_api_key_bearer() {
     CHECK(q27::extract_api_key("Bearer sk-abc123", "") == "sk-abc123");
     CHECK(q27::extract_api_key("Bearer ", "") == ""); // empty token after prefix
-    CHECK(q27::extract_api_key("bearer sk-abc123", "") == ""); // case-sensitive, matches llama.cpp
+    CHECK(q27::extract_api_key("bearer sk-abc123", "") == "sk-abc123");
+    CHECK(q27::extract_api_key("bEaReR\t  sk-abc123", "") == "sk-abc123");
+    CHECK(q27::extract_api_key("BearerX sk-abc123", "") == "");
     CHECK(q27::extract_api_key("Basic sk-abc123", "") == ""); // wrong scheme
     CHECK(q27::extract_api_key("", "") == "");
 }

--- a/tools/test_auth_integration.cpp
+++ b/tools/test_auth_integration.cpp
@@ -4,8 +4,9 @@
 // exercises the exact same handler shape wired into server.cu's main(),
 // verbatim, against real HTTP requests over a real loopback socket --
 // not a mock of the HTTP layer.
-// NOTE: this test keeps a verbatim copy of the server.cu handler and must stay in sync with server.cu would still pass the test if only the copy were correct.
-// Build+run: g++ -std=c++17 -I src -I third_party -pthread tools/test_auth_integration.cpp -o build/test_auth_integration && ./build/test_auth_integration
+// This copied-handler fixture is supplemental. tools/test_responses_integration.py
+// exercises authentication against the exact production server binary.
+// Build+run: make build/test_auth_integration && ./build/test_auth_integration
 #include "api_common.h"
 #include "../third_party/httplib.h"
 
@@ -53,8 +54,15 @@ struct TestServer {
     void start(std::vector<std::string> keys) {
         api_keys = std::move(keys);
         install_auth(srv, api_keys);
-        srv.Get("/health", [](const httplib::Request&, httplib::Response& res) {
-            res.set_content("{\"status\":\"ok\"}", "application/json");
+        srv.Get("/health", [this](const httplib::Request& req, httplib::Response& res) {
+            const std::string provided = q27::extract_api_key(
+                req.get_header_value("Authorization"), req.get_header_value("x-api-key"));
+            nlohmann::json body = {{"status", "ok"}};
+            if (api_keys.empty() || q27::api_key_valid(provided, api_keys)) {
+                body["model"] = "fixture-model";
+                body["boot_id"] = "fixture-boot";
+            }
+            res.set_content(body.dump(), "application/json");
         });
         srv.Get("/v1/models", [](const httplib::Request&, httplib::Response& res) {
             res.set_content("{\"object\":\"list\",\"data\":[]}", "application/json");
@@ -88,6 +96,7 @@ static void test_no_auth_configured_everything_open() {
     httplib::Client cli("127.0.0.1", s.port);
     auto r1 = cli.Get("/health");
     CHECK(r1 && r1->status == 200);
+    if (r1) CHECK(json::parse(r1->body).contains("boot_id"));
     auto r2 = cli.Get("/v1/models");
     CHECK(r2 && r2->status == 200);
     auto r3 = cli.Post("/v1/messages", "{}", "application/json");
@@ -100,7 +109,18 @@ static void test_health_exempt_others_require_auth() {
     s.start({"secret-key"});
     httplib::Client cli("127.0.0.1", s.port);
     auto health = cli.Get("/health");
-    CHECK(health && health->status == 200); // no Authorization header sent at all
+    CHECK(health && health->status == 200); // liveness remains unauthenticated
+    if (health) {
+        const json body = json::parse(health->body);
+        CHECK((body == json{{"status", "ok"}}));
+    }
+    httplib::Headers health_auth = {{"Authorization", "Bearer secret-key"}};
+    auto detailed_health = cli.Get("/health", health_auth);
+    CHECK(detailed_health && detailed_health->status == 200);
+    if (detailed_health) CHECK(json::parse(detailed_health->body).contains("boot_id"));
+    httplib::Headers health_wrong = {{"x-api-key", "wrong-key"}};
+    auto wrong_health = cli.Get("/health", health_wrong);
+    CHECK(wrong_health && (json::parse(wrong_health->body) == json{{"status", "ok"}}));
 
     auto models_noauth = cli.Get("/v1/models");
     CHECK(models_noauth && models_noauth->status == 401);
@@ -182,6 +202,7 @@ static void test_malformed_header_no_crash_rejected() {
     auto r = cli.Get("/v1/models", h);
     CHECK(r && r->status == 401);
 }
+
 
 int main() {
     test_no_auth_configured_everything_open();

--- a/tools/test_chat_completions_integration.cpp
+++ b/tools/test_chat_completions_integration.cpp
@@ -387,6 +387,55 @@ static std::string jdump(const json& j) {
 json g_last_response;
 std::vector<json> g_sse_events; // parsed "data: {...}" payloads, [DONE] excluded
 
+struct PreparedAnthropicPrompt {
+    std::string rendered;
+    q27::ToolChoice tchoice;
+    json tools;
+    std::vector<std::string> tool_names;
+    bool thinking=false;
+    q27::ThinkCfg tcfg;
+};
+
+static PreparedAnthropicPrompt prepare_anthropic_prompt_for_test(
+        const json& body, bool no_think_srv) {
+    const bool req_think=true;
+    auto prepare_anthropic_prompt = [&](const json& body,
+                                         q27::ToolChoice& tchoice,
+                                         json& tools,
+                                         std::vector<std::string>& tool_names,
+                                         bool& thinking,
+                                         q27::ThinkCfg& tcfg,
+                                         size_t* stable_off,
+                                         size_t* sys_off) {
+        tchoice=q27::parse_anthropic_tool_choice(body);
+        json all_tools=q27::anthropic_tools_json(body);
+        json normalized={{"tools",all_tools}};
+        q27::OpenAIToolSelection selected=q27::select_openai_tools(normalized,tchoice);
+        const json unavailable=q27::unselected_openai_tools(all_tools,selected);
+        // Only eligible schemas enter the callable interface; the rest remain
+        // in a separately labelled accounting block.
+        tools=std::move(selected.tools);
+        tool_names=std::move(selected.names);
+        tcfg=q27::resolve_think_cfg(body,!no_think_srv,req_think,-1);
+        q27::validate_anthropic_tool_choice_thinking(tchoice,tcfg);
+        thinking=tcfg.enabled;
+        if(tchoice.mode==q27::ToolChoice::FORCED) {
+            thinking=false;
+            tcfg=q27::ThinkCfg{false,-1,false,true};
+        }
+        std::string rendered=q27::chatml_prompt(
+            q27::anthropic_msgs(body),tools,thinking,stable_off,sys_off,
+            q27::anthropic_tool_choice_instruction(tchoice),&unavailable);
+        if(tchoice.mode==q27::ToolChoice::FORCED) rendered+="<tool_call>\n";
+        return rendered;
+    };
+    PreparedAnthropicPrompt result;
+    result.rendered=prepare_anthropic_prompt(
+        body,result.tchoice,result.tools,result.tool_names,result.thinking,
+        result.tcfg,nullptr,nullptr);
+    return result;
+}
+
 static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv,
                         bool constrain_tools, bool sampled_on, int max_prompt,
                         int max_slot_ctx, std::atomic<long>& req_counter,
@@ -400,7 +449,7 @@ static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv
     const bool req_think = true;
     const int think_budget_flag = budget_flag;
     const std::vector<int> think_close_ids = tok.encode("</think>\n\n");
-    struct FakePfxCache { bool enabled() const { return false; } } pfx_cache;
+    struct DisabledPrefixCache { bool enabled() const { return false; } } pfx_cache;
 
     auto ms_since = [](std::chrono::steady_clock::time_point t) {
         return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t)
@@ -566,17 +615,21 @@ auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat
         q27::ToolChoice tchoice;
         std::vector<std::string> tool_names_v;
         if (routed_chat) {
-            tchoice = q27::parse_tool_choice(body);
-            tools = tchoice.mode == q27::ToolChoice::NONE ? json::array() : q27::openai_tools_json(body);
-            if (constrain_tools && tools.is_array())
-                for (auto& t : tools)
-                    if (t.contains("function") && t["function"].contains("name"))
-                        tool_names_v.push_back(t["function"]["name"].get<std::string>());
-            // named-forced tool_choice restricts the grammar to that one name;
-            // "required" (no name) leaves every registered tool eligible.
-            if (tchoice.mode == q27::ToolChoice::FORCED && !tchoice.forced_name.empty())
-                tool_names_v = {tchoice.forced_name};
+            try {
+                tchoice = q27::parse_tool_choice(body);
+                q27::apply_openai_parallel_tool_calls(body,tchoice);
+                q27::OpenAIToolSelection selected=q27::select_openai_tools(body,tchoice);
+                tools=std::move(selected.tools);
+                tool_names_v=std::move(selected.names);
+            } catch (const std::exception& e) {
+                res.status = 400;
+                res.set_content(json{{"error",{{"message",e.what()},
+                                                 {"type","invalid_request_error"}}}}.dump(),
+                                "application/json");
+                return;
+            }
         }
+        const std::set<std::string> allowed_tool_names(tool_names_v.begin(),tool_names_v.end());
         long rid = req_counter++;
         auto tk0 = std::chrono::steady_clock::now();
         std::vector<int> prompt;
@@ -759,18 +812,20 @@ auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat
             q27::ThinkBudgetState tb{think_budget};
             Engine::DecodeTask bt;
             q27::Utf8Gate ugate;
-            std::string think, text, tool_buf;
-            std::vector<q27::ToolCall> calls;
-            auto flush_tool = [&]() {
-                auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
-                tool_buf.clear();
-                if (c.ok) calls.push_back(std::move(c));
-                else text += c.raw; // stream parity: preserve generation order
-            };
+            std::vector<std::pair<StreamSplitter::Chan,std::string>> segments;
             auto route = [&](StreamSplitter::Chan ch, const std::string& t) {
-                if (ch == StreamSplitter::TOOL) { tool_buf += t; return; }
-                if (!tool_buf.empty()) flush_tool();
-                (ch == StreamSplitter::THINK ? think : text) += t;
+                if (ch == StreamSplitter::TOOL &&
+                    tchoice.mode == q27::ToolChoice::NONE)
+                    ch = StreamSplitter::TEXT;
+                if (t.empty()) {
+                    if (ch != StreamSplitter::TOOL && !segments.empty() &&
+                        segments.back().first == StreamSplitter::TOOL)
+                        segments.emplace_back(ch, std::string());
+                    return;
+                }
+                if (!segments.empty() && segments.back().first == ch)
+                    segments.back().second += t;
+                else segments.emplace_back(ch, t);
             };
             ToolConstrainer tc;
             tc.eng = &eng; tc.tok = &tok; tc.cache = &tool_mask_cache;
@@ -837,29 +892,39 @@ auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat
                 return;
             }
             for (auto& [ch, t] : sp.feed(ugate.flush())) route(ch, t);
+            const bool final_tool_incomplete=q27::unfinished_tool_wrapper(
+                n,n_max,bt.budget_truncated,sp.chan);
             for (auto& [ch, t] : sp.flush()) route(ch, t);
-            if (!tool_buf.empty()) flush_tool();
-
-            std::string tx = text;
-            if (tools.is_array() && !tools.empty()) {
-                // wrapper-less call recovery (see parse_bare_tool_calls)
-                std::string pre;
-                auto bcs = q27::parse_bare_tool_calls(tx, &pre, &tools);
-                if (!bcs.empty()) {
-                    fprintf(stderr,
-                            "[tool-fallback] %zu bare call(s) recovered (oai-nonstream)\n",
-                            bcs.size());
-                    tx = pre;
-                    for (auto& bc : bcs) calls.push_back(bc);
-                }
+            std::string unclosed_tool=q27::take_unclosed_final_tool_segment(
+                segments,final_tool_incomplete);
+            auto ordered = q27::resolve_ordered_tool_segments(
+                segments, tools.is_array() && !tools.empty() ? &tools : nullptr,
+                n < n_max && !bt.budget_truncated,
+                [&](const std::string& name, size_t accepted) {
+                    return q27::tool_choice_allows_call(
+                        tchoice, allowed_tool_names, name, accepted);
+                });
+            ordered.text+=unclosed_tool;
+            std::string tx = ordered.text;
+            std::vector<q27::ToolCall> eligible_calls = std::move(ordered.calls);
+            if (ordered.recovered)
+                fprintf(stderr,
+                        "[tool-fallback] %zu bare call(s) recovered (oai-nonstream)\n",
+                        ordered.recovered);
+            const bool any_call = !eligible_calls.empty();
+            if (q27::forced_tool_choice_missing_is_error(
+                    tchoice, any_call, n >= n_max || bt.budget_truncated)) {
+                res.status = 500;
+                res.set_content(json{{"error",{{"message","model produced no eligible tool call for forced tool_choice"},
+                                                 {"type","api_error"}}}}.dump(),
+                                "application/json");
+                return;
             }
-            bool any_call = false;
-            for (auto& c : calls)
-                if (c.ok) any_call = true;
-            json msg = q27::openai_chat_message_json(tx, calls, rid, think);
+            json msg = q27::openai_chat_message_json(
+                tx, eligible_calls, rid, ordered.reasoning);
             json choice = {{"index", 0},
-                          {"finish_reason", any_call ? "tool_calls" :
-                              ((n >= n_max || bt.budget_truncated) ? "length" : "stop")},
+                          {"finish_reason", q27::openai_tool_finish_reason(
+                              any_call,final_tool_incomplete,n>=n_max || bt.budget_truncated)},
                           {"message", msg}};
             json out = {{"id", "chatcmpl-q27-" + std::to_string(rid)}, {"object", obj},
                         {"created", created}, {"model", served_name},
@@ -885,9 +950,9 @@ auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat
             // handler's frame is dead (routing() and write_response() are
             // sibling calls in Server::process_request). `thinking` shipped as
             // a by-reference read of that dead frame from 2026-07-20 until the
-            // 07-24 audit -- benign only by stack-layout luck.
-            [&, samp, prompt, n_max, created, chat, obj, objd, rt, inc_usage, routed_chat,
-             tools, tool_names_v, tchoice, stable_len, has_tools, rid,
+            // fix; the bug was benign only by stack-layout luck.
+            [&, samp, prompt, n_max, created, chat, objd, rt, inc_usage, routed_chat,
+             tools, tool_names_v, allowed_tool_names, tchoice, stable_len, has_tools, rid,
              thinking, tcfg, sys_len, think_aware](size_t, httplib::DataSink& sink) {
                 Slot& sl = claim_slot(prompt,n_max,thinking,tcfg,think_aware);
                 auto sl_lease = slot_guard(sl);
@@ -989,17 +1054,19 @@ auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat
                 bool alive = true; // cleared when a write fails (client disconnected)
                 int tool_idx = 0;
                 bool any_call = false;
-                std::string tool_buf, text_accum;
+                std::string tool_buf;
+                q27::BareToolTextHoldback bare_text;
                 bool forced_control_token = false;
-                auto emit_tool = [&]() {
-                    auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
-                    tool_buf.clear();
-                    if (!c.ok) { // malformed: surface as text so nothing is lost
-                        if (!send(q27::openai_stream_chunk(cid, objd, created, served_name,
-                                                           json{{"content", c.raw}})))
-                            alive = false;
-                        return;
-                    }
+                auto emit_text = [&](const std::string& t) {
+                    if (t.empty()) return;
+                    if (!send(q27::openai_stream_chunk(cid, objd, created, served_name,
+                                                       json{{"content", t}})))
+                        alive = false;
+                };
+                auto emit_call = [&](const q27::ToolCall& c) {
+                    if (!c.ok || !q27::tool_choice_allows_call(
+                        tchoice,allowed_tool_names,c.name,any_call?1u:0u))
+                        return false;
                     any_call = true;
                     std::string tid =
                         "call_q27_" + std::to_string(rid) + "_" + std::to_string(tool_idx);
@@ -1008,9 +1075,46 @@ auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat
                         q27::openai_tool_call_delta(tool_idx, tid, c)));
                     tool_idx++;
                     if (!ok) alive = false;
+                    return true;
+                };
+                auto classify_bare = [&](const std::string& source,bool allow_repair,
+                                         auto&& visible) {
+                    std::string pre,residual;
+                    auto bcs = q27::parse_bare_tool_calls(
+                        source,&pre,&tools,true,allow_repair,&residual);
+                    if (bcs.empty()) return q27::BareToolCandidateResult{};
+                    size_t cursor=0,recovered=0;
+                    for (const auto& bc : bcs) {
+                        visible(source.substr(cursor,bc.source_begin-cursor));
+                        cursor=bc.source_end;
+                        if (emit_call(bc)) recovered++;
+                        else visible(source.substr(
+                            bc.source_begin,bc.source_end-bc.source_begin));
+                    }
+                    visible(source.substr(cursor));
+                    if (recovered)
+                        fprintf(stderr,
+                                "[tool-fallback] %zu bare call(s) recovered (oai-stream)\n",
+                                recovered);
+                    return q27::BareToolCandidateResult{true,recovered!=0};
+                };
+                auto emit_tool = [&]() {
+                    auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
+                    tool_buf.clear();
+                    if (!c.ok) {
+                        if (!classify_bare(c.raw,true,emit_text)) emit_text(c.raw);
+                    } else if (!emit_call(c)) emit_text(c.raw);
                 };
                 auto emit_seg = [&](StreamSplitter::Chan ch, const std::string& t) {
-                    if (ch == StreamSplitter::TOOL) { tool_buf += t; return; }
+                    if (ch == StreamSplitter::TOOL) {
+                        if (tool_buf.empty()) {
+                            bare_text.finish(false,allowed_tool_names,
+                                             emit_text,classify_bare);
+                            bare_text.reset_context();
+                        }
+                        tool_buf += t;
+                        return;
+                    }
                     if (!tool_buf.empty()) emit_tool();
                     if (t.empty()) return;
                     // reasoning_content (no official OpenAI field for this;
@@ -1019,6 +1123,9 @@ auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat
                     // tags into `content` (the bug this whole path also
                     // happens to fix).
                     if (ch == StreamSplitter::THINK) {
+                        bare_text.finish(false,allowed_tool_names,
+                                         emit_text,classify_bare);
+                        bare_text.reset_context();
                         if (!send(q27::openai_stream_chunk(cid, objd, created, served_name,
                                                             q27::openai_reasoning_delta(t))))
                             alive = false;
@@ -1028,10 +1135,10 @@ auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat
                     // Preserve ordinary leading whitespace, including when
                     // thinking is disabled or the model closes naturally.
                     if (forced_control_token && q27::strip_ws2(t).empty()) return;
-                    text_accum += t;
-                    if (!send(q27::openai_stream_chunk(cid, objd, created, served_name,
-                                                       json{{"content", t}})))
-                        alive = false;
+                    if (has_tools)
+                        bare_text.route(t,allowed_tool_names,
+                                        emit_text,classify_bare);
+                    else emit_text(t);
                 };
                 eng.on_pending = [&](int id) { tc.on_pending(id); };
                 eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
@@ -1064,38 +1171,36 @@ auto handle = [&](const httplib::Request& req, httplib::Response& res, bool chat
                 eng.on_round_gap = nullptr;
                 req_log(rt, qw, eng, sl.id, tg_stats(tc) + bat_stats(bt));
                 for (auto& [ch, t] : sp.feed(ugate.flush())) emit_seg(ch, t);
+                const bool final_tool_incomplete=q27::unfinished_tool_wrapper(
+                    produced,nm,bt.budget_truncated,sp.chan);
                 for (auto& [ch, t] : sp.flush()) emit_seg(ch, t);
-                if (!tool_buf.empty()) emit_tool();
-                if (has_tools) {
-                    // wrapper-less call recovery: text already streamed as a
-                    // content delta (cosmetic); the tool_calls delta still fires
-                    std::string pre;
-                    auto bcs = q27::parse_bare_tool_calls(text_accum, &pre, &tools);
-                    if (!bcs.empty()) {
-                        fprintf(stderr,
-                                "[tool-fallback] %zu bare call(s) recovered (oai-stream)\n",
-                                bcs.size());
-                        any_call = true;
-                        for (auto& bc : bcs) {
-                            std::string tid = "call_q27_" + std::to_string(rid) + "_" +
-                                              std::to_string(tool_idx);
-                            bool ok = send(q27::openai_stream_chunk(
-                                cid, objd, created, served_name,
-                                q27::openai_tool_call_delta(tool_idx, tid, bc)));
-                            tool_idx++;
-                            if (!ok) alive = false;
-                        }
-                    }
+                if (!tool_buf.empty()) {
+                    if (final_tool_incomplete) {
+                        emit_text(tool_buf);
+                        tool_buf.clear();
+                    } else emit_tool();
                 }
+                if (!final_tool_incomplete)
+                    bare_text.finish(produced < nm && !bt.budget_truncated,
+                                     allowed_tool_names,emit_text,classify_bare);
                 // TODO(batch error surfacing): no standard OpenAI mid-stream
                 // error chunk exists (matches the plain-text leg's TODO
                 // above); end=error lands in the [req] line, [req-error]
                 // carries the what() (batch_generate logs it unconditionally
                 // when err_out is null, same as that leg's nullptr err_out).
+                if (q27::forced_tool_choice_missing_is_error(
+                        tchoice, any_call, produced >= nm || bt.budget_truncated)) {
+                    send(json{{"error",{{"message","model produced no eligible tool call for forced tool_choice"},
+                                         {"type","api_error"}}}});
+                    std::string done = "data: [DONE]\n\n";
+                    sink.write(done.data(), done.size());
+                    sink.done();
+                    return true;
+                }
                 {
-                    const char* fr = any_call ? "tool_calls"
-                                              : ((produced >= nm || bt.budget_truncated)
-                                                     ? "length" : "stop");
+                    const char* fr=q27::openai_tool_finish_reason(
+                        any_call,final_tool_incomplete,
+                        produced>=nm || bt.budget_truncated);
                     send(q27::openai_stream_chunk(cid, objd, created, served_name,
                                                   json::object(), fr));
                 }
@@ -1162,6 +1267,10 @@ int main() {
     CHECK(!responses_completed.incomplete &&
           std::string(responses_completed.status)=="completed" &&
           std::string(responses_completed.event)=="response.completed");
+    const auto responses_exact_stop=q27::responses_terminal_state(false);
+    CHECK(!responses_exact_stop.incomplete &&
+          std::string(responses_exact_stop.status)=="completed" &&
+          std::string(responses_exact_stop.event)=="response.completed");
     const auto responses_limited=q27::responses_terminal_state(2,2,false);
     CHECK(responses_limited.incomplete &&
           std::string(responses_limited.status)=="incomplete" &&
@@ -1170,6 +1279,17 @@ int main() {
     CHECK(responses_budget_limited.incomplete &&
           std::string(responses_budget_limited.status)=="incomplete" &&
           std::string(responses_budget_limited.event)=="response.incomplete");
+    CHECK(q27::unfinished_tool_wrapper(
+        4,4,false,q27::StreamSplitter::TOOL));
+    CHECK(q27::unfinished_tool_wrapper(
+        3,4,true,q27::StreamSplitter::TOOL));
+    CHECK(!q27::unfinished_tool_wrapper(
+        4,4,false,q27::StreamSplitter::TEXT));
+    CHECK(!q27::unfinished_tool_wrapper(
+        3,4,false,q27::StreamSplitter::TOOL));
+    std::string responses_text="\nanswer ";
+    const std::string responses_done=q27::take_responses_output_text(responses_text);
+    CHECK(responses_done=="\nanswer " && responses_text.empty());
 
     // ---- Test 1: plain chat, no tools -> plain content, no tool_calls ----
     {
@@ -1522,6 +1642,35 @@ int main() {
         }
         CHECK(saw_reasoning);
         CHECK(saw_content);
+    }
+
+    // ---- Test 8c: a request reasoning budget closes THINK at the token
+    // boundary, routes subsequent output to content, and reports the trip. ----
+    {
+        FakeTok tok;
+        tok.pieces = {
+            /*0*/ "<eos>",
+            /*1*/ "first thought",
+            /*2*/ " then answer",
+        };
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1, 2}; // prompt already injected <think>
+        std::atomic<long> rc{0};
+        json body = {
+            {"enable_thinking", true},
+            {"thinking_token_budget", 1},
+            {"max_tokens", 4},
+            {"messages", json::array({{{"role","user"},{"content","answer"}}})},
+        };
+        run_request(tok, "q27-test", /*no_think_srv=*/false, false, true,
+                    100000, 100000, rc, cache, slots, body, true);
+        const auto& msg = g_last_response["choices"][0]["message"];
+        CHECK(msg["reasoning_content"] == "first thought");
+        CHECK(msg["content"] == " then answer");
+        CHECK(g_last_response["usage"]["reasoning_tokens"] == 1);
+        CHECK(g_last_response["usage"]["reasoning_budget_exceeded"] == true);
     }
 
     // ---- Test 9: malformed tool call body -> surfaced as content, not
@@ -2062,6 +2211,519 @@ int main() {
                           .get<std::string>();
         }
         CHECK(content == " beforenot valid json after");
+    }
+    // ---- Test 20: allowed_tools filters streamed wrapped calls. ----
+    {
+        FakeTok tok;
+        tok.pieces = {
+            /*0*/ "<eos>",
+            /*1*/ "<tool_call>\n{\"name\":\"privileged\",\"arguments\":{}}\n</tool_call>",
+        };
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1};
+        std::atomic<long> rc{0};
+        json declared=json::array({
+            {{"type","function"},{"function",{{"name","safe"},{"parameters",json::object()}}}},
+            {{"type","function"},{"function",{{"name","privileged"},{"parameters",json::object()}}}}
+        });
+        json allowed=json::array({
+            {{"type","function"},{"function",{{"name","safe"}}}}
+        });
+        json body = {
+            {"stream",true}, {"tools",declared},
+            {"tool_choice",{{"type","allowed_tools"},
+                {"allowed_tools",{{"mode","auto"},{"tools",allowed}}}}},
+            {"messages",json::array({{{"role","user"},{"content","run safe"}}})},
+        };
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        bool saw_tool=false, saw_raw=false, saw_stop=false;
+        for (auto& ev : g_sse_events) {
+            if (!ev.contains("choices") || ev["choices"].empty()) continue;
+            auto& choice=ev["choices"][0];
+            if (choice["delta"].contains("tool_calls")) saw_tool=true;
+            if (choice["delta"].contains("content") &&
+                choice["delta"]["content"].get<std::string>().find("privileged")!=std::string::npos)
+                saw_raw=true;
+            if (choice["finish_reason"] == "stop") saw_stop=true;
+        }
+        CHECK(!saw_tool);
+        CHECK(saw_raw);
+        CHECK(saw_stop);
+    }
+
+    // ---- Test 21: invalid named choice is a non-retryable client error. ----
+    {
+        FakeTok tok;
+        tok.pieces = {"<eos>"};
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        std::atomic<long> rc{0};
+        json body = {
+            {"tools",json::array({
+                {{"type","function"},{"function",{{"name","safe"},{"parameters",json::object()}}}}
+            })},
+            {"tool_choice",{{"type","function"},{"function",{{"name","missing"}}}}},
+            {"messages",json::array({{{"role","user"},{"content","run"}}})},
+        };
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        CHECK(g_last_response["__status"] == 400);
+        CHECK(g_last_response["error"]["type"] == "invalid_request_error");
+    }
+
+    // ---- Test 12: parallel_tool_calls=false keeps only the first wrapped call. ----
+    {
+        FakeTok tok;
+        tok.pieces = {
+            "<eos>",
+            "<tool_call>\n{\"name\":\"first\",\"arguments\":{}}\n</tool_call>",
+            "<tool_call>\n{\"name\":\"second\",\"arguments\":{}}\n</tool_call>",
+        };
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1,2};
+        std::atomic<long> rc{0};
+        json tools=json::array({
+            {{"type","function"},{"function",{{"name","first"},{"parameters",json::object()}}}},
+            {{"type","function"},{"function",{{"name","second"},{"parameters",json::object()}}}},
+        });
+        json body={{"tools",tools},{"parallel_tool_calls",false},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        auto& msg=g_last_response["choices"][0]["message"];
+        CHECK(msg["tool_calls"].size()==1);
+        CHECK(msg["tool_calls"][0]["function"]["name"]=="first");
+        CHECK(msg["content"].get<std::string>().find("second")!=std::string::npos);
+    }
+
+    // ---- Test 13: the same single-call contract holds for SSE output. ----
+    {
+        FakeTok tok;
+        tok.pieces = {
+            "<eos>",
+            "<tool_call>\n{\"name\":\"first\",\"arguments\":{}}\n</tool_call>",
+            "<tool_call>\n{\"name\":\"second\",\"arguments\":{}}\n</tool_call>",
+        };
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1,2};
+        std::atomic<long> rc{0};
+        json tools=json::array({
+            {{"type","function"},{"function",{{"name","first"},{"parameters",json::object()}}}},
+            {{"type","function"},{"function",{{"name","second"},{"parameters",json::object()}}}},
+        });
+        json body={{"stream",true},{"tools",tools},{"parallel_tool_calls",false},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        int call_count=0;
+        bool saw_first=false,saw_second_raw=false;
+        for(auto& ev:g_sse_events) {
+            if(!ev.contains("choices") || ev["choices"].empty()) continue;
+            const auto& delta=ev["choices"][0]["delta"];
+            if(delta.contains("tool_calls")) {
+                call_count++;
+                saw_first=delta["tool_calls"][0]["function"]["name"]=="first";
+            }
+            if(delta.contains("content") &&
+               delta["content"].get<std::string>().find("second")!=std::string::npos)
+                saw_second_raw=true;
+        }
+        CHECK(call_count==1);
+        CHECK(saw_first);
+        CHECK(saw_second_raw);
+    }
+
+    // ---- Test 13b: an earlier bare call beats a later wrapped call. ----
+    {
+        FakeTok tok;
+        tok.pieces = {
+            "<eos>",
+            "{\"name\":\"fi",
+            "rst\",\"arguments\":{}}",
+            "<tool_call>\n{\"name\":\"second\",\"arguments\":{}}\n</tool_call>",
+        };
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1,2,3};
+        std::atomic<long> rc{0};
+        json tools=json::array({
+            {{"type","function"},{"function",{{"name","first"},{"parameters",json::object()}}}},
+            {{"type","function"},{"function",{{"name","second"},{"parameters",json::object()}}}},
+        });
+        json body={{"stream",true},{"tools",tools},{"parallel_tool_calls",false},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        int call_count=0;
+        bool saw_first=false,saw_first_raw=false,saw_second_raw=false;
+        for(auto& ev:g_sse_events) {
+            if(!ev.contains("choices") || ev["choices"].empty()) continue;
+            const auto& delta=ev["choices"][0]["delta"];
+            if(delta.contains("tool_calls")) {
+                call_count++;
+                saw_first=delta["tool_calls"][0]["function"]["name"]=="first";
+            }
+            if(delta.contains("content")) {
+                const auto content=delta["content"].get<std::string>();
+                if(content.find("\"name\":\"first\"")!=std::string::npos)
+                    saw_first_raw=true;
+                if(content.find("second")!=std::string::npos)
+                    saw_second_raw=true;
+            }
+        }
+        CHECK(call_count==1);
+        CHECK(saw_first);
+        CHECK(!saw_first_raw);
+        CHECK(saw_second_raw);
+    }
+
+    // ---- Test 13c: a wrapper nested in an incomplete bare-call value stays text. ----
+    {
+        FakeTok tok;
+        tok.pieces = {
+            "<eos>",
+            "{\"name\":\"first\",\"arguments\":{\"x\":",
+            "<tool_call>\n{\"name\":\"second\",\"arguments\":{}}\n</tool_call>",
+        };
+        std::vector<std::string> vb = tok.pieces;
+        auto cache = fresh_cache(vb);
+        auto slots = fresh_slots();
+        slots[0].eng->script = {1,2};
+        std::atomic<long> rc{0};
+        json tools=json::array({
+            {{"type","function"},{"function",{{"name","first"},{"parameters",json::object()}}}},
+            {{"type","function"},{"function",{{"name","second"},{"parameters",json::object()}}}},
+        });
+        json body={{"stream",true},{"tools",tools},{"parallel_tool_calls",false},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        int call_count=0;
+        std::string visible;
+        for(auto& ev:g_sse_events) {
+            if(!ev.contains("choices") || ev["choices"].empty()) continue;
+            const auto& delta=ev["choices"][0]["delta"];
+            if(delta.contains("tool_calls")) call_count++;
+            if(delta.contains("content"))
+                visible+=delta["content"].get<std::string>();
+        }
+        CHECK(call_count==0);
+        CHECK(visible.find("\"name\":\"first\"")!=std::string::npos);
+        CHECK(visible.find("<tool_call>")!=std::string::npos);
+        CHECK(visible.find("\"name\":\"second\"")!=std::string::npos);
+    }
+
+    // ---- Test 13d: max-token truncation cannot expose an unclosed wrapper. ----
+    {
+        FakeTok tok;
+        tok.pieces={"<eos>","<tool_call>{\"name\":\"first\",\"arguments\":{}}"};
+        std::vector<std::string> vb=tok.pieces;
+        auto cache=fresh_cache(vb);
+        auto slots=fresh_slots();
+        slots[0].eng->script={1};
+        std::atomic<long> rc{0};
+        json tools=json::array({
+            {{"type","function"},{"function",{{"name","first"},{"parameters",json::object()}}}}
+        });
+        json body={{"max_tokens",1},{"tools",tools},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        const auto& choice=g_last_response["choices"][0];
+        CHECK(!choice["message"].contains("tool_calls"));
+        CHECK(choice["message"]["content"].get<std::string>().find("first")!=std::string::npos);
+        CHECK(choice["finish_reason"]=="length");
+    }
+    {
+        FakeTok tok;
+        tok.pieces={"<eos>","<tool_call>{\"name\":\"first\",\"arguments\":{}}"};
+        std::vector<std::string> vb=tok.pieces;
+        auto cache=fresh_cache(vb);
+        auto slots=fresh_slots();
+        slots[0].eng->script={1};
+        std::atomic<long> rc{0};
+        json tools=json::array({
+            {{"type","function"},{"function",{{"name","first"},{"parameters",json::object()}}}}
+        });
+        json body={{"stream",true},{"max_tokens",1},{"tools",tools},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        bool saw_tool=false,saw_raw=false,saw_length=false;
+        for(const auto& ev:g_sse_events) {
+            if(!ev.contains("choices") || ev["choices"].empty()) continue;
+            const auto& choice=ev["choices"][0];
+            const auto& delta=choice["delta"];
+            if(delta.contains("tool_calls")) saw_tool=true;
+            if(delta.contains("content") &&
+               delta["content"].get<std::string>().find("first")!=std::string::npos)
+                saw_raw=true;
+            if(choice["finish_reason"]=="length") saw_length=true;
+        }
+        CHECK(!saw_tool);
+        CHECK(saw_raw);
+        CHECK(saw_length);
+    }
+
+    // ---- Test 13e: a closed call remains actionable at the exact token cap. ----
+    {
+        FakeTok tok;
+        tok.pieces={"<eos>","<tool_call>{\"name\":\"first\",\"arguments\":{}}</tool_call>"};
+        std::vector<std::string> vb=tok.pieces;
+        auto cache=fresh_cache(vb);
+        auto slots=fresh_slots();
+        slots[0].eng->script={1};
+        std::atomic<long> rc{0};
+        json tools=json::array({
+            {{"type","function"},{"function",{{"name","first"},{"parameters",json::object()}}}}
+        });
+        json body={{"max_tokens",1},{"tools",tools},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        const auto& choice=g_last_response["choices"][0];
+        CHECK(choice["message"]["tool_calls"].size()==1);
+        CHECK(choice["message"]["tool_calls"][0]["function"]["name"]=="first");
+        CHECK(choice["finish_reason"]=="tool_calls");
+    }
+    {
+        FakeTok tok;
+        tok.pieces={"<eos>","<tool_call>{\"name\":\"first\",\"arguments\":{}}</tool_call>"};
+        std::vector<std::string> vb=tok.pieces;
+        auto cache=fresh_cache(vb);
+        auto slots=fresh_slots();
+        slots[0].eng->script={1};
+        std::atomic<long> rc{0};
+        json tools=json::array({
+            {{"type","function"},{"function",{{"name","first"},{"parameters",json::object()}}}}
+        });
+        json body={{"stream",true},{"max_tokens",1},{"tools",tools},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        bool saw_tool=false,saw_tool_finish=false;
+        for(const auto& ev:g_sse_events) {
+            if(!ev.contains("choices") || ev["choices"].empty()) continue;
+            const auto& choice=ev["choices"][0];
+            if(choice["delta"].contains("tool_calls")) saw_tool=true;
+            if(choice["finish_reason"]=="tool_calls") saw_tool_finish=true;
+        }
+        CHECK(saw_tool);
+        CHECK(saw_tool_finish);
+    }
+
+    // ---- Test 13f: a malformed wrapper can contain multiple valid calls. ----
+    {
+        FakeTok tok;
+        tok.pieces={"<eos>",
+            "<tool_call>{\"name\":\"first\",\"arguments\":{}}"
+            "{\"name\":\"second\",\"arguments\":{}}</tool_call>"};
+        std::vector<std::string> vb=tok.pieces;
+        auto cache=fresh_cache(vb);
+        auto slots=fresh_slots();
+        slots[0].eng->script={1};
+        std::atomic<long> rc{0};
+        json tools=json::array({
+            {{"type","function"},{"function",{{"name","first"},{"parameters",json::object()}}}},
+            {{"type","function"},{"function",{{"name","second"},{"parameters",json::object()}}}},
+        });
+        json body={{"stream",true},{"tools",tools},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        std::vector<std::string> call_names;
+        std::string visible;
+        for(const auto& ev:g_sse_events) {
+            if(!ev.contains("choices") || ev["choices"].empty()) continue;
+            const auto& delta=ev["choices"][0]["delta"];
+            if(delta.contains("tool_calls"))
+                call_names.push_back(delta["tool_calls"][0]["function"]["name"]);
+            if(delta.contains("content")) visible+=delta["content"].get<std::string>();
+        }
+        CHECK(call_names==std::vector<std::string>({"first","second"}));
+        CHECK(visible.find("\"name\":\"first\"")==std::string::npos);
+        CHECK(visible.find("\"name\":\"second\"")==std::string::npos);
+    }
+
+    // ---- Test 13g: balanced raw-value drift waits for tolerant final recovery. ----
+    {
+        FakeTok tok;
+        tok.pieces={"<eos>",R"({"name":"Write","arguments":{"content":"const s = "x";"}})"," tail"};
+        std::vector<std::string> vb=tok.pieces;
+        auto cache=fresh_cache(vb);
+        auto slots=fresh_slots();
+        slots[0].eng->script={1,2};
+        std::atomic<long> rc{0};
+        json tools=json::array({
+            {{"type","function"},{"function",{{"name","Write"},{"parameters",{
+                {"type","object"},{"properties",{{"content",{{"type","string"}}}}}
+            }}}}}
+        });
+        json body={{"stream",true},{"tools",tools},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        int call_count=0;
+        std::string visible;
+        for(const auto& ev:g_sse_events) {
+            if(!ev.contains("choices") || ev["choices"].empty()) continue;
+            const auto& delta=ev["choices"][0]["delta"];
+            if(delta.contains("tool_calls")) {
+                call_count++;
+                const auto& fn=delta["tool_calls"][0]["function"];
+                CHECK(fn["name"]=="Write");
+                CHECK(json::parse(fn["arguments"].get<std::string>())["content"]==
+                      "const s = \"x\";");
+            }
+            if(delta.contains("content")) visible+=delta["content"].get<std::string>();
+        }
+        CHECK(call_count==1);
+        CHECK(visible==" tail");
+    }
+
+    // ---- Test 14: malformed parallel_tool_calls is a client error. ----
+    {
+        FakeTok tok;
+        tok.pieces={"<eos>"};
+        std::vector<std::string> vb=tok.pieces;
+        auto cache=fresh_cache(vb);
+        auto slots=fresh_slots();
+        std::atomic<long> rc{0};
+        json body={{"parallel_tool_calls","no"},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        CHECK(g_last_response["__status"]==400);
+        CHECK(g_last_response["error"]["type"]=="invalid_request_error");
+    }
+
+    // ---- Test 15: forced non-stream truncation preserves partial output. ----
+    {
+        FakeTok tok;
+        tok.pieces={"<eos>","not a tool call"};
+        std::vector<std::string> vb=tok.pieces;
+        auto cache=fresh_cache(vb);
+        auto slots=fresh_slots();
+        slots[0].eng->script={1};
+        std::atomic<long> rc{0};
+        json body={{"max_tokens",1},{"tool_choice","required"},
+                   {"tools",json::array({{{"type","function"},{"function",{{"name","safe"},{"parameters",json::object()}}}}})},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        CHECK(g_last_response["__status"]==200);
+        CHECK(g_last_response["choices"][0]["finish_reason"]=="length");
+        CHECK(g_last_response["choices"][0]["message"]["content"]=="not a tool call");
+        CHECK(!g_last_response["choices"][0]["message"].contains("tool_calls"));
+    }
+
+    // ---- Test 16: forced SSE truncation terminates with length, not error. ----
+    {
+        FakeTok tok;
+        tok.pieces={"<eos>","not a tool call"};
+        std::vector<std::string> vb=tok.pieces;
+        auto cache=fresh_cache(vb);
+        auto slots=fresh_slots();
+        slots[0].eng->script={1};
+        std::atomic<long> rc{0};
+        json body={{"stream",true},{"max_tokens",1},{"tool_choice","required"},
+                   {"tools",json::array({{{"type","function"},{"function",{{"name","safe"},{"parameters",json::object()}}}}})},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",true,false,true,100000,100000,rc,cache,slots,body,true);
+        bool saw_error=false,saw_length=false,saw_partial=false;
+        for(const auto& ev:g_sse_events) {
+            if(ev.contains("error")) saw_error=true;
+            if(!ev.contains("choices") || ev["choices"].empty()) continue;
+            const auto& choice=ev["choices"][0];
+            if(choice["finish_reason"]=="length") saw_length=true;
+            if(choice.contains("delta") && choice["delta"].contains("content") &&
+               choice["delta"]["content"]=="not a tool call") saw_partial=true;
+        }
+        CHECK(!saw_error);
+        CHECK(saw_length);
+        CHECK(saw_partial);
+    }
+
+    // ---- Test 16b: a forced request that re-enters THINK and exhausts its
+    // reasoning budget is a truncated response, not a missing-tool error. ----
+    for(bool stream:{false,true}) {
+        FakeTok tok;
+        tok.pieces={"<eos>","</tool_call><think>","unreachable reasoning"};
+        std::vector<std::string> vb=tok.pieces;
+        auto cache=fresh_cache(vb);
+        auto slots=fresh_slots();
+        slots[0].eng->script={1,2};
+        std::atomic<long> rc{0};
+        json body={{"stream",stream},{"max_tokens",2},
+                   {"enable_thinking",true},{"thinking_token_budget",0},
+                   {"tool_choice","required"},
+                   {"tools",json::array({{{"type","function"},{"function",{
+                       {"name","safe"},{"parameters",json::object()}}}}})},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})}};
+        run_request(tok,"q27-test",false,false,true,100000,100000,rc,cache,slots,
+                    body,true);
+        if(!stream) {
+            CHECK(g_last_response["__status"]==200);
+            CHECK(g_last_response["choices"][0]["finish_reason"]=="length");
+        } else {
+            bool saw_error=false,saw_length=false;
+            for(const auto& ev:g_sse_events) {
+                if(ev.contains("error")) saw_error=true;
+                if(!ev.contains("choices") || ev["choices"].empty()) continue;
+                if(ev["choices"][0]["finish_reason"]=="length") saw_length=true;
+            }
+            CHECK(!saw_error);
+            CHECK(saw_length);
+        }
+    }
+
+    // ---- Test 17: count_tokens and live Anthropic requests share the exact
+    // tool filtering, thinking, and forced-opener prompt construction. ----
+    {
+        json tools=json::array({
+            {{"name","alpha"},{"description","first"},
+             {"input_schema",{{"type","object"},{"properties",json::object()}}}},
+            {{"name","beta"},{"description","second"},
+             {"input_schema",{{"type","object"},{"properties",json::object()}}}},
+        });
+        json body={{"system","stable"},{"tools",tools},
+                   {"messages",json::array({{{"role","user"},{"content","run"}}})},
+                   {"tool_choice",{{"type","none"}}}};
+        auto none=prepare_anthropic_prompt_for_test(body,false);
+        CHECK(none.tools.empty());
+        CHECK(none.tool_names.empty());
+        CHECK(none.thinking);
+        const json none_unavailable=q27::anthropic_tools_json(body);
+        CHECK(none.rendered==q27::chatml_prompt(
+            q27::anthropic_msgs(body),none.tools,none.thinking,nullptr,nullptr,
+            q27::anthropic_tool_choice_instruction(none.tchoice),&none_unavailable));
+        CHECK(none.rendered.find("# Tools")==std::string::npos);
+        CHECK(none.rendered.find("<unavailable_tools>")!=std::string::npos);
+
+        body["tool_choice"]={{"type","tool"},{"name","alpha"}};
+        auto forced=prepare_anthropic_prompt_for_test(body,false);
+        CHECK(forced.tchoice.mode==q27::ToolChoice::FORCED);
+        CHECK(!forced.thinking);
+        CHECK(forced.tool_names==std::vector<std::string>({"alpha"}));
+        CHECK(forced.tools.size()==1);
+        CHECK(forced.tools[0]["function"]["name"]=="alpha");
+        const json all_forced_tools=q27::anthropic_tools_json(body);
+        const json forced_unavailable=json::array({all_forced_tools[1]});
+        CHECK(forced.rendered==q27::chatml_prompt(
+            q27::anthropic_msgs(body),forced.tools,false,nullptr,nullptr,
+            q27::anthropic_tool_choice_instruction(forced.tchoice),
+            &forced_unavailable)+"<tool_call>\n");
+        CHECK(forced.rendered.find("# Tools")!=std::string::npos);
+        CHECK(forced.rendered.find("<unavailable_tools>")!=std::string::npos);
+        CHECK(forced.rendered.find("stable")<forced.rendered.find("You must call only"));
+
+        bool thinking_threw=false;
+        body["thinking"]={{"type","enabled"},{"budget_tokens",1024}};
+        try { (void)prepare_anthropic_prompt_for_test(body,false); }
+        catch(const std::invalid_argument&) { thinking_threw=true; }
+        CHECK(thinking_threw);
+        body.erase("thinking");
+
+        bool invalid_threw=false;
+        body["tool_choice"]={{"type","tool"},{"name","missing"}};
+        try { (void)prepare_anthropic_prompt_for_test(body,false); }
+        catch(const std::runtime_error&) { invalid_threw=true; }
+        CHECK(invalid_threw);
     }
 
     fprintf(stderr, failures ? "%d FAILURE(S)\n" : "all integration tests passed\n", failures);

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -28,6 +28,12 @@ static void test_tools_passthrough() {
         {{"type", "web_search"}},                      // hosted type, not "function"
         {{"type", "function"}},                         // missing "function" key
         {{"type", "function"}, {"function", json::object()}}, // missing name
+        {{"type", nullptr}, {"function", {{"name", "null_type"}}}},
+        {{"type", "function"}, {"function", {{"name", "null_description"},
+            {"description", nullptr}}}},
+        {{"type", "function"}, {"function", {{"name", "bad_parameters"},
+            {"parameters", json::array()}}}},
+        {{"type", "function"}, {"function", {{"name", ""}}}},
     })}};
     json tools = q27::openai_tools_json(body);
     CHECK(tools.is_array());
@@ -41,6 +47,24 @@ static void test_tools_absent() {
     json tools = q27::openai_tools_json(body);
     CHECK(tools.is_array());
     CHECK(tools.empty());
+}
+
+static void test_responses_tool_fields_reject_wrong_types() {
+    auto rejected=[](json tool) {
+        try {
+            q27::validate_responses_tool_fields(
+                json{{"tools",json::array({std::move(tool)})}});
+            return false;
+        } catch(const std::invalid_argument&) {
+            return true;
+        }
+    };
+    CHECK(rejected(json{{"type",nullptr}}));
+    CHECK(rejected(json{{"type","function"},{"name",nullptr}}));
+    CHECK(rejected(json{{"type","custom"},{"name","apply_patch"},
+                        {"description",nullptr}}));
+    CHECK(!rejected(json{{"type","function"},{"name","safe"},
+                         {"description","safe tool"}}));
 }
 
 static void test_msgs_plain_roundtrip() {
@@ -192,6 +216,21 @@ static void test_jint_float_and_absurd_magnitude() {
     CHECK(q27::jint(json::array(), "a", 5) == 5); // non-object body
 }
 
+static void test_parse_tool_call_requires_object_arguments() {
+    for(const char* raw:{
+            R"({"name":"first","arguments":null})",
+            R"({"name":"first","arguments":[]})",
+            R"({"name":"first","arguments":7})",
+            R"({"name":"first","arguments":"null"})"})
+        CHECK(!q27::parse_tool_call(raw).ok);
+    auto missing=q27::parse_tool_call(R"({"name":"first"})");
+    CHECK(missing.ok && missing.arguments.is_object());
+    auto encoded=q27::parse_tool_call(
+        R"({"name":"first","arguments":"{\"path\":\"safe\"}"})");
+    CHECK(encoded.ok && encoded.arguments.is_object() &&
+          encoded.arguments.value("path",std::string())=="safe");
+}
+
 // ---- malformed-shape robustness (must not throw -> no spurious 500) -------
 static void test_anthropic_msgs_non_object_message_skipped() {
     json body = json::parse(R"({"messages":["hi",3,{"role":"user","content":"real"}]})");
@@ -227,7 +266,7 @@ static void test_anthropic_msgs_tool_result_bare_string_content() {
 }
 
 static void test_anthropic_tools_non_array_and_non_object_entries() {
-    json body = json::parse(R"({"tools":["str",7,{"name":"Read","input_schema":{}}]})");
+    json body = json::parse(R"({"tools":["str",7,{"name":""},{"name":"Read","input_schema":{}}]})");
     json out = q27::anthropic_tools_json(body);
     CHECK(out.size() == 1);
     json body2 = json::parse(R"({"tools":{"not":"an array"}})");
@@ -283,11 +322,346 @@ static void test_tool_choice_required() {
     CHECK(tc.forced_name.empty());
 }
 
+static void test_forced_tool_choice_truncation() {
+    q27::ToolChoice forced;
+    forced.mode=q27::ToolChoice::FORCED;
+    CHECK(q27::forced_tool_choice_missing_is_error(forced,false,false));
+    CHECK(!q27::forced_tool_choice_missing_is_error(forced,false,true));
+    CHECK(!q27::forced_tool_choice_missing_is_error(forced,true,false));
+    q27::ToolChoice automatic;
+    CHECK(!q27::forced_tool_choice_missing_is_error(automatic,false,false));
+}
+
+static void test_anthropic_tool_stop_reason() {
+    CHECK(std::string(q27::anthropic_tool_stop_reason(true,false,false))=="tool_use");
+    CHECK(std::string(q27::anthropic_tool_stop_reason(true,true,true))=="max_tokens");
+    CHECK(std::string(q27::anthropic_tool_stop_reason(false,false,true))=="max_tokens");
+    CHECK(std::string(q27::anthropic_tool_stop_reason(false,false,false))=="end_turn");
+    CHECK(std::string(q27::openai_tool_finish_reason(true,false,false))=="tool_calls");
+    CHECK(std::string(q27::openai_tool_finish_reason(true,true,true))=="length");
+    CHECK(std::string(q27::openai_tool_finish_reason(false,false,true))=="length");
+    CHECK(std::string(q27::openai_tool_finish_reason(false,false,false))=="stop");
+}
+
 static void test_tool_choice_named_function() {
     json body = {{"tool_choice", {{"type","function"},{"function",{{"name","get_weather"}}}}}};
     auto tc = q27::parse_tool_choice(body);
     CHECK(tc.mode == q27::ToolChoice::FORCED);
     CHECK(tc.forced_name == "get_weather");
+}
+
+static void test_tool_choice_malformed_named_is_invalid() {
+    for (const json& value : json::array({
+             json{{"type","function"},{"function",json::object()}},
+             json{{"type","function"},{"function",{{"name",""}}}},
+             json{{"type",nullptr},{"function",{{"name","get_weather"}}}}
+         })) {
+        auto tc = q27::parse_tool_choice(json{{"tool_choice",value}});
+        CHECK(tc.mode == q27::ToolChoice::AUTO);
+        CHECK(tc.invalid);
+    }
+}
+
+static void test_tool_choice_allowed_tools() {
+    json tools=json::array({
+        {{"type","function"},{"function",{{"name","get_weather"}}}},
+        {{"type","function"},{"function",{{"name","get_time"}}}}
+    });
+    auto automatic=q27::parse_tool_choice({{"tool_choice",{{"type","allowed_tools"},
+        {"allowed_tools",{{"mode","auto"},{"tools",tools}}}}}});
+    CHECK(automatic.mode == q27::ToolChoice::AUTO);
+    CHECK(!automatic.invalid);
+    CHECK(automatic.allowed_names.size() == 2);
+    auto required=q27::parse_tool_choice({{"tool_choice",{{"type","allowed_tools"},
+        {"allowed_tools",{{"mode","required"},{"tools",tools}}}}}});
+    CHECK(required.mode == q27::ToolChoice::FORCED);
+    CHECK(!required.invalid);
+    CHECK(required.allowed_names.size() == 2);
+    json body={{"tools",json::array({
+        {{"type","function"},{"function",{{"name","get_weather"}}}},
+        {{"type","function"},{"function",{{"name","privileged"}}}},
+        {{"type","function"},{"function",{{"name","get_time"}}}}
+    })}};
+    auto selected=q27::select_openai_tools(body,required);
+    CHECK(selected.names.size() == 2);
+    CHECK(selected.names[0] == "get_weather");
+    CHECK(selected.names[1] == "get_time");
+    CHECK(selected.tools.size() == 2);
+    auto missing=q27::parse_tool_choice({{"tool_choice",{{"type","function"},
+        {"function",{{"name","missing"}}}}}});
+    bool threw=false;
+    try { (void)q27::select_openai_tools(body,missing); }
+    catch (const std::runtime_error&) { threw=true; }
+    CHECK(threw);
+}
+
+static void test_openai_parallel_tool_calls() {
+    const std::set<std::string> declared={"first","second"};
+    q27::ToolChoice single=q27::parse_tool_choice(json::object());
+    q27::apply_openai_parallel_tool_calls({{"parallel_tool_calls",false}},single);
+    CHECK(single.disable_parallel_tool_use);
+    CHECK(q27::tool_choice_allows_call(single,declared,"first",0));
+    CHECK(!q27::tool_choice_allows_call(single,declared,"second",1));
+
+    q27::ToolChoice parallel=q27::parse_responses_tool_choice(json::object());
+    q27::apply_openai_parallel_tool_calls({{"parallel_tool_calls",true}},parallel);
+    CHECK(!parallel.disable_parallel_tool_use);
+    CHECK(q27::tool_choice_allows_call(parallel,declared,"second",1));
+
+    q27::ToolChoice malformed=q27::parse_tool_choice(json::object());
+    q27::apply_openai_parallel_tool_calls({{"parallel_tool_calls","no"}},malformed);
+    CHECK(malformed.invalid);
+}
+
+static void test_recovered_call_batch_eligibility() {
+    const std::set<std::string> declared={"first","second"};
+    q27::ToolCall first; first.ok=true; first.name="first";
+    q27::ToolCall second; second.ok=true; second.name="second";
+    std::vector<q27::ToolCall> calls={first,second};
+
+    q27::ToolChoice parallel=q27::parse_tool_choice(json::object());
+    CHECK(q27::tool_choice_allows_all_calls(parallel,declared,calls));
+
+    q27::ToolChoice single=q27::parse_tool_choice(json::object());
+    q27::apply_openai_parallel_tool_calls({{"parallel_tool_calls",false}},single);
+    CHECK(!q27::tool_choice_allows_all_calls(single,declared,calls));
+    CHECK(q27::tool_choice_allows_all_calls(single,declared,{first}));
+    CHECK(!q27::tool_choice_allows_all_calls(single,declared,{first},1));
+
+    q27::ToolChoice named=q27::parse_tool_choice({{"tool_choice",{{"type","function"},
+        {"function",{{"name","first"}}}}}});
+    CHECK(!q27::tool_choice_allows_all_calls(named,declared,{second}));
+}
+
+static void test_anthropic_tool_choice_shapes() {
+    auto absent=q27::parse_anthropic_tool_choice(json::object());
+    CHECK(absent.mode == q27::ToolChoice::AUTO);
+    CHECK(!absent.invalid);
+    auto automatic=q27::parse_anthropic_tool_choice(
+        {{"tool_choice",{{"type","auto"},{"disable_parallel_tool_use",true}}}});
+    CHECK(automatic.mode == q27::ToolChoice::AUTO);
+    CHECK(!automatic.invalid);
+    CHECK(automatic.disable_parallel_tool_use);
+    auto none=q27::parse_anthropic_tool_choice({{"tool_choice",{{"type","none"}}}});
+    CHECK(none.mode == q27::ToolChoice::NONE);
+    auto any=q27::parse_anthropic_tool_choice({{"tool_choice",{{"type","any"}}}});
+    CHECK(any.mode == q27::ToolChoice::FORCED);
+    CHECK(any.forced_name.empty());
+    auto named=q27::parse_anthropic_tool_choice(
+        {{"tool_choice",{{"type","tool"},{"name","get_weather"}}}});
+    CHECK(named.mode == q27::ToolChoice::FORCED);
+    CHECK(named.forced_name == "get_weather");
+    CHECK(named.allowed_names.size() == 1);
+    CHECK(q27::anthropic_tool_choice_instruction(automatic).empty());
+    CHECK(q27::anthropic_tool_choice_instruction(none).find("disabled")!=std::string::npos);
+    CHECK(q27::anthropic_tool_choice_instruction(any).find("at least one")!=std::string::npos);
+    CHECK(q27::anthropic_tool_choice_instruction(named).find("get_weather")!=std::string::npos);
+    const json thinking_body={
+        {"thinking",{{"type","enabled"},{"budget_tokens",1024}}}};
+    const q27::ThinkCfg requested_thinking=q27::resolve_think_cfg(
+        thinking_body,false,true,-1);
+    bool forced_thinking_threw=false;
+    try {
+        q27::validate_anthropic_tool_choice_thinking(named,requested_thinking);
+    } catch(const std::invalid_argument&) { forced_thinking_threw=true; }
+    CHECK(forced_thinking_threw);
+    q27::validate_anthropic_tool_choice_thinking(
+        named,q27::resolve_think_cfg(thinking_body,false,false,-1));
+    q27::validate_anthropic_tool_choice_thinking(
+        named,q27::resolve_think_cfg(json::object(),true,true,-1));
+    q27::validate_anthropic_tool_choice_thinking(none,requested_thinking);
+    json body={{"tools",json::array({
+        {{"name","get_weather"},{"description","weather"},
+         {"input_schema",{{"type","object"}}}},
+        {{"name","get_time"},{"input_schema",{{"type","object"}}}}
+    })}};
+    json normalized={{"tools",q27::anthropic_tools_json(body)}};
+    auto selected=q27::select_openai_tools(normalized,named);
+    CHECK(selected.names.size() == 1);
+    CHECK(selected.names[0] == "get_weather");
+    const std::set<std::string> declared={"get_weather","get_time"};
+    CHECK(q27::tool_choice_allows_call(named,declared,"get_weather",0));
+    CHECK(!q27::tool_choice_allows_call(named,declared,"get_time",0));
+    CHECK(!q27::tool_choice_allows_call(none,declared,"get_weather",0));
+    CHECK(q27::tool_choice_allows_call(automatic,declared,"get_weather",0));
+    CHECK(!q27::tool_choice_allows_call(automatic,declared,"get_time",1));
+    CHECK(!q27::tool_choice_allows_call(automatic,declared,"undeclared",0));
+    bool missing_threw=false;
+    try {
+        auto missing=q27::parse_anthropic_tool_choice(
+            {{"tool_choice",{{"type","tool"},{"name","missing"}}}});
+        (void)q27::select_openai_tools(normalized,missing);
+    } catch(const std::runtime_error&) { missing_threw=true; }
+    CHECK(missing_threw);
+    for(const json& value:json::array({
+            json("auto"), json::object(), json{{"type","tool"}},
+            json{{"type","tool"},{"name",""}}, json{{"type","unknown"}}
+        })) {
+        auto malformed=q27::parse_anthropic_tool_choice({{"tool_choice",value}});
+        CHECK(malformed.invalid);
+    }
+    auto bad_parallel=q27::parse_anthropic_tool_choice(
+        {{"tool_choice",{{"type","auto"},{"disable_parallel_tool_use","yes"}}}});
+    CHECK(bad_parallel.invalid);
+}
+
+static void test_responses_tool_choice_shapes() {
+    auto named=q27::parse_responses_tool_choice({{"tool_choice",{{"type","function"},{"name","get_weather"}}}});
+    CHECK(named.mode == q27::ToolChoice::FORCED);
+    CHECK(named.forced_name == "get_weather");
+    auto custom=q27::parse_responses_tool_choice({{"tool_choice",{{"type","custom"},{"name","shell"}}}});
+    CHECK(custom.mode == q27::ToolChoice::FORCED);
+    CHECK(custom.forced_name == "shell");
+    auto allowed=q27::parse_responses_tool_choice({{"tool_choice",{{"type","allowed_tools"},
+        {"mode","auto"},{"tools",json::array({
+            {{"type","function"},{"name","get_weather"}},
+            {{"type","custom"},{"name","shell"}}
+        })}}}});
+    CHECK(!allowed.invalid);
+    CHECK(allowed.mode == q27::ToolChoice::AUTO);
+    CHECK(allowed.allowed_names.size() == 2);
+    CHECK(allowed.allowed_names[0] == "get_weather");
+    CHECK(allowed.allowed_names[1] == "shell");
+    auto hosted=q27::parse_responses_tool_choice({{"tool_choice",{{"type","shell"}}}});
+    CHECK(!hosted.invalid);
+    CHECK(hosted.mode == q27::ToolChoice::FORCED);
+    CHECK(hosted.forced_name == "shell");
+    const json shell_tools=q27::responses_shell_prompt_tools();
+    CHECK(shell_tools.is_array() && shell_tools.size()==2);
+    CHECK(shell_tools[0]["function"]["name"]=="exec_command");
+    CHECK(shell_tools[0]["function"]["parameters"]["required"]==json::array({"cmd"}));
+    CHECK(shell_tools[0]["function"]["parameters"]["properties"].contains("yield_time_ms"));
+    CHECK(shell_tools[1]["function"]["name"]=="write_stdin");
+    CHECK(shell_tools[1]["function"]["parameters"]["required"]==json::array({"session_id"}));
+    auto hosted_allowed=q27::parse_responses_tool_choice({{"tool_choice",{{"type","allowed_tools"},
+        {"mode","required"},{"tools",json::array({{{"type","shell"}}})}}}});
+    CHECK(!hosted_allowed.invalid);
+    CHECK(hosted_allowed.mode == q27::ToolChoice::FORCED);
+    CHECK(hosted_allowed.allowed_names.size() == 1);
+    CHECK(hosted_allowed.allowed_names[0] == "shell");
+    const std::set<std::string> hosted_types={"shell"};
+    auto registered_hosted=q27::responses_registered_tool_choice(hosted,hosted_types);
+    CHECK(registered_hosted.mode == q27::ToolChoice::FORCED);
+    CHECK(registered_hosted.forced_name.empty());
+    CHECK(registered_hosted.allowed_names ==
+          std::vector<std::string>({"exec_command","write_stdin"}));
+    auto registered_allowed=q27::responses_registered_tool_choice(hosted_allowed,hosted_types);
+    CHECK(registered_allowed.mode == q27::ToolChoice::FORCED);
+    CHECK(registered_allowed.allowed_names ==
+          std::vector<std::string>({"exec_command","write_stdin"}));
+    auto registered_mixed=q27::responses_registered_tool_choice(allowed,hosted_types);
+    CHECK(registered_mixed.mode == q27::ToolChoice::AUTO);
+    CHECK(registered_mixed.allowed_names ==
+          std::vector<std::string>({"exec_command","get_weather","write_stdin"}));
+    CHECK(q27::responses_tool_names_ambiguous(
+        {"exec_command"},{},hosted_types));
+    CHECK(q27::responses_tool_names_ambiguous(
+        {},{"write_stdin"},hosted_types));
+    CHECK(q27::responses_tool_names_ambiguous(
+        {"shell"},{},hosted_types));
+    CHECK(q27::responses_tool_names_ambiguous(
+        {"duplicate"},{"duplicate"},{}));
+    CHECK(!q27::responses_tool_names_ambiguous(
+        {"get_weather"},{"apply_patch"},hosted_types));
+    q27::validate_responses_tool_choice_declarations(
+        {{"tool_choice",{{"type","custom"},{"name","apply_patch"}}}},
+        {"get_weather"},{"apply_patch"},hosted_types);
+    bool mismatched_kind_threw=false;
+    try {
+        q27::validate_responses_tool_choice_declarations(
+            {{"tool_choice",{{"type","function"},{"name","apply_patch"}}}},
+            {"get_weather"},{"apply_patch"},hosted_types);
+    } catch(const std::runtime_error&) { mismatched_kind_threw=true; }
+    CHECK(mismatched_kind_threw);
+    bool mismatched_allowed_kind_threw=false;
+    try {
+        q27::validate_responses_tool_choice_declarations(
+            {{"tool_choice",{{"type","allowed_tools"},{"tools",json::array({
+                {{"type","custom"},{"name","get_weather"}}
+            })}}}},
+            {"get_weather"},{"apply_patch"},hosted_types);
+    } catch(const std::runtime_error&) { mismatched_allowed_kind_threw=true; }
+    CHECK(mismatched_allowed_kind_threw);
+    auto empty=q27::parse_responses_tool_choice({{"tool_choice",json::object()}});
+    CHECK(empty.invalid);
+    auto mcp=q27::parse_responses_tool_choice({{"tool_choice",{{"type","mcp"},
+        {"server_label","filesystem"},{"name","read_file"}}}});
+    CHECK(mcp.invalid);
+    auto mcp_allowed=q27::parse_responses_tool_choice({{"tool_choice",{{"type","allowed_tools"},
+        {"mode","auto"},{"tools",json::array({{{"type","mcp"},
+            {"server_label","filesystem"}}})}}}});
+    CHECK(!mcp_allowed.invalid && mcp_allowed.mode==q27::ToolChoice::NONE);
+    auto web_search=q27::parse_responses_tool_choice(
+        {{"tool_choice",{{"type","web_search_preview"}}}});
+    CHECK(web_search.invalid);
+    auto web_search_allowed=q27::parse_responses_tool_choice({{"tool_choice",{{"type","allowed_tools"},
+        {"mode","auto"},{"tools",json::array({{{"type","web_search_preview"}}})}}}});
+    CHECK(!web_search_allowed.invalid &&
+          web_search_allowed.mode==q27::ToolChoice::NONE);
+    auto mixed_hosted_allowed=q27::parse_responses_tool_choice({{"tool_choice",{{"type","allowed_tools"},
+        {"mode","auto"},{"tools",json::array({
+            {{"type","web_search_preview"}},
+            {{"type","function"},{"name","get_weather"}}
+        })}}}});
+    CHECK(!mixed_hosted_allowed.invalid &&
+          mixed_hosted_allowed.allowed_names==std::vector<std::string>({"get_weather"}));
+    auto required_web_search=q27::parse_responses_tool_choice({{"tool_choice",{{"type","allowed_tools"},
+        {"mode","required"},{"tools",json::array({{{"type","web_search_preview"}}})}}}});
+    CHECK(required_web_search.invalid);
+    auto unknown_string=q27::parse_responses_tool_choice({{"tool_choice","none "}});
+    CHECK(unknown_string.invalid);
+    auto malformed=q27::parse_responses_tool_choice({{"tool_choice",{{"type","function"},{"name",3}}}});
+    CHECK(malformed.invalid);
+    std::set<std::string> eligible={"get_weather"};
+    q27::add_responses_hosted_call_names(eligible,"shell");
+    auto none=q27::parse_responses_tool_choice({{"tool_choice","none"}});
+    CHECK(!q27::tool_choice_allows_call(none,eligible,"get_weather",0));
+    CHECK(!q27::tool_choice_allows_call(none,eligible,"exec_command",0));
+    CHECK(q27::tool_choice_allows_call(named,eligible,"get_weather",0));
+    CHECK(!q27::tool_choice_allows_call(named,eligible,"exec_command",0));
+    auto hosted_output=hosted;
+    hosted_output.forced_name.clear(); // hosted type maps to its concrete call names
+    CHECK(q27::tool_choice_allows_call(hosted_output,eligible,"exec_command",0));
+    q27::apply_openai_parallel_tool_calls({{"parallel_tool_calls",false}},hosted_output);
+    CHECK(!q27::tool_choice_allows_call(hosted_output,eligible,"write_stdin",1));
+    json response_tools=json::array({{{"type","function"},{"function",{
+        {"name","get_weather"},{"parameters",json::object()}}}}});
+    std::string bare_prefix,bare_remaining;
+    auto bare_calls=q27::parse_bare_tool_calls(
+        "answer {\"name\":\"get_weather\",\"arguments\":{\"city\":\"Tokyo\"}}",
+        &bare_prefix,&response_tools,true,true,&bare_remaining);
+    CHECK(bare_calls.size()==1 && bare_calls[0].ok &&
+          bare_calls[0].name=="get_weather" &&
+          bare_calls[0].arguments["city"]=="Tokyo");
+    CHECK(q27::responses_tool_tail_after_bare_calls(
+        false,
+        "answer {\"name\":\"get_weather\",\"arguments\":{\"city\":\"Tokyo\"}}",
+        bare_calls,named,eligible));
+    std::string trailing_prefix,trailing_remaining;
+    const std::string trailing_text =
+        "{\"name\":\"get_weather\",\"arguments\":{}} ordinary text";
+    auto trailing_calls=q27::parse_bare_tool_calls(
+        trailing_text,&trailing_prefix,&response_tools,true,true,&trailing_remaining);
+    CHECK(!q27::responses_tool_tail_after_bare_calls(
+        false,trailing_text,trailing_calls,named,eligible));
+    CHECK(!q27::responses_tool_tail_after_bare_calls(
+        true,"ordinary text",{},named,eligible));
+    CHECK(q27::responses_tool_tail_after_bare_calls(
+        true," \n\t",{},named,eligible));
+    auto required=q27::parse_responses_tool_choice({{"tool_choice","required"}});
+    CHECK(q27::tool_choice_allows_call(required,eligible,bare_calls[0].name,0));
+    CHECK(!q27::forced_tool_choice_missing_is_error(required,true,false));
+}
+
+static void test_stream_options_include_usage() {
+    CHECK(q27::openai_stream_includes_usage({{"stream",true},
+        {"stream_options",{{"include_usage",true}}}}));
+    CHECK(!q27::openai_stream_includes_usage({{"stream",false},
+        {"stream_options",{{"include_usage",true}}}}));
+    CHECK(!q27::openai_stream_includes_usage({{"stream",true},
+        {"stream_options",{{"include_usage","yes"}}}}));
+    CHECK(!q27::openai_stream_includes_usage({{"stream",true},
+        {"stream_options",json::array()}}));
 }
 
 static void test_tool_choice_unknown_string_is_auto() {
@@ -420,9 +794,1338 @@ static void test_tool_call_delta_shape() {
     CHECK(args["location"] == "Paris");
 }
 
+static void test_tool_call_invalid_utf8_replaced() {
+    q27::ToolCall c;
+    c.ok=true;
+    c.name="get_weather";
+    c.arguments={{"invalid",std::string(1,char(0xff))}};
+    const std::string replacement="\xef\xbf\xbd";
+    json invalid_delta=q27::openai_tool_call_delta(0,"call_invalid",c);
+    json delta_args=json::parse(
+        invalid_delta["tool_calls"][0]["function"]["arguments"].get<std::string>());
+    CHECK(delta_args["invalid"]==replacement);
+    json invalid_message=q27::openai_tool_call_json("call_invalid",c);
+    json message_args=json::parse(
+        invalid_message["function"]["arguments"].get<std::string>());
+    CHECK(message_args["invalid"]==replacement);
+}
+
+static std::string feed_tool_bytewise(q27::ToolCallStreamer& streamer,
+                                      const std::string& body,
+                                      int& opened_count) {
+    std::string out;
+    for (char c : body) {
+        bool opened = false;
+        out += streamer.feed(std::string(1, c), &opened);
+        if (opened) opened_count++;
+    }
+    return out;
+}
+
+static void test_tool_streamer_bytewise_production_shape() {
+    q27::ToolCallStreamer streamer;
+    int opened_count = 0;
+    const std::string out = feed_tool_bytewise(streamer,
+        "{\"name\":\"weather\",\"arguments\":{\"city\":\"Paris\"}}",
+        opened_count);
+    std::string tail;
+    CHECK(opened_count == 1);
+    CHECK(streamer.opened);
+    CHECK(streamer.name == "weather");
+    CHECK(streamer.finalize(&tail));
+    CHECK(tail.empty());
+    CHECK(streamer.trail().empty());
+    CHECK(json::parse(out)["city"] == "Paris");
+}
+
+static void test_tool_streamer_inline_repairs() {
+    q27::ToolCallStreamer streamer;
+    bool opened = false;
+    const std::string raw_body = std::string(R"({"a":"b"} C:\tmp)") +
+        "\nliteral </content>} {\"note\":\"function\"} junk before the real close";
+    const std::string body =
+        "{\"name\":\"write\",\"arguments\":{\"text\":\"a\"b\nc\",\"body\":<content>" +
+        raw_body + "</content>}}";
+    std::string out = streamer.feed(body, &opened);
+    std::string tail;
+    CHECK(opened);
+    CHECK(!out.empty()); // raw bytes before the ambiguous close still stream
+    CHECK(streamer.finalize(&tail));
+    out += tail;
+    CHECK(!streamer.invalid());
+    const json args = json::parse(out);
+    CHECK(args["text"] == "a\"b\nc");
+    CHECK(args["body"] == raw_body);
+}
+
+static void test_tool_streamer_quoted_content_modes() {
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        std::string out = feed_tool_bytewise(streamer,
+            "{\"name\":\"write\",\"arguments\":{\"content\":\"line\\nC:\\\\tmp\",\"path\":\"x\"}}",
+            opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        CHECK(json::parse(out)["content"] == "line\nC:\\tmp");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        const std::string raw = std::string(R"({"a":"b"} C:\tmp)") +
+            "\nconst xs = [\"a\", \"b\"];\nline </content> literal";
+        const std::string body =
+            "{\"name\":\"write\",\"arguments\":{\"content\":\"" + raw +
+            "</content>,\"path\":\"x\"}}";
+        std::string out = feed_tool_bytewise(streamer, body, opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        CHECK(!streamer.invalid());
+        const json args = json::parse(out);
+        CHECK(args["content"] == raw);
+        CHECK(args["path"] == "x");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        const std::string raw = "say \"hi\"\nnext";
+        const std::string body =
+            "{\"name\":\"write\",\"arguments\":{\"content\":\"" + raw + "\"}}";
+        std::string out = feed_tool_bytewise(streamer, body, opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        CHECK(!streamer.invalid());
+        CHECK(json::parse(out)["content"] == raw);
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        std::string out = feed_tool_bytewise(streamer,
+            "{\"name\":\"write\",\"arguments\":{\"content\":\"line\\n</content>\",\"path\":\"x\"}}",
+            opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        const json args = json::parse(out);
+        CHECK(args["content"] == "line\n</content>");
+        CHECK(args["path"] == "x");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        std::string out = feed_tool_bytewise(streamer,
+            "{\"name\":\"write\",\"arguments\":{\"content\":\"a\",\"nested\":{\"content\":\"b\"}}}",
+            opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        const json args = json::parse(out);
+        CHECK(args["content"] == "a");
+        CHECK(args["nested"]["content"] == "b");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        const std::string raw_text = "a\nb";
+        const std::string body =
+            "{\"name\":\"write\",\"arguments\":{\"content\":\"keep </content>\",\"text\":\"" +
+            raw_text + "\"}}";
+        std::string out = feed_tool_bytewise(streamer, body, opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        const json args = json::parse(out);
+        CHECK(args["content"] == "keep </content>");
+        CHECK(args["text"] == raw_text);
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        const std::string raw_content = "say \"hi\"\n";
+        const std::string body =
+            "{\"name\":\"write\",\"arguments\":{\"content\":\"" + raw_content +
+            "\",\"body\":<content>x</content>}}";
+        std::string out = feed_tool_bytewise(streamer, body, opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        const json args = json::parse(out);
+        CHECK(args["content"] == raw_content);
+        CHECK(args["body"] == "x");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        const std::string body =
+            "{\"name\":\"write\",\"arguments\":{\"content\":\"raw</content>,"
+            "\"path\":\"literal </content>\"}}";
+        std::string out = feed_tool_bytewise(streamer, body, opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        const json args = json::parse(out);
+        CHECK(args["content"] == "raw");
+        CHECK(args["path"] == "literal </content>");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        const std::string raw = "say \"hi\"</content>";
+        const std::string body =
+            "{\"name\":\"write\",\"arguments\":{\"content\":\"" + raw +
+            "\",\"path\":\"x\"}}";
+        std::string out = feed_tool_bytewise(streamer, body, opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        const json args = json::parse(out);
+        CHECK(args["content"] == raw);
+        CHECK(args["path"] == "x");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        std::string body = "{\"name\":\"write\",\"arguments\":{\"content\":\"a\nb\"";
+        for (int i = 0; i < 512; i++) body += ",\"content\":\"v\"";
+        body += "}}";
+        bool opened = false;
+        std::string out = streamer.feed(body, &opened);
+        std::string tail;
+        CHECK(opened);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        CHECK(json::parse(out)["content"] == "v");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        std::string out = feed_tool_bytewise(streamer,
+            "{\"name\":\"write\",\"arguments\":{\"body\":\"x</content>,y\",\"path\":\"p\"}}",
+            opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        const json args = json::parse(out);
+        CHECK(args["body"] == "x</content>,y");
+        CHECK(args["path"] == "p");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        std::string out = feed_tool_bytewise(streamer,
+            "{\"name\":\"write\",\"arguments\":{\"old\":<content>a</content>,"
+            "\"new\":<content>b</content>}}",
+            opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        const json args = json::parse(out);
+        CHECK(args["old"] == "a");
+        CHECK(args["new"] == "b");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        std::string out = feed_tool_bytewise(streamer,
+            "{\"name\":\"write\",\"arguments\":{\"content\":\"ok\","
+            "\"items\":[{\"content\":\"raw</content>}]}}",
+            opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        const json args = json::parse(out);
+        CHECK(args["content"] == "ok");
+        CHECK(args["items"][0]["content"] == "raw");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        std::string out = feed_tool_bytewise(streamer,
+            "{\"name\":\"write\",\"arguments\":{\"old\":<content>a</content>,"
+            "\"new\":<content>b</content>} literal</content>}}",
+            opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        const json args = json::parse(out);
+        CHECK(args["old"] == "a");
+        CHECK(args["new"] == "b</content>} literal");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        std::string out = feed_tool_bytewise(streamer,
+            "{\"name\":\"write\",\"arguments\":{\"cont\\u0065nt\":\"raw</content>,\"path\":\"x\"}}",
+            opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        const json args = json::parse(out);
+        CHECK(args["content"] == "raw");
+        CHECK(args["path"] == "x");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        std::string out = feed_tool_bytewise(streamer,
+            "{\"name\":\"w\",\"arguments\":{\"nested\":{\"body\":<content>x</content>}",
+            opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(!streamer.finalize(&tail));
+        out += tail;
+        CHECK(out == "{\"nested\":{\"body\":\"x\"}");
+    }
+    {
+        q27::ToolCallStreamer streamer;
+        int opened_count = 0;
+        const std::string second =
+            "{\"name\":\"b\",\"arguments\":{\"new\":<content>y</content>}}";
+        std::string out = feed_tool_bytewise(streamer,
+            "{\"name\":\"a\",\"arguments\":{\"old\":<content>x</content>}}" + second,
+            opened_count);
+        std::string tail;
+        CHECK(opened_count == 1);
+        CHECK(streamer.finalize(&tail));
+        out += tail;
+        CHECK(json::parse(out)["old"] == "x");
+        CHECK(streamer.trail() == second);
+    }
+}
+
+static void test_tool_streamer_fallback_is_byte_exact() {
+    q27::ToolCallStreamer streamer;
+    const std::string body = "{ \"arguments\":{}, \"name\":\"wrong-order\" }";
+    bool opened = false;
+    CHECK(streamer.feed(body, &opened).empty());
+    CHECK(!opened);
+    CHECK(streamer.state == q27::ToolCallStreamer::FALLBACK);
+    CHECK(streamer.raw == body);
+}
+
+static void test_tool_streamer_preserves_packed_call_trail() {
+    q27::ToolCallStreamer streamer;
+    bool opened = false;
+    const std::string second = "{\"name\":\"b\",\"arguments\":{\"y\":2}}";
+    std::string out = streamer.feed(
+        "{\"name\":\"a\",\"arguments\":{\"content\":\"x\",\"x\":1}}" + second,
+        &opened);
+    std::string tail;
+    CHECK(opened);
+    CHECK(streamer.finalize(&tail));
+    out += tail;
+    CHECK(json::parse(out)["x"] == 1);
+    CHECK(json::parse(out)["content"] == "x");
+    CHECK(streamer.trail() == second);
+}
+
+static void test_tool_streamer_escapes_all_control_bytes() {
+    q27::ToolCallStreamer streamer;
+    std::string body="{\"name\":\"control\",\"arguments\":{\"input\":\"";
+    std::string expected;
+    for(unsigned char c:{(unsigned char)'\b',(unsigned char)'\f',(unsigned char)0,
+                         (unsigned char)1,(unsigned char)'\n',(unsigned char)'\t'}) {
+        body.push_back((char)c);
+        expected.push_back((char)c);
+    }
+    body+="\"}}";
+    bool opened=false;
+    std::string out=streamer.feed(body,&opened);
+    std::string tail;
+    CHECK(opened);
+    CHECK(streamer.finalize(&tail));
+    out+=tail;
+    CHECK(json::parse(out)["input"].get<std::string>()==expected);
+    CHECK(q27::escape_json_interior(expected).find("\\u0000")!=std::string::npos);
+}
+
+static void test_tool_streamer_can_refuse_tail_repair() {
+    q27::ToolCallStreamer streamer;
+    bool opened=false;
+    (void)streamer.feed("{\"name\":\"write\",\"arguments\":{\"path\":\"danger",&opened);
+    std::string tail;
+    CHECK(opened);
+    CHECK(!streamer.finalize(&tail,false));
+    CHECK(tail.empty());
+    CHECK(streamer.state==q27::ToolCallStreamer::ARGS);
+}
+
+static void test_bare_tool_parser_can_refuse_eof_repair() {
+    const std::string call="{\"name\":\"exec\",\"arguments\":{\"cmd\":\"danger";
+    const std::string raw="before "+call;
+    std::string prefix,remaining;
+    CHECK(q27::parse_bare_tool_calls(raw,&prefix,nullptr,false,false).empty());
+    const auto repaired=q27::parse_bare_tool_calls(raw,&prefix,nullptr,false,true,&remaining);
+    CHECK(repaired.size()==1);
+    CHECK(repaired[0].arguments["cmd"]=="danger");
+    CHECK(repaired[0].source_begin==7 && repaired[0].source_end==raw.size());
+    CHECK(repaired[0].raw==call);
+    CHECK(remaining=="before ");
+    const json tools=json::parse(R"([
+      {"type":"function","function":{"name":"exec","parameters":{
+        "type":"object","properties":{"cmd":{"type":"string"}},"required":["cmd"]}}}
+    ])");
+    const std::string nested="{\"name\":{\"cmd\":\"danger\"}";
+    CHECK(q27::parse_bare_tool_calls(
+        nested,&prefix,&tools,false,false,&remaining).empty());
+    CHECK(remaining==nested);
+    const std::string executable_call =
+        R"({"name":"exec","arguments":{"cmd":"danger"}})";
+    const std::string quoted_call = "He wrote \"example: " + executable_call + "\"";
+    CHECK(q27::parse_bare_tool_calls(
+        quoted_call,&prefix,&tools,false,true,&remaining).empty());
+    CHECK(remaining==quoted_call);
+
+    const std::string quoted_then_executable = quoted_call + "\n" + executable_call;
+    const auto executable_calls = q27::parse_bare_tool_calls(
+        quoted_then_executable,&prefix,&tools,false,true,&remaining);
+    CHECK(executable_calls.size()==1);
+    CHECK(executable_calls[0].source_begin==quoted_call.size()+1);
+    CHECK(remaining==quoted_call+"\n");
+    const std::string nested_json =
+        R"({"payload":{"name":"exec","arguments":{"cmd":"danger"}}})";
+    CHECK(q27::parse_bare_tool_calls(
+        nested_json,&prefix,&tools,false,true,&remaining).empty());
+    CHECK(remaining==nested_json);
+    const std::string unterminated_nested_json =
+        R"({"payload":{"name":"exec","arguments":{"cmd":"danger"}})";
+    CHECK(q27::parse_bare_tool_calls(
+        unterminated_nested_json,&prefix,&tools,false,true,&remaining).empty());
+    CHECK(remaining==unterminated_nested_json);
+    const std::string array_json =
+        R"([{"name":"exec","arguments":{"cmd":"danger"}}])";
+    CHECK(q27::parse_bare_tool_calls(
+        array_json,&prefix,&tools,false,true,&remaining).empty());
+    CHECK(remaining==array_json);
+
+    const std::string quoted_namedrop =
+        "He wrote \"example: {\"name\":{\"cmd\":\"danger\"}\"";
+    std::vector<q27::ToolCall> namedropped_calls;
+    size_t namedropped_first=std::string::npos;
+    q27::scan_namedropped(
+        quoted_namedrop,&tools,namedropped_calls,&namedropped_first);
+    CHECK(namedropped_calls.empty());
+    CHECK(namedropped_first==std::string::npos);
+
+    const std::string quoted_raw_value =
+        "He wrote \"example: {\"name\":\"exec\",\"arguments\":{\"cmd\":\"say \"hi\"\nnext\"}}\"";
+    std::vector<q27::ToolCall> raw_value_calls;
+    CHECK(!q27::recover_raw_value_call(quoted_raw_value,tools,raw_value_calls));
+    CHECK(raw_value_calls.empty());
+}
+
+static void test_tool_streamer_marks_invalid_completed_args() {
+    q27::ToolCallStreamer streamer;
+    bool opened = false;
+    (void)streamer.feed("{\"name\":\"bad\",\"arguments\":{\"x\":,}}", &opened);
+    CHECK(opened);
+    CHECK(streamer.invalid());
+    CHECK(streamer.state == q27::ToolCallStreamer::INVALID_DONE);
+}
+
+static void test_bare_tool_stream_holdback_bounds() {
+    CHECK(q27::plausible_bare_tool_prefix("{"));
+    CHECK(q27::plausible_bare_tool_prefix("{  \n\"na"));
+    CHECK(q27::plausible_bare_tool_prefix("{\"arguments\":{"));
+    CHECK(q27::plausible_bare_tool_prefix("{\"tool_name\":\"read\"}"));
+    CHECK(!q27::plausible_bare_tool_prefix("{\"title\":\"ordinary\"}"));
+    CHECK(!q27::plausible_bare_tool_prefix("{code block"));
+    const std::string complete="{\"name\":\"read\",\"arguments\":{\"text\":\"} kept\"}} tail";
+    CHECK(q27::balanced_json_object_prefix_end(complete)==complete.size()-5);
+    CHECK(q27::balanced_json_object_prefix_end("{\"name\":\"read\"")==
+          std::string::npos);
+    q27::IncrementalBareJsonEnd object_scan;
+    object_scan.begin(false);
+    std::string object_chunks="{\"name\":\"read\",\"arguments\":{\"text\":\"}";
+    CHECK(object_scan.advance(object_chunks)==std::string::npos);
+    const size_t scanned=object_scan.cursor;
+    object_chunks+=" kept\"}} tail";
+    CHECK(object_scan.advance(object_chunks)==object_chunks.size()-5);
+    CHECK(scanned<object_scan.cursor);
+    q27::IncrementalBareJsonEnd mode10_scan;
+    mode10_scan.begin(true);
+    std::string mode10_chunks="first\", \"payload\":{\"text\":\"}\"}";
+    CHECK(mode10_scan.advance(mode10_chunks)==std::string::npos);
+    mode10_chunks+="}";
+    CHECK(mode10_scan.advance(mode10_chunks)==mode10_chunks.size());
+    const std::set<std::string> names={"first","second"};
+    CHECK(q27::bare_mode10_signature_position(
+              "before first\", \"path\"",names)==7);
+    CHECK(q27::bare_mode10_signature_position(
+              "before \"first\", \"path\"",names)==std::string::npos);
+    CHECK(q27::bare_mode10_probe_start("ordinary fi",names)==9);
+    CHECK(q27::bare_mode10_probe_start("ordinary text",names)==std::string::npos);
+    q27::JsonStringLexState quoted_chunk;
+    quoted_chunk.consume("{\"note\":\"use ");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,quoted_chunk)==std::string::npos);
+    CHECK(q27::bare_mode10_probe_start("fi",names,quoted_chunk)==
+          std::string::npos);
+    quoted_chunk.consume("\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,quoted_chunk)==
+          std::string::npos);
+    CHECK(q27::bare_object_position(
+              "{\"name\":\"first\",\"arguments\":{}}",quoted_chunk)==
+          std::string::npos);
+    q27::MarkdownFenceLexState fenced_chunk;
+    fenced_chunk.consume("```json\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},fenced_chunk)==
+          std::string::npos);
+    CHECK(q27::bare_mode10_probe_start("fi",names,{},fenced_chunk)==
+          std::string::npos);
+    CHECK(q27::bare_object_position(
+              "{\"name\":\"first\",\"arguments\":{}}",{},fenced_chunk)==
+          std::string::npos);
+    fenced_chunk.consume("```\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},fenced_chunk)==0);
+    q27::MarkdownFenceLexState long_fenced_chunk;
+    long_fenced_chunk.consume("``````json\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},long_fenced_chunk)==
+          std::string::npos);
+    long_fenced_chunk.consume("```\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},long_fenced_chunk)==
+          std::string::npos);
+    long_fenced_chunk.consume(" ``````not-a-close\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},long_fenced_chunk)==
+          std::string::npos);
+    long_fenced_chunk.consume("  ``````   \n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},long_fenced_chunk)==0);
+    q27::MarkdownFenceLexState tilde_fenced_chunk;
+    tilde_fenced_chunk.consume("~~~json\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},tilde_fenced_chunk)==
+          std::string::npos);
+    tilde_fenced_chunk.consume("~~~not-a-close\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},tilde_fenced_chunk)==
+          std::string::npos);
+    tilde_fenced_chunk.consume("~~~\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},tilde_fenced_chunk)==0);
+    q27::MarkdownFenceLexState quote_fenced_chunk;
+    quote_fenced_chunk.consume("> ```json\n> ");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},quote_fenced_chunk)==
+          std::string::npos);
+    quote_fenced_chunk.consume("displayed\n> ```\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},quote_fenced_chunk)==0);
+    q27::MarkdownFenceLexState list_fenced_chunk;
+    list_fenced_chunk.consume("- ```json\n  ");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},list_fenced_chunk)==
+          std::string::npos);
+    list_fenced_chunk.consume("displayed\n      ```\n  ");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},list_fenced_chunk)==
+          std::string::npos);
+    list_fenced_chunk.consume("```\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},list_fenced_chunk)==0);
+    q27::MarkdownFenceLexState nested_list_quote_fence;
+    nested_list_quote_fence.consume("- > ~~~json\n  > ");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},nested_list_quote_fence)==
+          std::string::npos);
+    nested_list_quote_fence.consume("displayed\n  > ~~~\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},nested_list_quote_fence)==0);
+    q27::MarkdownFenceLexState nested_list_fence;
+    nested_list_fence.consume("- - ```json\n    ");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},nested_list_fence)==
+          std::string::npos);
+    nested_list_fence.consume("displayed\n    ```\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},nested_list_fence)==0);
+    q27::MarkdownFenceLexState indented_fence;
+    indented_fence.consume("    ```json\n    ");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},indented_fence)==
+          std::string::npos);
+    indented_fence.consume("displayed\n    ```\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},indented_fence)==0);
+    q27::MarkdownFenceLexState indented_code;
+    indented_code.consume("Example:\n\n    ");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"danger\"}",names,{},indented_code)==
+          std::string::npos);
+    CHECK(q27::bare_object_position(
+              "{\"name\":\"first\",\"arguments\":{}}",{},indented_code)==
+          std::string::npos);
+    q27::MarkdownFenceLexState tab_indented_code;
+    tab_indented_code.consume("Example:\n\n\t");
+    CHECK(q27::bare_object_position(
+              "{\"name\":\"first\",\"arguments\":{}}",{},tab_indented_code)==
+          std::string::npos);
+    q27::MarkdownFenceLexState blockquote_code;
+    blockquote_code.consume("> quoted ");
+    CHECK(q27::bare_object_position(
+              "{\"name\":\"first\",\"arguments\":{}}",{},blockquote_code)==
+          std::string::npos);
+    CHECK(q27::bare_mode10_probe_start("fi",names,{},blockquote_code)==
+          std::string::npos);
+    q27::MarkdownFenceLexState list_code;
+    list_code.consume("- example ");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"danger\"}",names,{},list_code)==
+          std::string::npos);
+    q27::MarkdownFenceLexState list_continuation;
+    list_continuation.consume("- example\n  ");
+    CHECK(q27::bare_object_position(
+              "{\"name\":\"first\",\"arguments\":{}}",{},list_continuation)==
+          std::string::npos);
+    list_continuation.consume("displayed\nplain\n");
+    CHECK(q27::bare_object_position(
+              "{\"name\":\"first\",\"arguments\":{}}",{},list_continuation)==0);
+    q27::MarkdownFenceLexState list_fence_deindent;
+    list_fence_deindent.consume("- ~~~json\n  displayed\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "  first\", \"path\":\"a\"}",names,{},list_fence_deindent)==
+          std::string::npos);
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},list_fence_deindent)==0);
+    q27::MarkdownFenceLexState quote_fence_exit;
+    quote_fence_exit.consume("> ~~~json\n> displayed\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "> first\", \"path\":\"a\"}",names,{},quote_fence_exit)==
+          std::string::npos);
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},quote_fence_exit)==0);
+    q27::MarkdownFenceLexState multiline_inline;
+    multiline_inline.consume("Use `example:\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"danger\"}\n`",names,{},
+              multiline_inline,false)==std::string::npos);
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"danger\"}",names,{},
+              multiline_inline,false)==std::string::npos);
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"danger\"}",names,{},
+              multiline_inline,true)==0);
+    q27::MarkdownFenceLexState inline_markers;
+    inline_markers.consume("Use ```foo``` here\n");
+    CHECK(q27::bare_mode10_signature_position(
+              "first\", \"path\":\"a\"}",names,{},inline_markers)==0);
+    const std::string long_fenced_text=
+        "``````json\n{\"name\":\"first\",\"arguments\":{}}\n``````\nafter";
+    CHECK(q27::bare_position_is_displayed(
+        long_fenced_text,long_fenced_text.find("{\"name\"")));
+    CHECK(!q27::bare_position_is_displayed(
+        long_fenced_text,long_fenced_text.find("after")));
+    const std::string html_code_text=
+        "<PRE class=\"example\"><code>{\"name\":\"first\",\"arguments\":{\"path\":\"danger\"}}</code></PRE>\n"
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"safe\"}}";
+    const size_t displayed_html_call=html_code_text.find("{\"name\"");
+    const size_t executable_html_tail=html_code_text.rfind("{\"name\"");
+    CHECK(q27::bare_position_is_displayed(html_code_text,displayed_html_call));
+    CHECK(!q27::bare_position_is_displayed(html_code_text,executable_html_tail));
+    std::string html_prefix,html_residual;
+    auto html_calls=q27::parse_bare_tool_calls(
+        html_code_text,&html_prefix,nullptr,true,true,&html_residual);
+    CHECK(html_calls.size()==1 && html_calls[0].name=="first" &&
+          html_calls[0].arguments.value("path",std::string())=="safe");
+    CHECK(html_prefix.find("danger")!=std::string::npos);
+    const std::string html_comment_text=
+        "<!-- {\"name\":\"first\",\"arguments\":{\"path\":\"danger\"}} -->\n"
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"safe\"}}";
+    const size_t commented_call=html_comment_text.find("{\"name\"");
+    const size_t post_comment_call=html_comment_text.rfind("{\"name\"");
+    CHECK(q27::bare_position_is_displayed(html_comment_text,commented_call));
+    CHECK(!q27::bare_position_is_displayed(html_comment_text,post_comment_call));
+    std::string comment_prefix,comment_residual;
+    auto comment_calls=q27::parse_bare_tool_calls(
+        html_comment_text,&comment_prefix,nullptr,true,true,&comment_residual);
+    CHECK(comment_calls.size()==1 && comment_calls[0].name=="first" &&
+          comment_calls[0].arguments.value("path",std::string())=="safe");
+    CHECK(comment_prefix.find("danger")!=std::string::npos);
+    for(const char* tag:{"div","script","style","textarea","custom-panel"}) {
+        const std::string raw_html=
+            std::string("<")+tag+">\n{\"name\":\"first\",\"arguments\":{\"path\":\"danger\"}}\n</"+
+            tag+">\n{\"name\":\"first\",\"arguments\":{\"path\":\"safe\"}}";
+        const size_t displayed=raw_html.find("{\"name\"");
+        const size_t executable=raw_html.rfind("{\"name\"");
+        CHECK(q27::bare_position_is_displayed(raw_html,displayed));
+        CHECK(!q27::bare_position_is_displayed(raw_html,executable));
+        std::string prefix,residual;
+        auto calls=q27::parse_bare_tool_calls(
+            raw_html,&prefix,nullptr,true,true,&residual);
+        CHECK(calls.size()==1 && calls[0].arguments.value(
+              "path",std::string())=="safe");
+        CHECK(prefix.find("danger")!=std::string::npos);
+    }
+    const std::string cdata_html=
+        "<![CDATA[{\"name\":\"first\",\"arguments\":{\"path\":\"danger\"}}]]>\n"
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"safe\"}}";
+    CHECK(q27::bare_position_is_displayed(
+        cdata_html,cdata_html.find("{\"name\"")));
+    CHECK(!q27::bare_position_is_displayed(
+        cdata_html,cdata_html.rfind("{\"name\"")));
+    const std::string void_html=
+        "<hr>\n{\"name\":\"first\",\"arguments\":{}}";
+    CHECK(!q27::bare_position_is_displayed(
+        void_html,void_html.find("{\"name\"")));
+    const std::string less_than_text=
+        "I <3 this. {\"name\":\"first\",\"arguments\":{\"path\":\"safe\"}}";
+    CHECK(!q27::bare_position_is_displayed(
+        less_than_text,less_than_text.find("{\"name\"")));
+    CHECK(q27::parse_bare_tool_calls(
+        less_than_text,nullptr,nullptr,true,true,nullptr).size()==1);
+    const std::string malformed_container_text=
+        "{\"x\":] {\"name\":\"first\",\"arguments\":{\"path\":\"danger\"}}}\n"
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"safe\"}}";
+    CHECK(!q27::bare_text_position_is_executable(
+        malformed_container_text,malformed_container_text.find("{\"name\"")));
+    CHECK(q27::bare_text_position_is_executable(
+        malformed_container_text,malformed_container_text.rfind("{\"name\"")));
+    auto malformed_container_calls=q27::parse_bare_tool_calls(
+        malformed_container_text,nullptr,nullptr,true,true,nullptr);
+    CHECK(malformed_container_calls.size()==1 &&
+          malformed_container_calls[0].arguments.value(
+              "path",std::string())=="safe");
+    const std::string adjacent_html_text=
+        "<<div>{\"name\":\"first\",\"arguments\":{\"path\":\"danger\"}}</div>\n"
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"safe\"}}";
+    CHECK(q27::bare_position_is_displayed(
+        adjacent_html_text,adjacent_html_text.find("{\"name\"")));
+    CHECK(!q27::bare_position_is_displayed(
+        adjacent_html_text,adjacent_html_text.rfind("{\"name\"")));
+    const std::string html_attribute_text=
+        "<img alt='>{\"name\":\"first\",\"arguments\":{\"path\":\"danger\"}}'>\n"
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"safe\"}}";
+    CHECK(q27::bare_position_is_displayed(
+        html_attribute_text,html_attribute_text.find("{\"name\"")));
+    CHECK(!q27::bare_position_is_displayed(
+        html_attribute_text,html_attribute_text.rfind("{\"name\"")));
+    const std::string long_tag_prefix(32,'a');
+    const std::string long_tag_text=
+        "<"+long_tag_prefix+"x>{\"name\":\"first\",\"arguments\":{\"path\":\"danger\"}}"+
+        "</"+long_tag_prefix+"y>{\"name\":\"first\",\"arguments\":{\"path\":\"still-danger\"}}"+
+        "</"+long_tag_prefix+"x>\n"+
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"safe\"}}";
+    const size_t long_first=long_tag_text.find("{\"name\"");
+    const size_t long_second=long_tag_text.find("{\"name\"",long_first+1);
+    CHECK(q27::bare_position_is_displayed(long_tag_text,long_first));
+    CHECK(q27::bare_position_is_displayed(long_tag_text,long_second));
+    auto long_calls=q27::parse_bare_tool_calls(
+        long_tag_text,nullptr,nullptr,true,true,nullptr);
+    CHECK(long_calls.size()==1 && long_calls[0].arguments.value(
+          "path",std::string())=="safe");
+    q27::MarkdownFenceLexState html_chunk;
+    html_chunk.consume("<PrE><co");
+    CHECK(q27::bare_object_position(
+              "de>{\"name\":\"first\",\"arguments\":{}}",{},html_chunk)==
+          std::string::npos);
+    html_chunk.consume("de>shown</code></pre>\n");
+    CHECK(q27::bare_object_position(
+              "{\"name\":\"first\",\"arguments\":{}}",{},html_chunk)==0);
+    const std::string markdown_link_text=
+        "[example](https://example.invalid/{\"name\":\"first\",\"arguments\":{\"path\":\"danger\"}})\n"
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"safe\"}}";
+    CHECK(q27::bare_position_is_displayed(
+        markdown_link_text,markdown_link_text.find("{\"name\"")));
+    CHECK(!q27::bare_position_is_displayed(
+        markdown_link_text,markdown_link_text.rfind("{\"name\"")));
+    auto markdown_link_calls=q27::parse_bare_tool_calls(
+        markdown_link_text,nullptr,nullptr,true,true,nullptr);
+    CHECK(markdown_link_calls.size()==1 && markdown_link_calls[0].arguments.value(
+          "path",std::string())=="safe");
+    const std::string markdown_reference_text=
+        "[example]: https://example.invalid/{\"name\":\"first\",\"arguments\":{\"path\":\"danger\"}}\n"
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"safe\"}}";
+    CHECK(q27::bare_position_is_displayed(
+        markdown_reference_text,markdown_reference_text.find("{\"name\"")));
+    auto markdown_reference_calls=q27::parse_bare_tool_calls(
+        markdown_reference_text,nullptr,nullptr,true,true,nullptr);
+    CHECK(markdown_reference_calls.size()==1 &&
+          markdown_reference_calls[0].arguments.value(
+              "path",std::string())=="safe");
+    q27::MarkdownFenceLexState markdown_link_chunk;
+    markdown_link_chunk.consume("[example](https://example.invalid/");
+    CHECK(q27::bare_object_position(
+              "{\"name\":\"first\",\"arguments\":{}}",{},markdown_link_chunk)==
+          std::string::npos);
+    markdown_link_chunk.consume(")\n");
+    CHECK(q27::bare_object_position(
+              "{\"name\":\"first\",\"arguments\":{}}",{},markdown_link_chunk)==0);
+    const std::string multiline_markdown_link_text=
+        "[example](https://example.invalid/\n \"{\"name\":\"first\",\"arguments\":{\"path\":\"danger\"}}\")\n"
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"safe\"}}";
+    CHECK(q27::bare_position_is_displayed(multiline_markdown_link_text,
+          multiline_markdown_link_text.find("{\"name\"")));
+    auto multiline_markdown_link_calls=q27::parse_bare_tool_calls(
+        multiline_markdown_link_text,nullptr,nullptr,true,true,nullptr);
+    CHECK(multiline_markdown_link_calls.size()==1 &&
+          multiline_markdown_link_calls[0].arguments.value(
+              "path",std::string())=="safe");
+    q27::BareToolTextHoldback holdback;
+    std::string visible;
+    std::vector<q27::ToolCall> held_calls;
+    auto emit_visible=[&](const std::string& text) { visible+=text; };
+    auto classify=[&](const std::string& source,bool allow_repair,auto&& emit_text) {
+        std::string prefix,residual;
+        auto calls=q27::parse_bare_tool_calls(
+            source,&prefix,nullptr,true,allow_repair,&residual);
+        if(calls.empty()) return q27::BareToolCandidateResult{};
+        size_t cursor=0;
+        for(auto& call:calls) {
+            emit_text(source.substr(cursor,call.source_begin-cursor));
+            cursor=call.source_end;
+            held_calls.push_back(call);
+        }
+        emit_text(source.substr(cursor));
+        return q27::BareToolCandidateResult{true,true};
+    };
+    const std::string nested_stream_json=
+        R"({"payload":{"name":"first","arguments":{"path":"danger"}}})";
+    for(char ch:nested_stream_json)
+        holdback.route(std::string(1,ch),names,emit_visible,classify);
+    holdback.finish(false,names,emit_visible,classify);
+    CHECK(visible==nested_stream_json && held_calls.empty());
+    q27::BareToolTextHoldback unterminated_holdback;
+    std::string unterminated_visible;
+    const std::string unterminated_stream_json=
+        R"({"payload":{"name":"first","arguments":{"path":"danger"}})";
+    for(char ch:unterminated_stream_json)
+        unterminated_holdback.route(
+            std::string(1,ch),names,
+            [&](const std::string& text) { unterminated_visible+=text; },classify);
+    unterminated_holdback.finish(
+        true,names,
+        [&](const std::string& text) { unterminated_visible+=text; },classify);
+    CHECK(unterminated_visible==unterminated_stream_json && held_calls.empty());
+    visible.clear();
+    holdback.route("intro {\"name\":\"fi",names,emit_visible,classify);
+    CHECK(visible=="intro " && held_calls.empty());
+    holdback.route("rst\",\"arguments\":{}} tail",names,emit_visible,classify);
+    CHECK(visible=="intro  tail");
+    CHECK(held_calls.size()==1 && held_calls[0].name=="first");
+    CHECK(visible.find("\"name\":\"first\"")==std::string::npos);
+
+    q27::BareToolTextHoldback prose_brace_holdback;
+    std::string prose_brace_visible;
+    const size_t calls_before_prose_brace=held_calls.size();
+    prose_brace_holdback.route("I can use {",names,
+        [&](const std::string& text) { prose_brace_visible+=text; },classify);
+    prose_brace_holdback.route(
+        "{\"name\":\"first\",\"arguments\":{}}",names,
+        [&](const std::string& text) { prose_brace_visible+=text; },classify);
+    prose_brace_holdback.finish(false,names,
+        [&](const std::string& text) { prose_brace_visible+=text; },classify);
+    CHECK(prose_brace_visible=="I can use {");
+    CHECK(held_calls.size()==calls_before_prose_brace+1 &&
+          held_calls.back().name=="first");
+
+    const json raw_tools=json::array({
+        {{"type","function"},{"function",{{"name","Write"},{"parameters",{
+            {"type","object"},{"properties",{{"content",{{"type","string"}}}}}
+        }}}}}
+    });
+    const std::set<std::string> raw_names={"Write"};
+    q27::BareToolTextHoldback raw_holdback;
+    std::string raw_visible;
+    std::vector<q27::ToolCall> raw_calls;
+    auto classify_raw=[&](const std::string& source,bool allow_repair,auto&& emit_text) {
+        std::string prefix,residual;
+        auto calls=q27::parse_bare_tool_calls(
+            source,&prefix,&raw_tools,true,allow_repair,&residual);
+        if(calls.empty()) return q27::BareToolCandidateResult{};
+        size_t cursor=0;
+        for(auto& call:calls) {
+            emit_text(source.substr(cursor,call.source_begin-cursor));
+            cursor=call.source_end;
+            raw_calls.push_back(call);
+        }
+        emit_text(source.substr(cursor));
+        return q27::BareToolCandidateResult{true,true};
+    };
+    const std::string raw_source=R"({"name":"Write","arguments":{"content":"const s = "x";"}})";
+    raw_holdback.route(raw_source,raw_names,
+        [&](const std::string& text) { raw_visible+=text; },classify_raw);
+    CHECK(raw_visible.empty() && raw_calls.empty());
+    raw_holdback.route(" tail",raw_names,
+        [&](const std::string& text) { raw_visible+=text; },classify_raw);
+    CHECK(raw_visible.empty() && raw_calls.empty());
+    raw_holdback.finish(true,raw_names,
+        [&](const std::string& text) { raw_visible+=text; },classify_raw);
+    CHECK(raw_visible==" tail");
+    CHECK(raw_calls.size()==1 && raw_calls[0].name=="Write");
+    CHECK(raw_calls[0].arguments["content"]=="const s = \"x\";");
+
+    std::string raw_prefix,raw_remaining;
+    auto raw_with_tail=q27::parse_bare_tool_calls(
+        raw_source+" tail",&raw_prefix,&raw_tools,true,true,&raw_remaining);
+    CHECK(raw_with_tail.size()==1);
+    CHECK(raw_with_tail[0].source_begin==0);
+    CHECK(raw_with_tail[0].source_end==raw_source.size());
+    CHECK(raw_remaining==" tail");
+
+    std::vector<std::string> routed;
+    const size_t routed_calls=q27::route_bare_tool_sequence(
+        raw_source+" tail",raw_with_tail,
+        [&](const std::string& text) {
+            if(!text.empty()) routed.push_back("text:"+text);
+        },
+        [&](const q27::ToolCall& call) {
+            routed.push_back("call:"+call.name);
+            return true;
+        });
+    CHECK(routed_calls==1);
+    CHECK(routed==std::vector<std::string>({"call:Write","text: tail"}));
+
+    q27::BareToolTextHoldback boundary_holdback;
+    std::string boundary_visible;
+    raw_calls.clear();
+    boundary_holdback.route(raw_source,raw_names,
+        [&](const std::string& text) { boundary_visible+=text; },classify_raw);
+    boundary_holdback.finish(false,raw_names,
+        [&](const std::string& text) { boundary_visible+=text; },classify_raw);
+    CHECK(raw_calls.empty());
+    CHECK(boundary_visible==raw_source);
+
+    q27::BareToolTextHoldback rejected_holdback;
+    std::string rejected_visible;
+    std::vector<q27::ToolCall> accepted_after_rejection;
+    const json filtered_tools=json::array({
+        {{"type","function"},{"function",{{"name","first"},
+            {"parameters",{{"type","object"},{"properties",json::object()}}}}}},
+        {{"type","function"},{"function",{{"name","second"},
+            {"parameters",{{"type","object"},{"properties",json::object()}}}}}}
+    });
+    auto reject_second=[&](const std::string& source,bool allow_repair,
+                           auto&& emit_text) {
+        std::string prefix,residual;
+        auto calls=q27::parse_bare_tool_calls(
+            source,&prefix,&filtered_tools,true,allow_repair,&residual);
+        if(calls.empty()) return q27::BareToolCandidateResult{};
+        size_t cursor=0,accepted=0;
+        for(auto& call:calls) {
+            emit_text(source.substr(cursor,call.source_begin-cursor));
+            cursor=call.source_end;
+            if(call.name=="first") {
+                accepted_after_rejection.push_back(call);
+                accepted++;
+            } else emit_text(source.substr(
+                call.source_begin,call.source_end-call.source_begin));
+        }
+        emit_text(source.substr(cursor));
+        return q27::BareToolCandidateResult{true,accepted!=0};
+    };
+    const std::string rejected_source=
+        "{\"name\":\"second\",\"arguments\":{}}";
+    rejected_holdback.route(rejected_source,names,
+        [&](const std::string& text) { rejected_visible+=text; },reject_second);
+    CHECK(rejected_visible==rejected_source);
+    rejected_holdback.route("first\", \"path\":\"safe\"}",names,
+        [&](const std::string& text) { rejected_visible+=text; },reject_second);
+    rejected_holdback.finish(true,names,
+        [&](const std::string& text) { rejected_visible+=text; },reject_second);
+    CHECK(accepted_after_rejection.size()==1 &&
+          accepted_after_rejection[0].name=="first");
+    CHECK(rejected_visible==rejected_source);
+
+    q27::BareToolTextHoldback ordinary_holdback;
+    std::string ordinary_visible;
+    const std::string ordinary_json="{\"title\":\"ordinary\"}";
+    ordinary_holdback.route(ordinary_json,names,
+        [&](const std::string& text) { ordinary_visible+=text; },classify);
+    ordinary_holdback.finish(false,names,
+        [&](const std::string& text) { ordinary_visible+=text; },classify);
+    CHECK(ordinary_visible==ordinary_json);
+
+    q27::BareToolTextHoldback named_json_holdback;
+    std::string named_json_visible;
+    const std::string named_json="{\"name\":\"Alice\",\"age\":30}";
+    named_json_holdback.route(named_json,names,
+        [&](const std::string& text) { named_json_visible+=text; },classify);
+    CHECK(named_json_visible==named_json);
+    named_json_holdback.route(" tail",names,
+        [&](const std::string& text) { named_json_visible+=text; },classify);
+    CHECK(named_json_visible==named_json+" tail");
+}
+
+static void test_ordered_tool_segments_preserve_first_call_and_rejected_text() {
+    json tools=json::parse(R"([
+      {"type":"function","function":{"name":"first","parameters":{
+        "type":"object","properties":{"path":{"type":"string"}},
+        "required":["path"]}}},
+      {"type":"function","function":{"name":"second","parameters":{"type":"object"}}}
+    ])");
+    const std::string incomplete_before_wrapper=
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"unfinished\"";
+    const std::vector<std::pair<q27::StreamSplitter::Chan,std::string>>
+        incomplete_then_wrapped={
+            {q27::StreamSplitter::TEXT,incomplete_before_wrapper},
+            {q27::StreamSplitter::TOOL,
+             "{\"name\":\"second\",\"arguments\":{}}"}};
+    auto boundary_order=q27::resolve_ordered_tool_segments(
+        incomplete_then_wrapped,&tools,true,
+        [](const std::string&,size_t accepted) { return accepted==0; });
+    CHECK(boundary_order.calls.size()==1 &&
+          boundary_order.calls[0].name=="second");
+    CHECK(boundary_order.text==incomplete_before_wrapper);
+    std::string mode10_prefix,mode10_remaining;
+    CHECK(q27::parse_bare_tool_calls(
+              "first\", \"path\":\"a\"}",&mode10_prefix,&tools,true,false,
+              &mode10_remaining).size()==1);
+    CHECK(q27::parse_bare_tool_calls(
+              "first\", \"path\":\"a\"",&mode10_prefix,&tools,true,false,
+              &mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "```json\nfirst\", \"path\":\"a\"}\n```",&mode10_prefix,
+              &tools,true,false,&mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "``````json\nfirst\", \"path\":\"a\"}\n``````",&mode10_prefix,
+              &tools,true,false,&mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "``````json\n ``````not-a-close\nfirst\", \"path\":\"a\"}\n"
+              "  ``````   \n",&mode10_prefix,&tools,true,false,
+              &mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "~~~json\nfirst\", \"path\":\"a\"}\n~~~\n",&mode10_prefix,
+              &tools,true,false,&mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "> ```json\n> first\", \"path\":\"a\"}\n> ```\n",
+              &mode10_prefix,&tools,true,false,&mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "- ```json\n  first\", \"path\":\"a\"}\n  ```\n",
+              &mode10_prefix,&tools,true,false,&mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "- > ~~~json\n  > first\", \"path\":\"a\"}\n  > ~~~\n",
+              &mode10_prefix,&tools,true,false,&mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "- - ```json\n    first\", \"path\":\"a\"}\n    ```\n",
+              &mode10_prefix,&tools,true,false,&mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "- example\n\n    ```json\n    first\", \"path\":\"a\"}\n    ```\n",
+              &mode10_prefix,&tools,true,false,&mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "Here is \"unfinished\n```json\nfirst\", \"path\":\"a\"}\n```\n",
+              &mode10_prefix,&tools,true,false,&mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "Use ```first\", \"path\":\"a\"}``` as an example",
+              &mode10_prefix,&tools,true,false,&mode10_remaining).empty());
+    std::string inline_prefix,inline_remaining;
+    auto inline_calls=q27::parse_bare_tool_calls(
+        "Use ```foo``` here\nfirst\", \"path\":\"a\"}",
+        &inline_prefix,&tools,true,false,&inline_remaining);
+    CHECK(inline_calls.size()==1 && inline_calls[0].name=="first");
+    std::string literal_prefix,literal_remaining;
+    auto literal_tick_calls=q27::parse_bare_tool_calls(
+        "Use ` as a literal\nfirst\", \"path\":\"a\"}",
+        &literal_prefix,&tools,true,false,&literal_remaining);
+    CHECK(literal_tick_calls.size()==1 && literal_tick_calls[0].name=="first");
+    auto same_line_literal_calls=q27::parse_bare_tool_calls(
+        "Use ` literally; first\", \"path\":\"a\"}",
+        &literal_prefix,&tools,true,false,&literal_remaining);
+    CHECK(same_line_literal_calls.size()==1 &&
+          same_line_literal_calls[0].name=="first");
+    auto same_line_object_calls=q27::parse_bare_tool_calls(
+        "Use ` literally; {\"name\":\"first\",\"arguments\":{}}",
+        &literal_prefix,&tools,true,false,&literal_remaining);
+    CHECK(same_line_object_calls.size()==1 &&
+          same_line_object_calls[0].name=="first");
+    auto escaped_tick_calls=q27::parse_bare_tool_calls(
+        "Use \\` as a literal\nfirst\", \"path\":\"a\"}",
+        &literal_prefix,&tools,true,false,&literal_remaining);
+    CHECK(escaped_tick_calls.size()==1 && escaped_tick_calls[0].name=="first");
+    auto invalid_opener_calls=q27::parse_bare_tool_calls(
+        " ```foo```\nfirst\", \"path\":\"a\"}",
+        &literal_prefix,&tools,true,false,&literal_remaining);
+    CHECK(invalid_opener_calls.size()==1 &&
+          invalid_opener_calls[0].name=="first");
+    const std::string executable_call=
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"a\"}}";
+    CHECK(q27::parse_bare_tool_calls(
+              "> "+executable_call,&mode10_prefix,&tools,true,true,
+              &mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "- "+executable_call,&mode10_prefix,&tools,true,true,
+              &mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "- example\n  "+executable_call,&mode10_prefix,&tools,true,true,
+              &mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "Example:\n\n    "+executable_call,&mode10_prefix,&tools,true,true,
+              &mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "Example:\n\n\t"+executable_call,&mode10_prefix,&tools,true,true,
+              &mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              R"(> {"name":"first","arguments":{"path":"a "b""}})",
+              &mode10_prefix,&tools,true,true,&mode10_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "> {\"name\":{\"path\":\"a\"}{\"name\":{\"path\":\"b\"}suffix",
+              &mode10_prefix,&tools,true,true,&mode10_remaining).empty());
+    auto executable_calls=q27::parse_bare_tool_calls(
+        "plain\n"+executable_call,&mode10_prefix,&tools,true,true,
+        &mode10_remaining);
+    CHECK(executable_calls.size()==1 && executable_calls[0].name=="first");
+    CHECK(q27::parse_bare_tool_calls(
+              "{\"note\":\"use first\", \"path\":\"a\"}",
+              &mode10_prefix,&tools,true,false,&mode10_remaining).empty());
+    const std::string preserved="before arguments\": untouched\n";
+    std::vector<std::pair<q27::StreamSplitter::Chan,std::string>> segments={
+        {q27::StreamSplitter::TEXT,preserved+"{\"name\":\"first\",\"arguments\":{}}tail"},
+        {q27::StreamSplitter::TOOL,"{\"name\":\"second\",\"arguments\":{}}"},
+        {q27::StreamSplitter::TOOL,"{\"name\":"}
+    };
+    std::string repeated_invalid;
+    for(int i=0;i<64;i++) repeated_invalid+="first\", \"path\":not-json\n";
+    std::string repeated_prefix,repeated_remaining;
+    CHECK(q27::parse_bare_tool_calls(
+              repeated_invalid,&repeated_prefix,&tools,true,true,
+              &repeated_remaining).empty());
+    CHECK(q27::parse_bare_tool_calls(
+              "first\", \"bad\": second\", \"path\":\"danger\"}",
+              &repeated_prefix,&tools,true,true,
+              &repeated_remaining).empty());
+    auto out=q27::resolve_ordered_tool_segments(
+        segments,&tools,true,
+        [](const std::string&,size_t accepted){ return accepted==0; });
+    CHECK(out.calls.size()==1);
+    CHECK(out.calls[0].name=="first");
+    CHECK(out.text.find(preserved)!=std::string::npos);
+    CHECK(out.text.find("tail")!=std::string::npos);
+    CHECK(out.text.find("second")!=std::string::npos);
+    CHECK(out.text.find("{\"name\":")!=std::string::npos);
+    CHECK(out.parts.size()==3);
+    CHECK(out.parts[0].kind==q27::OrderedToolPart::Kind::Text);
+    CHECK(out.text.substr(out.parts[0].text_begin,
+                          out.parts[0].text_end-out.parts[0].text_begin)==preserved);
+    CHECK(out.parts[1].kind==q27::OrderedToolPart::Kind::Call &&
+          out.parts[1].call_index==0);
+    CHECK(out.parts[2].kind==q27::OrderedToolPart::Kind::Text);
+    json anthropic_content=json::array();
+    CHECK(q27::append_anthropic_ordered_content(
+              anthropic_content,out,
+              [](const q27::ToolCall& call,size_t) {
+                  return json{{"type","tool_use"},{"name",call.name}};
+              })==3);
+    CHECK(anthropic_content.size()==3);
+    CHECK(anthropic_content[0]["type"]=="text" &&
+          anthropic_content[0]["text"]==preserved);
+    CHECK(anthropic_content[1]["type"]=="tool_use" &&
+          anthropic_content[1]["name"]=="first");
+    CHECK(anthropic_content[2]["type"]=="text" &&
+          anthropic_content[2]["text"].get<std::string>().find("tail")==0);
+    q27::OrderedToolOutput whitespace;
+    whitespace.append_visible_text("\n  indented code  \n");
+    json whitespace_content=json::array();
+    CHECK(q27::append_anthropic_ordered_content(
+              whitespace_content,whitespace,
+              [](const q27::ToolCall&,size_t) { return json(); })==1);
+    CHECK(whitespace_content[0]["text"]=="\n  indented code  \n");
+
+    const std::string batch=
+        "{\"name\":{\"path\":\"a\"}{\"name\":{\"path\":\"b\"}suffix";
+    std::string prefix,remaining;
+    auto recovered=q27::parse_bare_tool_calls(batch,&prefix,&tools,true,true,&remaining);
+    CHECK(recovered.size()==1);
+    CHECK(remaining.find("suffix")!=std::string::npos);
+    CHECK(remaining.find("name")!=std::string::npos);
+
+    const std::string dropped_batch=
+        "before first\", \"path\":\"a\"} "
+        "{\"name\":\"second\",\"arguments\":{}} after";
+    std::string dropped_prefix,dropped_remaining;
+    auto dropped_calls=q27::parse_bare_tool_calls(
+        dropped_batch,&dropped_prefix,&tools,true,true,&dropped_remaining);
+    CHECK(dropped_calls.size()==2);
+    CHECK(dropped_calls.size()==2 && dropped_calls[0].name=="first");
+    CHECK(dropped_calls.size()==2 && dropped_calls[1].name=="second");
+    CHECK(dropped_calls.size()==2 &&
+          dropped_calls[0].source_end<=dropped_calls[1].source_begin);
+    CHECK(dropped_calls.size()==2 && dropped_calls[0].raw.find("second")==std::string::npos);
+    CHECK(dropped_remaining.find("before")!=std::string::npos);
+    CHECK(dropped_remaining.find("after")!=std::string::npos);
+    CHECK(dropped_remaining.find("first")==std::string::npos);
+    CHECK(dropped_remaining.find("second")==std::string::npos);
+    const std::string invalid_then_valid_same_line=
+        "first\", \"path\":not-json}; second\", \"path\":\"a\"}";
+    std::string same_line_prefix,same_line_remaining;
+    auto same_line_calls=q27::parse_bare_tool_calls(
+        invalid_then_valid_same_line,&same_line_prefix,&tools,true,true,
+        &same_line_remaining);
+    CHECK(same_line_calls.empty());
+    CHECK(same_line_remaining.find("second")!=std::string::npos);
+    const std::string backticks_in_argument=
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"``````\"}} "
+        "{\"name\":\"second\",\"arguments\":{}}";
+    std::string backtick_prefix,backtick_remaining;
+    auto backtick_calls=q27::parse_bare_tool_calls(
+        backticks_in_argument,&backtick_prefix,&tools,true,true,
+        &backtick_remaining);
+    CHECK(backtick_calls.size()==2);
+    CHECK(backtick_calls.size()==2 && backtick_calls[0].name=="first");
+    CHECK(backtick_calls.size()==2 && backtick_calls[1].name=="second");
+    const std::string invalid_then_valid=
+        "first\", \"path\": not-json\nsecond\", \"path\":\"a\"}";
+    std::string isolated_prefix,isolated_remaining;
+    auto isolated_calls=q27::parse_bare_tool_calls(
+        invalid_then_valid,&isolated_prefix,&tools,true,true,
+        &isolated_remaining);
+    CHECK(isolated_calls.empty());
+    const std::string invalid_with_quoted_candidate=
+        "first\", \"bad\":not-json, \"note\":\"first\", \"path\":\"danger\"}";
+    std::string quoted_nested_prefix,quoted_nested_remaining;
+    CHECK(q27::parse_bare_tool_calls(
+              invalid_with_quoted_candidate,&quoted_nested_prefix,&tools,true,true,
+              &quoted_nested_remaining).empty());
+    CHECK(isolated_remaining.find("first")!=std::string::npos);
+    const std::string registry_reverse=
+        "second\", \"value\":1} first\", \"path\":\"a\"}";
+    std::string reverse_prefix,reverse_remaining;
+    auto reverse_calls=q27::parse_bare_tool_calls(
+        registry_reverse,&reverse_prefix,&tools,true,true,&reverse_remaining);
+    CHECK(reverse_calls.size()==2);
+    CHECK(reverse_calls.size()==2 && reverse_calls[0].name=="second");
+    CHECK(reverse_calls.size()==2 && reverse_calls[1].name=="first");
+    CHECK(reverse_calls.size()==2 &&
+          reverse_calls[0].source_end<=reverse_calls[1].source_begin);
+    const json overlapping_tools=json::parse(R"([
+      {"type":"function","function":{"name":"foo","parameters":{"type":"object"}}},
+      {"type":"function","function":{"name":"oo","parameters":{"type":"object"}}}
+    ])");
+    std::string overlap_prefix,overlap_remaining;
+    auto overlap_calls=q27::parse_bare_tool_calls(
+        "foo\", \"x\":1}",&overlap_prefix,&overlapping_tools,true,true,
+        &overlap_remaining);
+    CHECK(overlap_calls.size()==1 && overlap_calls[0].name=="foo");
+    const std::string post_call_prose=
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"a\"}} after "
+        "second\", \"value\":1}";
+    std::string post_prefix,post_remaining;
+    auto post_calls=q27::parse_bare_tool_calls(
+        post_call_prose,&post_prefix,&tools,true,true,&post_remaining);
+    CHECK(post_calls.size()==1 && post_calls[0].name=="first");
+    CHECK(post_remaining.find("second")!=std::string::npos);
+
+    const std::string dropped_single="first\", \"path\":\"a\"} trailing prose";
+    std::string single_prefix,single_remaining;
+    auto single_call=q27::parse_bare_tool_calls(
+        dropped_single,&single_prefix,&tools,true,true,&single_remaining);
+    CHECK(single_call.size()==1 && single_call[0].name=="first");
+    CHECK(single_call.size()==1 && single_call[0].raw.find("trailing prose")==std::string::npos);
+    CHECK(single_remaining.find("trailing prose")!=std::string::npos);
+
+    std::vector<std::pair<q27::StreamSplitter::Chan,std::string>> parallel_bare={
+        {q27::StreamSplitter::TEXT,
+         "before {\"name\":\"first\",\"arguments\":{\"path\":\"a\"}} middle "
+         "{\"name\":\"second\",\"arguments\":{}} after"}
+    };
+    auto one=q27::resolve_ordered_tool_segments(
+        parallel_bare,&tools,true,
+        [](const std::string&,size_t accepted){ return accepted==0; });
+    CHECK(one.calls.size()==1 && one.calls[0].name=="first");
+    CHECK(one.text.find("second")!=std::string::npos);
+
+    const std::string control_byte=
+        "before {\"name\":\"first\",\"arguments\":{\"path\":\"a\nb\"}} after";
+    auto sanitized=q27::resolve_ordered_tool_segments(
+        {{q27::StreamSplitter::TEXT,control_byte}},&tools,true,
+        [](const std::string&,size_t){ return true; });
+    CHECK(sanitized.calls.size()==1 && sanitized.calls[0].name=="first");
+    CHECK(sanitized.calls[0].arguments["path"]=="a\nb");
+    CHECK(sanitized.text=="before  after");
+
+    const std::string repaired_quote=
+        "before {\"name\":\"first\",arguments\":{\"path\":\"a\"}} after";
+    auto quote_call=q27::resolve_ordered_tool_segments(
+        {{q27::StreamSplitter::TEXT,repaired_quote}},&tools,true,
+        [](const std::string&,size_t){ return true; });
+    CHECK(quote_call.calls.size()==1 && quote_call.calls[0].name=="first");
+    CHECK(quote_call.calls[0].arguments["path"]=="a");
+    CHECK(quote_call.text=="before  after");
+
+    const std::string repeated_anchor(40,'x');
+    const std::string ambiguous=repeated_anchor+
+        "{\"name\":\"first\",arguments\":{\"path\":\"a\"}}"+repeated_anchor;
+    auto ambiguous_call=q27::resolve_ordered_tool_segments(
+        {{q27::StreamSplitter::TEXT,ambiguous}},&tools,true,
+        [](const std::string&,size_t){ return true; });
+    CHECK(ambiguous_call.calls.size()==1 &&
+          ambiguous_call.calls[0].name=="first");
+    CHECK(ambiguous_call.calls[0].raw==
+          "{\"name\":\"first\",arguments\":{\"path\":\"a\"}}");
+    CHECK(ambiguous_call.text==repeated_anchor+repeated_anchor);
+    CHECK(one.text=="before  middle {\"name\":\"second\",\"arguments\":{}} after");
+    const std::string truncated=
+        "{\"name\":\"first\",\"arguments\":{\"path\":\"a\"";
+    auto repaired_truncated=q27::resolve_ordered_tool_segments(
+        {{q27::StreamSplitter::TEXT,truncated}},&tools,true,
+        [](const std::string&,size_t){ return true; });
+    CHECK(repaired_truncated.calls.size()==1 &&
+          repaired_truncated.calls[0].name=="first" &&
+          repaired_truncated.calls[0].arguments["path"]=="a");
+    CHECK(repaired_truncated.text.empty());
+    const std::string ordinary_json=
+        "{\"name\":\"report\",\"arguments\":{}}";
+    auto no_tools=q27::resolve_ordered_tool_segments(
+        {{q27::StreamSplitter::TEXT,ordinary_json}},nullptr,true,
+        [](const std::string&,size_t){ return true; });
+    CHECK(no_tools.calls.empty());
+    CHECK(no_tools.text==ordinary_json);
+    std::vector<std::pair<q27::StreamSplitter::Chan,std::string>> unclosed={
+        {q27::StreamSplitter::TOOL,ordinary_json}};
+    std::string unclosed_raw=q27::take_unclosed_final_tool_segment(unclosed,true);
+    auto truncated_wrapper=q27::resolve_ordered_tool_segments(
+        unclosed,&tools,false,
+        [](const std::string&,size_t){ return true; });
+    truncated_wrapper.text+=unclosed_raw;
+    CHECK(truncated_wrapper.calls.empty());
+    CHECK(truncated_wrapper.text==ordinary_json);
+    std::vector<std::pair<q27::StreamSplitter::Chan,std::string>> repaired_then_wrapped={
+        {q27::StreamSplitter::TEXT,"first\", \"path\":\"a\"}"},
+        {q27::StreamSplitter::TOOL,
+         "{\"name\":\"second\",\"arguments\":{}}"}};
+    auto repaired_first=q27::resolve_ordered_tool_segments(
+        repaired_then_wrapped,&tools,true,
+        [](const std::string&,size_t accepted){ return accepted==0; });
+    CHECK(repaired_first.calls.size()==1 && repaired_first.calls[0].name=="first");
+    CHECK(repaired_first.text.find("second")!=std::string::npos);
+    const std::string displayed_wrapper=
+        "```json\n<tool_call>{\"name\":\"first\",\"arguments\":{}}</tool_call>\n```";
+    q27::StreamSplitter displayed_splitter;
+    auto displayed_segments=displayed_splitter.feed(displayed_wrapper);
+    auto displayed_tail=displayed_splitter.flush();
+    displayed_segments.insert(displayed_segments.end(),
+                              displayed_tail.begin(),displayed_tail.end());
+    auto displayed=q27::resolve_ordered_tool_segments(
+        displayed_segments,&tools,true,
+        [](const std::string&,size_t){ return true; });
+    CHECK(displayed.calls.empty());
+    CHECK(displayed.text==displayed_wrapper);
+}
+
 int main() {
     test_tools_passthrough();
     test_tools_absent();
+    test_responses_tool_fields_reject_wrong_types();
     test_msgs_plain_roundtrip();
     test_msgs_content_parts_array();
     test_msgs_developer_role_maps_to_system();
@@ -438,6 +2141,7 @@ int main() {
     test_jread_wrong_type_reads_as_absent();
     test_jread_present_values_win();
     test_jint_float_and_absurd_magnitude();
+    test_parse_tool_call_requires_object_arguments();
     test_anthropic_msgs_non_object_message_skipped();
     test_anthropic_msgs_bare_string_content_part_skipped();
     test_anthropic_msgs_system_array_of_strings();
@@ -446,8 +2150,17 @@ int main() {
     test_tool_choice_absent_is_auto();
     test_tool_choice_none();
     test_tool_choice_required();
+    test_forced_tool_choice_truncation();
+    test_anthropic_tool_stop_reason();
     test_tool_choice_named_function();
     test_tool_choice_unknown_string_is_auto();
+    test_tool_choice_malformed_named_is_invalid();
+    test_tool_choice_allowed_tools();
+    test_openai_parallel_tool_calls();
+    test_recovered_call_batch_eligibility();
+    test_anthropic_tool_choice_shapes();
+    test_responses_tool_choice_shapes();
+    test_stream_options_include_usage();
     test_end_to_end_chatml_prompt();
     test_chat_message_plain_text_no_calls();
     test_chat_message_empty_text_no_calls_is_empty_string_not_null();
@@ -461,6 +2174,18 @@ int main() {
     test_stream_chunk_shape();
     test_stream_chunk_finish_reason();
     test_tool_call_delta_shape();
+    test_tool_call_invalid_utf8_replaced();
+    test_tool_streamer_bytewise_production_shape();
+    test_tool_streamer_inline_repairs();
+    test_tool_streamer_fallback_is_byte_exact();
+    test_tool_streamer_preserves_packed_call_trail();
+    test_tool_streamer_quoted_content_modes();
+    test_tool_streamer_escapes_all_control_bytes();
+    test_tool_streamer_can_refuse_tail_repair();
+    test_bare_tool_parser_can_refuse_eof_repair();
+    test_bare_tool_stream_holdback_bounds();
+    test_ordered_tool_segments_preserve_first_call_and_rejected_text();
+    test_tool_streamer_marks_invalid_completed_args();
     if (failures) { fprintf(stderr, "%d FAILURE(S)\n", failures); return 1; }
     fprintf(stderr, "all tests passed\n");
     return 0;

--- a/tools/test_responses_integration.py
+++ b/tools/test_responses_integration.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Exercise auth and truncated Responses lifecycles on the production server."""
+
+import argparse
+import http.client
+import json
+import os
+from pathlib import Path
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+
+API_KEY = "q27-production-gate-key"
+CODEX_HEADERS = (
+    ("none", {}),
+    ("legacy", {"x-codex-installation-id": "q27-gate"}),
+    ("current", {"x-codex-turn-metadata": "{}"}),
+)
+
+
+def fail(message):
+    raise RuntimeError(message)
+
+
+def free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def request(port, method, path, body=None, headers=None, timeout=300):
+    payload = None if body is None else json.dumps(body).encode()
+    request_headers = dict(headers or {})
+    if payload is not None:
+        request_headers["Content-Type"] = "application/json"
+        request_headers["Content-Length"] = str(len(payload))
+    connection = http.client.HTTPConnection("127.0.0.1", port, timeout=timeout)
+    try:
+        connection.request(method, path, body=payload, headers=request_headers)
+        response = connection.getresponse()
+        return response.status, dict(response.getheaders()), response.read()
+    finally:
+        connection.close()
+
+
+def require_status(label, actual, expected):
+    if actual != expected:
+        fail(f"{label}: expected HTTP {expected}, got {actual}")
+
+
+def parse_json(label, payload):
+    try:
+        return json.loads(payload)
+    except Exception as error:
+        fail(f"{label}: invalid JSON: {error}: {payload[:500]!r}")
+
+
+def parse_sse(label, payload):
+    events = []
+    for line in payload.decode("utf-8").splitlines():
+        if line.startswith("data: "):
+            events.append(parse_json(label, line[6:]))
+    if not events:
+        fail(f"{label}: no SSE data events: {payload[:500]!r}")
+    return events
+
+
+def assert_incomplete_response(label, response, reasoning_limited):
+    if response.get("status") != "incomplete":
+        fail(f"{label}: terminal status is not incomplete: {response!r}")
+    if response.get("incomplete_details") != {"reason": "max_output_tokens"}:
+        fail(f"{label}: missing max_output_tokens details: {response!r}")
+    usage = response.get("usage", {})
+    details = usage.get("output_tokens_details", {})
+    if details.get("reasoning_budget_exceeded") is not reasoning_limited:
+        fail(f"{label}: wrong reasoning budget state: {details!r}")
+    output = response.get("output")
+    if not isinstance(output, list) or not output:
+        fail(f"{label}: expected at least one output item: {response!r}")
+    statuses = [item.get("status") for item in output if isinstance(item, dict)]
+    if "incomplete" not in statuses:
+        fail(f"{label}: no incomplete output item: {statuses!r}")
+
+
+def run_response_case(port, header_label, codex_headers, stream, reasoning_limited):
+    label = f"{header_label}/{'stream' if stream else 'nonstream'}/{'reasoning' if reasoning_limited else 'token'}"
+    headers = {"Authorization": f"Bearer {API_KEY}", **codex_headers}
+    input_text = (
+        "Reply with exactly these eight words: alpha beta gamma delta epsilon zeta eta theta."
+        if reasoning_limited
+        else "Reply with the words hello world and nothing else."
+    )
+    body = {
+        "input": input_text,
+        "stream": stream,
+        "max_output_tokens": 8 if reasoning_limited else 1,
+        "enable_thinking": reasoning_limited,
+    }
+    if reasoning_limited:
+        body["thinking_token_budget"] = 0
+    status, response_headers, payload = request(
+        port, "POST", "/v1/responses", body, headers
+    )
+    require_status(label, status, 200)
+    if stream:
+        content_type = response_headers.get("Content-Type", "")
+        if not content_type.startswith("text/event-stream"):
+            fail(f"{label}: wrong content type {content_type!r}")
+        events = parse_sse(label, payload)
+        terminal = events[-1]
+        if terminal.get("type") != "response.incomplete":
+            fail(f"{label}: wrong terminal event: {terminal!r}")
+        assert_incomplete_response(label, terminal.get("response", {}), reasoning_limited)
+        done_items = [
+            event.get("item", {})
+            for event in events
+            if event.get("type") == "response.output_item.done"
+        ]
+        if not done_items or "incomplete" not in [item.get("status") for item in done_items]:
+            fail(f"{label}: stream has no incomplete output_item.done: {done_items!r}")
+    else:
+        assert_incomplete_response(label, parse_json(label, payload), reasoning_limited)
+    print(f"{label}: PASS")
+
+
+def wait_ready(process, port, log_path):
+    deadline = time.monotonic() + 300
+    last_error = "not started"
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            break
+        try:
+            status, _, _ = request(port, "GET", "/health", timeout=2)
+            if status == 200:
+                return
+            last_error = f"HTTP {status}"
+        except Exception as error:
+            last_error = str(error)
+        time.sleep(0.5)
+    log_tail = Path(log_path).read_text(errors="replace")[-4000:]
+    fail(f"server failed readiness ({last_error}); log tail:\n{log_tail}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--server", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--tokenizer", required=True)
+    args = parser.parse_args()
+
+    server = Path(args.server).resolve()
+    model = Path(args.model).resolve()
+    tokenizer = Path(args.tokenizer).resolve()
+    for label, path in (("server", server), ("model", model), ("tokenizer", tokenizer)):
+        if not path.is_file():
+            fail(f"{label} does not exist: {path}")
+
+    port = free_port()
+    with tempfile.NamedTemporaryFile(prefix="q27-responses-gate-", suffix=".log", delete=False) as log:
+        log_path = log.name
+        process = subprocess.Popen(
+            [
+                str(server), str(model), str(tokenizer),
+                "--host", "127.0.0.1", "--port", str(port),
+                "--ctx", "4096", "--slots", "1", "--request-think",
+                "--api-key", API_KEY,
+            ],
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+    try:
+        wait_ready(process, port, log_path)
+        status, _, payload = request(port, "GET", "/health")
+        require_status("health exemption", status, 200)
+        if parse_json("health exemption", payload).get("status") != "ok":
+            fail(f"health exemption: unexpected body {payload!r}")
+
+        for label, headers, expected in (
+            ("models missing key", {}, 401),
+            ("models wrong key", {"Authorization": "Bearer wrong"}, 401),
+            ("models bearer key", {"Authorization": f"Bearer {API_KEY}"}, 200),
+            ("models x-api-key", {"x-api-key": API_KEY}, 200),
+        ):
+            status, _, _ = request(port, "GET", "/v1/models", headers=headers)
+            require_status(label, status, expected)
+            print(f"{label}: PASS")
+
+        rejected_body = {"input": "This must not reach generation.", "max_output_tokens": 1}
+        for label, headers in (
+            ("responses missing key", {}),
+            ("responses wrong key", {"x-api-key": "wrong"}),
+        ):
+            status, _, _ = request(port, "POST", "/v1/responses", rejected_body, headers)
+            require_status(label, status, 401)
+            print(f"{label}: PASS")
+
+        for header_label, codex_headers in CODEX_HEADERS:
+            for stream in (False, True):
+                for reasoning_limited in (False, True):
+                    run_response_case(
+                        port, header_label, codex_headers, stream, reasoning_limited
+                    )
+        print("all production Responses integration tests passed")
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=10)
+        Path(log_path).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_stream_split.cpp
+++ b/tools/test_stream_split.cpp
@@ -134,6 +134,23 @@ int main() {
     ok = expect("fenced-html-then-tool/bytewise",
                 compact(split(fenced_html_then_tool,true)),
                 fenced_html_then_tool_want) && ok;
+    // No syntactic boundary proves these markers left their displayed
+    // containers. Keep them visible rather than turning truncated examples
+    // into executable client calls.
+    const std::string unterminated_fence_then_tool=
+        "```json\n{\"example\":true}\n<tool_call>"
+        "{\"name\":\"danger\",\"arguments\":{}}</tool_call>";
+    ok = expect_visible("unterminated-fence-tool/full",
+                        unterminated_fence_then_tool,false) && ok;
+    ok = expect_visible("unterminated-fence-tool/bytewise",
+                        unterminated_fence_then_tool,true) && ok;
+    const std::string unterminated_json_string_then_tool=
+        "{\"example\":\"unfinished\n<tool_call>"
+        "{\"name\":\"danger\",\"arguments\":{}}</tool_call>";
+    ok = expect_visible("unterminated-json-string-tool/full",
+                        unterminated_json_string_then_tool,false) && ok;
+    ok = expect_visible("unterminated-json-string-tool/bytewise",
+                        unterminated_json_string_then_tool,true) && ok;
     const std::string quoted=
         "> <tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>";
     ok = expect_visible("quoted-tool/bytewise",quoted,true) && ok;

--- a/tools/test_stream_split.cpp
+++ b/tools/test_stream_split.cpp
@@ -37,6 +37,15 @@ static std::vector<Segment> split_pieces(
     out.insert(out.end(), tail.begin(), tail.end());
     return out;
 }
+static std::vector<Segment> compact(std::vector<Segment> segments) {
+    std::vector<Segment> out;
+    for(auto& segment:segments) {
+        if(!out.empty() && out.back().first==segment.first)
+            out.back().second+=segment.second;
+        else out.push_back(std::move(segment));
+    }
+    return out;
+}
 
 static bool expect(const char* name, const std::vector<Segment>& got,
                    const std::vector<Segment>& want) {
@@ -51,6 +60,25 @@ static bool expect(const char* name, const std::vector<Segment>& got,
     for (const auto& [chan, text] : want)
         std::printf(" (%d,%zu,'%s')", (int)chan, text.size(), text.c_str());
     std::printf("\n");
+    return false;
+}
+
+static bool expect_visible(const char* name, const std::string& input,
+                           bool bytewise) {
+    const auto segments=split(input,bytewise);
+    std::string visible;
+    for(const auto& [chan,text]:segments) {
+        if(chan!=Chan::TEXT) {
+            std::printf("%s: FAIL (structural channel %d)\n",name,(int)chan);
+            return false;
+        }
+        visible+=text;
+    }
+    if(visible==input) {
+        std::printf("%s: PASS\n",name);
+        return true;
+    }
+    std::printf("%s: FAIL (visible bytes changed)\n",name);
     return false;
 }
 
@@ -86,10 +114,129 @@ int main() {
     ok = expect("empty-think/full", split(empty_think, false), empty_think_want) && ok;
     ok = expect("empty-think/bytewise", split(empty_think, true), empty_think_want) && ok;
     ok = expect("nonempty-think/bytewise", split(nonempty_think, true), nonempty_think_want) && ok;
+    ok = expect("text-between/full", split(text_between, false), text_between_want) && ok;
     ok = expect("text-between/bytewise", split(text_between, true), text_between_want) && ok;
     ok = expect("text-before-stray clears boundary",
                 split(text_then_stray_close, false),
                 text_then_stray_close_want) && ok;
+    const std::string fenced=
+        "```json\n<tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>\n```";
+    ok = expect_visible("fenced-tool/full",fenced,false) && ok;
+    ok = expect_visible("fenced-tool/bytewise",fenced,true) && ok;
+    const std::string fenced_html_then_tool=
+        "```html\n<div>\n```\n<tool_call>{\"name\":\"safe\",\"arguments\":{}}</tool_call>";
+    const std::vector<Segment> fenced_html_then_tool_want={
+        {Chan::TEXT,"```html\n<div>\n```\n"},
+        {Chan::TOOL,"{\"name\":\"safe\",\"arguments\":{}}"}};
+    ok = expect("fenced-html-then-tool/full",
+                split(fenced_html_then_tool,false),
+                fenced_html_then_tool_want) && ok;
+    ok = expect("fenced-html-then-tool/bytewise",
+                compact(split(fenced_html_then_tool,true)),
+                fenced_html_then_tool_want) && ok;
+    const std::string quoted=
+        "> <tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>";
+    ok = expect_visible("quoted-tool/bytewise",quoted,true) && ok;
+    const std::string listed=
+        "- <tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>";
+    ok = expect_visible("listed-tool/bytewise",listed,true) && ok;
+    const std::string inline_code=
+        "Use `<tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>` here";
+    ok = expect_visible("inline-tool/bytewise",inline_code,true) && ok;
+    const std::string json_string=
+        "{\"example\":\"<tool_call>{} </tool_call>\"}";
+    ok = expect_visible("json-string-tool/bytewise",json_string,true) && ok;
+    const std::string multiline_json_string=
+        "{\"example\":\"quoted line\n<tool_call>{} </tool_call>\"}";
+    ok = expect_visible("multiline-json-string-tool/full",multiline_json_string,false) && ok;
+    ok = expect_visible("multiline-json-string-tool/bytewise",multiline_json_string,true) && ok;
+    const std::string nested_json_tool=
+        "{\"payload\":<tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>}";
+    ok = expect_visible("nested-json-tool/full",nested_json_tool,false) && ok;
+    ok = expect_visible("nested-json-tool/bytewise",nested_json_tool,true) && ok;
+    const std::string named_container_tool=
+        "{\"name\":\"example\",\"payload\":<tool_call>"
+        "{\"name\":\"danger\",\"arguments\":{}}</tool_call>}";
+    ok = expect_visible("named-container-tool/full",named_container_tool,false) && ok;
+    ok = expect_visible("named-container-tool/bytewise",named_container_tool,true) && ok;
+    const std::string malformed_json_then_tool=
+        "{\"x\":]}<tool_call>{\"name\":\"safe\",\"arguments\":{}}</tool_call>";
+    const std::vector<Segment> malformed_json_then_tool_want={
+        {Chan::TEXT,"{\"x\":]}"},
+        {Chan::TOOL,"{\"name\":\"safe\",\"arguments\":{}}"}};
+    ok = expect("malformed-json-then-tool/full",
+                compact(split(malformed_json_then_tool,false)),
+                malformed_json_then_tool_want) && ok;
+    ok = expect("malformed-json-then-tool/bytewise",
+                compact(split(malformed_json_then_tool,true)),
+                malformed_json_then_tool_want) && ok;
+    const std::string malformed_json_inner_tool=
+        "{\"x\":]<tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>}"
+        "<tool_call>{\"name\":\"safe\",\"arguments\":{}}</tool_call>";
+    const std::vector<Segment> malformed_json_inner_tool_want={
+        {Chan::TEXT,
+         "{\"x\":]<tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>}"},
+        {Chan::TOOL,"{\"name\":\"safe\",\"arguments\":{}}"}};
+    ok = expect("malformed-json-inner-tool/full",
+                compact(split(malformed_json_inner_tool,false)),
+                malformed_json_inner_tool_want) && ok;
+    ok = expect("malformed-json-inner-tool/bytewise",
+                compact(split(malformed_json_inner_tool,true)),
+                malformed_json_inner_tool_want) && ok;
+    const std::string prose_brace_tool=
+        "I can use {<tool_call>{\"name\":\"safe\",\"arguments\":{}}</tool_call>";
+    const std::vector<Segment> prose_brace_want={
+        {Chan::TEXT,"I can use {"},
+        {Chan::TOOL,"{\"name\":\"safe\",\"arguments\":{}}"}};
+    ok = expect("prose-brace-tool/full",compact(split(prose_brace_tool,false)),
+                prose_brace_want) && ok;
+    ok = expect("prose-brace-tool/bytewise",compact(split(prose_brace_tool,true)),
+                prose_brace_want) && ok;
+    const std::string html_comment=
+        "<!-- <tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call> -->";
+    ok = expect_visible("html-comment-tool/full",html_comment,false) && ok;
+    ok = expect_visible("html-comment-tool/bytewise",html_comment,true) && ok;
+    const std::string html_block=
+        "<div>\n<tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>\n</div>";
+    ok = expect_visible("html-block-tool/full",html_block,false) && ok;
+    ok = expect_visible("html-block-tool/bytewise",html_block,true) && ok;
+    const std::string html_cdata=
+        "<![CDATA[<tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>]]>";
+    ok = expect_visible("html-cdata-tool/bytewise",html_cdata,true) && ok;
+    const std::string adjacent_html_opener=
+        "<<div><tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call></div>";
+    ok = expect_visible("adjacent-html-opener/full",adjacent_html_opener,false) && ok;
+    ok = expect_visible("adjacent-html-opener/bytewise",adjacent_html_opener,true) && ok;
+    const std::string html_attribute=
+        "<img alt='><tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>'>";
+    ok = expect_visible("html-attribute-tool/full",html_attribute,false) && ok;
+    ok = expect_visible("html-attribute-tool/bytewise",html_attribute,true) && ok;
+    const std::string long_tag_prefix(32,'a');
+    const std::string long_tag_html=
+        "<"+long_tag_prefix+"x><tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>"+
+        "</"+long_tag_prefix+"y><tool_call>{\"name\":\"still-danger\",\"arguments\":{}}</tool_call>"+
+        "</"+long_tag_prefix+"x>";
+    ok = expect_visible("long-html-tag/full",long_tag_html,false) && ok;
+    ok = expect_visible("long-html-tag/bytewise",long_tag_html,true) && ok;
+    const std::string markdown_link=
+        "[example](https://example.invalid/<tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>)";
+    ok = expect_visible("markdown-link-tool/full",markdown_link,false) && ok;
+    ok = expect_visible("markdown-link-tool/bytewise",markdown_link,true) && ok;
+    const std::string markdown_reference=
+        "[example]: https://example.invalid/<tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>";
+    ok = expect_visible("markdown-reference-tool/full",markdown_reference,false) && ok;
+    ok = expect_visible("markdown-reference-tool/bytewise",markdown_reference,true) && ok;
+    const std::string multiline_markdown_link=
+        "[example](https://example.invalid/\n \"<tool_call>{\"name\":\"danger\",\"arguments\":{}}</tool_call>\")";
+    ok = expect_visible("multiline-markdown-link-tool/full",multiline_markdown_link,false) && ok;
+    ok = expect_visible("multiline-markdown-link-tool/bytewise",multiline_markdown_link,true) && ok;
+    const std::string less_than_prose=
+        "I <3 this. <tool_call>{\"name\":\"safe\",\"arguments\":{}}</tool_call>";
+    const std::vector<Segment> less_than_want={
+        {Chan::TEXT,"I <3 this. "},
+        {Chan::TOOL,"{\"name\":\"safe\",\"arguments\":{}}"}};
+    ok = expect("less-than-prose/full",split(less_than_prose,false),less_than_want) && ok;
+    ok = expect("less-than-prose/bytewise",compact(split(less_than_prose,true)),less_than_want) && ok;
 
     q27::StreamSplitter unfinished;
     std::vector<Segment> unfinished_got = unfinished.feed("<tool_call>a</tool_call><think>");

--- a/tools/test_tool_drift_corpus.cpp
+++ b/tools/test_tool_drift_corpus.cpp
@@ -104,7 +104,7 @@ int main() {
         }
     }
 
-    printf(fails ? "\nCORPUS: %d FAIL\n" : "\nCORPUS: all pass (%zu fixtures)\n",
-           fails ? fails : (int)fx.size());
+    if(fails) printf("\nCORPUS: %d FAIL\n",fails);
+    else printf("\nCORPUS: all pass (%zu fixtures)\n",fx.size());
     return fails ? 1 : 0;
 }


### PR DESCRIPTION
## Summary

- restore the shared OpenAI, Anthropic, and Responses serving behavior on current upstream after the Metal core series
- make wrapped and wrapper-less tool-call recovery stream-safe while keeping quoted, Markdown, HTML, and JSON-contained examples visible and non-executable
- preserve malformed/invalid output bytes, UTF-8 replacement semantics, tool-choice filtering, usage accounting, and truthful incomplete Responses lifecycles
- add ordinary optional API-key authentication plus exact-production auth/Responses integration coverage
- add explicit host gate targets without adding Metal serving, `ToolCallStreamer`, CUDA compiler-policy changes, or auth-rejection connection-close policy

## Scope

This is the shared API/CUDA serving stage from issue #8, replayed directly onto `3a15b1907de0`.

Exact source: `9d2f8663247aabffef72f268569a753276c0f494`
Tree: `01ae8352fabb315851772913ac9c9757861480e5`

13 files, +6,868/-634 versus the parent.

## Verification completed

On the exact source tip:

- pinned CUDA build passed with nvcc 12.8.93 / `sm_86`:
  - `make -B build/q27-server-w8 build/test_auth_integration`
- the exact production binary passed the model-backed Responses/auth matrix:
  - health exemption
  - missing, wrong, Bearer, and `x-api-key` authentication
  - streaming and non-streaming `/v1/responses`
  - token-cap and reasoning-budget truncation
  - legacy, current, and absent Codex headers
  - truthful terminal response/item status and `incomplete_details`
- extracted production handlers match their host fixture byte-for-byte:
  - `make check-chat-extract`
- host gates pass:
  - `build/test_stream_split`
  - `build/test_openai_bridge --selftest`
  - `build/test_tokenizer --selftest`
  - `build/test_chat_completions_integration`
  - `build/test_auth`
  - `build/test_auth_integration`
- `git diff --check` passes
- final structured review reported no accepted/actionable findings

## Live decode A/B

Matched A/B runs used the same RTX 3090, model and tokenizer artifacts, CUDA build flags, 128-token deterministic no-thinking response, and four sequential runs per leg. The first run was treated as warm-up; the table reports the median of the remaining three.

| Build | Median decode throughput |
|---|---:|
| upstream `3a15b1907de0` | 83.459 tokens/s |
| this branch `9d2f8663247a` | 83.479 tokens/s |
| delta | +0.024% |

The measured serving path is effectively unchanged at this precision.

## Model-free parser comparison

Median of seven matched runs against upstream `3a15b1907de0`:

| Workload | Upstream | This branch | Delta |
|---|---:|---:|---:|
| 8 KiB brace-heavy bare-call parse | 0.288 ms/request | 0.518 ms/request | +0.230 ms, 1.80x latency |
| 9 KiB 64-byte-chunk stream split | 0.131 ms/request | 0.022 ms/request | 5.86x faster |
| 128 KiB brace-heavy parser stress | 4.642 ms/request | 33.016 ms/request | 7.11x latency |

The 8 KiB case is the representative generated-output scale; the 128 KiB case records the worst synthetic brace-heavy regression rather than hiding it. The model-backed A/B above directly measures the live serving outcome.

## Files (13)

- Makefile [MODIFIED] (+26 -7)
- src/api_common.h [MODIFIED] (+2212 -115)
- src/markdown_lex.h [ADDED] (+771 -0)
- src/server.cu [MODIFIED] (+934 -393)
- src/stream_split.h [MODIFIED] (+48 -25)
- src/test_tokenizer.cpp [MODIFIED] (+9 -3)
- tools/extract_check.sh [MODIFIED] (+1 -0)
- tools/test_auth.cpp [MODIFIED] (+3 -1)
- tools/test_auth_integration.cpp [MODIFIED] (+26 -5)
- tools/test_chat_completions_integration.cpp [MODIFIED] (+746 -84)
- tools/test_openai_bridge.cpp [MODIFIED] (+1726 -1)
- tools/test_responses_integration.py [ADDED] (+219 -0)
- tools/test_stream_split.cpp [MODIFIED] (+147 -0)
