### PR TITLE
metal: add production serving stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ NVCCFLAGS ?= -O2 -std=c++17 -gencode arch=compute_86,code=sm_86 \
 
 .PHONY: all clean test-inspect test-metal-backend metal-engine test-metal-contracts test-metal test-metal-canonical check-chat-extract check-responses-integration
 all: build/inspect build/test_sampling build/test_kernels build/test_argmax_tie build/q27 build/q27-server build/test_tokenizer build/test_stream_split build/test_tool_drift build/test_tool_drift_corpus build/test_think_resolve build/test_openai_bridge build/test_chat_completions_integration build/test_depthctl build/test_toolconstrain
-
 build/q27: src/engine.cu src/engine.cuh src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp \
            src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/device_model.h src/loader.h src/cuda_common.h src/depthctl.h src/prefix_cache.h src/prefix_ram.h | build
 	$(NVCC) $(NVCCFLAGS) src/engine.cu src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp -o $@
@@ -63,7 +62,6 @@ check-chat-extract: tools/extract_check.sh src/server.cu tools/test_chat_complet
 SERVER ?= build/q27-server
 check-responses-integration: $(SERVER) tools/test_responses_integration.py
 	python3 tools/test_responses_integration.py --server "$(SERVER)" --model "$(MODEL)" --tokenizer "$(TOKENIZER)"
-
 build/test_depthctl: tools/test_depthctl.cpp src/depthctl.h | build
 	$(CXX) $(CXXFLAGS) tools/test_depthctl.cpp -o $@
 
@@ -93,7 +91,7 @@ build/test_argmax_tie: tools/test_argmax_tie.cu src/blocks.cu src/blocks.cuh | b
 build/q27-server: src/server.cu src/engine.cuh src/conductor.h src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu \
                   src/device_model.cu src/loader.cpp src/tokenizer.cpp src/api_common.h src/stream_split.h src/markdown_lex.h \
                   src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/cuda_common.h src/toolgram.h \
-                  src/depthctl.h src/toolconstrain.h src/tokenizer.h src/prefix_cache.h src/prefix_ram.h | build
+                  src/depthctl.h src/toolconstrain.h src/tokenizer.h src/prefix_cache.h src/prefix_ram.h third_party/httplib.h | build
 	$(NVCC) $(NVCCFLAGS) -Xcompiler -pthread src/server.cu src/blocks.cu src/prefill.cu src/kernels.cu \
 	        src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp src/tokenizer.cpp -o $@
 
@@ -138,7 +136,7 @@ build/turbo5_test: tools/turbo5_test.cu src/turbo5.cuh src/turbo3.cuh | build
 build/q27-server-w8: src/server.cu src/engine.cuh src/conductor.h src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu \
                      src/device_model.cu src/loader.cpp src/tokenizer.cpp src/api_common.h src/stream_split.h src/markdown_lex.h \
                      src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/cuda_common.h src/toolgram.h \
-                     src/depthctl.h src/toolconstrain.h src/tokenizer.h src/prefix_cache.h src/prefix_ram.h | build
+                     src/depthctl.h src/toolconstrain.h src/tokenizer.h src/prefix_cache.h src/prefix_ram.h third_party/httplib.h | build
 	$(NVCC) $(NVCCFLAGS) -DQ27_W_MAX=8 -Xcompiler -pthread src/server.cu src/blocks.cu src/prefill.cu src/kernels.cu \
 	        src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp src/tokenizer.cpp -o $@
 
@@ -163,7 +161,7 @@ build/fused_smoke: tools/fused_smoke.cu src/engine.cuh src/conductor.h src/prefi
 build/q27-server-w16: src/server.cu src/engine.cuh src/conductor.h src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu \
                       src/device_model.cu src/loader.cpp src/tokenizer.cpp src/api_common.h src/stream_split.h src/markdown_lex.h \
                       src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/cuda_common.h src/toolgram.h \
-                      src/depthctl.h src/toolconstrain.h src/tokenizer.h src/prefix_cache.h src/prefix_ram.h | build
+                      src/depthctl.h src/toolconstrain.h src/tokenizer.h src/prefix_cache.h src/prefix_ram.h third_party/httplib.h | build
 	$(NVCC) $(NVCCFLAGS) -DQ27_W_MAX=16 -Xcompiler -pthread src/server.cu src/blocks.cu src/prefill.cu src/kernels.cu \
 	        src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp src/tokenizer.cpp -o $@
 
@@ -188,22 +186,24 @@ build/test-metal-ops: src/metal/test_metal_ops.cpp src/metal/metal_backend.mm \
 
 build/metal-engine.o: src/metal/metal_engine.cpp src/metal/metal_engine.h \
                       src/metal/metal_backend.h src/backend.h src/loader.h \
-                      src/sampling.h src/suffixdraft.h third_party/json.hpp | build
+                      src/sampling.h third_party/json.hpp | build
 	$(CXX) $(METALFLAGS) -c src/metal/metal_engine.cpp -o $@
 
 build/test_metal_engine_contracts: src/metal/test_metal_engine_contracts.cpp \
                                    src/metal/metal_engine.cpp src/metal/metal_engine.h \
                                    src/metal/metal_backend.mm src/metal/metal_backend.h \
                                    src/metal/q27_kernels.metal src/backend.h \
-                                   src/loader.cpp src/loader.h src/sampling.h src/suffixdraft.h \
+                                   src/loader.cpp src/loader.h src/sampling.h \
                                    third_party/json.hpp | build
 	$(CXX) $(METALFLAGS) src/metal/test_metal_engine_contracts.cpp \
 	       src/metal/metal_engine.cpp src/metal/metal_backend.mm src/loader.cpp \
 	       $(METALLIBS) -o $@
 
-test-metal-contracts: build/test_metal_engine_contracts
+test-metal-contracts: build/test_metal_engine_contracts build/test_metal_model_contracts build/test_metal_stream
 	@test -n "$(MODEL)" || { echo "set MODEL=...q4s.q27" >&2; exit 2; }
 	./build/test_metal_engine_contracts "$(MODEL)"
+	./build/test_metal_model_contracts "$(MODEL)"
+	./build/test_metal_stream
 
 metal-engine: build/metal-engine.o
 
@@ -211,12 +211,65 @@ build/q27-metal: src/metal/metal_cli.cpp src/metal/metal_engine.cpp \
                  src/metal/metal_backend.mm src/metal/metal_engine.h \
                  src/metal/metal_backend.h src/metal/q27_kernels.metal \
                  src/backend.h src/loader.cpp src/loader.h src/tokenizer.cpp \
-                 src/tokenizer.h src/sampling.h src/suffixdraft.h third_party/json.hpp | build
+                 src/tokenizer.h src/sampling.h third_party/json.hpp | build
 	$(CXX) $(METALFLAGS) src/metal/metal_cli.cpp src/metal/metal_engine.cpp \
 	       src/metal/metal_backend.mm src/loader.cpp src/tokenizer.cpp \
 	       $(METALLIBS) -o $@
 
-test-metal: test-metal-backend build/q27-metal
+build/test_metal_model_contracts: src/metal/test_metal_model_contracts.cpp \
+                                  src/metal/metal_engine.cpp src/metal/metal_backend.mm \
+                                  src/metal/metal_engine.h src/metal/metal_backend.h \
+                                  src/metal/q27_kernels.metal src/backend.h src/loader.cpp | build
+	$(CXX) $(METALFLAGS) src/metal/test_metal_model_contracts.cpp \
+	       src/metal/metal_engine.cpp src/metal/metal_backend.mm src/loader.cpp \
+	       $(METALLIBS) -o $@
+
+test-metal-validation: build/inspect build/q27-metal
+	@test -n "$(TOKENIZER)" || { echo "set TOKENIZER=...tok" >&2; exit 2; }
+	python3 tools/test_inspect.py ./build/inspect ./build/q27-metal "$(TOKENIZER)"
+
+build/q27-metal-server: src/metal/metal_server.cpp src/metal/metal_engine.cpp \
+                        src/metal/metal_backend.mm src/metal/metal_engine.h \
+                        src/metal/metal_backend.h src/metal/stream_format.h \
+                        src/metal/serving_policy.h src/metal/disk_snapshot_store.h \
+                        src/metal/snapshot_evict.h \
+                        src/metal/q27_kernels.metal src/api_common.h src/stream_split.h \
+                        src/toolconstrain.h src/toolgram.h src/backend.h src/loader.h src/loader.cpp \
+                        src/sampling.h src/tokenizer.h src/tokenizer.cpp \
+                        third_party/httplib.h third_party/json.hpp | build
+	$(CXX) $(METALFLAGS) -I src/metal src/metal/metal_server.cpp src/metal/metal_engine.cpp \
+	        src/metal/metal_backend.mm src/loader.cpp src/tokenizer.cpp $(METALLIBS) -o $@
+
+build/q27-metal-server-test: src/metal/metal_server.cpp src/metal/metal_engine.cpp \
+                             src/metal/metal_backend.mm src/metal/metal_engine.h \
+                             src/metal/metal_backend.h src/metal/stream_format.h \
+                             src/metal/serving_policy.h src/metal/disk_snapshot_store.h \
+                             src/metal/snapshot_evict.h \
+                             src/metal/q27_kernels.metal src/api_common.h src/stream_split.h \
+                             src/toolconstrain.h src/toolgram.h src/backend.h src/loader.h src/loader.cpp \
+                             src/sampling.h src/tokenizer.h src/tokenizer.cpp \
+                             third_party/httplib.h third_party/json.hpp | build
+	$(CXX) $(METALFLAGS) -DQ27_METAL_TEST_FAILPOINTS=1 -I src/metal \
+	        src/metal/metal_server.cpp src/metal/metal_engine.cpp src/metal/metal_backend.mm \
+	        src/loader.cpp src/tokenizer.cpp $(METALLIBS) -o $@
+
+build/test_metal_stream: src/metal/test_metal_stream.cpp src/metal/stream_format.h \
+                         src/metal/serving_policy.h src/api_common.h src/stream_split.h \
+                         third_party/json.hpp | build
+	$(CXX) $(CXXFLAGS) -I src/metal src/metal/test_metal_stream.cpp -o $@
+
+build/test_snapshot_store_shared: tools/test_snapshot_store_shared.cpp \
+                                  src/metal/disk_snapshot_store.h src/metal/snapshot_evict.h | build
+	$(CXX) $(CXXFLAGS) -I src/metal tools/test_snapshot_store_shared.cpp -o $@
+
+test-metal-recovery: build/q27-metal-server-test src/metal/test_server_recovery.py
+	@test -n "$(MODEL)" || { echo "set MODEL=...q4s.q27" >&2; exit 2; }
+	@test -n "$(TOKENIZER)" || { echo "set TOKENIZER=...tok" >&2; exit 2; }
+	python3 src/metal/test_server_recovery.py ./build/q27-metal-server-test "$(MODEL)" "$(TOKENIZER)"
+
+test-metal: test-metal-backend build/test_metal_stream build/test_snapshot_store_shared build/q27-metal
+	./build/test_metal_stream
+	./build/test_snapshot_store_shared
 	@test -n "$(MODEL)" || { echo "set MODEL=...q4s.q27" >&2; exit 2; }
 	@test -n "$(TOKENIZER)" || { echo "set TOKENIZER=...tok" >&2; exit 2; }
 	@if ./build/q27-metal "$(MODEL)" "$(TOKENIZER)" --tokens 760 --prompt "" >/dev/null 2>&1; then \
@@ -242,6 +295,10 @@ metal-engine:
 	@echo "metal-engine requires macOS" >&2; exit 1
 test-metal-contracts:
 	@echo "test-metal-contracts requires macOS" >&2; exit 1
+test-metal-recovery:
+	@echo "test-metal-recovery requires macOS" >&2; exit 1
+test-metal-validation:
+	@echo "test-metal-validation requires macOS" >&2; exit 1
 
 test-metal:
 	@echo "test-metal requires macOS" >&2; exit 1

--- a/src/metal/disk_snapshot_store.h
+++ b/src/metal/disk_snapshot_store.h
@@ -1,0 +1,521 @@
+#pragma once
+// Disk snapshot store (prefix snapshots Phase 2, docs/plans/2026-07-16-
+// prefix-snapshots.md). Extracted from metal_server.cpp into its own header
+// so the T1 eviction gate (tools/test_snapshot_evict_store.cpp) can drive
+// the REAL store offline — this box holds exactly one resident model, so
+// the eviction path must be testable without a server.
+//
+// token-prefix keyed: the server tokenizes every prompt itself, so "the
+// snapshot's stored token ids are a prefix of this request's tokens" is
+// exact and has no BPE-boundary hazard (recorded design deviation from
+// ds4's byte-SHA1, which exists for stateless clients that retokenize).
+// Files are named by the SHA1 of the token bytes, so an identical prefix
+// overwrites rather than duplicates. LRU by mtime; hits touch the file.
+// Directory lookup and eviction are pure file I/O. Snapshot save/load wraps
+// each backend transfer in one server lease while keeping file I/O outside it.
+//
+// The store reads snapshot metadata through a Peek functor injected at
+// construction: production passes q27::MetalEngine::peek_snapshot; the
+// offline gate passes a tiny stub that parses fabricated Q27SNAP1 fixtures.
+// SnapshotInfo mirrors q27::MetalEngine::SnapshotInfo's two fields the
+// store uses (position, logits_resident, tokens).
+
+#include "snapshot_evict.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <fcntl.h>
+#include <filesystem>
+#include <map>
+#include <mutex>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <stdexcept>
+#include <vector>
+
+#include <sys/stat.h>
+#include <sys/file.h>
+#include <unistd.h>
+
+struct SnapPeekInfo {
+    uint32_t position = 0;
+    bool logits_resident = true;
+    std::vector<uint32_t> tokens;
+};
+
+class DiskSnapshotStore {
+  public:
+    // peek: pinned descriptor + diagnostic path -> metadata. The store opens
+    // each candidate itself so lookup and restore can share one inode.
+    using PeekFn = SnapPeekInfo (*)(int,const std::string&);
+    // hash: token bytes -> 40-hex-char key (production: SHA1; the offline
+    // gate may use any deterministic hex). Injected so this header carries
+    // no platform crypto dependency and remains portable to Linux/CUDA hosts.
+    using HashFn = void (*)(const uint32_t* tokens, uint32_t count, char out_hex[41]);
+
+    explicit DiskSnapshotStore(PeekFn peek, HashFn hash) : peek_(peek), hash_(hash) {}
+
+    // tag = artifact/KV identity prefix baked into every filename, so one
+    // directory shared by different artifacts or fp16/turbo3 servers never
+    // cross-matches or overwrites incompatible snapshots; the deep header
+    // identity check at load stays underneath.
+    void init(std::string dir, uint64_t max_bytes, std::string tag, bool spine_pin=false) {
+        std::lock_guard<std::mutex> lk(m_);
+        dir_=std::move(dir); max_bytes_=max_bytes; tag_=std::move(tag); spine_pin_=spine_pin;
+        reclaim_stale_temporaries_locked();
+    }
+    bool enabled() const { return !dir_.empty(); }
+
+    struct Match {
+        std::string path;
+        SnapPeekInfo info;
+        int fd=-1;
+        Match() = default;
+        Match(const Match&) = delete;
+        Match& operator=(const Match&) = delete;
+        Match(Match&& other) noexcept
+            : path(std::move(other.path)),info(std::move(other.info)),fd(other.fd) {
+            other.fd=-1;
+        }
+        Match& operator=(Match&& other) noexcept {
+            if(this!=&other) {
+                if(fd>=0) ::close(fd);
+                path=std::move(other.path);
+                info=std::move(other.info);
+                fd=other.fd;
+                other.fd=-1;
+            }
+            return *this;
+        }
+        ~Match() { if(fd>=0) ::close(fd); }
+        explicit operator bool() const { return fd>=0; }
+    };
+
+    // Longest stored token prefix of `prompt`. Full-length matches whose
+    // logits are stale (mid-prefill saves) are skipped: state would be
+    // exact but no pending token could be derived.
+    Match best_match(const std::vector<uint32_t>& prompt) {
+        Match best;
+        if(!enabled()) return best;
+        std::lock_guard<std::mutex> lk(m_);
+        prune_missing_cached_paths_locked();
+        uint32_t best_len=0;
+        std::error_code ec;
+        for(const auto& e:std::filesystem::directory_iterator(dir_,ec)) {
+            if(e.path().extension()!=".q27snap") continue;
+            const std::string filename=e.path().filename().string();
+            if(filename.rfind(tag_,0)!=0 ||
+               filename.size()!=tag_.size()+40+std::string(".q27snap").size()) continue;
+            const std::string pstr=e.path().string();
+            const int fd=::open(pstr.c_str(),O_RDONLY|O_CLOEXEC|O_NOFOLLOW);
+            if(fd<0) continue;
+            struct stat st{};
+            if(::fstat(fd,&st)!=0 || !S_ISREG(st.st_mode)) {
+                ::close(fd);
+                continue;
+            }
+            SnapPeekInfo info;
+            if(!peek_fd_current(pstr,fd,st,info)) {
+                ::close(fd);
+                continue;
+            }
+            // Saves record exactly the encoded prefix; anything else is not
+            // resumable by token matching.
+            if(info.position!=info.tokens.size() || info.tokens.empty() ||
+               info.tokens.size()>prompt.size() ||
+               (info.tokens.size()==prompt.size() && !info.logits_resident) ||
+               info.tokens.size()<=best_len ||
+               !std::equal(info.tokens.begin(),info.tokens.end(),prompt.begin())) {
+                ::close(fd);
+                continue;
+            }
+            if(best.fd>=0) ::close(best.fd);
+            best.path=pstr;
+            best.info=std::move(info);
+            best.fd=fd;
+            best_len=(uint32_t)best.info.tokens.size();
+        }
+        if(best) {
+            const timespec now[2]={{0,UTIME_NOW},{0,UTIME_NOW}};
+            (void)::futimens(best.fd,now);
+        }
+        return best;
+    }
+
+    std::string path_for(const uint32_t* tokens,uint32_t count) {
+        char hex[41];
+        hash_(tokens,count,hex); hex[40]='\0';
+        return dir_+"/"+tag_+hex+".q27snap";
+    }
+
+    // True only when the exact token-key pathname currently contains a
+    // logits-resident snapshot with matching position/tokens. Callers use
+    // this immediately before a lease-serialized stale-logits save so an
+    // older save decision cannot downgrade a newly installed exact prefix.
+    bool exact_resident(const uint32_t* tokens,uint32_t count) {
+        if(!enabled() || !tokens || !count) return false;
+        char hex[41]; hash_(tokens,count,hex); hex[40]='\0';
+        const std::string path=dir_+"/"+tag_+hex+".q27snap";
+        std::lock_guard<std::mutex> lk(m_);
+        const int fd=::open(path.c_str(),O_RDONLY|O_CLOEXEC|O_NOFOLLOW);
+        if(fd<0) {
+            meta_.erase(path);
+            tokens_.erase(path);
+            return false;
+        }
+        struct stat st{};
+        SnapPeekInfo info;
+        const bool current=::fstat(fd,&st)==0 && S_ISREG(st.st_mode) &&
+                           peek_fd_current(path,fd,st,info);
+        ::close(fd);
+        return current && info.logits_resident && info.position==count &&
+               info.tokens.size()==count &&
+               std::equal(info.tokens.begin(),info.tokens.end(),tokens);
+    }
+
+    // Serialize the entire inspect -> save -> atomic-rename publication
+    // decision for one destination. The in-process mutex covers concurrent
+    // request engines; the bounded lock-file stripe covers other server
+    // processes sharing the cache directory. Lock files are intentionally
+    // persistent: unlinking one while another process waits on its inode can
+    // split future publishers across two different locks.
+    template<class PublishFn>
+    bool with_publication_lock(const std::string& path,PublishFn&& publish) {
+        uint64_t hash=1469598103934665603ull;
+        for(const unsigned char c:path) {
+            hash^=c;
+            hash*=1099511628211ull;
+        }
+        const std::string lock_path=dir_+"/.q27-publish-"+
+            std::to_string(hash%64)+".lock";
+        std::shared_ptr<std::mutex> local;
+        {
+            std::lock_guard<std::mutex> lk(m_);
+            auto& slot=publication_locks_[lock_path];
+            if(!slot) slot=std::make_shared<std::mutex>();
+            local=slot;
+        }
+        std::lock_guard<std::mutex> local_lk(*local);
+        const int fd=::open(lock_path.c_str(),O_RDWR|O_CREAT|O_CLOEXEC,0666);
+        if(fd<0) throw std::runtime_error("cannot open snapshot publication lock: "+lock_path);
+        struct stat st{};
+        if(::fstat(fd,&st)!=0 || !S_ISREG(st.st_mode)) {
+            ::close(fd);
+            throw std::runtime_error("invalid snapshot publication lock: "+lock_path);
+        }
+        if(::flock(fd,LOCK_EX)!=0) {
+            ::close(fd);
+            throw std::runtime_error("cannot acquire snapshot publication lock: "+lock_path);
+        }
+        try {
+            const bool result=publish();
+            (void)::flock(fd,LOCK_UN);
+            ::close(fd);
+            return result;
+        } catch(...) {
+            (void)::flock(fd,LOCK_UN);
+            ::close(fd);
+            throw;
+        }
+    }
+
+    // A candidate that passed the shallow header peek but failed the engine's
+    // full structural/configuration load is not usable. The descriptor pins
+    // the inode that actually failed. Serialize with publishers and unlink
+    // only if the pathname still names that inode; a repaired atomic
+    // replacement must survive an old reader finishing late.
+    void reject(const std::string& path,int rejected_fd) {
+        struct stat rejected{};
+        if(rejected_fd<0 || ::fstat(rejected_fd,&rejected)!=0) return;
+        with_publication_lock(path,[&] {
+            struct stat current{};
+            bool erase_cache=false;
+            if(::lstat(path.c_str(),&current)!=0) {
+                erase_cache=errno==ENOENT;
+            } else if(S_ISREG(current.st_mode) && current.st_dev==rejected.st_dev &&
+                      current.st_ino==rejected.st_ino) {
+                erase_cache=(::unlink(path.c_str())==0 || errno==ENOENT);
+            }
+            if(erase_cache) {
+                std::lock_guard<std::mutex> lk(m_);
+                meta_.erase(path);
+                tokens_.erase(path);
+            }
+            return erase_cache;
+        });
+    }
+
+    // Register tokens only after save_state has returned successfully. Failed
+    // attempts may never publish a file and must not leave unbounded entries
+    // that directory-based eviction can never discover.
+    void published(const std::string& path,const uint32_t* tokens,uint32_t count) {
+        std::lock_guard<std::mutex> lk(m_);
+        prune_missing_cached_paths_locked();
+        tokens_[path]=std::vector<uint32_t>(tokens,tokens+count);
+        meta_.erase(path);
+    }
+
+    // save_state can throw before rename or after rename while syncing the
+    // directory. In either case discard memory-only bookkeeping; if a file did
+    // land, the next lookup/eviction can reconstruct its tokens by peeking it.
+    void save_failed(const std::string& path) {
+        std::lock_guard<std::mutex> lk(m_);
+        meta_.erase(path);
+        tokens_.erase(path);
+    }
+
+    std::pair<size_t,size_t> cache_entry_counts() {
+        std::lock_guard<std::mutex> lk(m_);
+        return {meta_.size(),tokens_.size()};
+    }
+
+    // Budget enforcement until the directory fits. The just-written file is
+    // deletable too — the budget is a hard cap, and the gate asserts the
+    // total never exceeds it. Returns {files, bytes} removed so the --trace
+    // stream can record the eviction decision.
+    //
+    // T1 (2026-07-18-t1-snapshot-eviction-classes.md): with spine_pin_, a
+    // snapshot that is a strict token-prefix of another stored snapshot (a
+    // growing conversation's spine) is evicted only AFTER every non-spine
+    // (leaf) snapshot. Recency is already persisted by best_match()'s
+    // touch-on-hit mtime, so within each class the order stays mtime-oldest
+    // first — the pin only reorders ACROSS the spine/leaf classes. Eviction
+    // only ever deletes files: a wrong victim costs a re-prefill, never a
+    // wrong result (the restore path is untouched).
+    std::pair<size_t,uint64_t> evict_past_budget() {
+        if(!enabled() || !max_bytes_) return {0,0};
+        std::pair<size_t,uint64_t> result{0,0};
+        with_eviction_lock([&] {
+            result=evict_past_budget_locked();
+            return true;
+        });
+        return result;
+    }
+
+    std::pair<size_t,uint64_t> evict_past_budget_locked() {
+        if(!enabled() || !max_bytes_) return {0,0};
+        std::unique_lock<std::mutex> lk(m_);
+        reclaim_stale_temporaries_locked();
+        prune_missing_cached_paths_locked();
+        // mtime folds to an opaque ordering key for the shared ordering
+        // function (snapshot_evict.h — header-only so the T1 ordering is
+        // unit-testable offline without a resident model).
+        std::vector<q27::EvictCandidate> files; uint64_t total=0;
+        std::map<std::string,std::pair<uint64_t,uint64_t>> identities;
+        std::error_code ec;
+        for(const auto& e:std::filesystem::directory_iterator(dir_,ec)) {
+            const std::string path=e.path().string();
+            const std::string name=e.path().filename().string();
+            struct stat st{};
+            if(e.path().extension()!=".q27snap" || name.rfind(tag_,0)!=0 ||
+               ::lstat(path.c_str(),&st)!=0 || !S_ISREG(st.st_mode) || st.st_size<0)
+                continue;
+            std::error_code metadata_ec;
+            const auto write_time=e.last_write_time(metadata_ec);
+            if(metadata_ec) continue;
+            const auto mt=std::chrono::duration_cast<std::chrono::nanoseconds>(
+                              write_time.time_since_epoch()).count();
+            const uint64_t size=(uint64_t)st.st_size;
+            files.push_back({path,size,(uint64_t)mt,false});
+            identities[path]={(uint64_t)st.st_dev,(uint64_t)st.st_ino};
+            total+=size;
+        }
+        if(spine_pin_) {
+            // Lazily read each file's stored token ids once (small next to
+            // the state blobs), then mark spine = strict prefix of another.
+            for(const auto& f:files)
+                if(tokens_.find(f.path)==tokens_.end()) {
+                    const int fd=::open(f.path.c_str(),O_RDONLY|O_CLOEXEC|O_NOFOLLOW);
+                    if(fd>=0) {
+                        try { tokens_[f.path]=peek_(fd,f.path).tokens; }
+                        catch(...) { /* unreadable: stays a leaf, evictable */ }
+                        ::close(fd);
+                    }
+                }
+            q27::mark_spine(files,tokens_);
+        }
+        q27::eviction_order(files,spine_pin_);
+        lk.unlock();
+        size_t n=0; uint64_t freed=0; bool rescan=false;
+        for(const auto& f:files) {
+            if(total<=max_bytes_) break;
+            bool missing=false,replaced=false,removed=false;
+            uint64_t current_size=0;
+            with_publication_lock(f.path,[&] {
+                struct stat current{};
+                if(::lstat(f.path.c_str(),&current)!=0) {
+                    missing=errno==ENOENT;
+                    return false;
+                }
+                current_size=current.st_size<0?0:(uint64_t)current.st_size;
+                const auto identity=identities.find(f.path);
+                replaced=identity==identities.end() || !S_ISREG(current.st_mode) ||
+                    identity->second.first!=(uint64_t)current.st_dev ||
+                    identity->second.second!=(uint64_t)current.st_ino;
+                if(replaced) return false;
+                removed=(::unlink(f.path.c_str())==0 || errno==ENOENT);
+                return removed;
+            });
+            if(missing) {
+                total=total>f.size?total-f.size:0;
+                { std::lock_guard<std::mutex> cache_lk(m_);
+                  tokens_.erase(f.path); meta_.erase(f.path); }
+                continue;
+            }
+            if(replaced) {
+                total=total>f.size?total-f.size:0;
+                total+=current_size;
+                { std::lock_guard<std::mutex> cache_lk(m_);
+                  tokens_.erase(f.path); meta_.erase(f.path); }
+                rescan=true;
+                continue;
+            }
+            if(removed) {
+                total=total>f.size?total-f.size:0;
+                n++; freed+=current_size;
+                { std::lock_guard<std::mutex> cache_lk(m_);
+                  tokens_.erase(f.path);
+                  meta_.erase(f.path); }
+                if(f.spine) evicted_spine++; else evicted_leaf++;
+            }
+        }
+        if(total>max_bytes_ && (rescan || n>0)) {
+            const auto retry=evict_past_budget_locked();
+            n+=retry.first;
+            freed+=retry.second;
+        }
+        return {n,freed};
+    }
+
+    std::atomic<uint64_t> hits{0}, saves{0}, evicted_spine{0}, evicted_leaf{0};
+  private:
+    template<class EvictFn>
+    bool with_eviction_lock(EvictFn&& evict) {
+        std::lock_guard<std::mutex> local_lk(eviction_mutex_);
+        uint64_t hash=1469598103934665603ull;
+        for(const unsigned char c:tag_) {
+            hash^=c;
+            hash*=1099511628211ull;
+        }
+        const std::string lock_path=dir_+"/.q27-evict-"+std::to_string(hash)+".lock";
+        const int fd=::open(lock_path.c_str(),O_RDWR|O_CREAT|O_CLOEXEC,0666);
+        if(fd<0) throw std::runtime_error("cannot open snapshot eviction lock: "+lock_path);
+        struct stat st{};
+        if(::fstat(fd,&st)!=0 || !S_ISREG(st.st_mode)) {
+            ::close(fd);
+            throw std::runtime_error("invalid snapshot eviction lock: "+lock_path);
+        }
+        if(::flock(fd,LOCK_EX)!=0) {
+            ::close(fd);
+            throw std::runtime_error("cannot acquire snapshot eviction lock: "+lock_path);
+        }
+        try {
+            const bool result=evict();
+            (void)::flock(fd,LOCK_UN);
+            ::close(fd);
+            return result;
+        } catch(...) {
+            (void)::flock(fd,LOCK_UN);
+            ::close(fd);
+            throw;
+        }
+    }
+
+    void prune_missing_cached_paths_locked() {
+        auto prune=[](auto& cache) {
+            for(auto it=cache.begin();it!=cache.end();) {
+                struct stat st{};
+                if(::lstat(it->first.c_str(),&st)!=0 || !S_ISREG(st.st_mode))
+                    it=cache.erase(it);
+                else ++it;
+            }
+        };
+        prune(meta_);
+        prune(tokens_);
+    }
+
+    static bool is_hex_key(const std::string& value,size_t begin,size_t count) {
+        if(begin+count>value.size()) return false;
+        for(size_t i=begin;i<begin+count;i++) {
+            const unsigned char c=(unsigned char)value[i];
+            if(!((c>='0' && c<='9') || (c>='a' && c<='f') || (c>='A' && c<='F')))
+                return false;
+        }
+        return true;
+    }
+
+    bool owns_temporary_name(const std::string& name) const {
+        static constexpr char marker[]=".q27snap.tmp.";
+        static constexpr size_t marker_len=sizeof(marker)-1;
+        static constexpr size_t suffix_len=6;
+        if(name.rfind(tag_,0)!=0 || name.size()<tag_.size()+40+marker_len+suffix_len)
+            return false;
+        const size_t marker_pos=name.size()-marker_len-suffix_len;
+        if(name.compare(marker_pos,marker_len,marker)!=0) return false;
+        for(size_t i=name.size()-suffix_len;i<name.size();i++) {
+            const unsigned char c=(unsigned char)name[i];
+            if(!((c>='0' && c<='9') || (c>='a' && c<='z') || (c>='A' && c<='Z')))
+                return false;
+        }
+        const size_t key_begin=tag_.size();
+        const size_t key_len=marker_pos-key_begin;
+        return key_len==40 && is_hex_key(name,key_begin,40);
+    }
+
+    void reclaim_stale_temporaries_locked() {
+        if(dir_.empty()) return;
+        std::error_code ec;
+        const auto stale_before=std::filesystem::file_time_type::clock::now()-
+                                std::chrono::seconds(60);
+        for(const auto& e:std::filesystem::directory_iterator(dir_,ec)) {
+            const std::string name=e.path().filename().string();
+            if(!owns_temporary_name(name)) continue;
+            std::error_code time_ec;
+            const auto write_time=e.last_write_time(time_ec);
+            if(time_ec || write_time>stale_before) continue;
+            const std::string path=e.path().string();
+            const int fd=::open(path.c_str(),O_RDWR|O_CLOEXEC);
+            if(fd<0) continue;
+            struct stat opened{},current{};
+            const bool removable=::fstat(fd,&opened)==0 && S_ISREG(opened.st_mode) &&
+                ::flock(fd,LOCK_EX|LOCK_NB)==0 && ::lstat(path.c_str(),&current)==0 &&
+                opened.st_dev==current.st_dev && opened.st_ino==current.st_ino;
+            if(removable) (void)::unlink(path.c_str());
+            ::close(fd);
+        }
+    }
+
+
+    struct CachedMeta {
+        SnapPeekInfo info;
+        uint64_t device=0;
+        uint64_t inode=0;
+    };
+    bool peek_fd_current(const std::string& path,int fd,const struct stat& st,
+                         SnapPeekInfo& info) {
+        auto cached=meta_.find(path);
+        if(cached!=meta_.end() && cached->second.device==(uint64_t)st.st_dev &&
+           cached->second.inode==(uint64_t)st.st_ino) {
+            info=cached->second.info;
+            return true;
+        }
+        try { info=peek_(fd,path); }
+        catch(...) { return false; }
+        meta_[path]={info,(uint64_t)st.st_dev,(uint64_t)st.st_ino};
+        return true;
+    }
+    PeekFn peek_;
+    HashFn hash_;
+    std::string dir_; uint64_t max_bytes_=0; std::string tag_; std::mutex m_,eviction_mutex_;
+    bool spine_pin_=false;
+    std::map<std::string,std::vector<uint32_t>> tokens_;   // path -> token ids (eviction spine check)
+    // Atomic replacement changes inode, forcing a fresh peek even when a
+    // different server process publishes the same token-key pathname.
+    std::map<std::string,CachedMeta> meta_;
+    std::map<std::string,std::shared_ptr<std::mutex>> publication_locks_;
+};

--- a/src/metal/metal_backend.h
+++ b/src/metal/metal_backend.h
@@ -15,7 +15,18 @@ class MetalBackend final : public ComputeBackend {
     MetalBackend& operator=(const MetalBackend&) = delete;
 
     std::string name() const override;
+    static const char* shader_abi_tag();
+    std::string shader_source_sha1() const;
+    bool gemm_half_enabled() const;
+    uint32_t gqa_tile() const;
+    uint32_t gqa_block() const;
+    uint32_t gqa_threshold() const;
+    bool gpu_topk_supported() const;
+    bool healthy() const noexcept;
     std::shared_ptr<BackendBuffer> allocate(uint64_t bytes) override;
+    // GPU-private allocation (never host-read/written): used for the
+    // engines' blocked-GQA partials scratch.
+    std::shared_ptr<BackendBuffer> allocate_private(uint64_t bytes);
     void write(BackendBuffer& dst, uint64_t offset, const void* src,
                uint64_t bytes) override;
     void read(const BackendBuffer& src, uint64_t offset, void* dst,
@@ -24,11 +35,13 @@ class MetalBackend final : public ComputeBackend {
     void copy(const BackendBuffer& src, uint64_t src_offset,
               BackendBuffer& dst, uint64_t dst_offset, uint64_t bytes) override;
     BackendTensor upload(const Tensor& tensor) override;
-    // Aliases model's mapped bytes; model must outlive the returned tensor.
     BackendTensor upload(const Model& model, const Tensor& tensor) override;
     void begin_commands() override;
     void end_commands() override;
     void abort_commands() noexcept override;
+    // Mark the shared command queue unusable after host-side work fails
+    // following an already committed state mutation.
+    void poison() noexcept;
     void matvec(const BackendTensor& weight, const BackendBuffer& x,
                 BackendBuffer& y) override;
     void matvec_pair(const BackendTensor& a, BackendBuffer& a_out,
@@ -41,7 +54,7 @@ class MetalBackend final : public ComputeBackend {
     void matvec_quantized_pair(const BackendTensor& a, BackendBuffer& a_out,
                                const BackendTensor& b, BackendBuffer& b_out,
                                const BackendQuantized& x) override;
-    void matmul_quantized(const BackendTensor& weight,const BackendQuantized& x,
+void matmul_quantized(const BackendTensor& weight,const BackendQuantized& x,
                           uint32_t x_rows,BackendBuffer& y) override;
     void embedding_q8(const BackendTensor& weight, uint32_t token,
                       BackendBuffer& out) override;
@@ -67,17 +80,46 @@ class MetalBackend final : public ComputeBackend {
                    uint32_t n_rot, uint32_t stride, uint32_t position,
                    float freq_base) override;
     void argmax(const BackendBuffer& x, uint32_t n, BackendBuffer& out_index) override;
+    void topk(const BackendBuffer& x, uint32_t n, uint32_t k,
+              BackendBuffer& values, BackendBuffer& indices, BackendBuffer& count,
+              uint64_t x_offset_bytes = 0) override;
     void kv_store(const BackendBuffer& k, const BackendBuffer& v,
                   BackendBuffer& k_cache, BackendBuffer& v_cache,
                   uint32_t position, uint32_t kv_heads, uint32_t head_dim,
                   KvFormat format) override;
-    void turbo_wht(BackendBuffer& x, uint32_t heads, uint32_t stride,
-                   bool inverse) override;
     void attention(const BackendBuffer& q, uint32_t q_stride,
                    const BackendBuffer& k_cache, const BackendBuffer& v_cache,
                    BackendBuffer& out, uint32_t seq_len, uint32_t q_heads,
                    uint32_t kv_heads, uint32_t head_dim, float scale,
                    KvFormat format, BackendBuffer* partials) override;
+    // Constrained decoding: -inf every logit whose bit is clear in the
+    // uint32 bitset at mask_offset (word-aligned) inside masks.
+    void mask_logits(BackendBuffer& logits, const BackendBuffer& masks,
+                     uint64_t mask_offset, uint32_t n);
+    // GPU-resident greedy decode: embedding row selected by a device-side
+    // token id (the previous step's argmax output) — no CPU sync between
+    // chained decode steps.
+    void embedding_from_device(const BackendTensor& weight, const BackendBuffer& token,
+                               BackendBuffer& out);
+    void kv_store_f16(const BackendBuffer& k, const BackendBuffer& v,
+                      BackendBuffer& k_cache, BackendBuffer& v_cache,
+                      uint32_t position, uint32_t row_length);
+    void turbo_wht(BackendBuffer& x, uint32_t heads, uint32_t stride,
+                   bool inverse) override;
+    void kv_store_turbo3(const BackendBuffer& k, const BackendBuffer& v,
+                         BackendBuffer& k_cache, BackendBuffer& v_cache,
+                         uint32_t position, uint32_t kv_heads);
+    void attention_turbo3(const BackendBuffer& q, uint32_t q_stride,
+                          const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                          BackendBuffer& out,
+                          uint32_t seq_len, uint32_t q_heads, uint32_t kv_heads,
+                          uint32_t head_dim, float scale,
+                          BackendBuffer* partials);
+    void attention_f16(const BackendBuffer& q, uint32_t q_stride,
+                       const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                       BackendBuffer& out, uint32_t seq_len,
+                       uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
+                       float scale, BackendBuffer* partials);
     void gdn_gates(const BackendBuffer& alpha, const BackendBuffer& beta_raw,
                    const BackendTensor& ssm_a, const BackendTensor& ssm_dt,
                    BackendBuffer& g, BackendBuffer& beta, uint32_t heads) override;
@@ -128,45 +170,33 @@ class MetalBackend final : public ComputeBackend {
                           BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
                           uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
                           float scale, KvFormat format, BackendBuffer* partials) override;
-    void sigmoid_gate_mul_rows(BackendBuffer& out, const BackendBuffer& qg,
-                               uint32_t heads, uint32_t head_dim, uint32_t tokens) override;
-    void argmax_rows(const BackendBuffer& x, uint32_t n, uint32_t rows,
-                     BackendBuffer& out_indices) override;
-    void nll_rows(const BackendBuffer& logits, const BackendBuffer& targets,
-                  BackendBuffer& nll, uint32_t n, uint32_t rows) override;
-    void synchronize() override;
-
-    // Clears Q27_METAL_PROFILE accumulation (stats, command-buffer and
-    // busy/wait counters) so benches can exclude their warmup dispatches
-    // from the attribution table. No-op when profiling is disabled.
-    void profile_reset();
-
-    uint64_t recommended_working_set_size() const;
-    uint64_t max_buffer_length() const;
-    bool uses_per_tensor_upload(const Model& model) const;
-    uint64_t max_threadgroup_memory_length() const;
-    bool supports_quantized_matmul() const;
-
-  private:
-    void kv_store_f16(const BackendBuffer& k, const BackendBuffer& v,
-                      BackendBuffer& k_cache, BackendBuffer& v_cache,
-                      uint32_t position, uint32_t row_length);
-    void kv_store_turbo3(const BackendBuffer& k, const BackendBuffer& v,
-                         BackendBuffer& k_cache, BackendBuffer& v_cache,
-                         uint32_t position, uint32_t kv_heads);
-    void attention_f16(const BackendBuffer& q, uint32_t q_stride,
-                       const BackendBuffer& k_cache, const BackendBuffer& v_cache,
-                       BackendBuffer& out, uint32_t seq_len,
-                       uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
-                       float scale, BackendBuffer* partials);
-    void attention_turbo3(const BackendBuffer& q, uint32_t q_stride,
-                          const BackendBuffer& k_cache, const BackendBuffer& v_cache,
-                          BackendBuffer& out, uint32_t seq_len,
-                          uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
-                          float scale, BackendBuffer* partials);
     void kv_store_f16_rows(const BackendBuffer& k, const BackendBuffer& v,
                            BackendBuffer& k_cache, BackendBuffer& v_cache,
                            uint32_t position, uint32_t row_length, uint32_t tokens);
+    // KV fp16 exception cells (docs/metal/plans/2026-07-17-kv-except-production.md),
+    // Metal-only concrete entries (not on the ComputeBackend interface): copy
+    // one head's K/V rows into a kv_heads=1 fp16 side cache, and re-run f16
+    // attention over that head's query-head window against the side cache,
+    // overwriting the production dispatch's output rows. Head offsets ride
+    // the buffer bindings; production kernels and shader ABI untouched.
+    // codec 0 stores fp16; codec 1 rounds each value onto the e4m3 grid
+    // first (hot-cells arm, 2026-07-17-kv-e4m3-hot-cells.md) — still
+    // stored as half, values-exact for a real 1-byte e4m3 side cache.
+    void kv_store_f16_head_rows_side(const BackendBuffer& k, const BackendBuffer& v,
+                                     uint32_t head_offset_elems, uint32_t src_stride,
+                                     BackendBuffer& k_side, BackendBuffer& v_side,
+                                     uint32_t position, uint32_t row_length, uint32_t tokens,
+                                     uint32_t codec = 0);
+    void attention_f16_window(const BackendBuffer& q, uint32_t q_stride, uint32_t qh_start,
+                              const BackendBuffer& k_side, const BackendBuffer& v_side,
+                              BackendBuffer& out, uint32_t seq_len,
+                              uint32_t win_heads, uint32_t head_dim, float scale);
+    void attention_f16_causal_window(const BackendBuffer& q, uint32_t q_stride, uint32_t q_row_stride,
+                                     uint32_t qh_start, const BackendBuffer& k_side,
+                                     const BackendBuffer& v_side, BackendBuffer& out,
+                                     uint32_t out_row_stride, uint32_t base_len_plus_1,
+                                     uint32_t win_heads, uint32_t head_dim,
+                                     uint32_t tokens, float scale);
     void kv_store_turbo3_rows(const BackendBuffer& k, const BackendBuffer& v,
                               BackendBuffer& k_cache, BackendBuffer& v_cache,
                               uint32_t position, uint32_t kv_heads, uint32_t tokens);
@@ -182,6 +212,42 @@ class MetalBackend final : public ComputeBackend {
                                  BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
                                  uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
                                  float scale, BackendBuffer* partials);
+    void sigmoid_gate_mul_rows(BackendBuffer& out, const BackendBuffer& qg,
+                               uint32_t heads, uint32_t head_dim, uint32_t tokens) override;
+    void argmax_rows(const BackendBuffer& x, uint32_t n, uint32_t rows,
+                     BackendBuffer& out_indices) override;
+    void nll_rows(const BackendBuffer& logits, const BackendBuffer& targets,
+                  BackendBuffer& nll, uint32_t n, uint32_t rows) override;
+    void synchronize() override;
+
+    // Clears Q27_METAL_PROFILE accumulation (stats, command-buffer and
+    // busy/wait counters) so benches can exclude their warmup dispatches
+    // from the attribution table. No-op when profiling is disabled.
+    void profile_reset();
+
+    uint64_t recommended_working_set_size() const;
+    // Live device allocation total (weights are already inside this once the
+    // artifact is mapped) — the measured-free half of --ctx auto sizing.
+    uint64_t current_allocated_size() const;
+    // Effective causal-GQA block size (Q27_METAL_GQA_BLOCK or 1024): engines
+    // size their per-engine partials buffer from it at construction.
+    uint32_t gqa_block_size() const;
+    // Envelope-instrument hooks (docs/metal/plans/2026-07-16-envelope-instrument.md):
+    // flip the backend-global reduction-order knobs between two engines'
+    // lockstep passes. Instrument use only — production reads the env once.
+    // CONTRACT: these are BACKEND-scoped, not per-engine. Engines sharing
+    // one backend (Shared mapping) see every flip; only one engine may
+    // mutate them, and never while another engine's pass is in flight —
+    // the envelope instrument flips them sequentially by design. Concurrent
+    // flips would corrupt any A/B attribution riding on them.
+    void set_gemm_half(bool enabled);
+    void set_gqa_threshold(uint32_t threshold);
+    uint64_t max_buffer_length() const;
+    bool uses_per_tensor_upload(const Model& model) const;
+    uint64_t max_threadgroup_memory_length() const;
+    bool supports_quantized_matmul() const;
+
+  private:
     struct Impl;
     std::unique_ptr<Impl> impl_;
 };

--- a/src/metal/metal_backend.mm
+++ b/src/metal/metal_backend.mm
@@ -1,11 +1,13 @@
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 
+#include <CommonCrypto/CommonDigest.h>
 #include "metal_backend.h"
 
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
+#include <atomic>
 #include <cstdlib>
 #include <cstring>
 #include <limits>
@@ -79,7 +81,19 @@ uint64_t checked_mul(uint64_t a, uint64_t b, const char* operation) {
 // Must match the "Q27_SHADER_ABI" tag in q27_kernels.metal. Shaders compile
 // from that file at runtime, so a host binary built before a buffer-binding
 // change would otherwise misbind silently against a newer shader file.
-constexpr const char* kShaderAbiTag = "// Q27_SHADER_ABI 6";
+constexpr const char* kShaderAbiTag = "// Q27_SHADER_ABI 13";
+
+std::string source_sha1(NSString* source) {
+    NSData* data=[source dataUsingEncoding:NSUTF8StringEncoding];
+    unsigned char digest[CC_SHA1_DIGEST_LENGTH];
+    CC_SHA1(data.bytes,(CC_LONG)data.length,digest);
+    static const char hex[]="0123456789abcdef";
+    std::string out(40,'0');
+    for(int i=0;i<CC_SHA1_DIGEST_LENGTH;i++) {
+        out[2*i]=hex[digest[i]>>4]; out[2*i+1]=hex[digest[i]&15];
+    }
+    return out;
+}
 
 NSString* source_tree_shader_path() {
     uint32_t size = 0;
@@ -101,12 +115,16 @@ NSString* load_kernel_source() {
     if (const char* override_path = getenv("Q27_METAL_SOURCE"))
         [candidates addObject:[NSString stringWithUTF8String:override_path]];
 #ifdef Q27_SHADER_PATH
+    // Installed binaries trust the share-dir shader baked in at build time.
+    // A source file in the process working directory must not override it;
+    // intentional overrides remain explicit through Q27_METAL_SOURCE.
     [candidates addObject:@Q27_SHADER_PATH];
 #else
     // Source-tree binaries live under build/. Resolve from the executable so
     // invoking them outside the checkout does not depend on process cwd.
     if (NSString* path = source_tree_shader_path()) [candidates addObject:path];
-    // Preserve direct compiler/test invocations that place the binary elsewhere.
+    // Preserve direct compiler/test invocations that do not place the binary
+    // under the checkout's build directory.
     [candidates addObject:@"src/metal/q27_kernels.metal"];
 #endif
 
@@ -153,12 +171,21 @@ id<MTLComputePipelineState> make_pipeline(id<MTLDevice> device, id<MTLLibrary> l
     return pipeline;
 }
 
+// Threadgroup widths are pinned by kernel-side contracts.
+// kTurboThreads: the turbo3 WHT/KV-store kernels' butterfly barriers are only
+// well-formed at exactly 128 threads. kReduceThreads: the per-head attention
+// merge trees hardcode 8 simdgroup partials, the rmsnorm quantize strides
+// walk block += 8, and q27_l2norm_rows passes a literal 8 to reduce_sum —
+// all assume kReduceThreads/32 == 8. Changing either width means changing
+// those kernels in lockstep.
+constexpr uint32_t kTurboThreads = 128;
+constexpr uint32_t kReduceThreads = 256;
+
 struct MatvecArgs {
     uint32_t rows;
     uint32_t cols;
-    uint32_t simdgroups;
 };
-struct MatvecPairArgs { uint32_t rows_a, rows_b, cols, simdgroups; };
+struct MatvecPairArgs { uint32_t rows_a, rows_b, cols; };
 struct MatmulArgs { uint32_t rows,cols,x_rows,simdgroups; };
 struct VectorArgs { uint32_t n, groups; float eps; };
 struct HeadArgs { uint32_t heads, head_dim, stride, groups; float eps; };
@@ -169,8 +196,11 @@ struct KvStoreArgs { uint32_t position, row_length; };
 struct TurboWhtArgs { uint32_t heads, stride, inverse; };
 struct TurboStoreArgs { uint32_t position, kv_heads; };
 struct AttentionArgs { uint32_t q_stride, seq_len, q_heads, kv_heads, head_dim; float scale; };
+struct AttentionGqaArgs { uint32_t q_stride, seq_len, q_heads, kv_heads, head_dim, block, n_blocks; float scale; };
+struct AttentionGqaCausalArgs { uint32_t q_stride, q_row_stride, base_len, q_heads, kv_heads, head_dim, block, n_blocks_max, tokens; float scale; };
+struct TopkArgs { uint32_t n, k, capacity; };
 struct DeltaArgs { uint32_t value_heads, qk_heads, head_dim; };
-struct EmbedRowsArgs { uint32_t cols, count, tokens[12]; };
+struct EmbedRowsArgs { uint32_t cols, count, tokens[96]; };
 struct RowsNormArgs { uint32_t n, rows, groups; float eps; };
 struct MatvecPairRowsArgs { uint32_t rows_a, rows_b, cols, tokens; };
 struct GatesRowsArgs { uint32_t heads, tokens; };
@@ -183,10 +213,13 @@ struct TurboStoreRowsArgs { uint32_t position, kv_heads, tokens; };
 struct GateRowsArgs { uint32_t heads, head_dim, tokens; };
 struct ArgmaxRowsArgs { uint32_t n, rows; };
 struct AttentionCausalArgs { uint32_t q_stride, q_row_stride, base_len, q_heads, kv_heads, head_dim, tokens; float scale; };
+struct AttentionCausalWinArgs { uint32_t q_stride, q_row_stride, base_len, q_heads, kv_heads, head_dim, tokens, out_row_stride; float scale; };
+struct KvStoreHeadRowsArgs { uint32_t position, src_stride, row_length, tokens, codec; };
 
 } // namespace
 
 struct MetalBackend::Impl {
+    std::string shader_hash;
     id<MTLDevice> device;
     id<MTLCommandQueue> queue;
     id<MTLLibrary> library;
@@ -195,6 +228,14 @@ struct MetalBackend::Impl {
     id<MTLComputePipelineState> q8;
     id<MTLComputePipelineState> q4;
     id<MTLComputePipelineState> t2;
+    id<MTLComputePipelineState> t2_quantized_matmul_h;
+    id<MTLComputePipelineState> mask_logits_p;
+    // Half-staging chunk GEMMs: default ON (T2 landed at 1.22x chunk rate at
+    // quality parity — the GEMM envelope class, docs/plans/2026-07-15-
+    // margin-aware-gates.md); Q27_METAL_GEMM_HALF=0 opts out and exactly
+    // reproduces the float-staged routes (used to attribute the kl-kv
+    // calibration shift to the digit, 2026-07-16-kv-codec-step1.md).
+    bool gemm_half = true;
     id<MTLComputePipelineState> quantize;
     id<MTLComputePipelineState> q8_quantized;
     id<MTLComputePipelineState> q4_quantized;
@@ -205,6 +246,8 @@ struct MetalBackend::Impl {
     id<MTLComputePipelineState> t2_quantized_matmul;
     id<MTLComputePipelineState> embedding;
     id<MTLComputePipelineState> embedding_t2;
+    id<MTLComputePipelineState> embedding_dev;
+    id<MTLComputePipelineState> embedding_t2_dev;
     id<MTLComputePipelineState> embedding_t2_rows;
     id<MTLComputePipelineState> rms;
     id<MTLComputePipelineState> rms_quantized;
@@ -237,21 +280,152 @@ struct MetalBackend::Impl {
     id<MTLComputePipelineState> kv_store_rows;
     id<MTLComputePipelineState> kv_store_turbo3_rows;
     id<MTLComputePipelineState> attention_causal;
+    id<MTLComputePipelineState> attention_causal_win;
+    id<MTLComputePipelineState> kv_store_head_rows;
     id<MTLComputePipelineState> attention_turbo3_causal_p;
     id<MTLComputePipelineState> sigmoid_gate_rows;
     id<MTLComputePipelineState> argmax_rows_p;
     id<MTLComputePipelineState> nll_rows_p;
+    id<MTLComputePipelineState> attention_f16_gqa_p;
+    id<MTLComputePipelineState> attention_turbo3_gqa_p;
+    id<MTLComputePipelineState> attention_gqa_merge_p;
+    id<MTLComputePipelineState> attention_f16_causal_gqa_p;
+    id<MTLComputePipelineState> attention_turbo3_causal_gqa_p;
+    id<MTLComputePipelineState> attention_gqa_merge_rows_p;
+    // R1b token-tiled causal GQA (t2 = production route, t4 + hm = bench).
+    id<MTLComputePipelineState> attention_turbo3_causal_gqa_t2_p;
+    id<MTLComputePipelineState> attention_f16_causal_gqa_t2_p;
+    // Q27_METAL_GQA_TILE: causal token-tile factor, 1 (untiled A/B lever)
+    // or 2 (default; docs/plans/2026-07-15-cache-block-scheduling.md R1b).
+    uint32_t gqa_tile = 2;
+    // Q27_METAL_GQA_BLOCK: positions per (kvh, block) threadgroup. Default
+    // 1024; smaller blocks trade merge work for threadgroup count — the
+    // occupancy lever the latency-bound Phase-0 finding points at. Changing
+    // it changes the merge fold order (margin-aware-gates contract class),
+    // and chunk↔decode parity holds at any single value.
+    uint32_t gqa_block = 1024;
+    id<MTLComputePipelineState> topk_logits_p;
     id<MTLCommandBuffer> command;
     id<MTLComputeCommandEncoder> encoder;
     bool batching = false;
+    // A failed committed command may already have mutated device state. The
+    // shared backend is then unrecoverable: every attached engine must be
+    // discarded and rebuilt from a fresh model mapping.
+    std::atomic<bool> poisoned{false};
+
+    void require_healthy() const {
+        if (poisoned.load(std::memory_order_acquire))
+            throw std::runtime_error("q27 Metal: backend is poisoned after a command failure; recreate the engine");
+    }
 
     // Model mappings that fit maxBufferLength are wrapped as a single
     // MTLBuffer (tensors bind at offsets), and on macOS 15+ that buffer joins
-    // a residency set attached to the queue: pages stay wired between command
-    // buffers, so file-backed weight pages are neither faulted in token by
-    // token on first touch nor evictable under memory pressure mid-run.
+    // a residency set attached to the queue. requestResidency is preparatory
+    // and best-effort per Apple (steps may be postponed under system load),
+    // not a hard wire: in practice it faults pages in at load and makes
+    // eviction under mid-run pressure far less likely.
     std::map<const void*, std::weak_ptr<MetalBuffer>> model_wraps;
+#if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 150000
     API_AVAILABLE(macos(15.0)) id<MTLResidencySet> residency_set;
+#endif
+
+    // GQA KV-reuse decode attention: sequences at or beyond the threshold
+    // route to the blocked kernels that read each KV row once for all
+    // q_heads/kv_heads query heads. 0 disables; 1 forces every sequence
+    // (parity testing). The block partials scratch is caller-owned (each
+    // engine allocates its own at construction — audit E2), GPU-private,
+    // and only bounds-checked here: no growth on the hot path (audit C3).
+    uint32_t gqa_threshold = 2048;
+
+    void attention_gqa_dispatch(bool turbo3, const MetalBuffer& qb, uint32_t q_stride,
+                                const MetalBuffer& kc, const MetalBuffer& vc,
+                                MetalBuffer& output, uint32_t seq_len, uint32_t q_heads,
+                                uint32_t kv_heads, uint32_t head_dim, float scale,
+                                MetalBuffer& gqa_partials) {
+        const uint32_t block = gqa_block;
+        const uint32_t n_blocks = 1 + (seq_len - 1) / block;   // seq_len >= 1 host-checked
+        const uint32_t gqa = q_heads / kv_heads;
+        const uint64_t partial_bytes = (uint64_t)q_heads * n_blocks * 258 * 4;
+        if (gqa_partials.size() < partial_bytes)
+            throw std::runtime_error("q27 Metal: GQA partials buffer too small "
+                                     "(engine-owned, sized at construction)");
+        AttentionGqaArgs args{q_stride, seq_len, q_heads, kv_heads, head_dim,
+                              block, n_blocks, scale};
+        @autoreleasepool {
+            bool own;
+            auto enc = encoder_for_operation(own, turbo3 ? "q27_attention_turbo3_gqa"
+                                                         : "q27_attention_f16_gqa");
+            [enc setComputePipelineState:turbo3 ? attention_turbo3_gqa_p : attention_f16_gqa_p];
+            [enc setBuffer:qb.handle() offset:0 atIndex:0];
+            [enc setBuffer:kc.handle() offset:0 atIndex:1];
+            [enc setBuffer:vc.handle() offset:0 atIndex:2];
+            [enc setBuffer:gqa_partials.handle() offset:0 atIndex:3];
+            [enc setBytes:&args length:sizeof(args) atIndex:4];
+            [enc dispatchThreadgroups:MTLSizeMake(kv_heads, n_blocks, 1)
+                threadsPerThreadgroup:MTLSizeMake((NSUInteger)gqa * 32, 1, 1)];
+            // The merge consumes device writes from the producer dispatch.
+            // Dispatches inside one compute encoder are not ordered by tracked
+            // resource hazards, so make that dependency explicit.
+            id<MTLResource> partial_resources[] = { gqa_partials.handle() };
+            [enc memoryBarrierWithResources:partial_resources count:1];
+            [enc setComputePipelineState:attention_gqa_merge_p];
+            [enc setBuffer:gqa_partials.handle() offset:0 atIndex:0];
+            [enc setBuffer:output.handle() offset:0 atIndex:1];
+            [enc setBytes:&args length:sizeof(args) atIndex:2];
+            [enc dispatchThreadgroups:MTLSizeMake(q_heads, 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
+            if (own) finish_command("GQA attention");
+        }
+    }
+
+    void attention_gqa_causal_dispatch(bool turbo3, const MetalBuffer& qb, uint32_t q_stride,
+                                       uint32_t q_row_stride, const MetalBuffer& kc,
+                                       const MetalBuffer& vc, MetalBuffer& output,
+                                       uint32_t base_len, uint32_t q_heads, uint32_t kv_heads,
+                                       uint32_t head_dim, uint32_t tokens, float scale,
+                                       uint64_t q_byte_offset, uint64_t out_byte_offset,
+                                       MetalBuffer& gqa_partials) {
+        const uint32_t block = gqa_block;
+        const uint32_t max_seq = base_len + tokens - 1;     // overflow host-checked
+        const uint32_t n_blocks_max = 1 + (max_seq - 1) / block;
+        const uint32_t gqa = q_heads / kv_heads;
+        const uint64_t partial_bytes =
+            (uint64_t)tokens * q_heads * n_blocks_max * 258 * 4;
+        if (gqa_partials.size() < partial_bytes)
+            throw std::runtime_error("q27 Metal: GQA partials buffer too small "
+                                     "(engine-owned, sized at construction)");
+        AttentionGqaCausalArgs args{q_stride, q_row_stride, base_len, q_heads, kv_heads,
+                                    head_dim, block, n_blocks_max, tokens, scale};
+        // R1b: factor-2 token tiling — bit-identical per token to the untiled
+        // kernels, so the chunk↔decode parity contract is unaffected.
+        const bool tiled = gqa_tile >= 2 && tokens >= 2;
+        @autoreleasepool {
+            bool own;
+            auto enc = encoder_for_operation(own,
+                turbo3 ? (tiled ? "q27_attention_turbo3_causal_gqa_t2" : "q27_attention_turbo3_causal_gqa")
+                       : (tiled ? "q27_attention_f16_causal_gqa_t2" : "q27_attention_f16_causal_gqa"));
+            [enc setComputePipelineState:turbo3 ? (tiled ? attention_turbo3_causal_gqa_t2_p : attention_turbo3_causal_gqa_p)
+                                                : (tiled ? attention_f16_causal_gqa_t2_p : attention_f16_causal_gqa_p)];
+            [enc setBuffer:qb.handle() offset:(NSUInteger)q_byte_offset atIndex:0];
+            [enc setBuffer:kc.handle() offset:0 atIndex:1];
+            [enc setBuffer:vc.handle() offset:0 atIndex:2];
+            [enc setBuffer:gqa_partials.handle() offset:0 atIndex:3];
+            [enc setBytes:&args length:sizeof(args) atIndex:4];
+            [enc dispatchThreadgroups:MTLSizeMake(kv_heads, n_blocks_max, tiled ? (tokens + 1) / 2 : tokens)
+                threadsPerThreadgroup:MTLSizeMake((NSUInteger)gqa * 32, 1, 1)];
+            // The row merge consumes the producer's device writes in this
+            // encoder; explicitly order the two dispatches.
+            id<MTLResource> partial_resources[] = { gqa_partials.handle() };
+            [enc memoryBarrierWithResources:partial_resources count:1];
+            [enc setComputePipelineState:attention_gqa_merge_rows_p];
+            [enc setBuffer:gqa_partials.handle() offset:0 atIndex:0];
+            [enc setBuffer:output.handle() offset:(NSUInteger)out_byte_offset atIndex:1];
+            [enc setBytes:&args length:sizeof(args) atIndex:2];
+            [enc dispatchThreadgroups:MTLSizeMake(q_heads, tokens, 1)
+                threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
+            if (own) finish_command("GQA chunked attention");
+        }
+    }
 
     // Q27_METAL_PROFILE=1: per-dispatch GPU-time attribution. Every operation
     // runs in its own compute encoder bracketed by stage-boundary timestamp
@@ -267,20 +441,6 @@ struct MetalBackend::Impl {
     double gpu_busy_seconds = 0.0;
     double cpu_wait_seconds = 0.0;
     MTLTimestamp calibration_cpu = 0, calibration_gpu = 0;
-    bool poisoned = false;
-    std::string poison_reason;
-
-    void ensure_healthy() const {
-        if (!poisoned) return;
-        throw std::runtime_error("q27 Metal: backend is unusable after command failure; "
-                                 "reconstruct the Metal engine (original failure: " +
-                                 poison_reason + ")");
-    }
-
-    void poison(const std::string& reason) {
-        poisoned = true;
-        poison_reason = reason;
-    }
 
     void abort_command() noexcept {
         if (encoder) [encoder endEncoding];
@@ -291,7 +451,7 @@ struct MetalBackend::Impl {
     }
 
     void start_command(bool explicit_batch) {
-        ensure_healthy();
+        require_healthy();
         if (command || encoder || batching)
             throw std::runtime_error("q27 Metal: command batch already active");
         command = [queue commandBuffer];
@@ -309,7 +469,6 @@ struct MetalBackend::Impl {
     }
 
     id<MTLComputeCommandEncoder> encoder_for_operation(bool& own_command, const char* label) {
-        ensure_healthy();
         own_command = !batching;
         if (own_command) start_command(false);
         if (profile) {
@@ -334,7 +493,7 @@ struct MetalBackend::Impl {
     }
 
     void finish_command(const char* label) {
-        ensure_healthy();
+        require_healthy();
         if (!command || (!encoder && !profile))
             throw std::runtime_error("q27 Metal: no active command batch");
         if (encoder) { [encoder endEncoding]; encoder = nil; }
@@ -343,14 +502,28 @@ struct MetalBackend::Impl {
         [command waitUntilCompleted];
         cpu_wait_seconds += std::chrono::duration<double>(std::chrono::steady_clock::now() - wait_start).count();
         if (command.status == MTLCommandBufferStatusError) {
+            poisoned = true;
             std::string message = std::string("q27 Metal: ") + label + " failed";
             if (command.error) message += ": " + std::string(command.error.localizedDescription.UTF8String);
             command = nil;
             batching = false;
-            op_labels.clear();
-            poison(message);
             throw std::runtime_error(message);
         }
+#if Q27_METAL_TEST_FAILPOINTS
+        // Deterministic command failure injection exists only in the dedicated
+        // test binary; production builds contain no environment-controlled path.
+        static long fail_finish = [] {
+            const char* env = getenv("Q27_METAL_FAIL_FINISH");
+            return env && *env ? (long)strtoul(env, nullptr, 10) : 0;
+        }();
+        if (fail_finish > 0 && --fail_finish == 0) {
+            poisoned = true;
+            std::string message = std::string("q27 Metal: ") + label + " failed (injected)";
+            command = nil;
+            batching = false;
+            throw std::runtime_error(message);
+        }
+#endif
         if (profile) resolve_profile_samples();
         command = nil;
         batching = false;
@@ -412,6 +585,7 @@ MetalBackend::MetalBackend() : impl_(new Impl) {
         impl_->queue = [impl_->device newCommandQueue];
         if (!impl_->queue) throw std::runtime_error("q27 Metal: cannot create command queue");
 
+#if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 150000
         if (@available(macOS 15.0, *)) {
             const char* env = getenv("Q27_METAL_NO_RESIDENCY");
             if (!env || !*env || *env == '0') {
@@ -424,19 +598,25 @@ MetalBackend::MetalBackend() : impl_(new Impl) {
                 if (impl_->residency_set) [impl_->queue addResidencySet:impl_->residency_set];
             }
         }
+#endif
 
         MTLCompileOptions* options = [MTLCompileOptions new];
         // Correctness baseline; enable relaxed math only after CUDA comparison.
+#if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 150000
         if (@available(macOS 15.0, *)) {
             options.mathMode = MTLMathModeSafe;
-        } else {
+        } else
+#endif
+        {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
             options.fastMathEnabled = NO;
 #pragma clang diagnostic pop
         }
         NSError* error = nil;
-        impl_->library = [impl_->device newLibraryWithSource:load_kernel_source()
+        NSString* kernel_source=load_kernel_source();
+        impl_->shader_hash=source_sha1(kernel_source);
+        impl_->library = [impl_->device newLibraryWithSource:kernel_source
                                                       options:options
                                                         error:&error];
         if (!impl_->library)
@@ -447,6 +627,7 @@ MetalBackend::MetalBackend() : impl_(new Impl) {
         impl_->q8 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_q8_g128");
         impl_->q4 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_q4_g64");
         impl_->t2 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_t2_g128");
+        impl_->mask_logits_p = make_pipeline(impl_->device, impl_->library, @"q27_mask_logits");
         impl_->quantize = make_pipeline(impl_->device, impl_->library, @"q27_quantize_x");
         impl_->q8_quantized = make_pipeline(impl_->device, impl_->library, @"q27_matvec_q8_quantized");
         impl_->q4_quantized = make_pipeline(impl_->device, impl_->library, @"q27_matvec_q4_quantized");
@@ -458,9 +639,14 @@ MetalBackend::MetalBackend() : impl_(new Impl) {
             impl_->q4_quantized_matmul = make_pipeline(impl_->device, impl_->library, @"q27_matmul_q4_mm");
             impl_->q8_quantized_matmul = make_pipeline(impl_->device, impl_->library, @"q27_matmul_q8_mm");
             impl_->t2_quantized_matmul = make_pipeline(impl_->device, impl_->library, @"q27_matmul_t2_mm");
+            impl_->t2_quantized_matmul_h = make_pipeline(impl_->device, impl_->library, @"q27_matmul_t2_mm_h");
+            if (const char* env = getenv("Q27_METAL_GEMM_HALF"); env && *env)
+                impl_->gemm_half = strtoul(env, nullptr, 10) != 0;
         }
         impl_->embedding = make_pipeline(impl_->device, impl_->library, @"q27_embedding_q8");
         impl_->embedding_t2 = make_pipeline(impl_->device, impl_->library, @"q27_embedding_t2");
+        impl_->embedding_dev = make_pipeline(impl_->device, impl_->library, @"q27_embedding_q8_dev");
+        impl_->embedding_t2_dev = make_pipeline(impl_->device, impl_->library, @"q27_embedding_t2_dev");
         impl_->embedding_t2_rows = make_pipeline(impl_->device, impl_->library, @"q27_embedding_t2_rows");
         impl_->rms = make_pipeline(impl_->device, impl_->library, @"q27_rmsnorm");
         impl_->rms_quantized = make_pipeline(impl_->device, impl_->library, @"q27_rmsnorm_quantized");
@@ -493,10 +679,44 @@ MetalBackend::MetalBackend() : impl_(new Impl) {
         impl_->kv_store_rows = make_pipeline(impl_->device, impl_->library, @"q27_kv_store_f16_rows");
         impl_->kv_store_turbo3_rows = make_pipeline(impl_->device, impl_->library, @"q27_kv_store_turbo3_rows");
         impl_->attention_causal = make_pipeline(impl_->device, impl_->library, @"q27_attention_f16_causal");
+        impl_->attention_causal_win = make_pipeline(impl_->device, impl_->library, @"q27_attention_f16_causal_win");
+        impl_->kv_store_head_rows = make_pipeline(impl_->device, impl_->library, @"q27_kv_store_f16_head_rows");
         impl_->attention_turbo3_causal_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_turbo3_causal");
         impl_->sigmoid_gate_rows = make_pipeline(impl_->device, impl_->library, @"q27_sigmoid_gate_mul_rows");
         impl_->argmax_rows_p = make_pipeline(impl_->device, impl_->library, @"q27_argmax_rows");
         impl_->nll_rows_p = make_pipeline(impl_->device, impl_->library, @"q27_nll_rows");
+        impl_->attention_f16_gqa_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_f16_gqa");
+        impl_->attention_turbo3_gqa_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_turbo3_gqa");
+        impl_->attention_gqa_merge_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_gqa_merge");
+        impl_->attention_f16_causal_gqa_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_f16_causal_gqa");
+        impl_->attention_turbo3_causal_gqa_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_turbo3_causal_gqa");
+        impl_->attention_gqa_merge_rows_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_gqa_merge_rows");
+        impl_->attention_turbo3_causal_gqa_t2_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_turbo3_causal_gqa_t2");
+        impl_->attention_f16_causal_gqa_t2_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_f16_causal_gqa_t2");
+        if (const char* env = getenv("Q27_METAL_GQA_TILE"); env && *env) {
+            const unsigned long tile = strtoul(env, nullptr, 10);
+            if (tile != 1 && tile != 2)
+                throw std::runtime_error("q27 Metal: Q27_METAL_GQA_TILE must be 1 or 2");
+            impl_->gqa_tile = (uint32_t)tile;
+        }
+        if (const char* env = getenv("Q27_METAL_GQA_BLOCK"); env && *env) {
+            const unsigned long block = strtoul(env, nullptr, 10);
+            // Power of two in [128, 4096]: kernels stage 8-row tiles, and the
+            // straddle split assumes the threshold is block-aligned-agnostic.
+            if (block < 128 || block > 4096 || (block & (block - 1)))
+                throw std::runtime_error("q27 Metal: Q27_METAL_GQA_BLOCK must be a power of two in [128, 4096]");
+            impl_->gqa_block = (uint32_t)block;
+        }
+        impl_->topk_logits_p = make_pipeline(impl_->device, impl_->library, @"q27_topk_logits");
+        // GPU sampling is optional. Older Metal devices can keep the serial
+        // decode/full-logit CPU path even when they cannot dispatch the
+        // kernel's 1024-thread group.
+        if (impl_->topk_logits_p.maxTotalThreadsPerThreadgroup < 1024) {
+            impl_->topk_logits_p = nil;
+            fprintf(stderr,"q27 Metal: 1024-thread GPU top-k unavailable; using CPU sampling fallback\n");
+        }
+        if (const char* env = getenv("Q27_METAL_GQA_THRESHOLD"); env && *env)
+            impl_->gqa_threshold = (uint32_t)strtoul(env, nullptr, 10);
 
         if (const char* env = getenv("Q27_METAL_PROFILE"); env && *env && *env != '0') {
             id<MTLCounterSet> timestamps = nil;
@@ -526,15 +746,31 @@ MetalBackend::MetalBackend() : impl_(new Impl) {
 }
 
 MetalBackend::~MetalBackend() {
-    @autoreleasepool { impl_->report_profile(); }
+    @autoreleasepool {
+        impl_->abort_command();
+        impl_->report_profile();
+    }
 }
 
 std::string MetalBackend::name() const {
     return std::string(impl_->device.name.UTF8String);
 }
 
+bool MetalBackend::healthy() const noexcept {
+    return !impl_->poisoned.load(std::memory_order_acquire);
+}
+
+const char* MetalBackend::shader_abi_tag() { return kShaderAbiTag; }
+
+std::string MetalBackend::shader_source_sha1() const { return impl_->shader_hash; }
+bool MetalBackend::gemm_half_enabled() const { return impl_->gemm_half; }
+uint32_t MetalBackend::gqa_tile() const { return impl_->gqa_tile; }
+uint32_t MetalBackend::gqa_block() const { return impl_->gqa_block; }
+uint32_t MetalBackend::gqa_threshold() const { return impl_->gqa_threshold; }
+bool MetalBackend::gpu_topk_supported() const { return impl_->topk_logits_p!=nil; }
+
 std::shared_ptr<BackendBuffer> MetalBackend::allocate(uint64_t bytes) {
-    impl_->ensure_healthy();
+    impl_->require_healthy();
     if (!bytes || bytes > (uint64_t)impl_->device.maxBufferLength ||
         bytes > (uint64_t)std::numeric_limits<NSUInteger>::max())
         throw std::runtime_error("q27 Metal: invalid buffer length");
@@ -544,12 +780,25 @@ std::shared_ptr<BackendBuffer> MetalBackend::allocate(uint64_t bytes) {
     return std::make_shared<MetalBuffer>(buffer);
 }
 
+std::shared_ptr<BackendBuffer> MetalBackend::allocate_private(uint64_t bytes) {
+    impl_->require_healthy();
+    if (!bytes || bytes > (uint64_t)impl_->device.maxBufferLength ||
+        bytes > (uint64_t)std::numeric_limits<NSUInteger>::max())
+        throw std::runtime_error("q27 Metal: invalid buffer length");
+    id<MTLBuffer> buffer = [impl_->device newBufferWithLength:(NSUInteger)bytes
+                                                      options:MTLResourceStorageModePrivate];
+    if (!buffer) throw std::runtime_error("q27 Metal: buffer allocation failed");
+    return std::make_shared<MetalBuffer>(buffer);
+}
+
 void MetalBackend::write(BackendBuffer& dst, uint64_t offset, const void* src, uint64_t bytes) {
-    impl_->ensure_healthy();
+    impl_->require_healthy();
     MetalBuffer& buffer = metal_buffer(dst);
-    if (impl_->batching) throw std::runtime_error("q27 Metal: cannot CPU-write during command batch");
     check_range(buffer.size(), offset, bytes, "write");
     if (bytes && !src) throw std::runtime_error("q27 Metal: null write source");
+    // Same contract zero() already enforces: a host write racing an open
+    // command batch changes what already-encoded operations observe.
+    if (impl_->batching) throw std::runtime_error("q27 Metal: cannot CPU-write during command batch");
     if (bytes) std::memcpy((uint8_t*)buffer.handle().contents + offset, src, (size_t)bytes);
 }
 
@@ -562,12 +811,17 @@ void MetalBackend::read(const BackendBuffer& src, uint64_t offset, void* dst, ui
 }
 
 void MetalBackend::zero(BackendBuffer& dst) {
-    impl_->ensure_healthy();
+    impl_->require_healthy();
     MetalBuffer& buffer = metal_buffer(dst);
     if (impl_->batching) throw std::runtime_error("q27 Metal: cannot CPU-clear during command batch");
     std::memset(buffer.handle().contents, 0, (size_t)buffer.size());
 }
 
+// copy() is the ONE host-mutation path that stays legal during a command
+// batch: it dispatches a GPU kernel on the batch's own encoder (ordered with
+// the surrounding work) instead of touching shared-memory contents the way
+// write()/zero() do. Do not add the write/zero `if (batching) throw` guard
+// here — batched callers (KV moves, snapshot restores) depend on this.
 void MetalBackend::copy(const BackendBuffer& src, uint64_t src_offset,
                         BackendBuffer& dst, uint64_t dst_offset, uint64_t bytes) {
     const MetalBuffer& sb=metal_buffer(src); MetalBuffer& db=metal_buffer(dst);
@@ -611,6 +865,7 @@ BackendTensor MetalBackend::upload(const Tensor& tensor) {
 }
 
 BackendTensor MetalBackend::upload(const Model& model, const Tensor& tensor) {
+    impl_->require_healthy();
     if (!model.mapping_base() || !model.mapping_size())
         throw std::runtime_error("q27 Metal: invalid model view");
     const uint64_t logical_size = model.mapping_size();
@@ -618,10 +873,12 @@ BackendTensor MetalBackend::upload(const Model& model, const Tensor& tensor) {
     if (logical_size > UINT64_MAX - (page_size - 1))
         throw std::runtime_error("q27 Metal: model mapping size overflow");
     const uint64_t mapped_size = (logical_size + page_size - 1) / page_size * page_size;
-
-    // Preferred form: one MTLBuffer wraps the page-rounded mapping and every
-    // tensor binds at an offset. Metal requires no-copy lengths to cover whole
-    // virtual-memory pages; logical tensor extents remain independently bounded.
+    // Preferred form: one MTLBuffer wraps the whole mapping and every tensor
+    // binds at an offset. One buffer instead of two per tensor keeps the
+    // per-commit residency/tracking work constant in model size, and gives
+    // the residency set a single allocation to wire. Mappings larger than
+    // maxBufferLength (the 5.25 bpw tier) keep per-tensor page-aligned views
+    // and stay unwired -- they do not fit in memory either way.
     auto wrap_mapping = [&]() -> std::shared_ptr<MetalBuffer> {
         void* base = (void*)model.mapping_base();
         auto& slot = impl_->model_wraps[base];
@@ -633,13 +890,16 @@ BackendTensor MetalBackend::upload(const Model& model, const Tensor& tensor) {
                                                            deallocator:nil];
         if (!buffer) throw std::runtime_error("q27 Metal: cannot wrap model mmap");
         std::shared_ptr<MetalBuffer> wrapped;
+#if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 150000
         if (@available(macOS 15.0, *)) {
             if (id<MTLResidencySet> set = impl_->residency_set) {
                 [set addAllocation:buffer];
                 [set commit];
                 [set requestResidency];
-                // The set retains the buffer and requests best-effort residency;
-                // remove it before a later Model destruction can unmap the pages.
+                // The set retains the buffer and requests residency for its
+                // pages (best-effort, not wired); drop it when the last tensor
+                // goes away so a later munmap cannot leave the set holding a
+                // dead address range.
                 wrapped = std::shared_ptr<MetalBuffer>(
                     new MetalBuffer(buffer, false), [set](MetalBuffer* wrapper) {
                         if (@available(macOS 15.0, *)) {
@@ -650,6 +910,7 @@ BackendTensor MetalBackend::upload(const Model& model, const Tensor& tensor) {
                     });
             }
         }
+#endif
         if (!wrapped) wrapped = std::make_shared<MetalBuffer>(buffer, false);
         slot = wrapped;
         return wrapped;
@@ -666,7 +927,7 @@ BackendTensor MetalBackend::upload(const Model& model, const Tensor& tensor) {
         return offset;
     };
 
-    if (!uses_per_tensor_upload(model)) {
+    if (mapped_size <= (uint64_t)impl_->device.maxBufferLength) {
         BackendTensor result;
         result.dtype = tensor.dtype;
         result.rows = tensor.rows();
@@ -683,7 +944,8 @@ BackendTensor MetalBackend::upload(const Model& model, const Tensor& tensor) {
     }
 
     auto wrap = [&](const uint8_t* ptr, uint64_t bytes, uint64_t& inner) {
-        if (!ptr || !bytes) throw std::runtime_error("q27 Metal: invalid model view");
+        if (!ptr || !bytes)
+            throw std::runtime_error("q27 Metal: invalid model view");
         const uintptr_t base = (uintptr_t)model.mapping_base();
         const uintptr_t address = (uintptr_t)ptr;
         if (address < base) throw std::runtime_error("q27 Metal: tensor precedes model mapping");
@@ -691,14 +953,15 @@ BackendTensor MetalBackend::upload(const Model& model, const Tensor& tensor) {
         if (offset > logical_size || bytes > logical_size - offset)
             throw std::runtime_error("q27 Metal: tensor outside model mapping");
 
-        const uint64_t page_offset = offset - offset % page_size;
+        const uint64_t page = page_size;
+        const uint64_t page_offset = offset - offset % page;
         inner = offset - page_offset;
         if (bytes > UINT64_MAX - inner)
             throw std::runtime_error("q27 Metal: model view size overflow");
         uint64_t view_bytes = inner + bytes;
-        if (view_bytes > UINT64_MAX - (page_size - 1))
+        if (view_bytes > UINT64_MAX - (page - 1))
             throw std::runtime_error("q27 Metal: model view alignment overflow");
-        view_bytes = (view_bytes + page_size - 1) / page_size * page_size;
+        view_bytes = (view_bytes + page - 1) / page * page;
         if (view_bytes > mapped_size - page_offset || inner + bytes > view_bytes ||
             view_bytes > (uint64_t)impl_->device.maxBufferLength)
             throw std::runtime_error("q27 Metal: model view exceeds Metal buffer limits");
@@ -733,8 +996,16 @@ void MetalBackend::end_commands() {
     @autoreleasepool { impl_->finish_command("command batch"); }
 }
 
+// CONTRACT: only legal between begin_commands and end_commands — the held
+// command buffer is never committed, so dropping the reference discards it.
+// (MTLCommandBuffer has no cancel API; an already-committed buffer could not
+// be stopped here, which is why commit stays confined to end_commands.)
 void MetalBackend::abort_commands() noexcept {
     @autoreleasepool { impl_->abort_command(); }
+}
+
+void MetalBackend::poison() noexcept {
+    impl_->poisoned = true;
 }
 
 void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
@@ -742,14 +1013,6 @@ void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
     if (!weight.data) throw std::runtime_error("q27 Metal: matvec weight has no data");
     if (!weight.rows || !weight.cols || weight.rows > UINT32_MAX || weight.cols > UINT32_MAX)
         throw std::runtime_error("q27 Metal: unsupported matvec dimensions");
-    const uint64_t elements = checked_mul(weight.rows, weight.cols, "matvec weight");
-    uint64_t data_bytes = elements;
-    if (weight.dtype == DType::F32) data_bytes = checked_mul(elements, 4, "matvec weight");
-    if (weight.dtype == DType::F16) data_bytes = checked_mul(elements, 2, "matvec weight");
-    if (weight.dtype == DType::Q4_G64) data_bytes /= 2;
-    if (weight.dtype == DType::T2_G128) data_bytes /= 4;
-    check_range(x.size(), 0, weight.cols * sizeof(float), "matvec input");
-    check_range(y.size(), 0, weight.rows * sizeof(float), "matvec output");
 
     const MetalBuffer& data = metal_buffer_view(weight.data);
     const MetalBuffer& input = metal_buffer(x);
@@ -759,8 +1022,15 @@ void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
                                  weight.dtype == DType::Q4_G64 ? 64 : 0;
     if (quant_group && weight.cols % quant_group)
         throw std::runtime_error("q27 Metal: matvec columns do not match quantization group");
-    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size),
-                weight.data_offset, data_bytes, "matvec weight");
+    const uint64_t elements = checked_mul(weight.rows, weight.cols, "matvec weight");
+    uint64_t data_bytes = elements;
+    if (weight.dtype == DType::F32) data_bytes = checked_mul(elements, 4, "matvec weight");
+    if (weight.dtype == DType::F16) data_bytes = checked_mul(elements, 2, "matvec weight");
+    if (weight.dtype == DType::Q4_G64) data_bytes /= 2;
+    if (weight.dtype == DType::T2_G128) data_bytes /= 4;
+    check_range(x.size(), 0, weight.cols * sizeof(float), "matvec input");
+    check_range(y.size(), 0, weight.rows * sizeof(float), "matvec output");
+    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset, data_bytes, "matvec weight");
     id<MTLComputePipelineState> pipeline = nil;
     const char* label = nullptr;
     switch (weight.dtype) {
@@ -771,7 +1041,7 @@ void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
         case DType::T2_G128: pipeline = impl_->t2; label = "q27_matvec_t2_g128"; break;
         case DType::T3_G128:
         case DType::B1_G128:
-            throw std::runtime_error("q27 Metal: unsupported matvec dtype");
+            throw std::runtime_error("q27 Metal: packed dtype is not supported by this backend");
     }
     const MetalBuffer* quant_scales = nullptr;
     if (quant_group) {
@@ -779,11 +1049,10 @@ void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
         quant_scales = &metal_buffer_view(weight.scales);
         const uint64_t group = quant_group;
         const uint64_t scale_bytes = weight.rows * (weight.cols / group) * 2;
-        check_range(tensor_limit(quant_scales->size(), weight.scales_offset, weight.scales_size),
-                    weight.scales_offset, scale_bytes, "matvec scales");
+        check_range(tensor_limit(quant_scales->size(), weight.scales_offset, weight.scales_size), weight.scales_offset, scale_bytes, "matvec scales");
     }
 
-    MatvecArgs args{(uint32_t)weight.rows, (uint32_t)weight.cols, 8};
+    MatvecArgs args{(uint32_t)weight.rows, (uint32_t)weight.cols};
     @autoreleasepool {
         bool own_command;
         id<MTLComputeCommandEncoder> encoder = impl_->encoder_for_operation(own_command, label);
@@ -800,7 +1069,7 @@ void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
             [encoder setBuffer:output.handle() offset:0 atIndex:3];
             [encoder setBytes:&args length:sizeof(args) atIndex:4];
         }
-        // T2 runs 4 rows per simdgroup (32 per threadgroup); others 1 (8).
+        // T2 runs 4 rows per simdgroup (32 per threadgroup); others run 1 (8).
         const NSUInteger row_groups = weight.dtype == DType::T2_G128
             ? (NSUInteger)(weight.rows + 31) / 32 : (NSUInteger)(weight.rows + 7) / 8;
         [encoder dispatchThreadgroups:MTLSizeMake(row_groups, 1, 1)
@@ -812,8 +1081,8 @@ void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
 void MetalBackend::matvec_pair(const BackendTensor& a, BackendBuffer& a_out,
                                const BackendTensor& b, BackendBuffer& b_out,
                                const BackendBuffer& x) {
-    if(a.dtype!=DType::F16 || b.dtype!=DType::F16 || a.cols!=b.cols) {
-        matvec(a,x,a_out); matvec(b,x,b_out); return;
+    if(a.dtype!=DType::F16 || b.dtype!=DType::F16 || a.cols!=b.cols || (a.cols & 3)) {
+        matvec(a,x,a_out); matvec(b,x,b_out); return;   // cols%4: kernel packed_half4 loads
     }
     if(!a.data || !b.data || !a.rows || !b.rows || !a.cols || a.rows>UINT32_MAX ||
        b.rows>UINT32_MAX || a.cols>UINT32_MAX)
@@ -827,11 +1096,9 @@ void MetalBackend::matvec_pair(const BackendTensor& a, BackendBuffer& a_out,
     check_range(b_out.size(),0,b.rows*4,"fused matvec output B");
     const MetalBuffer& ad=metal_buffer_view(a.data); const MetalBuffer& bd=metal_buffer_view(b.data);
     const MetalBuffer& input=metal_buffer(x); MetalBuffer& ao=metal_buffer(a_out); MetalBuffer& bo=metal_buffer(b_out);
-    check_range(tensor_limit(ad.size(), a.data_offset, a.data_size),
-                a.data_offset,a_weight_bytes,"fused matvec weight A");
-    check_range(tensor_limit(bd.size(), b.data_offset, b.data_size),
-                b.data_offset,b_weight_bytes,"fused matvec weight B");
-    MatvecPairArgs args{(uint32_t)a.rows,(uint32_t)b.rows,(uint32_t)a.cols,8};
+    check_range(tensor_limit(ad.size(), a.data_offset, a.data_size), a.data_offset,a_weight_bytes,"fused matvec weight A");
+    check_range(tensor_limit(bd.size(), b.data_offset, b.data_size), b.data_offset,b_weight_bytes,"fused matvec weight B");
+    MatvecPairArgs args{(uint32_t)a.rows,(uint32_t)b.rows,(uint32_t)a.cols};
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_matvec_f16_pair"); [enc setComputePipelineState:impl_->f16_pair];
         [enc setBuffer:ad.handle() offset:(NSUInteger)a.data_offset atIndex:0]; [enc setBuffer:ao.handle() offset:0 atIndex:1];
@@ -880,12 +1147,10 @@ void MetalBackend::matvec_quantized(const BackendTensor& weight,
     const MetalBuffer& xv=metal_buffer_view(x.values); const MetalBuffer& xs=metal_buffer_view(x.scales); MetalBuffer& out=metal_buffer(y);
     const uint64_t divisor=weight.dtype==DType::Q4_G64?2:weight.dtype==DType::T2_G128?4:1;
     const uint64_t data_bytes=weight.rows*weight.cols/divisor;
-    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size),
-                weight.data_offset,data_bytes,"quantized matvec weight");
-    check_range(tensor_limit(ws.size(), weight.scales_offset, weight.scales_size),
-                weight.scales_offset,weight.rows*(weight.cols/group)*2,"quantized matvec weight scales");
+    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,data_bytes,"quantized matvec weight");
+    check_range(tensor_limit(ws.size(), weight.scales_offset, weight.scales_size), weight.scales_offset,weight.rows*(weight.cols/group)*2,"quantized matvec weight scales");
     check_range(xv.size(),0,x.count,"quantized matvec values"); check_range(xs.size(),0,(uint64_t)(x.count/32)*4,"quantized matvec activation scales");
-    MatvecArgs args{(uint32_t)weight.rows,(uint32_t)weight.cols,8};
+    MatvecArgs args{(uint32_t)weight.rows,(uint32_t)weight.cols};
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own,
             weight.dtype==DType::Q8_G128?"q27_matvec_q8_quantized":
@@ -896,11 +1161,12 @@ void MetalBackend::matvec_quantized(const BackendTensor& weight,
         [enc setBuffer:ws.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
         [enc setBuffer:xv.handle() offset:0 atIndex:2]; [enc setBuffer:xs.handle() offset:0 atIndex:3];
         [enc setBuffer:out.handle() offset:0 atIndex:4]; [enc setBytes:&args length:sizeof(args) atIndex:5];
-        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(weight.rows+7)/8,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        // Q4 runs its promoted 4-rows-per-simdgroup kernel; Q8/T2 keep one row.
+        const NSUInteger rpg = weight.dtype==DType::Q4_G64 ? 32 : 8;
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(weight.rows+rpg-1)/rpg,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
         if(own) impl_->finish_command("quantized matvec");
     }
 }
-
 // Two independent packed-dot dispatches now beat a fused pair kernel: the
 // rewritten GEMV is weight-stream-bound, so sharing the (cached) activation
 // bytes buys nothing, while the fused kernel's doubled register pressure
@@ -923,33 +1189,35 @@ void MetalBackend::matmul_quantized(const BackendTensor& weight,const BackendQua
         weight.dtype!=DType::T2_G128) || !weight.data || !weight.scales)
         throw std::runtime_error("q27 Metal: quantized matmul requires Q4/Q8/T2 weight");
     uint64_t group=weight.dtype==DType::Q4_G64?64:128;
-    if(!x_rows || x_rows>12 || !weight.rows || !weight.cols || weight.rows>UINT32_MAX || weight.cols>UINT32_MAX ||
+    // Wide prefill chunks: the kernels tile tokens 16 per threadgroup on
+    // grid.y (docs/plans/2026-07-15-wide-chunks.md phase A). 96 = 8x12.
+    if(!x_rows || x_rows>96 || !weight.rows || !weight.cols || weight.rows>UINT32_MAX || weight.cols>UINT32_MAX ||
        weight.cols%group || (uint64_t)weight.cols*x_rows>UINT32_MAX || x.count!=weight.cols*x_rows || !x.values || !x.scales)
         throw std::runtime_error("q27 Metal: invalid quantized matmul dimensions");
     check_range(y.size(),0,weight.rows*x_rows*4,"quantized matmul output");
     const MetalBuffer& data=metal_buffer_view(weight.data); const MetalBuffer& ws=metal_buffer_view(weight.scales);
     const MetalBuffer& xv=metal_buffer_view(x.values); const MetalBuffer& xs=metal_buffer_view(x.scales); MetalBuffer& out=metal_buffer(y);
     uint64_t divisor=weight.dtype==DType::Q4_G64?2:weight.dtype==DType::T2_G128?4:1;
-    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size),
-                weight.data_offset,weight.rows*weight.cols/divisor,"quantized matmul weight");
-    check_range(tensor_limit(ws.size(), weight.scales_offset, weight.scales_size),
-                weight.scales_offset,weight.rows*(weight.cols/group)*2,"quantized matmul weight scales");
+    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,weight.rows*weight.cols/divisor,"quantized matmul weight");
+    check_range(tensor_limit(ws.size(), weight.scales_offset, weight.scales_size), weight.scales_offset,weight.rows*(weight.cols/group)*2,"quantized matmul weight scales");
     check_range(xv.size(),0,x.count,"quantized matmul values"); check_range(xs.size(),0,(uint64_t)(x.count/32)*4,"quantized matmul scales");
     MatmulArgs args{(uint32_t)weight.rows,(uint32_t)weight.cols,x_rows,1};
     @autoreleasepool {
+        // Q27_METAL_GEMM_HALF controls the production T2 half-staging GEMM.
+        // Q4 and Q8 stay on their validated float-staged kernels.
+        const bool h = impl_->gemm_half;
         bool own; auto enc=impl_->encoder_for_operation(own,
             weight.dtype==DType::Q8_G128?"q27_matmul_q8_mm":
-            weight.dtype==DType::T2_G128?"q27_matmul_t2_mm":"q27_matmul_q4_mm");
+            weight.dtype==DType::T2_G128?(h?"q27_matmul_t2_mm_h":"q27_matmul_t2_mm"):"q27_matmul_q4_mm");
         [enc setComputePipelineState:weight.dtype==DType::Q8_G128?impl_->q8_quantized_matmul:
-                                     weight.dtype==DType::T2_G128?impl_->t2_quantized_matmul:impl_->q4_quantized_matmul];
+                                     weight.dtype==DType::T2_G128?(h?impl_->t2_quantized_matmul_h:impl_->t2_quantized_matmul):impl_->q4_quantized_matmul];
         [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0]; [enc setBuffer:ws.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
         [enc setBuffer:xv.handle() offset:0 atIndex:2]; [enc setBuffer:xs.handle() offset:0 atIndex:3]; [enc setBuffer:out.handle() offset:0 atIndex:4];
         [enc setBytes:&args length:sizeof(args) atIndex:5];
-        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(weight.rows+31)/32,1,1) threadsPerThreadgroup:MTLSizeMake(128,1,1)];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(weight.rows+31)/32,(NSUInteger)(x_rows+15)/16,1) threadsPerThreadgroup:MTLSizeMake(128,1,1)];
         if(own) impl_->finish_command("quantized simdgroup matmul");
     }
 }
-
 void MetalBackend::embedding_q8(const BackendTensor& weight, uint32_t token,
                                  BackendBuffer& out) {
     const bool t2 = weight.dtype == DType::T2_G128;
@@ -963,8 +1231,8 @@ void MetalBackend::embedding_q8(const BackendTensor& weight, uint32_t token,
     const MetalBuffer& scales = metal_buffer_view(weight.scales);
     check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,
                 weight.rows * weight.cols / (t2 ? 4 : 1), "embedding weight");
-    check_range(tensor_limit(scales.size(), weight.scales_offset, weight.scales_size),
-                weight.scales_offset, weight.rows * (weight.cols / 128) * 2, "embedding scales");
+    check_range(tensor_limit(scales.size(), weight.scales_offset, weight.scales_size), weight.scales_offset,
+                weight.rows * (weight.cols / 128) * 2, "embedding scales");
     MetalBuffer& output = metal_buffer(out);
     @autoreleasepool {
         bool own; id<MTLComputeCommandEncoder> enc = impl_->encoder_for_operation(own,
@@ -981,15 +1249,50 @@ void MetalBackend::embedding_q8(const BackendTensor& weight, uint32_t token,
     }
 }
 
+// GPU-resident greedy decode: same row lookup, but the token id lives in a
+// device buffer written by the previous step's argmax — chained steps need
+// no CPU sync. The id cannot be range-checked host-side; argmax only writes
+// ids < vocab, and the kernels never index past the id row.
+void MetalBackend::embedding_from_device(const BackendTensor& weight, const BackendBuffer& token,
+                                         BackendBuffer& out) {
+    const bool t2 = weight.dtype == DType::T2_G128;
+    if ((weight.dtype != DType::Q8_G128 && !t2) || !weight.data || !weight.scales ||
+        !weight.rows || !weight.cols || weight.rows > UINT32_MAX || weight.cols > UINT32_MAX ||
+        weight.cols % 128)
+        throw std::runtime_error("q27 Metal: invalid embedding tensor");
+    check_range(out.size(), 0, weight.cols * 4, "embedding output");
+    const MetalBuffer& tokb = metal_buffer(token);
+    check_range(tokb.size(), 0, 4, "embedding token id");
+    const MetalBuffer& data = metal_buffer_view(weight.data);
+    const MetalBuffer& scales = metal_buffer_view(weight.scales);
+    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,
+                weight.rows * weight.cols / (t2 ? 4 : 1), "embedding weight");
+    check_range(tensor_limit(scales.size(), weight.scales_offset, weight.scales_size), weight.scales_offset,
+                weight.rows * (weight.cols / 128) * 2, "embedding scales");
+    MetalBuffer& output = metal_buffer(out);
+    @autoreleasepool {
+        bool own; id<MTLComputeCommandEncoder> enc = impl_->encoder_for_operation(own,
+            t2 ? "q27_embedding_t2_dev" : "q27_embedding_q8_dev");
+        [enc setComputePipelineState:t2 ? impl_->embedding_t2_dev : impl_->embedding_dev];
+        [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
+        [enc setBuffer:scales.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
+        [enc setBuffer:output.handle() offset:0 atIndex:2];
+        [enc setBuffer:tokb.handle() offset:0 atIndex:3];
+        uint32_t cols = (uint32_t)weight.cols;
+        [enc setBytes:&cols length:sizeof(cols) atIndex:4];
+        [enc dispatchThreads:MTLSizeMake(cols, 1, 1) threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        if (own) impl_->finish_command("embedding (device token)");
+    }
+}
+
 void MetalBackend::rmsnorm(const BackendBuffer& x, const BackendTensor& weight,
                             BackendBuffer& out, uint32_t n, float eps) {
     const MetalBuffer& w = tensor_data(weight, DType::F32, "rmsnorm");
     const MetalBuffer& input = metal_buffer(x); MetalBuffer& output = metal_buffer(out);
     check_range(input.size(), 0, (uint64_t)n * 4, "rmsnorm input");
     check_range(output.size(), 0, (uint64_t)n * 4, "rmsnorm output");
-    check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size),
-                weight.data_offset, (uint64_t)n * 4, "rmsnorm weight");
-    VectorArgs args{n, 8, eps};
+    check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size), weight.data_offset, (uint64_t)n * 4, "rmsnorm weight");
+    VectorArgs args{n, kReduceThreads / 32, eps};
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own, "q27_rmsnorm");
         [enc setComputePipelineState:impl_->rms];
@@ -997,7 +1300,7 @@ void MetalBackend::rmsnorm(const BackendBuffer& x, const BackendTensor& weight,
         [enc setBuffer:w.handle() offset:(NSUInteger)weight.data_offset atIndex:1];
         [enc setBuffer:output.handle() offset:0 atIndex:2];
         [enc setBytes:&args length:sizeof(args) atIndex:3];
-        [enc dispatchThreadgroups:MTLSizeMake(1,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        [enc dispatchThreadgroups:MTLSizeMake(1,1,1) threadsPerThreadgroup:MTLSizeMake(kReduceThreads,1,1)];
         if (own) impl_->finish_command("rmsnorm");
     }
 }
@@ -1011,15 +1314,14 @@ void MetalBackend::rmsnorm_quantized(const BackendBuffer& x,const BackendTensor&
     const MetalBuffer& input=metal_buffer(x); MetalBuffer& output=metal_buffer(out);
     MetalBuffer& values=metal_buffer(*quantized.values); MetalBuffer& scales=metal_buffer(*quantized.scales);
     check_range(input.size(),0,(uint64_t)n*4,"fused rmsnorm input"); check_range(output.size(),0,(uint64_t)n*4,"fused rmsnorm output");
-    check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size), weight.data_offset,
-                (uint64_t)n*4,"fused rmsnorm weight"); check_range(values.size(),0,n,"fused rmsnorm values");
-    check_range(scales.size(),0,(uint64_t)(n/32)*4,"fused rmsnorm scales"); VectorArgs args{n,8,eps};
+    check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size), weight.data_offset,(uint64_t)n*4,"fused rmsnorm weight"); check_range(values.size(),0,n,"fused rmsnorm values");
+    check_range(scales.size(),0,(uint64_t)(n/32)*4,"fused rmsnorm scales"); VectorArgs args{n,kReduceThreads/32,eps};
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_rmsnorm_quantized"); [enc setComputePipelineState:impl_->rms_quantized];
         [enc setBuffer:input.handle() offset:0 atIndex:0]; [enc setBuffer:w.handle() offset:(NSUInteger)weight.data_offset atIndex:1];
         [enc setBuffer:output.handle() offset:0 atIndex:2]; [enc setBuffer:values.handle() offset:0 atIndex:3];
         [enc setBuffer:scales.handle() offset:0 atIndex:4]; [enc setBytes:&args length:sizeof(args) atIndex:5];
-        [enc dispatchThreadgroups:MTLSizeMake(1,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        [enc dispatchThreadgroups:MTLSizeMake(1,1,1) threadsPerThreadgroup:MTLSizeMake(kReduceThreads,1,1)];
         if(own) impl_->finish_command("fused rmsnorm quantize");
     }
 }
@@ -1030,16 +1332,15 @@ void MetalBackend::rmsnorm_heads(BackendBuffer& x, const BackendTensor& weight,
     const MetalBuffer& w = tensor_data(weight, DType::F32, "head rmsnorm");
     MetalBuffer& input = metal_buffer(x);
     check_range(input.size(), 0, ((uint64_t)(heads - 1) * stride + head_dim) * 4, "head rmsnorm input");
-    check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size),
-                weight.data_offset, (uint64_t)head_dim * 4, "head rmsnorm weight");
-    HeadArgs args{heads, head_dim, stride, 8, eps};
+    check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size), weight.data_offset, (uint64_t)head_dim * 4, "head rmsnorm weight");
+    HeadArgs args{heads, head_dim, stride, kReduceThreads / 32, eps};
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own, "q27_rmsnorm_heads");
         [enc setComputePipelineState:impl_->rms_heads];
         [enc setBuffer:input.handle() offset:0 atIndex:0];
         [enc setBuffer:w.handle() offset:(NSUInteger)weight.data_offset atIndex:1];
         [enc setBytes:&args length:sizeof(args) atIndex:2];
-        [enc dispatchThreadgroups:MTLSizeMake(heads,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        [enc dispatchThreadgroups:MTLSizeMake(heads,1,1) threadsPerThreadgroup:MTLSizeMake(kReduceThreads,1,1)];
         if (own) impl_->finish_command("head rmsnorm");
     }
 }
@@ -1048,13 +1349,13 @@ void MetalBackend::l2norm_heads(BackendBuffer& x, uint32_t heads, uint32_t head_
                                  float eps) {
     MetalBuffer& input = metal_buffer(x);
     check_range(input.size(), 0, (uint64_t)heads * head_dim * 4, "l2norm input");
-    HeadArgs args{heads, head_dim, head_dim, 8, eps};
+    HeadArgs args{heads, head_dim, head_dim, kReduceThreads / 32, eps};
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own, "q27_l2norm_heads");
         [enc setComputePipelineState:impl_->l2_heads];
         [enc setBuffer:input.handle() offset:0 atIndex:0];
         [enc setBytes:&args length:sizeof(args) atIndex:1];
-        [enc dispatchThreadgroups:MTLSizeMake(heads,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        [enc dispatchThreadgroups:MTLSizeMake(heads,1,1) threadsPerThreadgroup:MTLSizeMake(kReduceThreads,1,1)];
         if (own) impl_->finish_command("l2norm");
     }
 }
@@ -1089,9 +1390,8 @@ void MetalBackend::add_inplace(BackendBuffer& x, const BackendBuffer& y, uint32_
 void MetalBackend::concat(const BackendBuffer& a, uint32_t a_count,
                            const BackendBuffer& b, uint32_t b_count,
                            BackendBuffer& out) {
-    const uint64_t total = (uint64_t)a_count + b_count;
-    if (total > UINT32_MAX)
-        throw std::runtime_error("q27 Metal: concat element count overflow");
+    const uint64_t total=(uint64_t)a_count+b_count;
+    if(total>UINT32_MAX) throw std::runtime_error("concat element count overflow");
     const MetalBuffer& ab=metal_buffer(a); const MetalBuffer& bb=metal_buffer(b); MetalBuffer& ob=metal_buffer(out);
     check_range(ab.size(),0,(uint64_t)a_count*4,"concat a"); check_range(bb.size(),0,(uint64_t)b_count*4,"concat b");
     check_range(ob.size(),0,total*4,"concat output"); ConcatArgs args{a_count,b_count};
@@ -1141,6 +1441,52 @@ void MetalBackend::argmax(const BackendBuffer& x, uint32_t n, BackendBuffer& out
         [enc setBytes:&n length:4 atIndex:2];
         [enc dispatchThreadgroups:MTLSizeMake(1,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
         if(own) impl_->finish_command("argmax");
+    }
+}
+
+void MetalBackend::topk(const BackendBuffer& x, uint32_t n, uint32_t k,
+                        BackendBuffer& values, BackendBuffer& indices, BackendBuffer& count,
+                        uint64_t x_offset_bytes) {
+    const MetalBuffer& input=metal_buffer(x);
+    MetalBuffer& vb=metal_buffer(values); MetalBuffer& ib=metal_buffer(indices); MetalBuffer& cb=metal_buffer(count);
+    if (!n || !k || k > 256) throw std::runtime_error("q27 Metal: top-k requires 1..256 candidates");
+    if (x_offset_bytes % 4) throw std::runtime_error("q27 Metal: top-k input offset must be float-aligned");
+    check_range(input.size(),x_offset_bytes,(uint64_t)n*4,"top-k input");
+    check_range(cb.size(),0,4,"top-k count");
+    const uint64_t capacity=std::min(vb.size(),ib.size())/4;
+    if (capacity < 2*(uint64_t)k) throw std::runtime_error("q27 Metal: top-k output capacity below 2k");
+    if (impl_->batching) throw std::runtime_error("q27 Metal: top-k requires its own command");
+    std::memset(cb.handle().contents,0,4);
+    if(!impl_->topk_logits_p) return;
+    TopkArgs args{n,k,(uint32_t)std::min<uint64_t>(capacity,UINT32_MAX)};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_topk_logits"); [enc setComputePipelineState:impl_->topk_logits_p];
+        [enc setBuffer:input.handle() offset:(NSUInteger)x_offset_bytes atIndex:0];
+        [enc setBuffer:vb.handle() offset:0 atIndex:1];
+        [enc setBuffer:ib.handle() offset:0 atIndex:2]; [enc setBuffer:cb.handle() offset:0 atIndex:3];
+        [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake(1,1,1) threadsPerThreadgroup:MTLSizeMake(1024,1,1)];
+        if(own) impl_->finish_command("top-k");
+    }
+}
+
+void MetalBackend::mask_logits(BackendBuffer& logits, const BackendBuffer& masks,
+                                uint64_t mask_offset, uint32_t n) {
+    MetalBuffer& lb = metal_buffer(logits);
+    const MetalBuffer& mb = metal_buffer(masks);
+    if (!n) throw std::runtime_error("q27 Metal: empty mask_logits");
+    check_range(lb.size(), 0, (uint64_t)n * 4, "mask_logits logits");
+    check_range(mb.size(), mask_offset, ((uint64_t)n + 31) / 32 * 4, "mask_logits mask");
+    if (mask_offset % 4) throw std::runtime_error("q27 Metal: mask offset must be word-aligned");
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_mask_logits");
+        [enc setComputePipelineState:impl_->mask_logits_p];
+        [enc setBuffer:lb.handle() offset:0 atIndex:0];
+        [enc setBuffer:mb.handle() offset:(NSUInteger)mask_offset atIndex:1];
+        [enc setBytes:&n length:sizeof(n) atIndex:2];
+        [enc dispatchThreadgroups:MTLSizeMake((n + 255) / 256, 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        if (own) impl_->finish_command("mask logits");
     }
 }
 
@@ -1212,7 +1558,7 @@ void MetalBackend::turbo_wht(BackendBuffer& x, uint32_t heads, uint32_t stride,
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_turbo_wht"); [enc setComputePipelineState:impl_->turbo_wht];
         [enc setBuffer:xb.handle() offset:0 atIndex:0]; [enc setBytes:&args length:sizeof(args) atIndex:1];
-        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)heads*2,1,1) threadsPerThreadgroup:MTLSizeMake(128,1,1)];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)heads*2,1,1) threadsPerThreadgroup:MTLSizeMake(kTurboThreads,1,1)];
         if(own) impl_->finish_command("turbo3 WHT");
     }
 }
@@ -1234,7 +1580,7 @@ void MetalBackend::kv_store_turbo3(const BackendBuffer& k, const BackendBuffer& 
         [enc setBuffer:kb.handle() offset:0 atIndex:0]; [enc setBuffer:vb.handle() offset:0 atIndex:1];
         [enc setBuffer:kc.handle() offset:0 atIndex:2]; [enc setBuffer:vc.handle() offset:0 atIndex:3];
         [enc setBytes:&args length:sizeof(args) atIndex:4];
-        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)kv_heads*2,2,1) threadsPerThreadgroup:MTLSizeMake(128,1,1)];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)kv_heads*2,2,1) threadsPerThreadgroup:MTLSizeMake(kTurboThreads,1,1)];
         if(own) impl_->finish_command("turbo3 KV store");
     }
 }
@@ -1244,7 +1590,6 @@ void MetalBackend::attention_turbo3(const BackendBuffer& q, uint32_t q_stride,
                                      BackendBuffer& out, uint32_t seq_len,
                                      uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
                                      float scale, BackendBuffer* partials) {
-    (void)partials;
     if (!seq_len || !kv_heads || q_heads%kv_heads || head_dim != 256)
         throw std::runtime_error("q27 Metal: invalid turbo3 attention dimensions");
     const MetalBuffer& qb=metal_buffer(q); const MetalBuffer& kc=metal_buffer(k_cache); const MetalBuffer& vc=metal_buffer(v_cache);
@@ -1253,12 +1598,20 @@ void MetalBackend::attention_turbo3(const BackendBuffer& q, uint32_t q_stride,
     const uint64_t cache_bytes=(uint64_t)seq_len*kv_heads*2*50;
     check_range(kc.size(),0,cache_bytes,"turbo3 K cache"); check_range(vc.size(),0,cache_bytes,"turbo3 V cache");
     check_range(output.size(),0,(uint64_t)q_heads*head_dim*4,"turbo3 attention output");
+    const uint32_t gqa=q_heads/kv_heads;
+    if (impl_->gqa_threshold && seq_len >= impl_->gqa_threshold && gqa >= 2 && gqa <= 8) {
+        if (!partials)
+            throw std::runtime_error("q27 Metal: blocked GQA route needs a partials buffer");
+        impl_->attention_gqa_dispatch(true,qb,q_stride,kc,vc,output,seq_len,q_heads,kv_heads,head_dim,scale,
+                                      metal_buffer(*partials));
+        return;
+    }
     AttentionArgs args{q_stride,seq_len,q_heads,kv_heads,head_dim,scale};
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_attention_turbo3"); [enc setComputePipelineState:impl_->attention_turbo3];
         [enc setBuffer:qb.handle() offset:0 atIndex:0]; [enc setBuffer:kc.handle() offset:0 atIndex:1]; [enc setBuffer:vc.handle() offset:0 atIndex:2];
         [enc setBuffer:output.handle() offset:0 atIndex:3]; [enc setBytes:&args length:sizeof(args) atIndex:4];
-        [enc dispatchThreadgroups:MTLSizeMake(q_heads,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        [enc dispatchThreadgroups:MTLSizeMake(q_heads,1,1) threadsPerThreadgroup:MTLSizeMake(kReduceThreads,1,1)];
         if(own) impl_->finish_command("turbo3 attention");
     }
 }
@@ -1268,7 +1621,6 @@ void MetalBackend::attention_f16(const BackendBuffer& q, uint32_t q_stride,
                                   BackendBuffer& out, uint32_t seq_len,
                                   uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
                                   float scale, BackendBuffer* partials) {
-    (void)partials;
     if (!seq_len || !kv_heads || q_heads%kv_heads || !head_dim || head_dim > 256)
         throw std::runtime_error("q27 Metal: invalid attention dimensions");
     const MetalBuffer& qb=metal_buffer(q); const MetalBuffer& kc=metal_buffer(k_cache); const MetalBuffer& vc=metal_buffer(v_cache);
@@ -1277,12 +1629,20 @@ void MetalBackend::attention_f16(const BackendBuffer& q, uint32_t q_stride,
     const uint64_t cache_bytes=(uint64_t)seq_len*kv_heads*head_dim*2;
     check_range(kc.size(),0,cache_bytes,"attention K cache"); check_range(vc.size(),0,cache_bytes,"attention V cache");
     check_range(output.size(),0,(uint64_t)q_heads*head_dim*4,"attention output");
+    const uint32_t gqa=q_heads/kv_heads;
+    if (impl_->gqa_threshold && seq_len >= impl_->gqa_threshold && gqa >= 2 && gqa <= 8) {
+        if (!partials)
+            throw std::runtime_error("q27 Metal: blocked GQA route needs a partials buffer");
+        impl_->attention_gqa_dispatch(false,qb,q_stride,kc,vc,output,seq_len,q_heads,kv_heads,head_dim,scale,
+                                      metal_buffer(*partials));
+        return;
+    }
     AttentionArgs args{q_stride,seq_len,q_heads,kv_heads,head_dim,scale};
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_attention_f16"); [enc setComputePipelineState:impl_->attention];
         [enc setBuffer:qb.handle() offset:0 atIndex:0]; [enc setBuffer:kc.handle() offset:0 atIndex:1]; [enc setBuffer:vc.handle() offset:0 atIndex:2];
         [enc setBuffer:output.handle() offset:0 atIndex:3]; [enc setBytes:&args length:sizeof(args) atIndex:4];
-        [enc dispatchThreadgroups:MTLSizeMake(q_heads,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        [enc dispatchThreadgroups:MTLSizeMake(q_heads,1,1) threadsPerThreadgroup:MTLSizeMake(kReduceThreads,1,1)];
         if(own) impl_->finish_command("FP16 attention");
     }
 }
@@ -1295,8 +1655,7 @@ void MetalBackend::gdn_gates(const BackendBuffer& alpha, const BackendBuffer& be
     MetalBuffer& go=metal_buffer(g); MetalBuffer& bo=metal_buffer(beta);
     check_range(ar.size(),0,(uint64_t)heads*4,"GDN alpha"); check_range(br.size(),0,(uint64_t)heads*4,"GDN beta raw");
     check_range(go.size(),0,(uint64_t)heads*4,"GDN g"); check_range(bo.size(),0,(uint64_t)heads*4,"GDN beta");
-    check_range(tensor_limit(a.size(), ssm_a.data_offset, ssm_a.data_size), ssm_a.data_offset,(uint64_t)heads*4,"GDN a");
-    check_range(tensor_limit(dt.size(), ssm_dt.data_offset, ssm_dt.data_size), ssm_dt.data_offset,(uint64_t)heads*4,"GDN dt");
+    check_range(tensor_limit(a.size(), ssm_a.data_offset, ssm_a.data_size), ssm_a.data_offset,(uint64_t)heads*4,"GDN a"); check_range(tensor_limit(dt.size(), ssm_dt.data_offset, ssm_dt.data_size), ssm_dt.data_offset,(uint64_t)heads*4,"GDN dt");
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_gdn_gates"); [enc setComputePipelineState:impl_->gates];
         [enc setBuffer:ar.handle() offset:0 atIndex:0]; [enc setBuffer:br.handle() offset:0 atIndex:1];
@@ -1312,7 +1671,7 @@ void MetalBackend::conv_step(const BackendBuffer& ring_src, BackendBuffer& ring_
     const MetalBuffer& src=metal_buffer(ring_src); MetalBuffer& dst=metal_buffer(ring_dst); const MetalBuffer& q=metal_buffer(qkv);
     const MetalBuffer& w=tensor_data(conv_weight,DType::F32,"GDN convolution"); MetalBuffer& o=metal_buffer(out);
     check_range(src.size(),0,(uint64_t)channels*3*4,"conv ring source"); check_range(dst.size(),0,(uint64_t)channels*3*4,"conv ring destination");
-    check_range(q.size(),0,(uint64_t)channels*4,"conv input"); check_range(tensor_limit(w.size(), conv_weight.data_offset, conv_weight.data_size),conv_weight.data_offset,(uint64_t)channels*4*4,"conv weight"); check_range(o.size(),0,(uint64_t)channels*4,"conv output");
+    check_range(q.size(),0,(uint64_t)channels*4,"conv input"); check_range(tensor_limit(w.size(), conv_weight.data_offset, conv_weight.data_size), conv_weight.data_offset,(uint64_t)channels*4*4,"conv weight"); check_range(o.size(),0,(uint64_t)channels*4,"conv output");
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_conv_step"); [enc setComputePipelineState:impl_->conv];
         [enc setBuffer:src.handle() offset:0 atIndex:0]; [enc setBuffer:dst.handle() offset:0 atIndex:1]; [enc setBuffer:q.handle() offset:0 atIndex:2];
@@ -1346,19 +1705,19 @@ void MetalBackend::gated_norm_gdn(const BackendBuffer& x, const BackendTensor& w
                                    uint32_t heads, uint32_t head_dim, float eps) {
     const MetalBuffer& xb=metal_buffer(x); const MetalBuffer& w=tensor_data(weight,DType::F32,"GDN norm"); const MetalBuffer& gb=metal_buffer(gate); MetalBuffer& o=metal_buffer(out);
     const uint64_t bytes=(uint64_t)heads*head_dim*4;
-    check_range(xb.size(),0,bytes,"GDN norm input"); check_range(gb.size(),0,bytes,"GDN norm gate"); check_range(o.size(),0,bytes,"GDN norm output"); check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size),weight.data_offset,(uint64_t)head_dim*4,"GDN norm weight");
-    HeadArgs args{heads,head_dim,head_dim,8,eps};
+    check_range(xb.size(),0,bytes,"GDN norm input"); check_range(gb.size(),0,bytes,"GDN norm gate"); check_range(o.size(),0,bytes,"GDN norm output"); check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size), weight.data_offset,(uint64_t)head_dim*4,"GDN norm weight");
+    HeadArgs args{heads,head_dim,head_dim,kReduceThreads/32,eps};
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own, "q27_gated_norm_gdn"); [enc setComputePipelineState:impl_->gated_norm];
         [enc setBuffer:xb.handle() offset:0 atIndex:0]; [enc setBuffer:w.handle() offset:(NSUInteger)weight.data_offset atIndex:1]; [enc setBuffer:gb.handle() offset:0 atIndex:2]; [enc setBuffer:o.handle() offset:0 atIndex:3]; [enc setBytes:&args length:sizeof(args) atIndex:4];
-        [enc dispatchThreadgroups:MTLSizeMake(heads,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)]; if(own) impl_->finish_command("GDN gated norm");
+        [enc dispatchThreadgroups:MTLSizeMake(heads,1,1) threadsPerThreadgroup:MTLSizeMake(kReduceThreads,1,1)]; if(own) impl_->finish_command("GDN gated norm");
     }
 }
 
 void MetalBackend::embedding_q8_rows(const BackendTensor& weight, const uint32_t* tokens,
                                       uint32_t count, BackendBuffer& out) {
-    if (!tokens || !count || count > 12)
-        throw std::runtime_error("q27 Metal: chunked embedding requires 1..12 tokens");
+    if (!tokens || !count || count > 96)
+        throw std::runtime_error("q27 Metal: chunked embedding requires 1..96 tokens");
     const bool t2 = weight.dtype == DType::T2_G128;
     if ((weight.dtype != DType::Q8_G128 && !t2) || !weight.data || !weight.scales ||
         !weight.rows || !weight.cols || weight.rows > UINT32_MAX || weight.cols > UINT32_MAX ||
@@ -1374,8 +1733,7 @@ void MetalBackend::embedding_q8_rows(const BackendTensor& weight, const uint32_t
     const MetalBuffer& scales = metal_buffer_view(weight.scales);
     check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,
                 weight.rows * weight.cols / (t2 ? 4 : 1), "chunked embedding weight");
-    check_range(tensor_limit(scales.size(), weight.scales_offset, weight.scales_size),
-                weight.scales_offset, weight.rows * (weight.cols / 128) * 2, "chunked embedding scales");
+    check_range(tensor_limit(scales.size(), weight.scales_offset, weight.scales_size), weight.scales_offset, weight.rows * (weight.cols / 128) * 2, "chunked embedding scales");
     MetalBuffer& output = metal_buffer(out);
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own,
@@ -1401,11 +1759,10 @@ void MetalBackend::rmsnorm_rows_quantized(const BackendBuffer& x, const BackendT
     const uint64_t total = (uint64_t)n * rows;
     check_range(input.size(), 0, total * 4, "chunked rmsnorm input");
     check_range(output.size(), 0, total * 4, "chunked rmsnorm output");
-    check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size),
-                weight.data_offset, (uint64_t)n * 4, "chunked rmsnorm weight");
+    check_range(tensor_limit(w.size(), weight.data_offset, weight.data_size), weight.data_offset, (uint64_t)n * 4, "chunked rmsnorm weight");
     check_range(values.size(), 0, total, "chunked rmsnorm values");
     check_range(scales.size(), 0, (total / 32) * 4, "chunked rmsnorm scales");
-    RowsNormArgs args{n, rows, 8, eps};
+    RowsNormArgs args{n, rows, kReduceThreads / 32, eps};
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own, "q27_rmsnorm_rows_quantized");
         [enc setComputePipelineState:impl_->rms_rows_quantized];
@@ -1415,7 +1772,7 @@ void MetalBackend::rmsnorm_rows_quantized(const BackendBuffer& x, const BackendT
         [enc setBuffer:values.handle() offset:0 atIndex:3];
         [enc setBuffer:scales.handle() offset:0 atIndex:4];
         [enc setBytes:&args length:sizeof(args) atIndex:5];
-        [enc dispatchThreadgroups:MTLSizeMake(rows,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        [enc dispatchThreadgroups:MTLSizeMake(rows,1,1) threadsPerThreadgroup:MTLSizeMake(kReduceThreads,1,1)];
         if (own) impl_->finish_command("chunked rmsnorm quantize");
     }
 }
@@ -1426,21 +1783,21 @@ void MetalBackend::matvec_f16_pair_rows(const BackendTensor& a, BackendBuffer& a
     if (a.dtype != DType::F16 || b.dtype != DType::F16 || a.cols != b.cols || !a.data || !b.data ||
         !a.rows || !b.rows || !a.cols || a.rows > UINT32_MAX || b.rows > UINT32_MAX || a.cols > UINT32_MAX)
         throw std::runtime_error("q27 Metal: chunked F16 matvec pair requires compatible F16 weights");
-    if (!rows || rows > 12) throw std::runtime_error("q27 Metal: chunked F16 matvec pair requires 1..12 rows");
+    if (!rows || rows > 96) throw std::runtime_error("q27 Metal: chunked F16 matvec pair requires 1..96 rows");
     const uint64_t a_weight_bytes = checked_mul(checked_mul(a.rows, a.cols, "chunked matvec weight A"),
                                                 2, "chunked matvec weight A");
     const uint64_t b_weight_bytes = checked_mul(checked_mul(b.rows, b.cols, "chunked matvec weight B"),
                                                 2, "chunked matvec weight B");
+    if (a.cols & 3)   // kernel vector-loads packed_half4
+        throw std::runtime_error("q27 Metal: chunked F16 matvec pair requires cols % 4 == 0");
     check_range(x.size(), 0, (uint64_t)rows * a.cols * 4, "chunked matvec input");
     check_range(a_out.size(), 0, (uint64_t)rows * a.rows * 4, "chunked matvec output A");
     check_range(b_out.size(), 0, (uint64_t)rows * b.rows * 4, "chunked matvec output B");
     const MetalBuffer& ad = metal_buffer_view(a.data); const MetalBuffer& bd = metal_buffer_view(b.data);
     const MetalBuffer& input = metal_buffer(x);
     MetalBuffer& ao = metal_buffer(a_out); MetalBuffer& bo = metal_buffer(b_out);
-    check_range(tensor_limit(ad.size(), a.data_offset, a.data_size), a.data_offset,
-                a_weight_bytes, "chunked matvec weight A");
-    check_range(tensor_limit(bd.size(), b.data_offset, b.data_size), b.data_offset,
-                b_weight_bytes, "chunked matvec weight B");
+    check_range(tensor_limit(ad.size(), a.data_offset, a.data_size), a.data_offset, a_weight_bytes, "chunked matvec weight A");
+    check_range(tensor_limit(bd.size(), b.data_offset, b.data_size), b.data_offset, b_weight_bytes, "chunked matvec weight B");
     MatvecPairRowsArgs args{(uint32_t)a.rows, (uint32_t)b.rows, (uint32_t)a.cols, rows};
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own, "q27_matvec_f16_pair_rows");
@@ -1458,7 +1815,7 @@ void MetalBackend::gdn_gates_rows(const BackendBuffer& alpha, const BackendBuffe
                                   const BackendTensor& ssm_a, const BackendTensor& ssm_dt,
                                   BackendBuffer& g, BackendBuffer& beta,
                                   uint32_t heads, uint32_t tokens) {
-    if (!heads || !tokens || tokens > 12) throw std::runtime_error("q27 Metal: invalid chunked GDN gates");
+    if (!heads || !tokens || tokens > 96) throw std::runtime_error("q27 Metal: invalid chunked GDN gates");
     const MetalBuffer& ar = metal_buffer(alpha); const MetalBuffer& br = metal_buffer(beta_raw);
     const MetalBuffer& a = tensor_data(ssm_a, DType::F32, "chunked GDN a");
     const MetalBuffer& dt = tensor_data(ssm_dt, DType::F32, "chunked GDN dt");
@@ -1466,10 +1823,8 @@ void MetalBackend::gdn_gates_rows(const BackendBuffer& alpha, const BackendBuffe
     const uint64_t total = (uint64_t)heads * tokens * 4;
     check_range(ar.size(), 0, total, "chunked GDN alpha"); check_range(br.size(), 0, total, "chunked GDN beta raw");
     check_range(go.size(), 0, total, "chunked GDN g"); check_range(bo.size(), 0, total, "chunked GDN beta");
-    check_range(tensor_limit(a.size(), ssm_a.data_offset, ssm_a.data_size),
-                ssm_a.data_offset, (uint64_t)heads * 4, "chunked GDN a");
-    check_range(tensor_limit(dt.size(), ssm_dt.data_offset, ssm_dt.data_size),
-                ssm_dt.data_offset, (uint64_t)heads * 4, "chunked GDN dt");
+    check_range(tensor_limit(a.size(), ssm_a.data_offset, ssm_a.data_size), ssm_a.data_offset, (uint64_t)heads * 4, "chunked GDN a");
+    check_range(tensor_limit(dt.size(), ssm_dt.data_offset, ssm_dt.data_size), ssm_dt.data_offset, (uint64_t)heads * 4, "chunked GDN dt");
     GatesRowsArgs args{heads, tokens};
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own, "q27_gdn_gates_rows");
@@ -1488,7 +1843,7 @@ void MetalBackend::conv_chunk(const BackendBuffer& ring_src, BackendBuffer& ring
                               const BackendBuffer& qkv,
                               const BackendTensor& conv_weight, BackendBuffer& out,
                               uint32_t channels, uint32_t tokens) {
-    if (!channels || !tokens || tokens > 12) throw std::runtime_error("q27 Metal: invalid chunked convolution");
+    if (!channels || !tokens || tokens > 96) throw std::runtime_error("q27 Metal: invalid chunked convolution");
     const MetalBuffer& rs = metal_buffer(ring_src); MetalBuffer& rd = metal_buffer(ring_dst);
     const MetalBuffer& q = metal_buffer(qkv);
     const MetalBuffer& w = tensor_data(conv_weight, DType::F32, "chunked GDN convolution");
@@ -1496,8 +1851,7 @@ void MetalBackend::conv_chunk(const BackendBuffer& ring_src, BackendBuffer& ring
     check_range(rs.size(), 0, (uint64_t)channels * 3 * 4, "chunked conv ring src");
     check_range(rd.size(), 0, (uint64_t)channels * 3 * 4, "chunked conv ring dst");
     check_range(q.size(), 0, (uint64_t)channels * tokens * 4, "chunked conv input");
-    check_range(tensor_limit(w.size(), conv_weight.data_offset, conv_weight.data_size),
-                conv_weight.data_offset, (uint64_t)channels * 4 * 4, "chunked conv weight");
+    check_range(tensor_limit(w.size(), conv_weight.data_offset, conv_weight.data_size), conv_weight.data_offset, (uint64_t)channels * 4 * 4, "chunked conv weight");
     check_range(o.size(), 0, (uint64_t)channels * tokens * 4, "chunked conv output");
     ConvChunkArgs args{channels, tokens};
     @autoreleasepool {
@@ -1517,7 +1871,7 @@ void MetalBackend::delta_chunk(const BackendBuffer& state_src, BackendBuffer& st
                                const BackendBuffer& g, const BackendBuffer& beta,
                                BackendBuffer& out, uint32_t value_heads, uint32_t qk_heads,
                                uint32_t head_dim, uint32_t tokens) {
-    if (head_dim != 128 || qk_heads != 16 || !tokens || tokens > 12 ||
+    if (head_dim != 128 || qk_heads != 16 || !tokens || tokens > 96 ||
         impl_->delta_chunked.maxTotalThreadsPerThreadgroup < 512)
         throw std::runtime_error("q27 Metal: unsupported chunked DeltaNet shape");
     const MetalBuffer& ss = metal_buffer(state_src); MetalBuffer& sd = metal_buffer(state_dst);
@@ -1546,7 +1900,7 @@ void MetalBackend::delta_chunk(const BackendBuffer& state_src, BackendBuffer& st
 
 void MetalBackend::l2norm_rows(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
                                uint32_t row_stride, uint32_t tokens, float eps) {
-    if (!heads || !tokens || tokens > 12 || row_stride < heads * head_dim)
+    if (!heads || !tokens || tokens > 96 || row_stride < heads * head_dim)
         throw std::runtime_error("q27 Metal: invalid chunked l2norm");
     MetalBuffer& input = metal_buffer(x);
     check_range(input.size(), 0, ((uint64_t)(tokens - 1) * row_stride + (uint64_t)heads * head_dim) * 4,
@@ -1557,7 +1911,7 @@ void MetalBackend::l2norm_rows(BackendBuffer& x, uint32_t heads, uint32_t head_d
         [enc setComputePipelineState:impl_->l2_rows];
         [enc setBuffer:input.handle() offset:0 atIndex:0];
         [enc setBytes:&args length:sizeof(args) atIndex:1];
-        [enc dispatchThreadgroups:MTLSizeMake(heads,tokens,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        [enc dispatchThreadgroups:MTLSizeMake(heads,tokens,1) threadsPerThreadgroup:MTLSizeMake(kReduceThreads,1,1)];
         if (own) impl_->finish_command("chunked l2norm");
     }
 }
@@ -1565,7 +1919,7 @@ void MetalBackend::l2norm_rows(BackendBuffer& x, uint32_t heads, uint32_t head_d
 void MetalBackend::rope_neox_rows(BackendBuffer& x, uint32_t heads, uint32_t head_dim,
                                   uint32_t n_rot, uint32_t stride, uint32_t row_stride,
                                   uint32_t position, uint32_t tokens, float freq_base) {
-    if (!n_rot || n_rot > head_dim || (n_rot & 1) || !tokens || tokens > 12)
+    if (!n_rot || n_rot > head_dim || (n_rot & 1) || !tokens || tokens > 96)
         throw std::runtime_error("q27 Metal: invalid chunked RoPE dimensions");
     MetalBuffer& input = metal_buffer(x);
     check_range(input.size(), 0,
@@ -1627,7 +1981,7 @@ void MetalBackend::attention_causal(const BackendBuffer& q, uint32_t q_stride,
 void MetalBackend::kv_store_f16_rows(const BackendBuffer& k, const BackendBuffer& v,
                                      BackendBuffer& k_cache, BackendBuffer& v_cache,
                                      uint32_t position, uint32_t row_length, uint32_t tokens) {
-    if (!tokens || tokens > 12) throw std::runtime_error("q27 Metal: invalid chunked KV store");
+    if (!tokens || tokens > 96) throw std::runtime_error("q27 Metal: invalid chunked KV store");
     const MetalBuffer& kb = metal_buffer(k); const MetalBuffer& vb = metal_buffer(v);
     MetalBuffer& kc = metal_buffer(k_cache); MetalBuffer& vc = metal_buffer(v_cache);
     check_range(kb.size(), 0, (uint64_t)row_length * tokens * 4, "chunked K rows");
@@ -1646,10 +2000,101 @@ void MetalBackend::kv_store_f16_rows(const BackendBuffer& k, const BackendBuffer
     }
 }
 
+// --- KV fp16 exception cells (docs/plans/2026-07-17-kv-except-production.md).
+// The excepted head's K/V rows are copied out of the packed staging buffers
+// into a kv_heads=1 fp16 side cache, and the existing f16 attention math
+// re-runs over a WINDOW of query heads against that side cache, overwriting
+// the production dispatch's output rows. Head offsets ride buffer bindings;
+// the production kernels and the shader ABI are untouched.
+
+void MetalBackend::kv_store_f16_head_rows_side(const BackendBuffer& k, const BackendBuffer& v,
+                                               uint32_t head_offset_elems, uint32_t src_stride,
+                                               BackendBuffer& k_side, BackendBuffer& v_side,
+                                               uint32_t position, uint32_t row_length, uint32_t tokens,
+                                               uint32_t codec) {
+    if (!tokens || tokens > 96 || !row_length || row_length > src_stride)
+        throw std::runtime_error("q27 Metal: invalid KV side store");
+    if (codec > 1)
+        throw std::runtime_error("q27 Metal: KV side store codec must be 0 (fp16) or 1 (e4m3)");
+    const MetalBuffer& kb = metal_buffer(k); const MetalBuffer& vb = metal_buffer(v);
+    MetalBuffer& kc = metal_buffer(k_side); MetalBuffer& vc = metal_buffer(v_side);
+    const uint64_t src_off = (uint64_t)head_offset_elems * 4;
+    const uint64_t src_need = ((uint64_t)(tokens - 1) * src_stride + row_length) * 4;
+    check_range(kb.size(), src_off, src_need, "KV side store K rows");
+    check_range(vb.size(), src_off, src_need, "KV side store V rows");
+    check_range(kc.size(), (uint64_t)position * row_length * 2, (uint64_t)row_length * tokens * 2, "K side cache");
+    check_range(vc.size(), (uint64_t)position * row_length * 2, (uint64_t)row_length * tokens * 2, "V side cache");
+    KvStoreHeadRowsArgs args{position, src_stride, row_length, tokens, codec};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_kv_store_f16_head_rows");
+        [enc setComputePipelineState:impl_->kv_store_head_rows];
+        [enc setBuffer:kb.handle() offset:(NSUInteger)src_off atIndex:0];
+        [enc setBuffer:vb.handle() offset:(NSUInteger)src_off atIndex:1];
+        [enc setBuffer:kc.handle() offset:0 atIndex:2]; [enc setBuffer:vc.handle() offset:0 atIndex:3];
+        [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreads:MTLSizeMake(row_length,tokens,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if (own) impl_->finish_command("KV side store");
+    }
+}
+
+void MetalBackend::attention_f16_window(const BackendBuffer& q, uint32_t q_stride, uint32_t qh_start,
+                                        const BackendBuffer& k_side, const BackendBuffer& v_side,
+                                        BackendBuffer& out, uint32_t seq_len,
+                                        uint32_t win_heads, uint32_t head_dim, float scale) {
+    if (!seq_len || !win_heads || !head_dim || head_dim > 256)
+        throw std::runtime_error("q27 Metal: invalid window attention dimensions");
+    const MetalBuffer& qb=metal_buffer(q); const MetalBuffer& kc=metal_buffer(k_side); const MetalBuffer& vc=metal_buffer(v_side);
+    MetalBuffer& output=metal_buffer(out);
+    const uint64_t q_off = (uint64_t)qh_start * q_stride * 4;
+    const uint64_t out_off = (uint64_t)qh_start * head_dim * 4;
+    check_range(qb.size(), q_off, ((uint64_t)(win_heads-1)*q_stride+head_dim)*4, "window attention Q");
+    const uint64_t cache_bytes=(uint64_t)seq_len*head_dim*2;
+    check_range(kc.size(),0,cache_bytes,"window K side"); check_range(vc.size(),0,cache_bytes,"window V side");
+    check_range(output.size(),out_off,(uint64_t)win_heads*head_dim*4,"window attention output");
+    AttentionArgs args{q_stride,seq_len,win_heads,1,head_dim,scale};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_attention_f16_window"); [enc setComputePipelineState:impl_->attention];
+        [enc setBuffer:qb.handle() offset:(NSUInteger)q_off atIndex:0];
+        [enc setBuffer:kc.handle() offset:0 atIndex:1]; [enc setBuffer:vc.handle() offset:0 atIndex:2];
+        [enc setBuffer:output.handle() offset:(NSUInteger)out_off atIndex:3];
+        [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake(win_heads,1,1) threadsPerThreadgroup:MTLSizeMake(kReduceThreads,1,1)];
+        if(own) impl_->finish_command("window FP16 attention");
+    }
+}
+
+void MetalBackend::attention_f16_causal_window(const BackendBuffer& q, uint32_t q_stride, uint32_t q_row_stride,
+                                               uint32_t qh_start, const BackendBuffer& k_side,
+                                               const BackendBuffer& v_side, BackendBuffer& out,
+                                               uint32_t out_row_stride, uint32_t base_len_plus_1,
+                                               uint32_t win_heads, uint32_t head_dim,
+                                               uint32_t tokens, float scale) {
+    if (!tokens || tokens > 96 || !win_heads || !head_dim || head_dim > 256 || !base_len_plus_1)
+        throw std::runtime_error("q27 Metal: invalid window causal attention dimensions");
+    const MetalBuffer& qb=metal_buffer(q); const MetalBuffer& kc=metal_buffer(k_side); const MetalBuffer& vc=metal_buffer(v_side);
+    MetalBuffer& output=metal_buffer(out);
+    const uint64_t q_off = (uint64_t)qh_start * q_stride * 4;
+    const uint64_t out_off = (uint64_t)qh_start * head_dim * 4;
+    check_range(qb.size(), q_off, ((uint64_t)(tokens-1)*q_row_stride+(uint64_t)(win_heads-1)*q_stride+head_dim)*4, "window causal Q");
+    const uint64_t cache_bytes=(uint64_t)(base_len_plus_1+tokens-1)*head_dim*2;
+    check_range(kc.size(),0,cache_bytes,"window causal K side"); check_range(vc.size(),0,cache_bytes,"window causal V side");
+    check_range(output.size(),out_off,((uint64_t)(tokens-1)*out_row_stride+(uint64_t)win_heads*head_dim)*4,"window causal output");
+    AttentionCausalWinArgs args{q_stride,q_row_stride,base_len_plus_1,win_heads,1,head_dim,tokens,out_row_stride,scale};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own, "q27_attention_f16_causal_win"); [enc setComputePipelineState:impl_->attention_causal_win];
+        [enc setBuffer:qb.handle() offset:(NSUInteger)q_off atIndex:0];
+        [enc setBuffer:kc.handle() offset:0 atIndex:1]; [enc setBuffer:vc.handle() offset:0 atIndex:2];
+        [enc setBuffer:output.handle() offset:(NSUInteger)out_off atIndex:3];
+        [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake(win_heads,tokens,1) threadsPerThreadgroup:MTLSizeMake(kReduceThreads,1,1)];
+        if(own) impl_->finish_command("window causal FP16 attention");
+    }
+}
+
 void MetalBackend::kv_store_turbo3_rows(const BackendBuffer& k, const BackendBuffer& v,
                                         BackendBuffer& k_cache, BackendBuffer& v_cache,
                                         uint32_t position, uint32_t kv_heads, uint32_t tokens) {
-    if (!kv_heads || !tokens || tokens > 12)
+    if (!kv_heads || !tokens || tokens > 96)
         throw std::runtime_error("q27 Metal: invalid chunked turbo3 KV store");
     const MetalBuffer& kb = metal_buffer(k); const MetalBuffer& vb = metal_buffer(v);
     MetalBuffer& kc = metal_buffer(k_cache); MetalBuffer& vc = metal_buffer(v_cache);
@@ -1666,7 +2111,7 @@ void MetalBackend::kv_store_turbo3_rows(const BackendBuffer& k, const BackendBuf
         [enc setBuffer:kc.handle() offset:0 atIndex:2]; [enc setBuffer:vc.handle() offset:0 atIndex:3];
         [enc setBytes:&args length:sizeof(args) atIndex:4];
         [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)kv_heads*2,2,tokens)
-                threadsPerThreadgroup:MTLSizeMake(128,1,1)];
+                threadsPerThreadgroup:MTLSizeMake(kTurboThreads,1,1)];
         if (own) impl_->finish_command("chunked turbo3 KV store");
     }
 }
@@ -1677,9 +2122,8 @@ void MetalBackend::attention_f16_causal(const BackendBuffer& q, uint32_t q_strid
                                         BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
                                         uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
                                         float scale, BackendBuffer* partials) {
-    (void)partials;
     if (!base_len || !kv_heads || q_heads % kv_heads || !head_dim || head_dim > 256 ||
-        !tokens || tokens > 12)
+        !tokens || tokens > 96)
         throw std::runtime_error("q27 Metal: invalid chunked attention dimensions");
     if (base_len > UINT32_MAX - (tokens - 1))
         throw std::runtime_error("q27 Metal: chunked attention sequence length overflow");
@@ -1694,14 +2138,34 @@ void MetalBackend::attention_f16_causal(const BackendBuffer& q, uint32_t q_strid
     check_range(kc.size(), 0, cache_bytes, "chunked attention K cache");
     check_range(vc.size(), 0, cache_bytes, "chunked attention V cache");
     check_range(output.size(), 0, (uint64_t)tokens * q_heads * head_dim * 4, "chunked attention output");
-    AttentionCausalArgs args{q_stride, q_row_stride, base_len, q_heads, kv_heads, head_dim, tokens, scale};
+    // Each chunk row must take the same path serial decode takes at that
+    // row's sequence length, or chunked prefill and serial ingestion diverge
+    // at the threshold. Rows past the threshold go to the GQA kernels; a
+    // chunk straddling it splits into two dispatches.
+    const uint32_t gqa = q_heads / kv_heads;
+    uint32_t gqa_from = tokens;
+    if (impl_->gqa_threshold && gqa >= 2 && gqa <= 8)
+        gqa_from = base_len >= impl_->gqa_threshold ? 0
+                 : std::min(tokens, impl_->gqa_threshold - base_len);
+    if (gqa_from < tokens) {
+        if (!partials)
+            throw std::runtime_error("q27 Metal: blocked GQA route needs a partials buffer");
+        impl_->attention_gqa_causal_dispatch(false, qb, q_stride, q_row_stride, kc, vc, output,
+                                             base_len + gqa_from, q_heads, kv_heads, head_dim,
+                                             tokens - gqa_from, scale,
+                                             (uint64_t)gqa_from * q_row_stride * 4,
+                                             (uint64_t)gqa_from * q_heads * head_dim * 4,
+                                             metal_buffer(*partials));
+        if (gqa_from == 0) return;
+    }
+    AttentionCausalArgs args{q_stride, q_row_stride, base_len, q_heads, kv_heads, head_dim, gqa_from, scale};
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own, "q27_attention_f16_causal");
         [enc setComputePipelineState:impl_->attention_causal];
         [enc setBuffer:qb.handle() offset:0 atIndex:0]; [enc setBuffer:kc.handle() offset:0 atIndex:1];
         [enc setBuffer:vc.handle() offset:0 atIndex:2];
         [enc setBuffer:output.handle() offset:0 atIndex:3]; [enc setBytes:&args length:sizeof(args) atIndex:4];
-        [enc dispatchThreadgroups:MTLSizeMake(q_heads,tokens,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        [enc dispatchThreadgroups:MTLSizeMake(q_heads,gqa_from,1) threadsPerThreadgroup:MTLSizeMake(kReduceThreads,1,1)];
         if (own) impl_->finish_command("chunked FP16 attention");
     }
 }
@@ -1712,8 +2176,7 @@ void MetalBackend::attention_turbo3_causal(const BackendBuffer& q, uint32_t q_st
                                            BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
                                            uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
                                            float scale, BackendBuffer* partials) {
-    (void)partials;
-    if (!base_len || !kv_heads || q_heads % kv_heads || head_dim != 256 || !tokens || tokens > 12)
+    if (!base_len || !kv_heads || q_heads % kv_heads || head_dim != 256 || !tokens || tokens > 96)
         throw std::runtime_error("q27 Metal: invalid chunked turbo3 attention dimensions");
     if (base_len > UINT32_MAX - (tokens - 1))
         throw std::runtime_error("q27 Metal: chunked attention sequence length overflow");
@@ -1728,21 +2191,41 @@ void MetalBackend::attention_turbo3_causal(const BackendBuffer& q, uint32_t q_st
     check_range(kc.size(), 0, cache_bytes, "chunked turbo3 K cache");
     check_range(vc.size(), 0, cache_bytes, "chunked turbo3 V cache");
     check_range(output.size(), 0, (uint64_t)tokens * q_heads * head_dim * 4, "chunked turbo3 attention output");
-    AttentionCausalArgs args{q_stride, q_row_stride, base_len, q_heads, kv_heads, head_dim, tokens, scale};
+    // Each chunk row must take the same path serial decode takes at that
+    // row's sequence length, or chunked prefill and serial ingestion diverge
+    // at the threshold. Rows past the threshold go to the GQA kernels; a
+    // chunk straddling it splits into two dispatches.
+    const uint32_t gqa = q_heads / kv_heads;
+    uint32_t gqa_from = tokens;
+    if (impl_->gqa_threshold && gqa >= 2 && gqa <= 8)
+        gqa_from = base_len >= impl_->gqa_threshold ? 0
+                 : std::min(tokens, impl_->gqa_threshold - base_len);
+    if (gqa_from < tokens) {
+        if (!partials)
+            throw std::runtime_error("q27 Metal: blocked GQA route needs a partials buffer");
+        impl_->attention_gqa_causal_dispatch(true, qb, q_stride, q_row_stride, kc, vc, output,
+                                             base_len + gqa_from, q_heads, kv_heads, head_dim,
+                                             tokens - gqa_from, scale,
+                                             (uint64_t)gqa_from * q_row_stride * 4,
+                                             (uint64_t)gqa_from * q_heads * head_dim * 4,
+                                             metal_buffer(*partials));
+        if (gqa_from == 0) return;
+    }
+    AttentionCausalArgs args{q_stride, q_row_stride, base_len, q_heads, kv_heads, head_dim, gqa_from, scale};
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own, "q27_attention_turbo3_causal");
         [enc setComputePipelineState:impl_->attention_turbo3_causal_p];
         [enc setBuffer:qb.handle() offset:0 atIndex:0]; [enc setBuffer:kc.handle() offset:0 atIndex:1];
         [enc setBuffer:vc.handle() offset:0 atIndex:2];
         [enc setBuffer:output.handle() offset:0 atIndex:3]; [enc setBytes:&args length:sizeof(args) atIndex:4];
-        [enc dispatchThreadgroups:MTLSizeMake(q_heads,tokens,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        [enc dispatchThreadgroups:MTLSizeMake(q_heads,gqa_from,1) threadsPerThreadgroup:MTLSizeMake(kReduceThreads,1,1)];
         if (own) impl_->finish_command("chunked turbo3 attention");
     }
 }
 
 void MetalBackend::sigmoid_gate_mul_rows(BackendBuffer& out, const BackendBuffer& qg,
                                          uint32_t heads, uint32_t head_dim, uint32_t tokens) {
-    if (!heads || !head_dim || !tokens || tokens > 12)
+    if (!heads || !head_dim || !tokens || tokens > 96)
         throw std::runtime_error("q27 Metal: invalid chunked sigmoid gate");
     MetalBuffer& o = metal_buffer(out); const MetalBuffer& gates = metal_buffer(qg);
     const uint64_t n = (uint64_t)heads * head_dim * tokens;
@@ -1761,7 +2244,9 @@ void MetalBackend::sigmoid_gate_mul_rows(BackendBuffer& out, const BackendBuffer
 
 void MetalBackend::argmax_rows(const BackendBuffer& x, uint32_t n, uint32_t rows,
                                BackendBuffer& out_indices) {
-    if (!n || !rows || rows > 12) throw std::runtime_error("q27 Metal: invalid chunked argmax");
+    // Cap matches VERIFY_CHUNK_MAX (lever 2): the verify/oracle path argmaxes
+    // up to 48 rows; the kernel is one threadgroup per row, width-agnostic.
+    if (!n || !rows || rows > 48) throw std::runtime_error("q27 Metal: invalid chunked argmax");
     const MetalBuffer& input = metal_buffer(x); MetalBuffer& output = metal_buffer(out_indices);
     check_range(input.size(), 0, (uint64_t)n * rows * 4, "chunked argmax input");
     check_range(output.size(), 0, (uint64_t)rows * 4, "chunked argmax output");
@@ -1780,15 +2265,14 @@ void MetalBackend::argmax_rows(const BackendBuffer& x, uint32_t n, uint32_t rows
 void MetalBackend::nll_rows(const BackendBuffer& logits, const BackendBuffer& targets,
                             BackendBuffer& nll, uint32_t n, uint32_t rows) {
     if (!n || !rows) throw std::runtime_error("q27 Metal: invalid NLL shape");
-    const uint64_t elements = uint64_t(n) * rows;
-    if (elements > UINT64_MAX / 4)
-        throw std::runtime_error("q27 Metal: size overflow in NLL logits");
+    const uint64_t elements = checked_mul((uint64_t)n, rows, "NLL logits");
+    const uint64_t logits_bytes = checked_mul(elements, 4, "NLL logits");
     const MetalBuffer& input = metal_buffer(logits);
     const MetalBuffer& tgt = metal_buffer(targets);
     MetalBuffer& out = metal_buffer(nll);
-    check_range(input.size(), 0, elements * 4, "NLL logits");
-    check_range(tgt.size(), 0, uint64_t(rows) * 4, "NLL targets");
-    check_range(out.size(), 0, uint64_t(rows) * 4, "NLL output");
+    check_range(input.size(), 0, logits_bytes, "NLL logits");
+    check_range(tgt.size(), 0, (uint64_t)rows * 4, "NLL targets");
+    check_range(out.size(), 0, (uint64_t)rows * 4, "NLL output");
     struct NllRowsArgs { uint32_t n; uint32_t rows; } args{n, rows};
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own, "q27_nll_rows");
@@ -1804,7 +2288,7 @@ void MetalBackend::nll_rows(const BackendBuffer& logits, const BackendBuffer& ta
 }
 
 void MetalBackend::synchronize() {
-    impl_->ensure_healthy();
+    impl_->require_healthy();
     @autoreleasepool {
         if (impl_->batching)
             throw std::runtime_error("q27 Metal: end command batch before synchronizing");
@@ -1813,10 +2297,8 @@ void MetalBackend::synchronize() {
         [command commit];
         [command waitUntilCompleted];
         if (command.status == MTLCommandBufferStatusError) {
-            std::string message = "q27 Metal: synchronization failed";
-            if (command.error) message += ": " + std::string(command.error.localizedDescription.UTF8String);
-            impl_->poison(message);
-            throw std::runtime_error(message);
+            impl_->poisoned = true;
+            throw std::runtime_error("q27 Metal: synchronization failed; recreate the engine");
         }
     }
 }
@@ -1833,10 +2315,25 @@ uint64_t MetalBackend::recommended_working_set_size() const {
     return (uint64_t)impl_->device.recommendedMaxWorkingSetSize;
 }
 
+uint64_t MetalBackend::current_allocated_size() const {
+    return (uint64_t)impl_->device.currentAllocatedSize;
+}
+
+uint32_t MetalBackend::gqa_block_size() const {
+    return impl_->gqa_block;
+}
+
+void MetalBackend::set_gemm_half(bool enabled) {
+    impl_->gemm_half = enabled;
+}
+
+void MetalBackend::set_gqa_threshold(uint32_t threshold) {
+    impl_->gqa_threshold = threshold;
+}
+
 uint64_t MetalBackend::max_buffer_length() const {
     return (uint64_t)impl_->device.maxBufferLength;
 }
-
 bool MetalBackend::uses_per_tensor_upload(const Model& model) const {
     if (!model.mapping_base() || !model.mapping_size())
         throw std::runtime_error("q27 Metal: invalid model view");
@@ -1847,6 +2344,7 @@ bool MetalBackend::uses_per_tensor_upload(const Model& model) const {
     const uint64_t mapped_size = (logical_size + page_size - 1) / page_size * page_size;
     return mapped_size > max_buffer_length();
 }
+
 
 bool MetalBackend::supports_quantized_matmul() const {
     return impl_->q4_quantized_matmul && impl_->q8_quantized_matmul && impl_->t2_quantized_matmul;

--- a/src/metal/metal_cli.cpp
+++ b/src/metal/metal_cli.cpp
@@ -162,8 +162,10 @@ int main(int argc, char** argv) {
         q27::MetalEngine engine(model_path, context, turbo3_kv);
         if (serial_prefill) engine.set_chunked_prefill(false);
         const auto loaded = std::chrono::steady_clock::now();
-        fprintf(stderr, "Metal q4s model ready on %s in %.2f s\n", engine.backend().name().c_str(),
-                std::chrono::duration<double>(loaded - start).count());
+        fprintf(stderr, "Metal q4s model ready on %s in %.2f s (shader sha1 %s)\n",
+                engine.backend().name().c_str(),
+                std::chrono::duration<double>(loaded - start).count(),
+                engine.backend().shader_source_sha1().c_str());
         if (validate_only) {
             puts("q4s artifacts and Metal architecture: OK");
             return 0;

--- a/src/metal/metal_engine.cpp
+++ b/src/metal/metal_engine.cpp
@@ -1,19 +1,28 @@
 #include "metal_engine.h"
 
 #include "../../third_party/json.hpp"
-#include "../suffixdraft.h"
 
-#include <array>
 #include <algorithm>
+#include <cassert>
+#include <cerrno>
+#include <cstddef>
 #include <chrono>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
+#include <random>
 #include <stdexcept>
+
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <CommonCrypto/CommonDigest.h>
 
 namespace q27 {
 namespace {
-
 
 class CommandBatch {
   public:
@@ -43,8 +52,15 @@ struct MetalEngine::Snapshot {
     const MetalEngine* owner = nullptr;
     uint32_t position = 0;
     bool logits_resident = false;
+    bool mtp_cache_valid = false;
     std::vector<StoredLayer> layers;
     std::shared_ptr<BackendBuffer> mtp_k_cache, mtp_v_cache, hidden, logits;
+    // KV fp16 exception side rows (snapshot v2): flat, in kv_fp16_side_
+    // traversal order (attn_idx asc, head asc), K then V per masked head.
+    // Empty when the engine has no exception cells or position was 0. The
+    // owner check pins the config: a Snapshot never crosses engines, so
+    // the side layout always matches.
+    std::vector<std::shared_ptr<BackendBuffer>> kv_side;
 };
 
 std::shared_ptr<BackendBuffer> MetalEngine::alloc_f32(uint64_t count) {
@@ -170,30 +186,200 @@ void MetalEngine::validate_architecture() const {
     matrix(p + "ffn_down.weight", DType::Q8_G128, N_EMBD, N_FFN);
 }
 
-MetalEngine::MetalEngine(const std::string& model_path, uint32_t context, bool turbo3_kv)
-    : model_(Model::open(model_path)), max_context_(context), turbo3_kv_(turbo3_kv) {
-    if (!context || context > 262144) throw std::runtime_error("q27 Metal: context must be 1..262144");
-    validate_architecture();
-    has_mtp_ = model_.find("blk.64.attn_norm.weight") != nullptr;
-    const uint64_t cache_row_bytes = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
-                                                : (uint64_t)N_KV * HEAD_DIM * 2;
-    const uint64_t total_cache_bytes =
-        (16ull + (has_mtp_ ? 1 : 0)) * 2 * max_context_ * cache_row_bytes;
-    if (total_cache_bytes > backend_.recommended_working_set_size() / 2)
-        throw std::runtime_error("q27 Metal: requested KV cache is too large for this device; use --kv turbo3 or reduce --ctx");
-
-    per_tensor_upload_ = backend_.uses_per_tensor_upload(model_);
+std::shared_ptr<MetalEngine::Shared> MetalEngine::open_shared(const std::string& model_path) {
+    auto shared = std::make_shared<Shared>(Model::open(model_path));
+    shared->path = model_path;
+    const bool per_tensor = shared->backend.uses_per_tensor_upload(shared->model);
     constexpr double gibibyte = 1024.0 * 1024.0 * 1024.0;
     std::fprintf(stderr,
                  "q27 Metal: model upload path: %s (mapping %.2f GiB, max buffer %.2f GiB)\n",
-                 per_tensor_upload_ ? "per-tensor" : "whole-mapping",
-                 model_.mapping_size() / gibibyte,
-                 backend_.max_buffer_length() / gibibyte);
+                 per_tensor ? "per-tensor" : "whole-mapping",
+                 shared->model.mapping_size() / gibibyte,
+                 shared->backend.max_buffer_length() / gibibyte);
+    return shared;
+}
 
-    // All wrappers alias the mmap. No weight-sized copy is created.
-    weights_.reserve(model_.tensors.size());
-    for (const Tensor& tensor : model_.tensors)
-        weights_.emplace(tensor.name, backend_.upload(model_, tensor));
+// Return this engine's KV budget to the mapping so later engines on a
+// still-live Shared are not falsely rejected. The assertion catches a
+// double return or accounting underflow; the runtime check below prevents
+// a silent wrap in release builds.
+MetalEngine::~MetalEngine() {
+    assert(shared_->cache_bytes >= engine_cache_bytes_ && "KV reservation underflow");
+    // Destructors cannot throw, so clamp and log rather than wrapping.
+    if (shared_->cache_bytes < engine_cache_bytes_) {
+        fprintf(stderr, "q27 Metal: KV reservation underflow — double return?\n");
+        shared_->cache_bytes = 0;
+    } else {
+        shared_->cache_bytes -= engine_cache_bytes_;
+    }
+}
+
+int MetalEngine::mask_pool_add(const void* bits) {
+    constexpr uint64_t words = ((uint64_t)VOCAB + 31) / 32;
+    if (!bits) throw std::runtime_error("q27 Metal: null constraint mask");
+    if (mask_pool_used >= MASK_POOL_CAP) return -1;
+    if (!mask_pool_) mask_pool_ = backend_.allocate(words * 4 * MASK_POOL_CAP);
+    backend_.write(*mask_pool_, (uint64_t)mask_pool_used * words * 4, bits, words * 4);
+    return mask_pool_used++;
+}
+
+void MetalEngine::reset_mask_pool() {
+    active_mask_ = -1;
+    mask_pool_used = 0;
+}
+
+void MetalEngine::set_tool_constraint(int mask_id) {
+    if (mask_id >= mask_pool_used)
+        throw std::runtime_error("q27 Metal: constraint mask id out of range");
+    active_mask_ = mask_id < 0 ? -1 : mask_id;
+}
+
+namespace {
+std::shared_ptr<MetalEngine::Shared> require_shared(std::shared_ptr<MetalEngine::Shared> shared) {
+    if (!shared) throw std::runtime_error("q27 Metal: null shared context");
+    return shared;
+}
+
+struct ProductionKvSideConfig {
+    std::array<uint8_t,16> head_masks{};
+    uint64_t heads=0;
+    uint32_t codec=0;
+};
+
+ProductionKvSideConfig production_kv_side_config(bool turbo3,bool log_ignored) {
+    ProductionKvSideConfig config;
+    const char* cells_env=getenv("Q27_METAL_KV_FP16_CELLS");
+    if(cells_env) {
+        if(turbo3) {
+            uint8_t side_masks[16][4] = {};
+            const std::string list(cells_env);
+            size_t at=0;
+            while(at<list.size()) {
+                size_t comma=list.find(',',at);
+                if(comma==std::string::npos) comma=list.size();
+                const std::string field=list.substr(at,comma-at);
+                size_t used=0;
+                const unsigned long cell=std::stoul(field,&used);
+                if(used!=field.size())
+                    throw std::runtime_error("q27 Metal: malformed Q27_METAL_KV_FP16_CELLS entry: "+field);
+                if(cell>=128)
+                    throw std::runtime_error("q27 Metal: Q27_METAL_KV_FP16_CELLS cells must be 0..127");
+                side_masks[cell>>3][(cell>>1)&3] |= uint8_t(1u<<(cell&1u));
+                at=comma+1;
+            }
+            for(uint32_t li=0;li<16;li++)
+                for(uint32_t h=0;h<4;h++) {
+                    if(side_masks[li][h]==0) continue;
+                    if(side_masks[li][h]!=3)
+                        throw std::runtime_error("q27 Metal: Q27_METAL_KV_FP16_CELLS v1 needs a head's K and V cells together (step 4b: only the pair is protective)");
+                    config.head_masks[li] |= uint8_t(1u<<h);
+                    config.heads++;
+                }
+        } else if(log_ignored) {
+            fprintf(stderr,"q27 Metal: Q27_METAL_KV_FP16_CELLS ignored on an fp16-KV engine (cells already fp16)\n");
+        }
+    }
+    if(const char* codec_env=getenv("Q27_METAL_KV_CELLS_CODEC")) {
+        const std::string codec(codec_env);
+        if(codec!="fp16" && codec!="e4m3")
+            throw std::runtime_error("q27 Metal: Q27_METAL_KV_CELLS_CODEC must be fp16 or e4m3");
+        if(codec=="e4m3") {
+            if(!config.heads)
+                throw std::runtime_error("q27 Metal: Q27_METAL_KV_CELLS_CODEC=e4m3 needs a non-empty Q27_METAL_KV_FP16_CELLS (nothing to encode)");
+            config.codec=1;
+        }
+    }
+    return config;
+}
+} // namespace
+
+uint64_t MetalEngine::serving_reservation_bytes(const Shared& shared,uint32_t context,
+                                                bool turbo3_kv,size_t snapshot_entries) {
+    if(!context || context>262144)
+        throw std::runtime_error("q27 Metal: context must be 1..262144");
+    const bool has_mtp=shared.model.find("blk.64.attn_norm.weight")!=nullptr;
+    const bool chunked=shared.backend.supports_quantized_matmul() && has_mtp;
+    const auto side=production_kv_side_config(turbo3_kv,false);
+    const uint64_t cache_row=turbo3_kv ? (uint64_t)N_KV*2*50
+                                         : (uint64_t)N_KV*HEAD_DIM*2;
+    const uint64_t side_bytes=side.heads*2ull*context*HEAD_DIM*2;
+    const uint64_t cache_bytes=(16ull+(has_mtp?1ull:0ull))*2*context*cache_row+
+        gqa_partial_peak(context,shared.backend.gqa_block_size(),chunked)+side_bytes;
+    const uint64_t attn_layers=N_LAYER/4, gdn_layers=N_LAYER-attn_layers;
+    const uint64_t active=(uint64_t)context*cache_row;
+    uint64_t snapshot=gdn_layers*((uint64_t)GDN_HEADS*GDN_DIM*GDN_DIM+3ull*GDN_CH)*4;
+    snapshot+=attn_layers*2*active;
+    if(has_mtp) snapshot+=2*active;
+    snapshot+=(uint64_t)N_EMBD*4+(uint64_t)VOCAB*4+side_bytes;
+    const uint64_t base=cache_bytes+fixed_state_bytes(chunked,has_mtp);
+    if(snapshot_entries && snapshot>(UINT64_MAX-base)/snapshot_entries) return UINT64_MAX;
+    return base+(uint64_t)snapshot_entries*snapshot;
+}
+
+MetalEngine::MetalEngine(const std::string& model_path, uint32_t context, bool turbo3_kv)
+    : MetalEngine(open_shared(model_path), context, turbo3_kv) {}
+
+MetalEngine::MetalEngine(std::shared_ptr<Shared> shared, uint32_t context, bool turbo3_kv)
+    : shared_(require_shared(std::move(shared))), model_(shared_->model),
+      backend_(shared_->backend), max_context_(context), turbo3_kv_(turbo3_kv),
+      weights_(shared_->weights) {
+    if (!context || context > 262144) throw std::runtime_error("q27 Metal: context must be 1..262144");
+    validate_architecture();
+    per_tensor_upload_ = backend_.uses_per_tensor_upload(model_);
+    has_mtp_ = model_.find("blk.64.attn_norm.weight") != nullptr;
+    const uint64_t cache_row_bytes = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
+                                                : (uint64_t)N_KV * HEAD_DIM * 2;
+    // Per-engine blocked-GQA partials (audit E2): sized once here for this
+    // engine's own context at the widest attention width this device can
+    // dispatch, and reserved alongside the caches — it is the other
+    // ctx-scaled allocation. Sizing deliberately ignores the GQA threshold:
+    // the envelope instrument flips it at runtime, which must only change
+    // routing, never invalidate the buffer.
+    const bool chunk_capable = backend_.supports_quantized_matmul() && has_mtp_;
+    const uint64_t partial_bytes =
+        gqa_partial_peak(max_context_, backend_.gqa_block_size(), chunk_capable);
+    // Production KV fp16 exception cells
+    // (docs/metal/plans/2026-07-17-kv-except-production.md): parse the env once
+    // here so the side-cache bytes join the same reservation. Cells use
+    // census numbering (attn_idx*8 + head*2 + side); v1 requires a head's K
+    // and V cells together (step 4b: K alone retains nothing, V alone
+    // amplifies — only the pair is meaningful). fp16-KV engines ignore the
+    // env (their cells are already fp16), so the kl-kv baseline coexists.
+    const auto side_config=production_kv_side_config(turbo3_kv_,true);
+    for(uint32_t li=0;li<16;li++) kv_fp16_head_masks_[li]=side_config.head_masks[li];
+    kv_fp16_except_=side_config.heads!=0;
+    kv_fp16_side_codec_=side_config.codec;
+    const uint64_t kv_side_bytes=side_config.heads*2ull*max_context_*HEAD_DIM*2;
+    const uint64_t total_cache_bytes =
+        (16ull + (has_mtp_ ? 1 : 0)) * 2 * max_context_ * cache_row_bytes
+        + partial_bytes + kv_side_bytes;
+    // Budget the combined caches of every engine on this mapping, not just
+    // this one. Shared defaults to half the device recommendation; serving
+    // callers may install an explicit policy ceiling before constructing.
+    if(shared_->cache_bytes+total_cache_bytes>shared_->cache_budget)
+        throw std::runtime_error("q27 Metal: requested KV cache (across engines on this mapping) exceeds the configured cache budget; use --kv turbo3, raise --budget-mb, or reduce --ctx");
+    // The destructor runs only for fully constructed engines, so a throw in
+    // any allocation below would otherwise strand this reservation and
+    // falsely reject later engines on a still-live Shared. Roll back unless
+    // construction completes; Shared is single-threaded by contract.
+    struct ReservationGuard {
+        Shared& shared;
+        uint64_t bytes;
+        bool committed = false;
+        ~ReservationGuard() { if (!committed) shared.cache_bytes -= bytes; }
+    } reservation{*shared_, total_cache_bytes};
+    shared_->cache_bytes += total_cache_bytes;
+    engine_cache_bytes_ = total_cache_bytes;
+
+    // All wrappers alias the mmap. Build the shared cache transactionally so
+    // an upload failure cannot leave later engines with a partial map.
+    if (shared_->weights.empty()) {
+        std::unordered_map<std::string, BackendTensor> uploaded;
+        uploaded.reserve(model_.tensors.size());
+        for (const Tensor& tensor : model_.tensors)
+            uploaded.emplace(tensor.name, backend_.upload(model_, tensor));
+        shared_->weights = std::move(uploaded);
+    }
 
     layers_.resize(N_LAYER);
     for (uint32_t layer = 0; layer < N_LAYER; layer++) {
@@ -215,6 +401,14 @@ MetalEngine::MetalEngine(const std::string& model_path, uint32_t context, bool t
     conv_out_ = alloc_f32(GDN_CH); delta_out_ = alloc_f32(GDN_V); gated_out_ = alloc_f32(GDN_V);
     ffn_gate_ = alloc_f32(N_FFN); ffn_up_ = alloc_f32(N_FFN);
     logits_ = alloc_f32(VOCAB); token_out_ = backend_.allocate(sizeof(uint32_t));
+    topk_values_ = alloc_f32(TOPK_CAPACITY);
+    topk_indices_ = backend_.allocate(TOPK_CAPACITY * sizeof(uint32_t));
+    topk_count_ = backend_.allocate(sizeof(uint32_t));
+    token_ring_ = backend_.allocate(RESIDENT_MAX * sizeof(uint32_t));
+    if (const char* env = getenv("Q27_METAL_GPU_SAMPLE"); env && *env)
+        gpu_sample_ = strtoul(env, nullptr, 10) != 0;
+    if (const char* env = getenv("Q27_METAL_RESIDENT"); env && *env)
+        resident_ = strtoul(env, nullptr, 10) != 0;
     if (has_mtp_) {
         mtp_embed_norm_ = alloc_f32(N_EMBD); mtp_hidden_norm_ = alloc_f32(N_EMBD);
         mtp_concat_ = alloc_f32(2 * N_EMBD); mtp_x_ = alloc_f32(N_EMBD);
@@ -225,36 +419,49 @@ MetalEngine::MetalEngine(const std::string& model_path, uint32_t context, bool t
     q5120_=backend_.allocate_quantized(N_EMBD); q6144_=backend_.allocate_quantized(GDN_V);
     q10240_=backend_.allocate_quantized(GDN_CH); q17408_=backend_.allocate_quantized(N_FFN);
 
-    // Layer-major chunked prefill routes projections through the simdgroup
-    // GEMM, so it requires the same device family. The per-chunk activation
-    // buffers total a few MiB. Every attention kernel is online-softmax now,
-    // so no probability scratch exists on any path at any context length.
-    chunked_prefill_ = backend_.supports_quantized_matmul();
+    gqa_partials_ = backend_.allocate_private(partial_bytes);
+
+    if (kv_fp16_except_)
+        for (uint32_t li = 0; li < 16; li++)
+            for (uint32_t h = 0; h < 4; h++)
+                if (kv_fp16_head_masks_[li] & (1u << h))
+                    kv_fp16_side_[li].push_back(KvFp16Side{
+                        h,
+                        backend_.allocate_private((uint64_t)max_context_ * HEAD_DIM * 2),
+                        backend_.allocate_private((uint64_t)max_context_ * HEAD_DIM * 2)});
+
+    // Layer-major chunked prefill routes every projection through
+    // activation-quantized simdgroup GEMM. The q4s artifact carries the
+    // required MTP layer, so the device-family capability is the remaining gate.
+    chunked_prefill_ = chunk_capable;
     if (chunked_prefill_) {
-        ch_ = alloc_f32((uint64_t)CHUNK_MAX * N_EMBD);
-        cx1_ = alloc_f32((uint64_t)CHUNK_MAX * N_EMBD);
-        cy_ = alloc_f32((uint64_t)CHUNK_MAX * N_EMBD);
-        cqg_ = alloc_f32((uint64_t)CHUNK_MAX * 2 * N_HEAD * HEAD_DIM);
-        ckbuf_ = alloc_f32((uint64_t)CHUNK_MAX * N_KV * HEAD_DIM);
-        cvbuf_ = alloc_f32((uint64_t)CHUNK_MAX * N_KV * HEAD_DIM);
-        cattn_out_ = alloc_f32((uint64_t)CHUNK_MAX * N_HEAD * HEAD_DIM);
-        cqkv_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_CH);
-        cz_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_V);
-        calpha_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_HEADS);
-        cbeta_raw_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_HEADS);
-        cg_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_HEADS);
-        cbeta_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_HEADS);
-        cconv_out_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_CH);
-        cdelta_out_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_V);
-        cgated_out_ = alloc_f32((uint64_t)CHUNK_MAX * GDN_V);
-        cffn_gate_ = alloc_f32((uint64_t)CHUNK_MAX * N_FFN);
-        cffn_up_ = alloc_f32((uint64_t)CHUNK_MAX * N_FFN);
-        cq5120_ = backend_.allocate_quantized(CHUNK_MAX * N_EMBD);
-        cq6144_ = backend_.allocate_quantized(CHUNK_MAX * GDN_V);
-        cq17408_ = backend_.allocate_quantized(CHUNK_MAX * N_FFN);
-        cfinal_ = alloc_f32((uint64_t)CHUNK_MAX * N_EMBD);
-        clogits_ = alloc_f32((uint64_t)CHUNK_MAX * VOCAB);
-        cpred_ = backend_.allocate((uint64_t)CHUNK_MAX * sizeof(uint32_t));
+        ch_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * N_EMBD);
+        cx1_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * N_EMBD);
+        cy_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * N_EMBD);
+        cqg_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * 2 * N_HEAD * HEAD_DIM);
+        ckbuf_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * N_KV * HEAD_DIM);
+        cvbuf_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * N_KV * HEAD_DIM);
+        cattn_out_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * N_HEAD * HEAD_DIM);
+        cqkv_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * GDN_CH);
+        cz_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * GDN_V);
+        calpha_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * GDN_HEADS);
+        cbeta_raw_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * GDN_HEADS);
+        cg_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * GDN_HEADS);
+        cbeta_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * GDN_HEADS);
+        cconv_out_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * GDN_CH);
+        cdelta_out_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * GDN_V);
+        cgated_out_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * GDN_V);
+        cffn_gate_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * N_FFN);
+        cffn_up_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * N_FFN);
+        cq5120_ = backend_.allocate_quantized(PREFILL_CHUNK_MAX * N_EMBD);
+        cq6144_ = backend_.allocate_quantized(PREFILL_CHUNK_MAX * GDN_V);
+        cq17408_ = backend_.allocate_quantized(PREFILL_CHUNK_MAX * N_FFN);
+        // Verify-width surfaces (lever 2): sized for VERIFY_CHUNK_MAX so
+        // oracle/verify rounds can run past the width-12 NLL/KL contract;
+        // the teacher-force paths keep slicing at CHUNK_MAX regardless.
+        cfinal_ = alloc_f32((uint64_t)VERIFY_CHUNK_MAX * N_EMBD);
+        clogits_ = alloc_f32((uint64_t)VERIFY_CHUNK_MAX * VOCAB);
+        cpred_ = backend_.allocate((uint64_t)VERIFY_CHUNK_MAX * sizeof(uint32_t));
         ctargets_ = backend_.allocate((uint64_t)CHUNK_MAX * sizeof(uint32_t));
         cnll_ = alloc_f32(CHUNK_MAX);
         // Batched MTP verification parks each GDN layer's chunk inputs
@@ -265,48 +472,151 @@ MetalEngine::MetalEngine(const std::string& model_path, uint32_t context, bool t
         const uint32_t gdn_layers = N_LAYER - N_LAYER / 4;
         park_qkv_.reserve(gdn_layers); park_g_.reserve(gdn_layers); park_beta_.reserve(gdn_layers);
         for (uint32_t i = 0; i < gdn_layers; i++) {
-            park_qkv_.push_back(alloc_f32((uint64_t)CHUNK_MAX * GDN_CH));
-            park_g_.push_back(alloc_f32((uint64_t)CHUNK_MAX * GDN_HEADS));
-            park_beta_.push_back(alloc_f32((uint64_t)CHUNK_MAX * GDN_HEADS));
+            park_qkv_.push_back(alloc_f32((uint64_t)VERIFY_CHUNK_MAX * GDN_CH));
+            park_g_.push_back(alloc_f32((uint64_t)VERIFY_CHUNK_MAX * GDN_HEADS));
+            park_beta_.push_back(alloc_f32((uint64_t)VERIFY_CHUNK_MAX * GDN_HEADS));
         }
         discard_recurrent_ = alloc_f32((uint64_t)GDN_HEADS * GDN_DIM * GDN_DIM);
         discard_ring_ = alloc_f32((uint64_t)3 * GDN_CH);
     }
     reset();
+    reservation.committed = true;
 }
 
 void MetalEngine::set_chunked_prefill(bool enabled) {
+    if (enabled && !has_mtp_)
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; chunked prefill is unavailable");
     if (enabled && !ch_)
         throw std::runtime_error("q27 Metal: chunked prefill requires quantized matmul support");
     chunked_prefill_ = enabled;
 }
 
+void MetalEngine::initialize_mtp_sentinel() {
+    if (!mtp_k_cache_) return;
+    static const std::array<unsigned char, N_KV * HEAD_DIM * 2> zero_row{};
+    const uint64_t row_bytes = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
+                                          : (uint64_t)N_KV * HEAD_DIM * 2;
+    backend_.write(*mtp_k_cache_, 0, zero_row.data(), row_bytes);
+    backend_.write(*mtp_v_cache_, 0, zero_row.data(), row_bytes);
+}
+
 void MetalEngine::reset() {
     position_ = 0;
     logits_resident_ = false;
+    mtp_cache_valid_ = false;
     for (LayerState& layer : layers_) {
         if (layer.recurrent) backend_.zero(*layer.recurrent);
         if (layer.ring) backend_.zero(*layer.ring);
         // KV rows are written before they become visible through position_;
         // clearing the full reserved context would make long-context reset O(ctx).
     }
-    // MTP attention includes row 0, but there is no predecessor hidden state
-    // from which to warm it. Keep that permanent sentinel deterministic while
-    // leaving the remaining O(context) cache rows write-before-visible.
+    // MTP attention at the first generated token reads row 0. A reset must
+    // establish that sentinel without making reset O(context).
     if (mtp_k_cache_) {
-        std::array<uint8_t, N_KV * HEAD_DIM * sizeof(uint16_t)> zero_row{};
-        const uint64_t cache_row = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
-                                              : zero_row.size();
-        backend_.write(*mtp_k_cache_, 0, zero_row.data(), cache_row);
-        backend_.write(*mtp_v_cache_, 0, zero_row.data(), cache_row);
+        initialize_mtp_sentinel();
+        mtp_cache_valid_ = true;
     }
+}
+
+// G6 admission accounting. snapshot_bytes mirrors capture_state()'s
+// allocations at worst case (position_ == max_context_); fixed_state_bytes
+// mirrors every persistent constructor allocation outside KV/GQA storage,
+// plus the serving-path lazy mask and wide-head buffers. gqa_partial_peak
+// mirrors the constructor's own per-engine partials allocation (audit E2).
+// Keep each term paired with its allocation site.
+uint64_t MetalEngine::snapshot_bytes() const {
+    const uint64_t cache_row = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
+                                          : (uint64_t)N_KV * HEAD_DIM * 2;
+    const uint64_t active = (uint64_t)max_context_ * cache_row;
+    const uint64_t attn_layers = N_LAYER / 4, gdn_layers = N_LAYER - attn_layers;
+    uint64_t bytes = gdn_layers * ((uint64_t)GDN_HEADS * GDN_DIM * GDN_DIM + 3ull * GDN_CH) * 4;
+    bytes += attn_layers * 2 * active;
+    if (has_mtp_) bytes += 2 * active;
+    bytes += (uint64_t)N_EMBD * 4 + (uint64_t)VOCAB * 4;   // hidden + logits
+    // Exception side rows (snapshot v2): K + V fp16 per masked head.
+    uint64_t side_entries = 0;
+    for (const auto& sides : kv_fp16_side_) side_entries += sides.size();
+    bytes += side_entries * 2ull * max_context_ * HEAD_DIM * 2;
+    return bytes;
+}
+
+uint64_t MetalEngine::fixed_state_bytes(bool chunked,bool has_mtp) {
+    const uint64_t attn_layers = N_LAYER / 4, gdn_layers = N_LAYER - attn_layers;
+    (void)attn_layers;
+    // Live GDN recurrence state (recurrent + conv ring per GDN layer).
+    uint64_t bytes = gdn_layers *
+        ((uint64_t)GDN_HEADS * GDN_DIM * GDN_DIM + 3ull * GDN_CH) * 4;
+    // Serial f32 surfaces: h/x1/y, qg, K/V, attention output, GDN
+    // qkv/z/gates/outputs, FFN gate/up, and main logits.
+    const uint64_t serial_f32 =
+        3ull * N_EMBD +
+        2ull * N_HEAD * HEAD_DIM +
+        2ull * N_KV * HEAD_DIM +
+        (uint64_t)N_HEAD * HEAD_DIM +
+        2ull * GDN_CH + 3ull * GDN_V + 4ull * GDN_HEADS +
+        2ull * N_FFN + VOCAB;
+    bytes += serial_f32 * 4;
+    // Serial activation-quantization values and per-32 scales.
+    bytes += (uint64_t)(N_EMBD + GDN_V + GDN_CH + N_FFN) * 9 / 8;
+    // Token output/ring and top-k candidate staging.
+    bytes += 4 + (uint64_t)RESIDENT_MAX * 4;
+    bytes += (uint64_t)TOPK_CAPACITY * (4 + 4) + 4;
+    // Constraint-mask pool at capacity (lazy in mask_pool_add).
+    bytes += (((uint64_t)VOCAB + 31) / 32) * 4 * MASK_POOL_CAP;
+    if (has_mtp) {
+        // MTP embed/hidden norms, concat, x, hidden output, and logits.
+        bytes += (6ull * N_EMBD + VOCAB) * 4;
+    }
+    if (!chunked) return bytes;
+    // Chunked-prefill f32 rows (ch/cx1/cy, cqg, ckbuf/cvbuf, cattn_out,
+    // cqkv, cz, alpha/beta_raw/g/beta, cconv_out, cdelta_out, cgated_out,
+    // ffn gate+up).
+    const uint64_t chunk_row = (uint64_t)N_EMBD * 3 + 2ull * N_HEAD * HEAD_DIM +
+                               2ull * N_KV * HEAD_DIM + (uint64_t)N_HEAD * HEAD_DIM +
+                               GDN_CH + GDN_V + 4ull * GDN_HEADS + GDN_CH + GDN_V + GDN_V +
+                               2ull * N_FFN;
+    bytes += (uint64_t)PREFILL_CHUNK_MAX * chunk_row * 4;
+    // Quantized activation copies (int8 values + f32 scales per 32).
+    bytes += (uint64_t)PREFILL_CHUNK_MAX * (N_EMBD + GDN_V + N_FFN) * 9 / 8;
+    // Verify surfaces: final/logits, predictions, targets, and NLL rows.
+    bytes += (uint64_t)VERIFY_CHUNK_MAX * ((uint64_t)N_EMBD + VOCAB) * 4;
+    bytes += ((uint64_t)VERIFY_CHUNK_MAX + 2ull * CHUNK_MAX) * 4;
+    // GDN replay parks (qkv + g + beta per GDN layer).
+    bytes += gdn_layers * (uint64_t)VERIFY_CHUNK_MAX *
+        (GDN_CH + 2ull * GDN_HEADS) * 4;
+    // Verify-chunk discard state slots (one shared pair per engine).
+    bytes += ((uint64_t)GDN_HEADS * GDN_DIM * GDN_DIM + 3ull * GDN_CH) * 4;
+    // Wide-head staging (lazy in teacher_force_logits_wide).
+    bytes += (uint64_t)CHUNK_MAX * N_EMBD * 4;
+    return bytes;
+}
+
+uint64_t MetalEngine::fp16_engine_reservation_bytes(uint32_t context) {
+    const uint64_t cache_row_bytes = (uint64_t)N_KV * HEAD_DIM * 2;
+    const uint64_t cache_bytes = 17ull * 2 * context * cache_row_bytes;
+    // 128 is the smallest supported Q27_METAL_GQA_BLOCK and therefore the
+    // largest possible partials allocation. Assume chunked prefill and MTP.
+    return cache_bytes + gqa_partial_peak(context, 128, true) + fixed_state_bytes(true,true);
+}
+
+uint64_t MetalEngine::gqa_partial_peak(uint32_t context, uint32_t block, bool chunked) {
+    const uint64_t b = std::max(block, 1u);
+    const uint64_t blocks = 1 + ((uint64_t)std::max(context, 1u) - 1) / b;
+    // Without chunked prefill the causal-GQA path only ever sees one query
+    // token (serial decode), so the widest partial buffer is one row.
+    // Allocated eagerly per engine (audit E2), so there is no transient
+    // allocate-then-replace coexistence to double-charge anymore.
+    const uint64_t tokens = chunked ? PREFILL_CHUNK_MAX : 1;
+    return tokens * N_HEAD * blocks * 258 * 4;
 }
 
 std::shared_ptr<MetalEngine::Snapshot> MetalEngine::capture_state() {
     backend_.synchronize();
     auto snapshot = std::make_shared<Snapshot>();
-    snapshot->owner = this; snapshot->position = position_; snapshot->layers.resize(N_LAYER);
+    snapshot->owner = this; snapshot->position = position_;
     snapshot->logits_resident = logits_resident_;
+    snapshot->mtp_cache_valid = mtp_cache_valid_;
+    snapshot->layers.resize(N_LAYER);
     const uint64_t cache_row = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
                                           : (uint64_t)N_KV * HEAD_DIM * 2;
     const uint64_t active_cache = (uint64_t)position_ * cache_row;
@@ -324,6 +634,19 @@ std::shared_ptr<MetalEngine::Snapshot> MetalEngine::capture_state() {
     }
     snapshot->hidden=backend_.allocate(x1_->size()); backend_.copy(*x1_,0,*snapshot->hidden,0,x1_->size());
     snapshot->logits=backend_.allocate(logits_->size()); backend_.copy(*logits_,0,*snapshot->logits,0,logits_->size());
+    // Exception side rows ride the snapshot (v2): copy() is a GPU kernel,
+    // so the private side caches are reachable; destinations are ordinary
+    // shared buffers like every other snapshot blob.
+    const uint64_t side_active=(uint64_t)position_*HEAD_DIM*2;
+    if(kv_fp16_except_ && side_active)
+        for(uint32_t li=0;li<16;li++)
+            for(const KvFp16Side& side : kv_fp16_side_[li]) {
+                auto k=backend_.allocate(side_active), v=backend_.allocate(side_active);
+                backend_.copy(*side.k,0,*k,0,side_active);
+                backend_.copy(*side.v,0,*v,0,side_active);
+                snapshot->kv_side.push_back(std::move(k));
+                snapshot->kv_side.push_back(std::move(v));
+            }
     batch.finish();
     return snapshot;
 }
@@ -331,6 +654,15 @@ std::shared_ptr<MetalEngine::Snapshot> MetalEngine::capture_state() {
 void MetalEngine::restore_state(const Snapshot& snapshot) {
     if(snapshot.owner!=this || snapshot.layers.size()!=N_LAYER || snapshot.position>max_context_)
         throw std::runtime_error("q27 Metal: incompatible state snapshot");
+    // Side-row bookkeeping must agree with the engine's exception config
+    // before any GPU write: a snapshot without side rows cannot serve an
+    // exception engine at position > 0 (the masked heads' fp16 history
+    // would be stale — the exact 41705bb P2 recombination hazard).
+    uint64_t side_entries=0;
+    for(const auto& sides : kv_fp16_side_) side_entries+=sides.size();
+    const uint64_t side_expected=snapshot.position?2*side_entries:0;
+    if(snapshot.kv_side.size()!=side_expected)
+        throw std::runtime_error("q27 Metal: incompatible state snapshot (KV fp16 exception side rows)");
     backend_.synchronize();
     const uint64_t cache_row = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
                                           : (uint64_t)N_KV * HEAD_DIM * 2;
@@ -345,31 +677,640 @@ void MetalEngine::restore_state(const Snapshot& snapshot) {
     if(snapshot.mtp_k_cache) { backend_.copy(*snapshot.mtp_k_cache,0,*mtp_k_cache_,0,active_cache); backend_.copy(*snapshot.mtp_v_cache,0,*mtp_v_cache_,0,active_cache); }
     backend_.copy(*snapshot.hidden,0,*x1_,0,x1_->size());
     if(snapshot.logits) backend_.copy(*snapshot.logits,0,*logits_,0,logits_->size());
+    if(!snapshot.kv_side.empty()) {
+        const uint64_t side_active=(uint64_t)snapshot.position*HEAD_DIM*2;
+        size_t si=0;
+        for(uint32_t li=0;li<16;li++)
+            for(KvFp16Side& side : kv_fp16_side_[li]) {
+                backend_.copy(*snapshot.kv_side[si++],0,*side.k,0,side_active);
+                backend_.copy(*snapshot.kv_side[si++],0,*side.v,0,side_active);
+            }
+    }
     batch.finish();
+    if(!snapshot.position) initialize_mtp_sentinel();
     position_=snapshot.position;
-    logits_resident_=snapshot.logits_resident;
+    logits_resident_ = snapshot.logits_resident;
+    mtp_cache_valid_ = snapshot.mtp_cache_valid;
 }
 
-// Serial-decode projection dispatch: T2 weights route to the float-activation
-// select-form GEMV (exact ternary math, no activation quantization — see the
-// ternary-tier plan, Phase 2); Q4/Q8 keep the packed-dot quantized path. Both
-// operand sets are always live at the call sites: the fused rmsnorm/quantize
-// kernels produce the float output and the int8 copy together.
-void MetalEngine::project(const BackendTensor& w, const BackendBuffer& x_float,
+// ---- Prefix snapshots to disk (docs/metal/plans/2026-07-16-prefix-snapshots.md).
+// Format Q27SNAP3 (LE): magic, whole-artifact and state-producing runtime
+// identities, KV layout, position, token metadata, persisted SHA-256, then
+// length-prefixed blobs in capture_state() order. Plain read/write, never mmap.
+//
+// KV fp16 exception extension (snapshot v2, docs/plans/2026-07-17-kv-
+// except-snapshot-v2.md): header reserved bit 1 marks its presence
+// (bit 0 remains !logits_resident). After the standard blobs: one
+// length-prefixed 16-byte head-mask blob (the snapshot-config identity —
+// side blob LENGTHS alone cannot distinguish cell lists of equal size),
+// then per masked head the K and V side blobs in capture_state() side
+// order. Presence and mask content must both match the loading engine
+// exactly; either mismatch is a loud pass-1 reject. Pre-v2 binaries
+// reject extended files via the trailing-bytes check.
+
+namespace {
+
+struct SnapshotHeader {
+    char magic[8];
+    uint64_t artifact_size;
+    unsigned char artifact_sha1[20];
+    unsigned char runtime_sha1[20];
+    uint32_t kv_dtype;      // 0 fp16, 1 turbo3
+    uint32_t position;
+    uint32_t token_count;
+    uint32_t reserved;
+    unsigned char prefix_sha1[20];   // Phase 2 server keying; zeros in Phase 1
+    unsigned char payload_sha256[CC_SHA256_DIGEST_LENGTH];
+};
+constexpr char SNAP_MAGIC[8] = {'Q','2','7','S','N','A','P','3'};
+constexpr char SNAP_RUNTIME_ABI[] = "q27-metal-state-v1";
+
+void snap_write(FILE* f, const void* data, size_t bytes, const std::string& path) {
+    if (fwrite(data, 1, bytes, f) != bytes)
+        throw std::runtime_error("q27 Metal: short write to snapshot: " + path);
+}
+
+void snap_pwrite(int fd, const void* data, size_t bytes, off_t offset,
+                 const std::string& path) {
+    const unsigned char* in = static_cast<const unsigned char*>(data);
+    size_t done = 0;
+    while (done < bytes) {
+        const ssize_t n = pwrite(fd, in + done, bytes - done, offset + (off_t)done);
+        if (n < 0 && errno == EINTR) continue;
+        if (n <= 0)
+            throw std::runtime_error("q27 Metal: cannot seal snapshot checksum: " + path);
+        done += (size_t)n;
+    }
+}
+
+class SnapshotReader {
+  public:
+    SnapshotReader(int fd, const std::string& path) : fd_(fd), path_(path) {
+        struct stat st{};
+        if (fstat(fd_, &st) != 0 || !S_ISREG(st.st_mode) || st.st_size < 0)
+            throw std::runtime_error("q27 Metal: cannot pin snapshot: " + path_);
+        size_ = (uint64_t)st.st_size;
+    }
+
+    void read(void* data, size_t bytes) {
+        if ((uint64_t)bytes > size_ - offset_)
+            throw std::runtime_error("q27 Metal: truncated snapshot: " + path_);
+        unsigned char* out = static_cast<unsigned char*>(data);
+        size_t done = 0;
+        while (done < bytes) {
+            const ssize_t n = pread(fd_, out + done, bytes - done,
+                                    (off_t)(offset_ + done));
+            if (n < 0 && errno == EINTR) continue;
+            if (n <= 0)
+                throw std::runtime_error("q27 Metal: truncated snapshot: " + path_);
+            done += (size_t)n;
+        }
+        offset_ += bytes;
+    }
+
+    void seek(uint64_t offset) {
+        if (offset > size_)
+            throw std::runtime_error("q27 Metal: truncated snapshot: " + path_);
+        offset_ = offset;
+    }
+
+    void skip(uint64_t bytes) {
+        if (bytes > size_ - offset_)
+            throw std::runtime_error("q27 Metal: truncated snapshot: " + path_);
+        offset_ += bytes;
+    }
+
+    uint64_t tell() const { return offset_; }
+    uint64_t size() const { return size_; }
+
+  private:
+    int fd_;
+    const std::string& path_;
+    uint64_t offset_ = 0;
+    uint64_t size_ = 0;
+};
+
+} // namespace
+
+// SHA1 over the whole mapped artifact — the bytes this engine actually
+// computes with. Chunked updates (CC_LONG is 32-bit); cached per Shared.
+const unsigned char* MetalEngine::snapshot_identity() {
+    if (!shared_->snap_sha_ready) {
+        CC_SHA1_CTX ctx;
+        CC_SHA1_Init(&ctx);
+        const unsigned char* base = (const unsigned char*)model_.mapping_base();
+        const uint64_t total = model_.mapping_size();
+        if (!base || !total)
+            throw std::runtime_error("q27 Metal: artifact mapping unavailable for snapshot identity");
+        for (uint64_t off = 0; off < total; off += 256u << 20)
+            CC_SHA1_Update(&ctx, base + off, (CC_LONG)std::min<uint64_t>(256u << 20, total - off));
+        CC_SHA1_Final(shared_->snap_sha1, &ctx);
+        shared_->snap_sha_ready = true;
+    }
+    return shared_->snap_sha1;
+}
+
+std::array<unsigned char,20> MetalEngine::snapshot_runtime_identity() const {
+    CC_SHA1_CTX ctx;
+    CC_SHA1_Init(&ctx);
+    auto add_string = [&](const std::string& value) {
+        const uint64_t size = value.size();
+        CC_SHA1_Update(&ctx, &size, (CC_LONG)sizeof size);
+        if (!value.empty()) CC_SHA1_Update(&ctx, value.data(), (CC_LONG)value.size());
+    };
+    auto add_u32 = [&](uint32_t value) {
+        CC_SHA1_Update(&ctx, &value, (CC_LONG)sizeof value);
+    };
+    add_string(SNAP_RUNTIME_ABI);
+    add_string(MetalBackend::shader_abi_tag());
+    add_string(backend_.shader_source_sha1());
+    add_string(backend_.name());
+    add_u32(backend_.gemm_half_enabled());
+    add_u32(backend_.gqa_tile());
+    add_u32(backend_.gqa_block());
+    add_u32(backend_.gqa_threshold());
+    add_u32(backend_.supports_quantized_matmul());
+    add_u32(chunked_prefill_);
+    std::array<unsigned char,20> digest{};
+    CC_SHA1_Final(digest.data(), &ctx);
+    return digest;
+}
+
+void MetalEngine::save_state(const std::string& path, const uint32_t* tokens,
+                             uint32_t token_count, bool logits_resident,
+                             const DeviceLease& with_device) {
+    if (token_count && !tokens)
+        throw std::runtime_error("q27 Metal: snapshot token metadata is null");
+    if (logits_resident && !logits_resident_)
+        throw std::runtime_error("q27 Metal: cannot save snapshot with stale logits marked resident");
+    auto run_device = [&](const std::function<void()>& operation) {
+        if (with_device) with_device(operation); else operation();
+    };
+    run_device([&] { backend_.synchronize(); });
+    const uint64_t cache_row = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
+                                          : (uint64_t)N_KV * HEAD_DIM * 2;
+    const uint64_t active_cache = (uint64_t)position_ * cache_row;
+    std::string tmp_template = path + ".tmp.XXXXXX";
+    std::vector<char> tmp_name(tmp_template.begin(), tmp_template.end());
+    tmp_name.push_back('\0');
+    // One temporary per writer. A shared `path + ".tmp"` lets another
+    // process unlink an open writer's name and replace it before rename,
+    // causing the first writer to publish the second writer's partial file.
+    const int tmp_fd = mkstemp(tmp_name.data());
+    const std::string tmp = tmp_fd >= 0 ? std::string(tmp_name.data()) : tmp_template;
+    const int fd_flags = tmp_fd >= 0 ? fcntl(tmp_fd, F_GETFD) : -1;
+    if (tmp_fd < 0 || fd_flags < 0 ||
+        fcntl(tmp_fd, F_SETFD, fd_flags | FD_CLOEXEC) != 0) {
+        if (tmp_fd >= 0) close(tmp_fd);
+        (void)unlink(tmp.c_str());
+        throw std::runtime_error("q27 Metal: cannot create snapshot: " + tmp);
+    }
+    int lock_fd = -1;
+    if (flock(tmp_fd, LOCK_EX | LOCK_NB) != 0 ||
+        (lock_fd = dup(tmp_fd)) < 0 ||
+        fcntl(lock_fd, F_SETFD, FD_CLOEXEC) != 0) {
+        if (lock_fd >= 0) close(lock_fd);
+        close(tmp_fd);
+        (void)unlink(tmp.c_str());
+        throw std::runtime_error("q27 Metal: cannot lock snapshot: " + tmp);
+    }
+    FILE* f = fdopen(tmp_fd, "wb");
+    if (!f) {
+        close(lock_fd);
+        close(tmp_fd);
+        (void)unlink(tmp.c_str());
+        throw std::runtime_error("q27 Metal: cannot create snapshot: " + tmp);
+    }
+    std::vector<unsigned char> stage(16u << 20);
+    try {
+        SnapshotHeader h{};
+        memcpy(h.magic, SNAP_MAGIC, sizeof h.magic);
+        h.artifact_size = model_.mapping_size();
+        run_device([&] { memcpy(h.artifact_sha1, snapshot_identity(), sizeof h.artifact_sha1); });
+        const auto runtime_identity = snapshot_runtime_identity();
+        memcpy(h.runtime_sha1, runtime_identity.data(), runtime_identity.size());
+        h.kv_dtype = turbo3_kv_ ? 1 : 0;
+        h.position = position_;
+        h.token_count = token_count;
+        h.reserved = (logits_resident ? 0u : 1u) | (kv_fp16_except_ ? 2u : 0u)
+                   | (kv_fp16_side_codec_ ? 4u : 0u)
+                   | (mtp_cache_valid_ ? 0u : 8u);
+        CC_SHA256_CTX payload_digest;
+        CC_SHA256_Init(&payload_digest);
+        CC_SHA256_Update(&payload_digest, &h, (CC_LONG)sizeof h);
+        auto put_payload = [&](const void* data, size_t bytes) {
+            snap_write(f, data, bytes, tmp);
+            CC_SHA256_Update(&payload_digest, data, (CC_LONG)bytes);
+        };
+        snap_write(f, &h, sizeof h, tmp);
+        if (token_count) put_payload(tokens, (size_t)token_count * 4);
+        auto put_blob = [&](const BackendBuffer* src, uint64_t bytes) {
+            put_payload(&bytes, sizeof bytes);
+            for (uint64_t off = 0; off < bytes; off += stage.size()) {
+                const uint64_t n = std::min<uint64_t>(stage.size(), bytes - off);
+                run_device([&] { backend_.read(*src, off, stage.data(), n); });
+                put_payload(stage.data(), n);
+            }
+        };
+        for (uint32_t i = 0; i < N_LAYER; i++) {
+            const LayerState& s = layers_[i];
+            put_blob(s.recurrent.get(), s.recurrent ? s.recurrent->size() : 0);
+            put_blob(s.ring.get(), s.ring ? s.ring->size() : 0);
+            put_blob(s.k_cache.get(), s.k_cache ? active_cache : 0);
+            put_blob(s.v_cache.get(), s.v_cache ? active_cache : 0);
+        }
+        put_blob(mtp_k_cache_.get(), mtp_k_cache_ ? active_cache : 0);
+        put_blob(mtp_v_cache_.get(), mtp_v_cache_ ? active_cache : 0);
+        put_blob(x1_.get(), x1_->size());
+        put_blob(logits_.get(), logits_->size());
+        if (kv_fp16_except_) {
+            // Head-mask blob, then the private side caches bounced through
+            // one shared staging buffer (copy() is the only host path that
+            // can source a StorageModePrivate buffer).
+            const uint64_t mask_bytes = sizeof kv_fp16_head_masks_;
+            put_payload(&mask_bytes, sizeof mask_bytes);
+            put_payload(kv_fp16_head_masks_, mask_bytes);
+            std::shared_ptr<BackendBuffer> staging;
+            run_device([&] { staging = backend_.allocate(stage.size()); });
+            auto put_side_blob = [&](const BackendBuffer& src, uint64_t bytes) {
+                put_payload(&bytes, sizeof bytes);
+                for (uint64_t off = 0; off < bytes; off += stage.size()) {
+                    const uint64_t n = std::min<uint64_t>(stage.size(), bytes - off);
+                    run_device([&] {
+                        backend_.copy(src, off, *staging, 0, n);
+                        backend_.read(*staging, 0, stage.data(), n);
+                    });
+                    put_payload(stage.data(), n);
+                }
+            };
+            const uint64_t side_active = (uint64_t)position_ * HEAD_DIM * 2;
+            for (uint32_t li = 0; li < 16; li++)
+                for (const KvFp16Side& side : kv_fp16_side_[li]) {
+                    put_side_blob(*side.k, side_active);
+                    put_side_blob(*side.v, side_active);
+                }
+            // Codec trailer, e4m3 sides only: a reserved bit alone cannot
+            // stop an older binary from silently continuing an e4m3 history
+            // with fp16 stores. This extra blob trips that binary's own
+            // trailing-bytes check. fp16-side files carry no trailer, so they
+            // stay loadable across the version boundary.
+            if (kv_fp16_side_codec_) {
+                const uint64_t codec_bytes = sizeof kv_fp16_side_codec_;
+                put_payload(&codec_bytes, sizeof codec_bytes);
+                put_payload(&kv_fp16_side_codec_, codec_bytes);
+            }
+        }
+        unsigned char payload_hash[CC_SHA256_DIGEST_LENGTH];
+        CC_SHA256_Final(payload_hash, &payload_digest);
+        if (fflush(f) != 0)
+            throw std::runtime_error("q27 Metal: cannot flush snapshot checksum: " + tmp);
+        snap_pwrite(fileno(f), payload_hash, sizeof payload_hash,
+                    (off_t)offsetof(SnapshotHeader, payload_sha256), tmp);
+#if Q27_METAL_TEST_FAILPOINTS
+        const char* snap_crash = getenv("Q27_METAL_SNAP_CRASH");
+        if (snap_crash && strcmp(snap_crash, "before-fsync") == 0) _exit(42);
+#endif
+        // rename gives atomicity, fsync gives content durability: a crash
+        // without it can leave a structurally valid file whose data pages
+        // read back as zeroes while every blob length still matches.
+        // fflush/fsync failures must still reach fclose; a short-circuit
+        // chain would leak the descriptor on every failed save.
+        if (fflush(f) != 0 || fsync(fileno(f)) != 0) {
+            fclose(f);
+            f = nullptr;
+            throw std::runtime_error("q27 Metal: cannot finish snapshot: " + tmp);
+        }
+        if (fclose(f) != 0) {
+            f = nullptr;
+            throw std::runtime_error("q27 Metal: cannot finish snapshot: " + tmp);
+        }
+        f = nullptr;
+        // The rename lives in the directory entry: without a directory fsync
+        // a crash can drop it after this call reported success. The snapshot
+        // is a correctness-bearing artifact, so failure here is fatal, never
+        // advisory. Open the directory before the rename so an open failure
+        // aborts while the previous snapshot is still in place. A post-rename
+        // fsync failure leaves the durable new file in place; only the
+        // rename's durability is uncertain, and either name resolves to a
+        // valid snapshot after a crash.
+        const std::string::size_type slash = path.find_last_of('/');
+        const std::string dir = slash == std::string::npos ? "."
+                              : slash == 0 ? "/" : path.substr(0, slash);
+        const int dfd = open(dir.c_str(), O_RDONLY);
+        if (dfd < 0)
+            throw std::runtime_error("q27 Metal: cannot open snapshot directory: " + dir);
+        if (rename(tmp.c_str(), path.c_str()) != 0) {
+            close(dfd);
+            throw std::runtime_error("q27 Metal: cannot move snapshot into place: " + path);
+        }
+        if (fsync(dfd) != 0) {
+            close(dfd);
+            throw std::runtime_error("q27 Metal: cannot sync snapshot directory: " + dir);
+        }
+        close(dfd);
+        close(lock_fd);
+        lock_fd = -1;
+#if Q27_METAL_TEST_FAILPOINTS
+        if (snap_crash && strcmp(snap_crash, "after-rename") == 0) _exit(42);
+#endif
+    } catch (...) {
+        if (f) fclose(f);
+        if (lock_fd >= 0) close(lock_fd);
+        remove(tmp.c_str());
+        throw;
+    }
+}
+
+uint32_t MetalEngine::load_state(const std::string& path,const DeviceLease& with_device,
+                                 const LoadCheckpoint& checkpoint) {
+    const int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+    if (fd < 0)
+        throw std::runtime_error("q27 Metal: cannot open snapshot: " + path);
+    try {
+        const uint32_t position = load_state_fd(fd, path, nullptr, with_device, checkpoint);
+        close(fd);
+        return position;
+    } catch (...) {
+        close(fd);
+        throw;
+    }
+}
+
+uint32_t MetalEngine::load_state_fd(int source_fd,const std::string& path,
+                                    const std::vector<uint32_t>* expected_tokens,
+                                    const DeviceLease& with_device,
+                                    const LoadCheckpoint& checkpoint) {
+    auto check_cancel = [&] { if (checkpoint) checkpoint(); };
+    auto run_device = [&](const std::function<void()>& operation) {
+        check_cancel();
+        if (with_device) with_device(operation); else operation();
+    };
+    check_cancel();
+    SnapshotReader reader(source_fd, path);
+        SnapshotHeader h{};
+        reader.read(&h, sizeof h);
+        if (memcmp(h.magic, SNAP_MAGIC, sizeof h.magic) != 0)
+            throw std::runtime_error("q27 Metal: not a q27 snapshot: " + path);
+        bool artifact_matches = false;
+        run_device([&] {
+            artifact_matches = memcmp(h.artifact_sha1, snapshot_identity(), 20) == 0;
+        });
+        if (h.artifact_size != model_.mapping_size() || !artifact_matches)
+            throw std::runtime_error("q27 Metal: snapshot was taken against a different artifact: " + path);
+        const auto runtime_identity = snapshot_runtime_identity();
+        if (memcmp(h.runtime_sha1, runtime_identity.data(), runtime_identity.size()) != 0)
+            throw std::runtime_error("q27 Metal: snapshot runtime configuration does not match this engine: " + path);
+        if (h.kv_dtype != (turbo3_kv_ ? 1u : 0u))
+            throw std::runtime_error("q27 Metal: snapshot KV dtype does not match this engine: " + path);
+        if (h.position > max_context_)
+            throw std::runtime_error("q27 Metal: snapshot position exceeds this engine's context: " + path);
+        // KV fp16 exception extension presence must match this engine's
+        // config exactly (v2): an env-unset snapshot has no fp16 history
+        // for the masked heads, and an exception snapshot's continuation
+        // assumed fp16 where a plain engine would have quantized.
+        if (bool(h.reserved & 2) != kv_fp16_except_)
+            throw std::runtime_error(kv_fp16_except_
+                ? "q27 Metal: snapshot carries no KV fp16 exception side rows but this engine needs them (Q27_METAL_KV_FP16_CELLS): " + path
+                : "q27 Metal: snapshot carries KV fp16 exception side rows but this engine has none: " + path);
+        // Side codec is config identity too (bit 2): an fp16-side snapshot
+        // continued under e4m3 stores (or vice versa) would mix codec
+        // histories silently. Binaries older than the hot-cells arm ignore
+        // this bit — recorded cross-version caveat.
+        if (bool(h.reserved & 4) != (kv_fp16_side_codec_ != 0))
+            throw std::runtime_error("q27 Metal: snapshot side-cache codec does not match this engine (Q27_METAL_KV_CELLS_CODEC): " + path);
+        if(expected_tokens && (h.token_count!=expected_tokens->size() ||
+           h.position!=h.token_count))
+            throw std::runtime_error("q27 Metal: snapshot tokens do not match the requested prefix: " + path);
+        const uint64_t payload_start = reader.tell();
+        reader.skip((uint64_t)h.token_count * 4);
+        const uint64_t cache_row = turbo3_kv_ ? (uint64_t)N_KV * 2 * 50
+                                              : (uint64_t)N_KV * HEAD_DIM * 2;
+        const uint64_t active_cache = (uint64_t)h.position * cache_row;
+        // The expected blob sequence, mirrored from save_state. Validating
+        // every length (pass 1) before the first GPU write (pass 2) means a
+        // rejected file never leaves partially restored state. Pass-2
+        // failures — mid-stream I/O errors or same-inode mutation caught by
+        // the TOCTOU re-checks — do leave indeterminate buffer state behind
+        // the old position_; callers must reset() or restore a known state
+        // before reuse, as the server's disk-tier fallback does.
+        // Kinds: Std
+        // streams into a shared buffer; Mask is host data whose CONTENT is
+        // validated in pass 1 (equal-length cell lists differ only there);
+        // Side bounces through staging into a private buffer.
+        struct BlobRef { BackendBuffer* buf; uint64_t bytes; enum Kind { Std, Mask, Side, Codec } kind; };
+        std::vector<BlobRef> blobs;
+        for (uint32_t i = 0; i < N_LAYER; i++) {
+            LayerState& d = layers_[i];
+            blobs.push_back({d.recurrent.get(), d.recurrent ? d.recurrent->size() : 0, BlobRef::Std});
+            blobs.push_back({d.ring.get(), d.ring ? d.ring->size() : 0, BlobRef::Std});
+            blobs.push_back({d.k_cache.get(), d.k_cache ? active_cache : 0, BlobRef::Std});
+            blobs.push_back({d.v_cache.get(), d.v_cache ? active_cache : 0, BlobRef::Std});
+        }
+        blobs.push_back({mtp_k_cache_.get(), mtp_k_cache_ ? active_cache : 0, BlobRef::Std});
+        blobs.push_back({mtp_v_cache_.get(), mtp_v_cache_ ? active_cache : 0, BlobRef::Std});
+        blobs.push_back({x1_.get(), x1_->size(), BlobRef::Std});
+        blobs.push_back({logits_.get(), logits_->size(), BlobRef::Std});
+        if (kv_fp16_except_) {
+            blobs.push_back({nullptr, sizeof kv_fp16_head_masks_, BlobRef::Mask});
+            const uint64_t side_active = (uint64_t)h.position * HEAD_DIM * 2;
+            for (uint32_t li = 0; li < 16; li++)
+                for (KvFp16Side& side : kv_fp16_side_[li]) {
+                    blobs.push_back({side.k.get(), side_active, BlobRef::Side});
+                    blobs.push_back({side.v.get(), side_active, BlobRef::Side});
+                }
+            // e4m3 sides carry a codec trailer (see save_state); its
+            // absence/presence is already pinned by reserved bit 2, its
+            // CONTENT is checked like the mask blob's.
+            if (kv_fp16_side_codec_)
+                blobs.push_back({nullptr, sizeof kv_fp16_side_codec_, BlobRef::Codec});
+        }
+        auto read_mask = [&](CC_SHA256_CTX& digest) {
+            uint8_t stored_masks[sizeof kv_fp16_head_masks_];
+            reader.read(stored_masks, sizeof stored_masks);
+            CC_SHA256_Update(&digest, stored_masks, (CC_LONG)sizeof stored_masks);
+            if (memcmp(stored_masks, kv_fp16_head_masks_, sizeof stored_masks) != 0)
+                throw std::runtime_error("q27 Metal: snapshot KV fp16 exception cells do not match this engine (Q27_METAL_KV_FP16_CELLS): " + path);
+        };
+        auto read_codec = [&](CC_SHA256_CTX& digest) {
+            uint32_t stored_codec = 0;
+            reader.read(&stored_codec, sizeof stored_codec);
+            CC_SHA256_Update(&digest, &stored_codec, (CC_LONG)sizeof stored_codec);
+            if (stored_codec != kv_fp16_side_codec_)
+                throw std::runtime_error("q27 Metal: snapshot side-cache codec does not match this engine (Q27_METAL_KV_CELLS_CODEC): " + path);
+        };
+        std::vector<unsigned char> stage(16u << 20);
+        CC_SHA256_CTX validated_digest;
+        CC_SHA256_Init(&validated_digest);
+        SnapshotHeader digest_header=h;
+        memset(digest_header.payload_sha256,0,sizeof digest_header.payload_sha256);
+        CC_SHA256_Update(&validated_digest,&digest_header,(CC_LONG)sizeof digest_header);
+        reader.seek(payload_start);
+        uint64_t token_offset=0;
+        for (uint64_t left=(uint64_t)h.token_count*4; left; ) {
+            const uint64_t n=std::min<uint64_t>(stage.size(),left);
+            reader.read(stage.data(),(size_t)n);
+            if(expected_tokens && memcmp(stage.data(),
+                reinterpret_cast<const unsigned char*>(expected_tokens->data())+token_offset,
+                (size_t)n)!=0)
+                throw std::runtime_error("q27 Metal: snapshot tokens do not match the requested prefix: " + path);
+            CC_SHA256_Update(&validated_digest,stage.data(),(CC_LONG)n);
+            token_offset+=n;
+            left-=n;
+        }
+        const uint64_t blob_start = reader.tell();
+        // Real file size up front: a seek past EOF succeeds silently, so the
+        // walk below could otherwise bless a file truncated inside its final
+        // blob and pass 2 would partially restore.
+        const uint64_t file_size = reader.size();
+        uint64_t expected_end = blob_start;
+        for (const auto& blob : blobs) {
+            check_cancel();
+            uint64_t stored = 0;
+            reader.read(&stored, sizeof stored);
+            CC_SHA256_Update(&validated_digest, &stored, (CC_LONG)sizeof stored);
+            if (stored != blob.bytes)
+                throw std::runtime_error("q27 Metal: snapshot blob layout does not match this engine: " + path);
+            expected_end += sizeof stored + stored;
+            if (expected_end > file_size)
+                throw std::runtime_error("q27 Metal: truncated snapshot: " + path);
+            if (blob.kind == BlobRef::Mask) { read_mask(validated_digest); continue; }
+            if (blob.kind == BlobRef::Codec) { read_codec(validated_digest); continue; }
+            for (uint64_t off = 0; off < stored; off += stage.size()) {
+                check_cancel();
+                const uint64_t n = std::min<uint64_t>(stage.size(), stored - off);
+                reader.read(stage.data(), (size_t)n);
+                CC_SHA256_Update(&validated_digest, stage.data(), (CC_LONG)n);
+            }
+        }
+        if (expected_end != file_size)
+            throw std::runtime_error("q27 Metal: trailing bytes after snapshot blobs: " + path);
+        unsigned char validated_hash[CC_SHA256_DIGEST_LENGTH];
+        CC_SHA256_Final(validated_hash, &validated_digest);
+        if (memcmp(validated_hash,h.payload_sha256,sizeof validated_hash)!=0)
+            throw std::runtime_error("q27 Metal: snapshot payload checksum mismatch: " + path);
+
+        // Pass 2: stream the validated blobs into the live buffers while
+        // hashing the bytes actually copied. Matching lengths alone cannot
+        // detect same-inode payload mutation between or during the passes.
+        run_device([&] { backend_.synchronize(); });
+        reader.seek(payload_start);
+        CC_SHA256_CTX restored_digest;
+        CC_SHA256_Init(&restored_digest);
+        CC_SHA256_Update(&restored_digest,&digest_header,(CC_LONG)sizeof digest_header);
+        for (uint64_t left=(uint64_t)h.token_count*4; left; ) {
+            const uint64_t n=std::min<uint64_t>(stage.size(),left);
+            reader.read(stage.data(),(size_t)n);
+            CC_SHA256_Update(&restored_digest,stage.data(),(CC_LONG)n);
+            left-=n;
+        }
+        std::shared_ptr<BackendBuffer> staging;
+        if (kv_fp16_except_)
+            run_device([&] { staging = backend_.allocate(stage.size()); });
+        for (const auto& blob : blobs) {
+            check_cancel();
+            uint64_t stored = 0;
+            reader.read(&stored, sizeof stored);
+            CC_SHA256_Update(&restored_digest, &stored, (CC_LONG)sizeof stored);
+            if (stored != blob.bytes)
+                throw std::runtime_error("q27 Metal: snapshot changed during load: " + path);
+            if (blob.kind == BlobRef::Mask) { read_mask(restored_digest); continue; }
+            if (blob.kind == BlobRef::Codec) { read_codec(restored_digest); continue; }
+            for (uint64_t off = 0; off < blob.bytes; off += stage.size()) {
+                check_cancel();
+                const uint64_t n = std::min<uint64_t>(stage.size(), blob.bytes - off);
+                reader.read(stage.data(), (size_t)n);
+                CC_SHA256_Update(&restored_digest, stage.data(), (CC_LONG)n);
+                if (blob.kind == BlobRef::Side) {
+                    // Private destination: write() cannot reach it — bounce
+                    // through the shared staging buffer with copy().
+                    run_device([&] {
+                        backend_.write(*staging, 0, stage.data(), n);
+                        backend_.copy(*staging, 0, *blob.buf, off, n);
+                    });
+                } else {
+                    run_device([&] { backend_.write(*blob.buf, off, stage.data(), n); });
+                }
+            }
+        }
+        unsigned char restored_hash[CC_SHA256_DIGEST_LENGTH];
+        CC_SHA256_Final(restored_hash, &restored_digest);
+        if (memcmp(validated_hash, restored_hash, sizeof validated_hash) != 0)
+            throw std::runtime_error("q27 Metal: snapshot payload changed during load: " + path);
+        // Position-zero snapshots carry no active KV payload, but row 0 is
+        // the MTP attention sentinel. Recreate it instead of inheriting any
+        // bytes left by the state being replaced.
+        if(!h.position) run_device([&] { initialize_mtp_sentinel(); });
+        position_ = h.position;
+        logits_resident_ = !(h.reserved & 1u);
+        // Bit 3 marks stale MTP history. Its absence keeps snapshots written
+        // by older binaries compatible: those binaries only exposed MTP after
+        // a warmed prefill and always serialized the active MTP rows.
+        mtp_cache_valid_ = !(h.reserved & 8u);
+        return position_;
+}
+
+MetalEngine::SnapshotInfo MetalEngine::peek_snapshot(const std::string& path) {
+    const int fd = open(path.c_str(), O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+    if (fd < 0)
+        throw std::runtime_error("q27 Metal: cannot open snapshot: " + path);
+    try {
+        SnapshotInfo info = peek_snapshot_fd(fd, path);
+        close(fd);
+        return info;
+    } catch (...) {
+        close(fd);
+        throw;
+    }
+}
+
+MetalEngine::SnapshotInfo MetalEngine::peek_snapshot_fd(
+    int source_fd, const std::string& path) {
+    SnapshotReader reader(source_fd, path);
+        SnapshotHeader h{};
+        reader.read(&h, sizeof h);
+        if (memcmp(h.magic, SNAP_MAGIC, sizeof h.magic) != 0)
+            throw std::runtime_error("q27 Metal: not a q27 snapshot: " + path);
+        SnapshotInfo info;
+        info.position = h.position;
+        // Bit test, not equality: bit 1 is the v2 exception extension.
+        info.logits_resident = (h.reserved & 1) == 0;
+        // Bound the metadata before allocating: max context plus the one
+        // legal pending emitted token used by resident agent sessions. A
+        // corrupt header must not drive a multi-GB scan-path allocation.
+        if (h.token_count > 262145)
+            throw std::runtime_error("q27 Metal: snapshot token count exceeds context plus pending token: " + path);
+        if (reader.size() < sizeof h + (uint64_t)h.token_count * 4)
+            throw std::runtime_error("q27 Metal: truncated snapshot: " + path);
+        reader.seek(sizeof h);
+        info.tokens.resize(h.token_count);
+        if (h.token_count)
+            reader.read(info.tokens.data(), (size_t)h.token_count * 4);
+        return info;
+}
+
+uint32_t MetalEngine::pending_from_logits() {
+    if (!logits_resident_)
+        throw std::runtime_error("q27 Metal: snapshot has no resident logits; continue prefill before generation");
+    CommandBatch batch(backend_);
+    backend_.argmax(*logits_, VOCAB, *token_out_);
+    batch.finish();
+    uint32_t pending = 0;
+    backend_.read(*token_out_, 0, &pending, sizeof pending);
+    return pending;
+}
+
+// Both operand sets are live at these call sites because rmsnorm_quantized
+// produces the float output and packed activation together. The official q4s
+// contract routes projections through the quantized kernels.
+void MetalEngine::project(const BackendTensor& w, const BackendBuffer&,
                           const BackendQuantized& xq, BackendBuffer& out) {
-    if (w.dtype == DType::T2_G128) backend_.matvec(w, x_float, out);
-    else backend_.matvec_quantized(w, xq, out);
+    backend_.matvec_quantized(w, xq, out);
 }
 
 void MetalEngine::project_pair(const BackendTensor& a, BackendBuffer& a_out,
                                const BackendTensor& b, BackendBuffer& b_out,
-                               const BackendBuffer& x_float, const BackendQuantized& xq) {
-    if (a.dtype == DType::T2_G128 || b.dtype == DType::T2_G128) {
-        project(a, x_float, xq, a_out);
-        project(b, x_float, xq, b_out);
-    } else {
-        backend_.matvec_quantized_pair(a, a_out, b, b_out, xq);
-    }
+                               const BackendBuffer&, const BackendQuantized& xq) {
+    backend_.matvec_quantized_pair(a, a_out, b, b_out, xq);
 }
 
 void MetalEngine::gdn_block(uint32_t layer) {
@@ -388,11 +1329,11 @@ void MetalEngine::gdn_block(uint32_t layer) {
     backend_.gated_norm_gdn(*delta_out_, layer_weight(layer, "ssm_norm.weight"), *z_,
                             *gated_out_, GDN_HEADS, GDN_DIM, EPS);
     const BackendTensor& ssm_out_w = layer_weight(layer, "ssm_out.weight");
-    if (ssm_out_w.dtype != DType::T2_G128) backend_.quantize(*gated_out_, q6144_);
+    backend_.quantize(*gated_out_, q6144_);
     project(ssm_out_w, *gated_out_, q6144_, *y_);
 }
 
-void MetalEngine::attention_block(uint32_t layer) {
+void MetalEngine::attention_block(uint32_t layer, uint32_t pos) {
     project(layer_weight(layer, "attn_q.weight"), *x1_, q5120_, *qg_);
     backend_.rmsnorm_heads(*qg_, layer_weight(layer, "attn_q_norm.weight"),
                            N_HEAD, HEAD_DIM, 2 * HEAD_DIM, EPS);
@@ -400,20 +1341,46 @@ void MetalEngine::attention_block(uint32_t layer) {
                  layer_weight(layer,"attn_v.weight"),*vbuf_,*x1_,q5120_);
     backend_.rmsnorm_heads(*kbuf_, layer_weight(layer, "attn_k_norm.weight"),
                            N_KV, HEAD_DIM, HEAD_DIM, EPS);
-    backend_.rope_neox(*qg_, N_HEAD, HEAD_DIM, N_ROT, 2 * HEAD_DIM, position_, FREQ_BASE);
-    backend_.rope_neox(*kbuf_, N_KV, HEAD_DIM, N_ROT, HEAD_DIM, position_, FREQ_BASE);
+    backend_.rope_neox(*qg_, N_HEAD, HEAD_DIM, N_ROT, 2 * HEAD_DIM, pos, FREQ_BASE);
+    backend_.rope_neox(*kbuf_, N_KV, HEAD_DIM, N_ROT, HEAD_DIM, pos, FREQ_BASE);
     LayerState& state = layers_[layer];
-    const KvFormat format = turbo3_kv_ ? KvFormat::TURBO3 : KvFormat::F16;
-    if (turbo3_kv_) backend_.turbo_wht(*qg_, N_HEAD, 2 * HEAD_DIM, false);
-    backend_.kv_store(*kbuf_, *vbuf_, *state.k_cache, *state.v_cache,
-                      position_, N_KV, HEAD_DIM, format);
-    backend_.attention(*qg_, 2 * HEAD_DIM, *state.k_cache, *state.v_cache,
-                       *attn_out_, position_ + 1, N_HEAD, N_KV, HEAD_DIM,
-                       1.0f / std::sqrt((float)HEAD_DIM), format, nullptr);
-    if (turbo3_kv_) backend_.turbo_wht(*attn_out_, N_HEAD, HEAD_DIM, true);
+    if (turbo3_kv_) {
+        backend_.turbo_wht(*qg_, N_HEAD, 2 * HEAD_DIM, false);
+        backend_.kv_store_turbo3(*kbuf_, *vbuf_, *state.k_cache, *state.v_cache, pos, N_KV);
+        // fp16 exception cells: side-store the masked heads' rows in the
+        // turbo3 WHT domain (kbuf/vbuf are dead after the store, so the
+        // in-place transform is safe) — the window re-attention below then
+        // sees exactly what the turbo3 kernel's dequant approximates, and
+        // the shared inverse WHT on attn_out_ fixes its rows with the rest.
+        const auto& side = kv_fp16_side_[layer / 4];
+        if (!side.empty()) {
+            backend_.turbo_wht(*kbuf_, N_KV, HEAD_DIM, false);
+            backend_.turbo_wht(*vbuf_, N_KV, HEAD_DIM, false);
+            for (const KvFp16Side& s : side)
+                backend_.kv_store_f16_head_rows_side(*kbuf_, *vbuf_, s.head * HEAD_DIM,
+                                                     N_KV * HEAD_DIM, *s.k, *s.v,
+                                                     pos, HEAD_DIM, 1, kv_fp16_side_codec_);
+        }
+        backend_.attention_turbo3(*qg_, 2 * HEAD_DIM, *state.k_cache, *state.v_cache,
+                                  *attn_out_, pos + 1, N_HEAD, N_KV,
+                                  HEAD_DIM, 1.0f / std::sqrt((float)HEAD_DIM),
+                                  gqa_partials_.get());
+        for (const KvFp16Side& s : side)
+            backend_.attention_f16_window(*qg_, 2 * HEAD_DIM, s.head * (N_HEAD / N_KV),
+                                          *s.k, *s.v, *attn_out_, pos + 1,
+                                          N_HEAD / N_KV, HEAD_DIM,
+                                          1.0f / std::sqrt((float)HEAD_DIM));
+        backend_.turbo_wht(*attn_out_, N_HEAD, HEAD_DIM, true);
+    } else {
+        backend_.kv_store_f16(*kbuf_, *vbuf_, *state.k_cache, *state.v_cache, pos, N_KV * HEAD_DIM);
+        backend_.attention_f16(*qg_, 2 * HEAD_DIM, *state.k_cache, *state.v_cache,
+                               *attn_out_, pos + 1, N_HEAD, N_KV,
+                               HEAD_DIM, 1.0f / std::sqrt((float)HEAD_DIM),
+                               gqa_partials_.get());
+    }
     backend_.sigmoid_gate_mul(*attn_out_, *qg_, N_HEAD, HEAD_DIM);
     const BackendTensor& attn_out_w = layer_weight(layer, "attn_output.weight");
-    if (attn_out_w.dtype != DType::T2_G128) backend_.quantize(*attn_out_, q6144_);
+    backend_.quantize(*attn_out_, q6144_);
     project(attn_out_w, *attn_out_, q6144_, *y_);
 }
 
@@ -422,17 +1389,27 @@ void MetalEngine::ffn(uint32_t layer) {
                  layer_weight(layer,"ffn_up.weight"),*ffn_up_,*x1_,q5120_);
     backend_.silu_mul(*ffn_gate_, *ffn_up_, *ffn_gate_, N_FFN);
     const BackendTensor& ffn_down_w = layer_weight(layer, "ffn_down.weight");
-    if (ffn_down_w.dtype != DType::T2_G128) backend_.quantize(*ffn_gate_, q17408_);
+    backend_.quantize(*ffn_gate_, q17408_);
     project(ffn_down_w, *ffn_gate_, q17408_, *y_);
 }
 
-void MetalEngine::encode_token(uint32_t token, bool produce_logits) {
-    if (token >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
-    if (position_ >= max_context_) throw std::runtime_error("q27 Metal: context exhausted");
-    backend_.embedding_q8(weight("token_embd.weight"), token, *h_);
+// position_ advances at the call site after successful finish, so a backend
+// throw leaves host state describing only completed work. mtp_round follows
+// the same rule.
+// pos_offset places the row for multi-token command batches (prefill,
+// resident decode): the token encodes at position_ + pos_offset.
+void MetalEngine::encode_token(uint32_t token, bool produce_logits, bool token_from_device,
+                               uint32_t pos_offset) {
+    if (!token_from_device && token >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
+    const uint32_t pos = position_ + pos_offset;
+    if (pos >= max_context_) throw std::runtime_error("q27 Metal: context exhausted");
+    if (token_from_device)
+        backend_.embedding_from_device(weight("token_embd.weight"), *token_out_, *h_);
+    else
+        backend_.embedding_q8(weight("token_embd.weight"), token, *h_);
     for (uint32_t layer = 0; layer < N_LAYER; layer++) {
         backend_.rmsnorm_quantized(*h_,layer_weight(layer,"attn_norm.weight"),*x1_,N_EMBD,EPS,q5120_);
-        if (attention_layer(layer)) attention_block(layer); else gdn_block(layer);
+        if (attention_layer(layer)) attention_block(layer, pos); else gdn_block(layer);
         backend_.add_inplace(*h_, *y_, N_EMBD);
         backend_.rmsnorm_quantized(*h_,layer_weight(layer,"post_attention_norm.weight"),*x1_,N_EMBD,EPS,q5120_);
         ffn(layer);
@@ -444,25 +1421,20 @@ void MetalEngine::encode_token(uint32_t token, bool produce_logits) {
         backend_.rmsnorm(*h_,weight("output_norm.weight"),*x1_,N_EMBD,EPS);
     if (produce_logits) {
         project(weight("output.weight"), *x1_, q5120_, *logits_);
+        if (active_mask_ >= 0)
+            backend_.mask_logits(*logits_, *mask_pool_,
+                                 (uint64_t)active_mask_ * (((uint64_t)VOCAB + 31) / 32) * 4, VOCAB);
         backend_.argmax(*logits_, VOCAB, *token_out_);
     }
-    position_++;
 }
 
 void MetalEngine::gdn_chunk(uint32_t layer, uint32_t count, bool verify) {
     BackendQuantized x5 = quantized_view(cq5120_, count * N_EMBD);
     backend_.matmul_quantized(layer_weight(layer, "attn_qkv.weight"), x5, count, *cqkv_);
     backend_.matmul_quantized(layer_weight(layer, "attn_gate.weight"), x5, count, *cz_);
-    // Official tier: fused F16 pair-rows kernel. Ternary tier: alpha/beta are
-    // T2 matrices; the T2 chunk GEMM writes the same [token][row] layout.
     const BackendTensor& alpha_w = layer_weight(layer, "ssm_alpha.weight");
     const BackendTensor& beta_w = layer_weight(layer, "ssm_beta.weight");
-    if (alpha_w.dtype == DType::T2_G128) {
-        backend_.matmul_quantized(alpha_w, x5, count, *calpha_);
-        backend_.matmul_quantized(beta_w, x5, count, *cbeta_raw_);
-    } else {
-        backend_.matvec_f16_pair_rows(alpha_w, *calpha_, beta_w, *cbeta_raw_, *cx1_, count);
-    }
+    backend_.matvec_f16_pair_rows(alpha_w, *calpha_, beta_w, *cbeta_raw_, *cx1_, count);
     backend_.gdn_gates_rows(*calpha_, *cbeta_raw_, layer_weight(layer, "ssm_a"),
                             layer_weight(layer, "ssm_dt.bias"), *cg_, *cbeta_, GDN_HEADS, count);
     LayerState& state = layers_[layer];
@@ -506,16 +1478,41 @@ void MetalEngine::attention_chunk(uint32_t layer, uint32_t count) {
                             N_KV * HEAD_DIM, position_, count, FREQ_BASE);
     LayerState& state = layers_[layer];
     const float scale = 1.0f / std::sqrt((float)HEAD_DIM);
-    const KvFormat format = turbo3_kv_ ? KvFormat::TURBO3 : KvFormat::F16;
-    if (turbo3_kv_) backend_.turbo_wht(*cqg_, count * N_HEAD, 2 * HEAD_DIM, false);
-    backend_.kv_store_rows(*ckbuf_, *cvbuf_, *state.k_cache, *state.v_cache,
-                           position_, N_KV, HEAD_DIM, count, format);
-    backend_.attention_causal(*cqg_, 2 * HEAD_DIM, 2 * N_HEAD * HEAD_DIM,
-                              *state.k_cache, *state.v_cache, *cattn_out_,
-                              position_ + 1, N_HEAD, N_KV, HEAD_DIM, count,
-                              scale, format, nullptr);
-    if (turbo3_kv_)
+    if (turbo3_kv_) {
+        backend_.turbo_wht(*cqg_, count * N_HEAD, 2 * HEAD_DIM, false);
+        backend_.kv_store_turbo3_rows(*ckbuf_, *cvbuf_, *state.k_cache, *state.v_cache,
+                                      position_, N_KV, count);
+        // fp16 exception cells: WHT-domain side store + window re-attention
+        // (see the serial branch for the domain argument). ckbuf/cvbuf are
+        // dead after the turbo3 store.
+        const auto& side = kv_fp16_side_[layer / 4];
+        if (!side.empty()) {
+            backend_.turbo_wht(*ckbuf_, count * N_KV, HEAD_DIM, false);
+            backend_.turbo_wht(*cvbuf_, count * N_KV, HEAD_DIM, false);
+            for (const KvFp16Side& s : side)
+                backend_.kv_store_f16_head_rows_side(*ckbuf_, *cvbuf_, s.head * HEAD_DIM,
+                                                     N_KV * HEAD_DIM, *s.k, *s.v,
+                                                     position_, HEAD_DIM, count, kv_fp16_side_codec_);
+        }
+        backend_.attention_turbo3_causal(*cqg_, 2 * HEAD_DIM, 2 * N_HEAD * HEAD_DIM,
+                                         *state.k_cache, *state.v_cache,
+                                         *cattn_out_, position_ + 1, N_HEAD, N_KV,
+                                         HEAD_DIM, count, scale, gqa_partials_.get());
+        for (const KvFp16Side& s : side)
+            backend_.attention_f16_causal_window(*cqg_, 2 * HEAD_DIM, 2 * N_HEAD * HEAD_DIM,
+                                                 s.head * (N_HEAD / N_KV), *s.k, *s.v,
+                                                 *cattn_out_, N_HEAD * HEAD_DIM,
+                                                 position_ + 1, N_HEAD / N_KV,
+                                                 HEAD_DIM, count, scale);
         backend_.turbo_wht(*cattn_out_, count * N_HEAD, HEAD_DIM, true);
+    } else {
+        backend_.kv_store_f16_rows(*ckbuf_, *cvbuf_, *state.k_cache, *state.v_cache,
+                                   position_, N_KV * HEAD_DIM, count);
+        backend_.attention_f16_causal(*cqg_, 2 * HEAD_DIM, 2 * N_HEAD * HEAD_DIM,
+                                      *state.k_cache, *state.v_cache,
+                                      *cattn_out_, position_ + 1, N_HEAD, N_KV,
+                                      HEAD_DIM, count, scale, gqa_partials_.get());
+    }
     backend_.sigmoid_gate_mul_rows(*cattn_out_, *cqg_, N_HEAD, HEAD_DIM, count);
     BackendQuantized x6 = quantized_view(cq6144_, count * N_HEAD * HEAD_DIM);
     backend_.quantize(*cattn_out_, x6);
@@ -534,7 +1531,10 @@ void MetalEngine::ffn_chunk(uint32_t layer, uint32_t count) {
 
 void MetalEngine::chunk_forward(const uint32_t* tokens, uint32_t count, bool verify) {
     if (!ch_) throw std::runtime_error("q27 Metal: chunked prefill is unavailable");
-    if (!count || count > CHUNK_MAX) throw std::runtime_error("q27 Metal: invalid chunk size");
+    // Verify chunks park per-layer inputs in CHUNK_MAX-sized buffers; plain
+    // prefill chunks only need the (wider) layer-stack activations.
+    if (!count || count > (verify ? VERIFY_CHUNK_MAX : PREFILL_CHUNK_MAX))
+        throw std::runtime_error("q27 Metal: invalid chunk size");
     if ((uint64_t)position_ + count > max_context_)
         throw std::runtime_error("q27 Metal: context exhausted");
     for (uint32_t i = 0; i < count; i++)
@@ -551,11 +1551,6 @@ void MetalEngine::chunk_forward(const uint32_t* tokens, uint32_t count, bool ver
         ffn_chunk(layer, count);
         backend_.add_inplace(*ch_, *cy_, count * N_EMBD);
     }
-}
-
-void MetalEngine::encode_chunk(const uint32_t* tokens, uint32_t count) {
-    chunk_forward(tokens, count);
-    position_ += count;
 }
 
 // Commits GDN state (recurrent + convolution ring) for the first `count`
@@ -578,22 +1573,74 @@ void MetalEngine::gdn_replay(uint32_t count) {
     }
 }
 
+// K chained greedy steps in one command buffer: each step's embedding reads
+// the token id the previous argmax wrote (docs/metal/plans/2026-07-15-resident-greedy.md),
+// and an in-batch copy archives every id into token_ring_ for one readback.
+// Refuses to run under an active tool constraint — grammar feeding is a
+// host-per-token loop by construction.
+uint32_t MetalEngine::decode_resident(uint32_t pending, uint32_t* out, uint32_t k) {
+    if (pending >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
+    if (!k || k > RESIDENT_MAX) throw std::runtime_error("q27 Metal: resident slice must be 1..8");
+    if (active_mask_ >= 0) throw std::runtime_error("q27 Metal: resident decode under tool constraint");
+    backend_.write(*token_out_, 0, &pending, sizeof(pending));
+    {
+        CommandBatch batch(backend_);
+        for (uint32_t i = 0; i < k; i++) {
+            encode_token(0, true, true, i);
+            backend_.copy(*token_out_, 0, *token_ring_, (uint64_t)i * sizeof(uint32_t),
+                          sizeof(uint32_t));
+        }
+        batch.finish();
+        position_ += k;
+        logits_resident_ = true;
+        mtp_cache_valid_ = false;
+    }
+    backend_.read(*token_ring_, 0, out, (uint64_t)k * sizeof(uint32_t));
+    return out[k - 1];
+}
+
 uint32_t MetalEngine::step(uint32_t token) {
     if (token >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
     if (position_ >= max_context_) throw std::runtime_error("q27 Metal: context exhausted");
-    logits_resident_ = false;
     CommandBatch batch(backend_);
     encode_token(token, true);
     batch.finish();
+    position_++;
     logits_resident_ = true;
+    mtp_cache_valid_ = false;
+    uint32_t next = 0;
+    backend_.read(*token_out_, 0, &next, sizeof(next));
+    return next;
+}
+uint32_t MetalEngine::prefill_serial_chunk(const uint32_t* tokens, uint32_t count,
+                                           bool warm_mtp, bool final_chunk) {
+    if (!tokens || !count || count > serial_prefill_chunk_max())
+        throw std::runtime_error("q27 Metal: invalid serial prefill chunk");
+    if ((uint64_t)position_ + count > max_context_)
+        throw std::runtime_error("q27 Metal: prompt exceeds context");
+    for (uint32_t i = 0; i < count; i++)
+        if (tokens[i] >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
+    CommandBatch batch(backend_);
+    if (warm_mtp && position_ > 0) mtp_warm(*x1_, tokens[0], position_);
+    for (uint32_t i = 0; i < count; i++) {
+        encode_token(tokens[i], final_chunk && i + 1 == count, false, i);
+        if (warm_mtp && i + 1 < count)
+            mtp_warm(*x1_, tokens[i + 1], position_ + i + 1);
+    }
+    batch.finish();
+    position_ += count;
+    logits_resident_ = final_chunk;
+    mtp_cache_valid_ = has_mtp_ && (warm_mtp || position_ <= 1);
+    if (!final_chunk) return 0;
     uint32_t next = 0;
     backend_.read(*token_out_, 0, &next, sizeof(next));
     return next;
 }
 
+
 void MetalEngine::mtp_warm(const BackendBuffer& hidden, uint32_t token, uint32_t position) {
     if (!has_mtp_)
-        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; MTP is unavailable for this artifact");
     constexpr uint32_t layer = 64;
     backend_.embedding_q8(weight("token_embd.weight"), token, *h_);
     backend_.rmsnorm(*h_, layer_weight(layer, "nextn.enorm.weight"), *mtp_embed_norm_, N_EMBD, EPS);
@@ -607,9 +1654,31 @@ void MetalEngine::mtp_warm(const BackendBuffer& hidden, uint32_t token, uint32_t
     backend_.rmsnorm_heads(*kbuf_, layer_weight(layer, "attn_k_norm.weight"),
                            N_KV, HEAD_DIM, HEAD_DIM, EPS);
     backend_.rope_neox(*kbuf_, N_KV, HEAD_DIM, N_ROT, HEAD_DIM, position, FREQ_BASE);
-    backend_.kv_store(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_, position,
-                      N_KV, HEAD_DIM,
-                      turbo3_kv_ ? KvFormat::TURBO3 : KvFormat::F16);
+    if (turbo3_kv_)
+        backend_.kv_store_turbo3(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_, position, N_KV);
+    else
+        backend_.kv_store_f16(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_, position, N_KV * HEAD_DIM);
+}
+
+// Scheduling-quantum prefill (multislot Phase 1): one bounded chunk encode
+// per call. prefill() below drives its chunked loop through this, so the
+// serving scheduler's per-quantum ingestion and whole-prompt ingestion are
+// the same code path by construction.
+void MetalEngine::prefill_chunk(const uint32_t* tokens, uint32_t count) {
+    if (!chunked_prefill_)
+        throw std::runtime_error("q27 Metal: prefill_chunk requires chunked prefill");
+    if (count < 2 || count > PREFILL_CHUNK_MAX)
+        throw std::runtime_error("q27 Metal: prefill chunk must be 2..96 tokens");
+    if ((uint64_t)position_ + count > max_context_)
+        throw std::runtime_error("q27 Metal: prompt exceeds context");
+    for (uint32_t i = 0; i < count; i++)
+        if (tokens[i] >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
+    CommandBatch batch(backend_);
+    chunk_forward(tokens, count);
+    batch.finish();
+    position_ += count;
+    logits_resident_ = false;
+    mtp_cache_valid_ = false;
 }
 
 uint32_t MetalEngine::prefill(const std::vector<uint32_t>& prompt, bool warm_mtp) {
@@ -618,7 +1687,6 @@ uint32_t MetalEngine::prefill(const std::vector<uint32_t>& prompt, bool warm_mtp
         throw std::runtime_error("q27 Metal: prompt exceeds context");
     for (uint32_t token : prompt)
         if (token >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
-    logits_resident_ = false;
     // Layer-major chunked ingestion. MTP warming needs each token's final
     // normalized hidden state, which the chunked path does not produce, so
     // MTP prompts stay on the token-serial path. The final prompt token is
@@ -629,10 +1697,8 @@ uint32_t MetalEngine::prefill(const std::vector<uint32_t>& prompt, bool warm_mtp
         const size_t chunkable = prompt.size() - 1;
         while (chunkable - serial_begin >= 2) {
             const uint32_t count =
-                (uint32_t)std::min<size_t>(CHUNK_MAX, chunkable - serial_begin);
-            CommandBatch batch(backend_);
-            encode_chunk(prompt.data() + serial_begin, count);
-            batch.finish();
+                (uint32_t)std::min<size_t>(PREFILL_CHUNK_MAX, chunkable - serial_begin);
+            prefill_chunk(prompt.data() + serial_begin, count);
             serial_begin += count;
         }
     }
@@ -644,12 +1710,14 @@ uint32_t MetalEngine::prefill(const std::vector<uint32_t>& prompt, bool warm_mtp
         if(begin==serial_begin && warm_mtp && position_>0) mtp_warm(*x1_,prompt.front(),position_);
         size_t end=std::min(prompt.size(),begin+COMMAND_CHUNK);
         for(size_t i=begin;i<end;i++) {
-            encode_token(prompt[i],i+1==prompt.size());
-            if(warm_mtp && i+1<prompt.size()) mtp_warm(*x1_,prompt[i+1],position_);
+            encode_token(prompt[i],i+1==prompt.size(),false,(uint32_t)(i-begin));
+            if(warm_mtp && i+1<prompt.size()) mtp_warm(*x1_,prompt[i+1],position_+(uint32_t)(i-begin)+1);
         }
         batch.finish();
+        position_ += (uint32_t)(end - begin);
     }
     logits_resident_ = true;
+    mtp_cache_valid_ = has_mtp_ && (warm_mtp || position_ <= 1);
     uint32_t next = 0;
     backend_.read(*token_out_, 0, &next, sizeof(next));
     return next;
@@ -657,11 +1725,13 @@ uint32_t MetalEngine::prefill(const std::vector<uint32_t>& prompt, bool warm_mtp
 
 uint32_t MetalEngine::mtp_forward(const BackendBuffer& hidden, uint32_t token,
                                   uint32_t position) {
+    if (active_mask_ >= 0)
+        throw std::runtime_error("q27 Metal: MTP is unmasked; tool constraints require serial decode");
     if (!has_mtp_)
-        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; MTP is unavailable for this artifact");
+    if (!mtp_cache_valid_)
+        throw std::runtime_error("q27 Metal: MTP cache is not valid for this prefix");
     if (position >= max_context_) throw std::runtime_error("q27 Metal: MTP context exhausted");
-    if (!logits_resident_)
-        throw std::runtime_error("q27 Metal: MTP pending token is stale for the current state");
     if (token >= VOCAB) throw std::runtime_error("q27 Metal: MTP token out of range");
     constexpr uint32_t layer = 64;
     CommandBatch batch(backend_);
@@ -683,14 +1753,21 @@ uint32_t MetalEngine::mtp_forward(const BackendBuffer& hidden, uint32_t token,
                            N_KV, HEAD_DIM, HEAD_DIM, EPS);
     backend_.rope_neox(*qg_, N_HEAD, HEAD_DIM, N_ROT, 2 * HEAD_DIM, position, FREQ_BASE);
     backend_.rope_neox(*kbuf_, N_KV, HEAD_DIM, N_ROT, HEAD_DIM, position, FREQ_BASE);
-    const KvFormat format = turbo3_kv_ ? KvFormat::TURBO3 : KvFormat::F16;
-    if (turbo3_kv_) backend_.turbo_wht(*qg_, N_HEAD, 2 * HEAD_DIM, false);
-    backend_.kv_store(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_, position,
-                      N_KV, HEAD_DIM, format);
-    backend_.attention(*qg_, 2 * HEAD_DIM, *mtp_k_cache_, *mtp_v_cache_,
-                       *attn_out_, position + 1, N_HEAD, N_KV, HEAD_DIM,
-                       1.0f / std::sqrt((float)HEAD_DIM), format, nullptr);
-    if (turbo3_kv_) backend_.turbo_wht(*attn_out_, N_HEAD, HEAD_DIM, true);
+    if (turbo3_kv_) {
+        backend_.turbo_wht(*qg_, N_HEAD, 2 * HEAD_DIM, false);
+        backend_.kv_store_turbo3(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_, position, N_KV);
+        backend_.attention_turbo3(*qg_, 2 * HEAD_DIM, *mtp_k_cache_, *mtp_v_cache_,
+                                  *attn_out_, position + 1, N_HEAD, N_KV,
+                                  HEAD_DIM, 1.0f / std::sqrt((float)HEAD_DIM),
+                                  gqa_partials_.get());
+        backend_.turbo_wht(*attn_out_, N_HEAD, HEAD_DIM, true);
+    } else {
+        backend_.kv_store_f16(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_, position, N_KV * HEAD_DIM);
+        backend_.attention_f16(*qg_, 2 * HEAD_DIM, *mtp_k_cache_, *mtp_v_cache_,
+                               *attn_out_, position + 1, N_HEAD, N_KV,
+                               HEAD_DIM, 1.0f / std::sqrt((float)HEAD_DIM),
+                               gqa_partials_.get());
+    }
     backend_.sigmoid_gate_mul(*attn_out_, *qg_, N_HEAD, HEAD_DIM);
     backend_.quantize(*attn_out_, q6144_);
     backend_.matvec_quantized(layer_weight(layer, "attn_output.weight"), q6144_, *y_);
@@ -738,11 +1815,267 @@ std::vector<uint32_t> MetalEngine::generate_mtp_batched(uint32_t pending, uint32
     return output;
 }
 
+// One MTP draft/verify/commit round — the scheduling quantum for MTP
+// generation (multislot Phase 1). Extracted verbatim from the streaming
+// loop below, which now drives it, so the CLI/server whole-generation path
+// and the per-quantum scheduler path cannot drift.
+uint32_t MetalEngine::mtp_round(uint32_t pending, uint32_t remaining, uint32_t eos,
+                                uint32_t width, uint32_t& live_width,
+                                std::vector<uint32_t>& committed) {
+    if (pending >= VOCAB) throw std::runtime_error("q27 Metal: pending token out of range");
+    if (active_mask_ >= 0)
+        throw std::runtime_error("q27 Metal: MTP is unmasked; tool constraints require serial decode");
+    if (!has_mtp_)
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; MTP is unavailable for this artifact");
+    if (!mtp_cache_valid_)
+        throw std::runtime_error("q27 Metal: MTP cache is not valid for this prefix");
+    if (width < 2 || width > CHUNK_MAX)
+        throw std::runtime_error("q27 Metal: MTP width must be 2..12");
+    if (!chunked_prefill_)
+        throw std::runtime_error("q27 Metal: batched MTP requires chunked prefill");
+    if (remaining < 2)
+        throw std::runtime_error("q27 Metal: MTP round needs remaining >= 2 (emit the last token directly)");
+    // A finished stream must not draft: EOS can arrive as the previous
+    // round's bonus prediction, and drafting past it would waste a full round
+    // and pollute speculation stats. Mirrors the live<2 fallback's EOS skip.
+    if (pending == eos) {
+        committed.push_back(pending);
+        return pending;
+    }
+    uint32_t live = std::min(std::min(live_width, width), remaining);
+    // The verify chunk stores a KV row for every lane, so it must stay
+    // inside the reserved context even before acceptance is known.
+    if ((uint64_t)position_ + live > max_context_)
+        live = (uint32_t)(max_context_ - position_);
+    if (live < 2) {
+        committed.push_back(pending);
+        if (pending == eos) return pending;
+        return step(pending);
+    }
+    static const bool trace = getenv("Q27_MTP_TRACE") != nullptr;
+    auto clock = [] { return std::chrono::steady_clock::now(); };
+    auto since = [](std::chrono::steady_clock::time_point start) {
+        return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+    };
+    auto draft_start = clock();
+    std::vector<uint32_t> lanes(live);
+    lanes[0] = pending;
+    const BackendBuffer* hidden = x1_.get();
+    for (uint32_t lane = 1; lane < live; lane++) {
+        lanes[lane] = mtp_forward(*hidden, lanes[lane - 1], position_ + lane - 1);
+        hidden = mtp_hidden_out_.get();
+    }
+    last_spec_stats_.rounds++;
+    last_spec_stats_.drafted += live - 1;
+    auto verify_start = clock();
+    {
+        CommandBatch batch(backend_);
+        chunk_forward(lanes.data(), live, /*verify=*/true);
+        BackendQuantized x5 = quantized_view(cq5120_, live * N_EMBD);
+        backend_.rmsnorm_rows_quantized(*ch_, weight("output_norm.weight"), *cfinal_,
+                                        N_EMBD, live, EPS, x5);
+        backend_.matmul_quantized(weight("output.weight"), x5, live, *clogits_);
+        backend_.argmax_rows(*clogits_, VOCAB, live, *cpred_);
+        batch.finish();
+    }
+    std::vector<uint32_t> predictions(live);
+    backend_.read(*cpred_, 0, predictions.data(), live * sizeof(uint32_t));
+    uint32_t accepted = 0;
+    while (accepted + 1 < live && predictions[accepted] == lanes[accepted + 1]) accepted++;
+    uint32_t commit_n = std::min(accepted + 1, remaining);
+    // The final output token is pushed but never encoded, exactly like
+    // the serial walk, so snapshots and continuations stay compatible.
+    uint32_t encoded = commit_n == remaining ? commit_n - 1 : commit_n;
+    // EOS inside the committed prefix: the stream stops there, so state must
+    // too. Hand the caller a committed slice ending at the EOS token and
+    // encode only the tokens before it. KV rows past it stay invisible behind
+    // position_, and GDN replays only the emitted prefix. The CLI's
+    // never-matching EOS sentinel leaves this loop inert, so sentinel-driven
+    // runs are bit-identical by construction.
+    for (uint32_t i = 0; i < commit_n; i++)
+        if (lanes[i] == eos) {
+            commit_n = i + 1;
+            encoded = i;
+            break;
+        }
+    last_spec_stats_.accepted += commit_n - 1;
+    auto commit_start = clock();
+    if (encoded) {
+        CommandBatch batch(backend_);
+        gdn_replay(encoded);
+        // Warming the final accepted draft writes x1_ as scratch. Do it
+        // before restoring the verified committed hidden row below.
+        if(encoded==live)
+            mtp_warm(*hidden,lanes[encoded-1],position_+encoded-1);
+        backend_.copy(*cfinal_, (uint64_t)(encoded - 1) * N_EMBD * sizeof(float),
+                      *x1_, 0, (uint64_t)N_EMBD * sizeof(float));
+        backend_.copy(*clogits_, (uint64_t)(encoded - 1) * VOCAB * sizeof(float),
+                      *logits_, 0, (uint64_t)VOCAB * sizeof(float));
+        batch.finish();
+    }
+    position_ += encoded;
+    if (trace)
+        fprintf(stderr, "mtp round: live %u accepted %u | draft %.2fs verify %.2fs commit %.2fs\n",
+                live, accepted, std::chrono::duration<double>(verify_start - draft_start).count(),
+                std::chrono::duration<double>(commit_start - verify_start).count(), since(commit_start));
+    committed.insert(committed.end(), lanes.begin(), lanes.begin() + commit_n);
+    // Width adaptation is a pure performance control: committed tokens
+    // are width-invariant, matching the recorded 2/4/8/12 gate.
+    live_width = accepted + 1 == live ? std::min(width, live_width + 2)
+                                      : std::max(2u, accepted + 2);
+    return predictions[commit_n - 1];
+}
+
+// Sampled MTP: greedy drafts, rejection-sample accept (Phase 0 host walk).
+// Draft + verify match mtp_round; only the accept/pending tail differs.
+uint32_t MetalEngine::mtp_sample_round(uint32_t pending, uint32_t remaining, uint32_t eos,
+                                       uint32_t width, uint32_t& live_width,
+                                       const SamplingParams& params, std::mt19937_64& rng,
+                                       std::vector<uint32_t>& committed) {
+    validate_sampling(params);
+    if (pending >= VOCAB) throw std::runtime_error("q27 Metal: pending token out of range");
+    if (active_mask_ >= 0)
+        throw std::runtime_error("q27 Metal: sampled MTP is unmasked; tool constraints require serial decode");
+    if (!has_mtp_)
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use plain sampling");
+    if (!mtp_cache_valid_)
+        throw std::runtime_error("q27 Metal: MTP cache is not valid for this prefix");
+    if (width < 2 || width > CHUNK_MAX)
+        throw std::runtime_error("q27 Metal: MTP width must be 2..12");
+    if (!chunked_prefill_)
+        throw std::runtime_error("q27 Metal: batched MTP requires chunked prefill");
+    if (remaining < 2)
+        throw std::runtime_error("q27 Metal: MTP sample round needs remaining >= 2");
+    if (pending == eos) {
+        committed.push_back(pending);
+        return pending;
+    }
+    uint32_t live = std::min(std::min(live_width, width), remaining);
+    if ((uint64_t)position_ + live > max_context_)
+        live = (uint32_t)(max_context_ - position_);
+    if (live < 2) {
+        // Serial sample fallback: emit pending, encode it, sample next.
+        committed.push_back(pending);
+        if (pending == eos) return pending;
+        (void)step(pending);
+        return sample_from_logits(params, rng);
+    }
+    static const bool trace = getenv("Q27_MTP_TRACE") != nullptr;
+    auto clock = [] { return std::chrono::steady_clock::now(); };
+    auto since = [](std::chrono::steady_clock::time_point start) {
+        return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+    };
+    auto draft_start = clock();
+    std::vector<uint32_t> lanes(live);
+    lanes[0] = pending;
+    const BackendBuffer* hidden = x1_.get();
+    for (uint32_t lane = 1; lane < live; lane++) {
+        lanes[lane] = mtp_forward(*hidden, lanes[lane - 1], position_ + lane - 1);
+        hidden = mtp_hidden_out_.get();
+    }
+    last_spec_stats_.rounds++;
+    last_spec_stats_.drafted += live - 1;
+    auto verify_start = clock();
+    {
+        CommandBatch batch(backend_);
+        chunk_forward(lanes.data(), live, /*verify=*/true);
+        BackendQuantized x5 = quantized_view(cq5120_, live * N_EMBD);
+        backend_.rmsnorm_rows_quantized(*ch_, weight("output_norm.weight"), *cfinal_,
+                                        N_EMBD, live, EPS, x5);
+        backend_.matmul_quantized(weight("output.weight"), x5, live, *clogits_);
+        // No argmax_rows — acceptance is rejection sampling on the served dist.
+        batch.finish();
+    }
+    std::vector<uint32_t> drafts(live - 1);
+    for (uint32_t i = 0; i + 1 < live; i++) drafts[i] = lanes[i + 1];
+
+    // Prefer per-lane GPU top-k when top_k is set (card recipe uses 20):
+    // ~k floats/ids per lane instead of full VOCAB readback + partial_sort.
+    // Fall back to full logits on opt-out, top_k==0, or degenerate over-set.
+    std::vector<ServedDistribution> lane_dists(live);
+    bool used_topk = false;
+    if (gpu_sample_ && params.temperature > 0.0f &&
+        params.top_k >= 1 && params.top_k <= 256) {
+        used_topk = true;
+        for (uint32_t lane = 0; lane < live; lane++) {
+            // Bind clogits_ row via byte offset — no full-row copy into logits_.
+            // topk requires its own command (CPU-clears count); not batchable.
+            const uint64_t row_off = (uint64_t)lane * VOCAB * sizeof(float);
+            backend_.topk(*clogits_, VOCAB, params.top_k, *topk_values_,
+                          *topk_indices_, *topk_count_, row_off);
+            uint32_t count = 0;
+            backend_.read(*topk_count_, 0, &count, sizeof(count));
+            if (count < params.top_k || count > TOPK_CAPACITY) {
+                used_topk = false;
+                break;
+            }
+            std::vector<float> values(count);
+            std::vector<uint32_t> indices(count);
+            backend_.read(*topk_values_, 0, values.data(), count * sizeof(float));
+            backend_.read(*topk_indices_, 0, indices.data(), count * sizeof(uint32_t));
+            lane_dists[lane] = build_served_from_candidates(
+                values.data(), indices.data(), count, params);
+        }
+    }
+    if (!used_topk) {
+        std::vector<float> lane_logits((size_t)live * VOCAB);
+        backend_.read(*clogits_, 0, lane_logits.data(),
+                      (uint64_t)live * VOCAB * sizeof(float));
+        for (uint32_t lane = 0; lane < live; lane++)
+            lane_dists[lane] = build_served_distribution(
+                lane_logits.data() + (size_t)lane * VOCAB, VOCAB, params);
+    }
+
+    SpecRejectResult accept =
+        spec_rejection_accept(lane_dists.data(), live, drafts.data(), rng);
+    // accepted drafts before first reject (or all), for width adaptation.
+    const uint32_t accepted = accept.n - 1;
+    uint32_t commit_n = std::min(accept.n, remaining);
+    uint32_t encoded = commit_n == remaining ? commit_n - 1 : commit_n;
+    for (uint32_t i = 0; i < commit_n; i++)
+        if (lanes[i] == eos) {
+            commit_n = i + 1;
+            encoded = i;
+            break;
+        }
+    last_spec_stats_.accepted += commit_n > 0 ? commit_n - 1 : 0;
+    auto commit_start = clock();
+    if (encoded) {
+        CommandBatch batch(backend_);
+        gdn_replay(encoded);
+        if(encoded==live)
+            mtp_warm(*hidden,lanes[encoded-1],position_+encoded-1);
+        backend_.copy(*cfinal_, (uint64_t)(encoded - 1) * N_EMBD * sizeof(float),
+                      *x1_, 0, (uint64_t)N_EMBD * sizeof(float));
+        backend_.copy(*clogits_, (uint64_t)(encoded - 1) * VOCAB * sizeof(float),
+                      *logits_, 0, (uint64_t)VOCAB * sizeof(float));
+        batch.finish();
+    }
+    position_ += encoded;
+    if (trace)
+        fprintf(stderr,
+                "mtp sample round: live %u n %u stop %u exclude %d topk %d | draft %.2fs verify %.2fs commit %.2fs\n",
+                live, accept.n, accept.stop_lane, (int)accept.exclude, used_topk ? 1 : 0,
+                std::chrono::duration<double>(verify_start - draft_start).count(),
+                std::chrono::duration<double>(commit_start - verify_start).count(),
+                since(commit_start));
+    committed.insert(committed.end(), lanes.begin(), lanes.begin() + commit_n);
+    live_width = accepted + 1 == live ? std::min(width, live_width + 2)
+                                      : std::max(2u, accepted + 2);
+    // Full walk used → pending already sampled. Remaining/EOS clamp → sample
+    // from the last committed lane (mirrors greedy predictions[c-1]).
+    if (commit_n == accept.n) return accept.pending;
+    return sample_served(lane_dists[commit_n - 1], rng, /*exclude=*/-1);
+}
+
 uint32_t MetalEngine::stream_mtp_batched(uint32_t pending, uint32_t count, uint32_t width,
                                          uint32_t eos, const TokenSink& sink, StopCause& cause) {
+    if (active_mask_ >= 0)
+        throw std::runtime_error("q27 Metal: MTP is unmasked; tool constraints require serial decode");
+    if (!mtp_cache_valid_)
+        throw std::runtime_error("q27 Metal: MTP cache is not valid for this prefix");
     uint32_t emitted = 0;
     cause = StopCause::MaxTokens;
-    // commit() streams one token through the sink, stopping on EOS or cancel.
     // Returns 0 = continue, 1 = EOS reached, 2 = client cancelled.
     auto commit = [&](uint32_t token) -> int {
         if (token == eos) { cause = StopCause::Eos; return 1; }
@@ -751,15 +2084,13 @@ uint32_t MetalEngine::stream_mtp_batched(uint32_t pending, uint32_t count, uint3
         return 0;
     };
     // Start narrow and let acceptance widen the window: committed tokens are
-    // width-invariant, and a wide first round pays for many serial drafts
-    // through a cold draft head before acceptance has been measured once.
+    // width-invariant, and a wide first round pays for cold draft work.
     uint32_t live_width = std::min(width, 4u);
     while (emitted < count) {
+        if (pending == eos) { cause = StopCause::Eos; return emitted; }
         if (emitted + 1 == count) { commit(pending); return emitted; }
-        const uint32_t remaining = (uint32_t)(count - emitted);
+        const uint32_t remaining = count - emitted;
         uint32_t live = std::min(live_width, remaining);
-        // The verify chunk stores a KV row for every lane, so it must stay
-        // inside the reserved context even before acceptance is known.
         if ((uint64_t)position_ + live > max_context_)
             live = (uint32_t)(max_context_ - position_);
         if (live < 2) {
@@ -799,16 +2130,22 @@ uint32_t MetalEngine::stream_mtp_batched(uint32_t pending, uint32_t count, uint3
         uint32_t accepted = 0;
         while (accepted + 1 < live && predictions[accepted] == lanes[accepted + 1]) accepted++;
         const uint32_t offered = std::min(accepted + 1, remaining);
-        // Determine the externally committed prefix before mutating recurrent,
-        // KV, hidden, or logits state. EOS and a rejecting sink do not consume
-        // their token; prior delivered tokens still need encoding so state
-        // predicts the stopped token exactly as the serial walk does.
+        // Decide the externally consumed prefix before recurrent, KV, hidden,
+        // or resident-logit state is committed. EOS and a rejecting sink do
+        // not consume their token; previously delivered tokens still do.
         uint32_t delivered = 0;
         int stop = 0;
         while (delivered < offered) {
             stop = commit(lanes[delivered]);
             if (stop) break;
             delivered++;
+        }
+        if (stop == 2 && emitted) {
+            // Once any token has escaped, a later cancellation cannot expose a
+            // partially committed speculative prefix as reusable state. The
+            // serving layer will restore its pre-generation prompt snapshot.
+            reset();
+            return emitted;
         }
         last_spec_stats_.accepted += delivered ? delivered - 1 : 0;
         const bool exhausted = emitted == count;
@@ -817,8 +2154,6 @@ uint32_t MetalEngine::stream_mtp_batched(uint32_t pending, uint32_t count, uint3
         if (encoded) {
             CommandBatch batch(backend_);
             gdn_replay(encoded);
-            // A fully accepted draft window advances beyond the final row
-            // written by mtp_forward; warm that consumed lane before the next round.
             if (encoded == live)
                 mtp_warm(*hidden, lanes[encoded - 1], position_ + encoded - 1);
             backend_.copy(*cfinal_, (uint64_t)(encoded - 1) * N_EMBD * sizeof(float),
@@ -834,8 +2169,6 @@ uint32_t MetalEngine::stream_mtp_batched(uint32_t pending, uint32_t count, uint3
                     std::chrono::duration<double>(commit_start - verify_start).count(), since(commit_start));
         if (stop || exhausted) return emitted;
         pending = predictions[delivered - 1];
-        // Width adaptation is a pure performance control: committed tokens
-        // are width-invariant, matching the recorded 2/4/8/12 gate.
         live_width = accepted + 1 == live ? std::min(width, live_width + 2)
                                           : std::max(2u, accepted + 2);
     }
@@ -850,11 +2183,17 @@ uint32_t MetalEngine::ingest_prompt(const std::vector<uint32_t>& tokens, bool wa
 
 std::vector<float> MetalEngine::read_logits() {
     if (!logits_resident_)
-        throw std::runtime_error("q27 Metal: logits are not resident for the current state");
+        throw std::runtime_error("q27 Metal: snapshot has no resident logits; continue prefill before reading logits");
     std::vector<float> result(VOCAB);
     backend_.synchronize();
     backend_.read(*logits_,0,result.data(),result.size()*sizeof(float));
     return result;
+}
+
+void MetalEngine::read_hidden(std::vector<float>& out) {
+    out.resize(N_EMBD);
+    backend_.synchronize();
+    backend_.read(*x1_,0,out.data(),out.size()*sizeof(float));
 }
 
 std::vector<float> MetalEngine::teacher_force_nll(const std::vector<uint32_t>& tokens) {
@@ -899,6 +2238,7 @@ std::vector<float> MetalEngine::teacher_force_nll(const std::vector<uint32_t>& t
                 batch.finish();
             }
             position_ += count;
+            mtp_cache_valid_ = false;
             std::vector<float> chunk_nll(count);
             backend_.read(*cnll_, 0, chunk_nll.data(), count * sizeof(float));
             result.insert(result.end(), chunk_nll.begin(), chunk_nll.end());
@@ -921,38 +2261,221 @@ std::vector<float> MetalEngine::teacher_force_nll(const std::vector<uint32_t>& t
             CommandBatch batch(backend_);
             encode_token(tokens[done], true);
             batch.finish();
-            logits_resident_ = true;
         }
-        std::vector<float> logits = read_logits();
-        result.push_back(nll_cpu(logits.data(), tokens[done + 1], VOCAB));
+        position_++;
+        logits_resident_ = true;
+        mtp_cache_valid_ = false;
+        if (chunked_prefill_) {
+            // The leftover row uses the same float GPU reduction as chunked
+            // rows. A CPU double tail would create a third numerical regime,
+            // while CUDA processes every row as float on the GPU. logits_ is
+            // one VOCAB row and is valid at rows=1.
+            backend_.write(*ctargets_, 0, &tokens[done + 1], sizeof(uint32_t));
+            {
+                CommandBatch batch(backend_);
+                backend_.nll_rows(*logits_, *ctargets_, *cnll_, VOCAB, 1);
+                batch.finish();
+            }
+            float row_nll = 0.0f;
+            backend_.read(*cnll_, 0, &row_nll, sizeof row_nll);
+            result.push_back(row_nll);
+        } else {
+            // Pre-Apple7 all-serial fallback: no ctargets_/cnll_ exist and
+            // the whole pass is one (CPU) regime already.
+            std::vector<float> logits = read_logits();
+            result.push_back(nll_cpu(logits.data(), tokens[done + 1], VOCAB));
+        }
         done++;
     }
+    // reset() creates a row-0 MTP sentinel, but teacher forcing never warms
+    // layer-64 rows for the advanced main-model prefix.
+    mtp_cache_valid_ = false;
     if (n_encode >= CHUNK_MAX) fprintf(stderr, "\n");
     return result;
 }
 
+void MetalEngine::teacher_force_logits(const uint32_t* tokens, uint32_t count,
+                                       std::vector<float>& out) {
+    if (!count || count > CHUNK_MAX)
+        throw std::runtime_error("q27 Metal: teacher_force_logits takes 1..12 tokens");
+    if (active_mask_ >= 0)
+        throw std::runtime_error("q27 Metal: teacher forcing refuses active tool constraints");
+    if ((uint64_t)position_ + count > max_context_)
+        throw std::runtime_error("q27 Metal: teacher-forced chunk exceeds context");
+    for (uint32_t i = 0; i < count; i++)
+        if (tokens[i] >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
+    out.resize((size_t)count * VOCAB);
+    if (chunked_prefill_ && count >= 2) {
+        {
+            CommandBatch batch(backend_);
+            chunk_forward(tokens, count);
+            BackendQuantized x5 = quantized_view(cq5120_, count * N_EMBD);
+            backend_.rmsnorm_rows_quantized(*ch_, weight("output_norm.weight"), *cfinal_,
+                                            N_EMBD, count, EPS, x5);
+            backend_.matmul_quantized(weight("output.weight"), x5, count, *clogits_);
+            // Commit recurrent/KV state and both serial coherence buffers as
+            // one unit. A command failure poisons the backend in finish().
+            backend_.copy(*clogits_, (uint64_t)(count - 1) * VOCAB * sizeof(float),
+                          *logits_, 0, (uint64_t)VOCAB * sizeof(float));
+            backend_.copy(*cfinal_, (uint64_t)(count - 1) * N_EMBD * sizeof(float),
+                          *x1_, 0, (uint64_t)N_EMBD * sizeof(float));
+            batch.finish();
+        }
+        position_ += count;
+        logits_resident_ = true;
+        mtp_cache_valid_ = false;
+        backend_.read(*clogits_, 0, out.data(), out.size() * sizeof(float));
+        return;
+    }
+    for (uint32_t i = 0; i < count; i++) {
+        {
+            CommandBatch batch(backend_);
+            encode_token(tokens[i], true);
+            batch.finish();
+        }
+        position_++;
+        logits_resident_ = true;
+        mtp_cache_valid_ = false;
+        backend_.read(*logits_, 0, out.data() + (size_t)i * VOCAB,
+                      (uint64_t)VOCAB * sizeof(float));
+    }
+}
+
+void MetalEngine::teacher_force_logits_wide(const uint32_t* tokens, uint32_t count,
+                                            std::vector<float>& out) {
+    if (!count || count > PREFILL_CHUNK_MAX)
+        throw std::runtime_error("q27 Metal: teacher_force_logits_wide takes 1..96 tokens");
+    if (active_mask_ >= 0)
+        throw std::runtime_error("q27 Metal: teacher forcing refuses active tool constraints");
+    if (count <= CHUNK_MAX) { teacher_force_logits(tokens, count, out); return; }
+    if (!chunked_prefill_ || !ch_)
+        throw std::runtime_error("q27 Metal: wide teacher forcing requires chunked prefill");
+    if ((uint64_t)position_ + count > max_context_)
+        throw std::runtime_error("q27 Metal: teacher-forced chunk exceeds context");
+    for (uint32_t i = 0; i < count; i++)
+        if (tokens[i] >= VOCAB) throw std::runtime_error("q27 Metal: token out of range");
+    out.resize((size_t)count * VOCAB);
+    if (!wide_head_stage_)
+        wide_head_stage_ = backend_.allocate((uint64_t)CHUNK_MAX * N_EMBD * sizeof(float));
+    {
+        CommandBatch batch(backend_);
+        chunk_forward(tokens, count);
+        batch.finish();
+    }
+    // chunk_forward has committed recurrent/KV state. Any later host-side or
+    // encoding failure must poison the backend: position_ cannot describe a
+    // reusable engine after a partial wide-head pass.
+    try {
+        // Head in CHUNK_MAX-row slices: cfinal_/clogits_ are CHUNK_MAX-sized,
+        // so each slice's hidden rows are staged to offset 0 first.
+        for (uint32_t s0 = 0; s0 < count; s0 += CHUNK_MAX) {
+            const uint32_t slice = std::min(CHUNK_MAX, count - s0);
+            const bool final_slice = s0 + slice == count;
+            {
+                CommandBatch batch(backend_);
+                backend_.copy(*ch_, (uint64_t)s0 * N_EMBD * sizeof(float),
+                              *wide_head_stage_, 0, (uint64_t)slice * N_EMBD * sizeof(float));
+                BackendQuantized x5 = quantized_view(cq5120_, slice * N_EMBD);
+                backend_.rmsnorm_rows_quantized(*wide_head_stage_, weight("output_norm.weight"),
+                                                *cfinal_, N_EMBD, slice, EPS, x5);
+                backend_.matmul_quantized(weight("output.weight"), x5, slice, *clogits_);
+                if (final_slice) {
+                    const uint32_t last_row = slice - 1;
+                    backend_.copy(*clogits_, (uint64_t)last_row * VOCAB * sizeof(float),
+                                  *logits_, 0, (uint64_t)VOCAB * sizeof(float));
+                    backend_.copy(*cfinal_, (uint64_t)last_row * N_EMBD * sizeof(float),
+                                  *x1_, 0, (uint64_t)N_EMBD * sizeof(float));
+                }
+                batch.finish();
+            }
+            backend_.read(*clogits_, 0, out.data() + (size_t)s0 * VOCAB,
+                          (uint64_t)slice * VOCAB * sizeof(float));
+        }
+    } catch (...) {
+        backend_.poison();
+        throw;
+    }
+    position_ += count;
+    logits_resident_ = true;
+    mtp_cache_valid_ = false;
+}
+
+// GPU-assisted sampling: when top-k is active and within the radix-select
+// range, extract the candidate over-set on the GPU and read back ~k pairs
+// A candidate count above capacity signals degenerate ties or a NaN
+// sentinel — fall back to the exact full-readback path, which validates
+// every logit and is also the Q27_METAL_GPU_SAMPLE=0 opt-out and the
+// temperature-0 / no-top-k route. Same-seed token sequences match the
+// full path exactly (one uniform draw either way; real logits don't tie).
+uint32_t MetalEngine::sample_next(const SamplingParams& params, std::mt19937_64& random) {
+    if (!logits_resident_)
+        throw std::runtime_error("q27 Metal: snapshot has no resident logits; continue prefill before sampling");
+    if (gpu_sample_ && params.temperature != 0.0f && params.top_k >= 1 && params.top_k <= 256) {
+        backend_.topk(*logits_, VOCAB, params.top_k, *topk_values_, *topk_indices_, *topk_count_);
+        uint32_t count = 0;
+        backend_.read(*topk_count_, 0, &count, sizeof(count));
+        // count >= k is provable from the kernel's two-pass construction
+        // (2026-07-17 triage doc); the lower bound here guards future
+        // kernel edits — an under-set must fall back, never silently
+        // sample from a truncated candidate list.
+        if (count >= (uint32_t)params.top_k && count <= TOPK_CAPACITY) {
+            std::vector<float> values(count);
+            std::vector<uint32_t> indices(count);
+            backend_.read(*topk_values_, 0, values.data(), count * sizeof(float));
+            backend_.read(*topk_indices_, 0, indices.data(), count * sizeof(uint32_t));
+            return sample_candidates_cpu(values, indices, count, params, random);
+        }
+    }
+    return sample_logits_cpu(read_logits(), params, random);
+}
+
+uint32_t MetalEngine::sample_from_logits(const SamplingParams& params, std::mt19937_64& rng) {
+    validate_sampling(params);
+    return sample_next(params, rng);
+}
+
 std::vector<uint32_t> MetalEngine::generate_sampled_from_logits(uint32_t count,
-                                                                 const SamplingParams& params) {
+                                                                 const SamplingParams& params,
+                                                                 uint32_t eos) {
     validate_sampling(params); last_spec_stats_={};
     if((uint64_t)position_+(count?count-1:0)>max_context_)
         throw std::runtime_error("q27 Metal: generation exceeds context");
+    if (eos < VOCAB) {
+        std::vector<uint32_t> output;
+        output.reserve(count);
+        StopCause cause;
+        stream_sampled_from_logits(count, eos, params,
+                                   [&](uint32_t token) { output.push_back(token); return true; }, cause);
+        return output;
+    }
     std::mt19937_64 random(params.seed); std::vector<uint32_t> output; output.reserve(count);
     for(uint32_t i=0;i<count;i++) {
-        // top_k == 0 must stay on the complete logits vector; candidate over-sets
-        // intentionally reject that configuration because they omit vocabulary entries.
-        uint32_t token=sample_logits_cpu(read_logits(),params,random); output.push_back(token);
+        uint32_t token=sample_next(params,random); output.push_back(token);
         if(i+1<count) step(token);
     }
     return output;
 }
 
 std::vector<uint32_t> MetalEngine::generate_sampled(const std::vector<uint32_t>& prompt,
-                                                     uint32_t count,const SamplingParams& params) {
+                                                     uint32_t count, const SamplingParams& params,
+                                                     uint32_t eos) {
     if(prompt.empty()) throw std::runtime_error("q27 Metal: prompt is empty");
     if((uint64_t)prompt.size()+count>max_context_+1)
         throw std::runtime_error("q27 Metal: prompt/generation exceeds context");
     ingest_prompt(prompt,false,true);
-    return generate_sampled_from_logits(count,params);
+    return generate_sampled_from_logits(count,params,eos);
+}
+
+uint32_t MetalEngine::force_tokens(const uint32_t* tokens, uint32_t count) {
+    if (!count) throw std::runtime_error("q27 Metal: forced token sequence is empty");
+    if (!tokens) throw std::runtime_error("q27 Metal: forced token sequence is null");
+    if ((uint64_t)position_ + count > max_context_)
+        throw std::runtime_error("q27 Metal: forced token sequence exceeds context");
+    for (uint32_t i = 0; i < count; i++)
+        if (tokens[i] >= VOCAB) throw std::runtime_error("q27 Metal: forced token out of range");
+    uint32_t pending = 0;
+    for (uint32_t i = 0; i < count; i++) pending = step(tokens[i]);
+    return pending;
 }
 
 uint32_t MetalEngine::stream_sampled_from_logits(uint32_t count, uint32_t eos,
@@ -965,7 +2488,7 @@ uint32_t MetalEngine::stream_sampled_from_logits(uint32_t count, uint32_t eos,
     cause = StopCause::MaxTokens;
     uint32_t emitted=0;
     while(emitted<count) {
-        uint32_t token=sample_logits_cpu(read_logits(),params,random);
+        uint32_t token=sample_next(params,random);
         if(token==eos) { cause=StopCause::Eos; return emitted; }
         if(!sink(token)) { cause=StopCause::Cancelled; return emitted; }
         if(++emitted==count) return emitted;
@@ -981,8 +2504,10 @@ uint32_t MetalEngine::stream_from_pending(uint32_t pending, uint32_t count, uint
     if (pending >= VOCAB) throw std::runtime_error("q27 Metal: pending token out of range");
     if (count && !logits_resident_)
         throw std::runtime_error("q27 Metal: pending token is stale for the current state");
+    if (mtp_width && active_mask_ >= 0)
+        throw std::runtime_error("q27 Metal: MTP is unmasked; tool constraints require serial decode");
     if (mtp_width && !has_mtp_)
-        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; MTP is unavailable for this artifact");
     if (mtp_width && (mtp_width < 2 || mtp_width > 12))
         throw std::runtime_error("q27 Metal: MTP width must be 2..12");
     if ((uint64_t)position_ + (count ? count - 1 : 0) > max_context_)
@@ -1005,17 +2530,27 @@ uint32_t MetalEngine::stream_from_pending(uint32_t pending, uint32_t count, uint
 }
 
 std::vector<uint32_t> MetalEngine::generate_from_pending(uint32_t pending, uint32_t count,
-                                                          uint32_t mtp_width) {
+                                                          uint32_t mtp_width, uint32_t eos) {
     last_spec_stats_={};
     if (pending >= VOCAB) throw std::runtime_error("q27 Metal: pending token out of range");
     if (count && !logits_resident_)
         throw std::runtime_error("q27 Metal: pending token is stale for the current state");
+    if (mtp_width && active_mask_ >= 0)
+        throw std::runtime_error("q27 Metal: MTP is unmasked; tool constraints require serial decode");
     if (mtp_width && !has_mtp_)
-        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; MTP is unavailable for this artifact");
     if (mtp_width && (mtp_width < 2 || mtp_width > 12))
         throw std::runtime_error("q27 Metal: MTP width must be 2..12");
     if ((uint64_t)position_ + (count ? count - 1 : 0) > max_context_)
         throw std::runtime_error("q27 Metal: generation exceeds context");
+    if (eos < VOCAB) {
+        std::vector<uint32_t> output;
+        output.reserve(count);
+        StopCause cause;
+        stream_from_pending(pending, count, eos, mtp_width,
+                            [&](uint32_t token) { output.push_back(token); return true; }, cause);
+        return output;
+    }
     if (mtp_width && chunked_prefill_)
         return generate_mtp_batched(pending, count, mtp_width);
     std::vector<uint32_t> output;
@@ -1023,6 +2558,16 @@ std::vector<uint32_t> MetalEngine::generate_from_pending(uint32_t pending, uint3
     if (!mtp_width) {
         if (!count) return output;
         output.push_back(pending);
+        if (resident_ && active_mask_ < 0) {
+            uint32_t ids[RESIDENT_MAX];
+            while (output.size() < count) {
+                const uint32_t take = std::min<uint32_t>(RESIDENT_MAX,
+                                                         (uint32_t)(count - output.size()));
+                pending = decode_resident(pending, ids, take);
+                output.insert(output.end(), ids, ids + take);
+            }
+            return output;
+        }
         for (uint32_t i=1;i<count;i++) { pending=step(pending); output.push_back(pending); }
         return output;
     }
@@ -1041,66 +2586,99 @@ std::vector<uint32_t> MetalEngine::generate_from_pending(uint32_t pending, uint3
         last_spec_stats_.rounds++; last_spec_stats_.drafted+=drafts.size();
         output.push_back(pending);
         uint32_t prediction = step(pending);
-        for (uint32_t draft : drafts) {
+        // mtp_forward populated the MTP KV row for every token this serial
+        // verify loop can commit. step() invalidates ordinary callers because
+        // they have no such row; restore validity only inside this MTP path.
+        mtp_cache_valid_ = true;
+        for (size_t draft_index=0;draft_index<drafts.size();draft_index++) {
+            const uint32_t draft=drafts[draft_index];
             if (prediction != draft) break;
             last_spec_stats_.accepted++;
             output.push_back(draft);
             if (output.size() == count) return output;
+            if(draft_index+1==drafts.size()) {
+                // The final draft was produced, not consumed, by the draft
+                // chain. Populate its row before committing it so the next
+                // round's cache-valid flag covers [0, position_).
+                CommandBatch batch(backend_);
+                mtp_warm(*hidden,draft,position_);
+                batch.finish();
+            }
             prediction = step(draft);
+            mtp_cache_valid_ = true;
         }
         pending = prediction;
     }
     return output;
 }
 
-std::vector<uint32_t> MetalEngine::generate(const std::vector<uint32_t>& prompt, uint32_t count) {
+std::vector<uint32_t> MetalEngine::generate(const std::vector<uint32_t>& prompt, uint32_t count,
+                                            uint32_t eos) {
     if (prompt.empty()) throw std::runtime_error("q27 Metal: prompt is empty");
     if ((uint64_t)prompt.size() + count > max_context_ + 1)
         throw std::runtime_error("q27 Metal: prompt/generation exceeds context");
     uint32_t pending = ingest_prompt(prompt, false, true);
-    return generate_from_pending(pending, count);
+    return generate_from_pending(pending, count, 0, eos);
 }
 
 std::vector<uint32_t> MetalEngine::generate_mtp(const std::vector<uint32_t>& prompt,
-                                                 uint32_t count, uint32_t width) {
+                                                uint32_t count, uint32_t width,
+                                                uint32_t eos) {
     if (prompt.empty()) throw std::runtime_error("q27 Metal: prompt is empty");
+    if (active_mask_ >= 0)
+        throw std::runtime_error("q27 Metal: MTP is unmasked; tool constraints require serial decode");
     if (!has_mtp_)
-        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; MTP is unavailable for this artifact");
     if ((uint64_t)prompt.size() + count > max_context_ + 1)
         throw std::runtime_error("q27 Metal: prompt/generation exceeds context");
     uint32_t pending = ingest_prompt(prompt, true, true);
-    return generate_from_pending(pending, count, width);
+    return generate_from_pending(pending, count, width, eos);
 }
 
-std::vector<uint32_t> MetalEngine::generate_suffix(const std::vector<uint32_t>& prompt,
-                                                    uint32_t count, uint32_t width,
-                                                    uint32_t minimum_match) {
-    if(prompt.empty()) throw std::runtime_error("q27 Metal: prompt is empty");
-    if(width<2 || width>12) throw std::runtime_error("q27 Metal: suffix width must be 2..12");
-    if((uint64_t)prompt.size()+count>max_context_+1)
+std::vector<uint32_t> MetalEngine::generate_mtp_sampled(const std::vector<uint32_t>& prompt,
+                                                          uint32_t count, uint32_t width,
+                                                          const SamplingParams& params,
+                                                          uint32_t eos) {
+    validate_sampling(params);
+    if (prompt.empty()) throw std::runtime_error("q27 Metal: prompt is empty");
+    if (active_mask_ >= 0)
+        throw std::runtime_error("q27 Metal: sampled MTP is unmasked; tool constraints require serial decode");
+    if (!has_mtp_)
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use plain sampling");
+    if (!chunked_prefill_)
+        throw std::runtime_error("q27 Metal: sampled MTP requires chunked prefill");
+    if (width < 2 || width > CHUNK_MAX)
+        throw std::runtime_error("q27 Metal: MTP width must be 2..12");
+    if ((uint64_t)prompt.size() + count > max_context_ + 1)
         throw std::runtime_error("q27 Metal: prompt/generation exceeds context");
-    uint32_t pending=ingest_prompt(prompt,false,true); last_spec_stats_={};
-    std::vector<int> history(prompt.begin(),prompt.end()); SuffixDraft drafter; drafter.reset(history);
-    std::vector<uint32_t> output; output.reserve(count);
-    while(output.size()<count) {
-        if(output.size()+1==count) { output.push_back(pending); break; }
-        const uint32_t lanes=std::min<uint32_t>(width-1,(uint32_t)(count-output.size()-1));
-        std::vector<int> proposals(lanes);
-        int match=drafter.propose_with((int)pending,(int)lanes,proposals.data());
-        last_spec_stats_.rounds++;
-        if(match>=(int)minimum_match) last_spec_stats_.drafted+=proposals.size();
-        output.push_back(pending); drafter.append((int)pending);
-        uint32_t prediction=step(pending);
-        if(match>=(int)minimum_match) for(int proposal:proposals) {
-            if(prediction!=(uint32_t)proposal) break;
-            last_spec_stats_.accepted++;
-            output.push_back((uint32_t)proposal); drafter.append(proposal);
-            if(output.size()==count) return output;
-            prediction=step((uint32_t)proposal);
+    last_spec_stats_ = {};
+    // Prefill leaves logits for the first gen token (always — including count==0
+    // so --dump-logits / reuse see prompt-conditioned state). Sample pending
+    // only when generating (not the greedy argmax from ingest_prompt's return).
+    (void)ingest_prompt(prompt, true, true);
+    if (!count) return {};
+    std::mt19937_64 rng(params.seed);
+    uint32_t pending = sample_from_logits(params, rng);
+    std::vector<uint32_t> generated;
+    generated.reserve(count);
+    uint32_t live_width = std::min(width, 4u);
+    std::vector<uint32_t> committed;
+    while (generated.size() < count) {
+        if (pending == eos) break;
+        if (generated.size() + 1 == count) {
+            generated.push_back(pending);
+            break;
         }
-        pending=prediction;
+        committed.clear();
+        pending = mtp_sample_round(pending, (uint32_t)(count - generated.size()),
+                                   eos, width, live_width, params, rng, committed);
+        for (uint32_t token : committed) {
+            if (token == eos) return generated;
+            generated.push_back(token);
+        }
     }
-    return output;
+    return generated;
 }
+
 
 } // namespace q27

--- a/src/metal/metal_engine.h
+++ b/src/metal/metal_engine.h
@@ -4,6 +4,7 @@
 #include "../sampling.h"
 #include "../loader.h"
 
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -17,39 +18,150 @@ class MetalEngine {
   public:
     struct Snapshot;
     struct SpecStats { uint64_t rounds=0,drafted=0,accepted=0; };
+    // One-per-artifact state shared by engines in the same process: the
+    // artifact mapping, the Metal queue/pipelines (the whole-mapping buffer
+    // and residency set live behind the backend), and the weight wrap.
+    // Engines sharing a Shared never map or wire the artifact twice, so the
+    // one-model-load memory policy sees a single load however many engines
+    // (e.g. an fp16-KV baseline and a turbo3-KV subject) attach to it.
+    // Contract: engines on one Shared must be constructed and driven from a
+    // single thread (or externally serialized) — they alias one command
+    // queue and one batching state, and nothing here locks.
+    struct Shared {
+        Model model;
+        MetalBackend backend;
+        std::unordered_map<std::string, BackendTensor> weights;
+        // Combined KV-cache footprint of every engine on this mapping, so a
+        // second engine cannot pass the per-engine budget check while the
+        // pair overcommits the device.
+        uint64_t cache_bytes = 0;
+        // Engine-local cache admission ceiling. Direct users retain the
+        // historical half-working-set default; servers may replace it with
+        // their explicit --budget-mb policy before constructing any slot.
+        uint64_t cache_budget = 0;
+        // Artifact path, kept for diagnostics, plus the disk-snapshot
+        // identity: SHA1 over the whole mapped artifact — the bytes this
+        // process actually opened, immune to pathname swaps — computed
+        // lazily on first snapshot use and cached, never on ordinary startup.
+        std::string path;
+        unsigned char snap_sha1[20] = {};
+        bool snap_sha_ready = false;
+        explicit Shared(Model&& opened) : model(std::move(opened)) {
+            cache_budget=backend.recommended_working_set_size()/2;
+        }
+    };
+    static std::shared_ptr<Shared> open_shared(const std::string& model_path);
     explicit MetalEngine(const std::string& model_path, uint32_t context = 128,
                          bool turbo3_kv = false);
+    MetalEngine(std::shared_ptr<Shared> shared, uint32_t context, bool turbo3_kv);
+    // Reference members alias shared GPU state; a copy with an independent
+    // position_ would corrupt its sibling. Engines are pinned to their spot.
+    MetalEngine(const MetalEngine&) = delete;
+    MetalEngine& operator=(const MetalEngine&) = delete;
+    ~MetalEngine();
+
+    // G6 admission accounting (docs/metal/plans/2026-07-16-g6-admission.md).
+    // These mirror the constructor's allocations and capture_state()'s
+    // snapshot composition — keep them paired with those sites.
+    bool has_mtp() const { return has_mtp_; }
+    // KV caches plus this engine's blocked-GQA partials scratch — every
+    // ctx-scaled reservation the constructor charges against the shared
+    // cross-engine budget (audit E2: partials are per-engine now).
+    uint64_t kv_reserved_bytes() const { return engine_cache_bytes_; }
+    uint64_t snapshot_bytes() const;               // worst case at max_context_
+    // Per-engine non-KV buffers; MTP terms exist on MTP artifacts and the
+    // chunk/verify/replay terms only when chunked prefill is available.
+    // The GQA partials are charged inside kv_reserved_bytes, not here.
+    static uint64_t fixed_state_bytes(bool chunked,bool has_mtp);
+    // Exact server-side footprint estimate before an engine allocates: KV and
+    // GQA scratch, fixed/lazy state, plus configured in-memory snapshots.
+    // Reads the same production KV-side-cache environment as the constructor.
+    static uint64_t serving_reservation_bytes(const Shared& shared,uint32_t context,
+                                              bool turbo3_kv,size_t snapshot_entries);
+    // Conservative pre-construction footprint for one fp16-KV engine:
+    // MTP-present cache, widest chunked buffers, and the smallest supported
+    // GQA block. Used by dual-engine CLI modes before either engine allocates.
+    static uint64_t fp16_engine_reservation_bytes(uint32_t context);
+    // Per-engine causal-GQA partials buffer at the widest available
+    // attention width (one token when chunked prefill is unavailable),
+    // sized from the backend's EFFECTIVE block (Q27_METAL_GQA_BLOCK-aware).
+    // Allocated eagerly by the constructor; the dispatch hot path only
+    // bounds-checks (audit C3). Sizing never depends on the GQA threshold,
+    // so runtime threshold flips (envelope instrument) only change routing.
+    static uint64_t gqa_partial_peak(uint32_t context, uint32_t block, bool chunked);
 
     void reset();
     uint32_t step(uint32_t token);
-    std::vector<uint32_t> generate(const std::vector<uint32_t>& prompt, uint32_t count);
+    std::vector<uint32_t> generate(const std::vector<uint32_t>& prompt, uint32_t count,
+                                   uint32_t eos = UINT32_MAX);
     std::vector<uint32_t> generate_mtp(const std::vector<uint32_t>& prompt,
-                                       uint32_t count, uint32_t width);
-    std::vector<uint32_t> generate_suffix(const std::vector<uint32_t>& prompt,
-                                          uint32_t count, uint32_t width,
-                                          uint32_t minimum_match = 12);
+                                       uint32_t count, uint32_t width,
+                                       uint32_t eos = UINT32_MAX);
+    // Sampled MTP whole-run driver (docs/metal/plans/2026-07-21-metal-sampled-mtp.md):
+    // sample first pending from prefill logits, then mtp_sample_round quanta.
+    // Requires has_mtp() + chunked_prefill(); temperature should be > 0.
+    std::vector<uint32_t> generate_mtp_sampled(const std::vector<uint32_t>& prompt,
+                                               uint32_t count, uint32_t width,
+                                               const SamplingParams& params,
+                                               uint32_t eos = UINT32_MAX);
+    // Verify/oracle width ceiling, decoupled from the width-12 NLL/KL
+    // contract exactly as PREFILL_CHUNK_MAX decoupled prompt ingestion
+    // (docs/metal/plans/2026-07-16-lever2-verify-width.md). Sizes cfinal_/
+    // clogits_/cpred_ and the gdn_replay parks; mtp_round stays capped at
+    // CHUNK_MAX until the MTP lane machinery is testable (24 GB rig).
+    static constexpr uint32_t VERIFY_CHUNK_MAX = 48;
     uint32_t ingest_prompt(const std::vector<uint32_t>& tokens, bool warm_mtp,
                            bool reset_first = true);
+    // One bounded token-serial prefill quantum. Unlike step(), this optionally
+    // warms the MTP lane state between tokens and avoids an output-head
+    // projection until final_chunk. The server uses it to release the shared
+    // command-queue lease every eight tokens during serial MTP prefill.
+    static constexpr uint32_t serial_prefill_chunk_max() { return 8; }
+    uint32_t prefill_serial_chunk(const uint32_t* tokens, uint32_t count,
+                                  bool warm_mtp, bool final_chunk);
+
     std::vector<uint32_t> generate_from_pending(uint32_t pending, uint32_t count,
-                                                uint32_t mtp_width = 0);
+                                                uint32_t mtp_width = 0,
+                                                uint32_t eos = UINT32_MAX);
     std::vector<float> read_logits();
+    // x1_ readback for the --chunk-parity hidden-row leg; hidden-row state is
+    // also persisted by capture_state and save_state.
+    void read_hidden(std::vector<float>& out);
     // Teacher-forced NLL for tokens[0..N): returns N-1 values where
     // result[i] = -log P(tokens[i+1] | tokens[0..i]). Uses layer-major
     // chunked encode + batched output head when available.
     std::vector<float> teacher_force_nll(const std::vector<uint32_t>& tokens);
+    // Teacher-forced chunk logits for cross-engine comparison gates (e.g.
+    // the KL KV-tolerance gate): encode tokens[0..count) at the engine's
+    // current position — count 1..12; a single token takes the serial path —
+    // and fill `out` with count x vocab logits rows. The caller loops over
+    // the stream and interleaves engines; both must advance in lockstep.
+    void teacher_force_logits(const uint32_t* tokens, uint32_t count,
+                              std::vector<float>& out);
+    // Wide-path variant: encode tokens[0..count) through the prompt-ingestion
+    // chunk width (count 1..PREFILL_CHUNK_MAX; <= CHUNK_MAX delegates to
+    // teacher_force_logits) and apply the output head in CHUNK_MAX-row slices.
+    // Exposing every row's logits lets distribution-level gates cover widths
+    // 17, 48, and 96 rather than only committed-token comparisons.
+    void teacher_force_logits_wide(const uint32_t* tokens, uint32_t count,
+                                   std::vector<float>& out);
     std::vector<uint32_t> generate_sampled(const std::vector<uint32_t>& prompt,
-                                           uint32_t count,const SamplingParams& params);
+                                           uint32_t count, const SamplingParams& params,
+                                           uint32_t eos = UINT32_MAX);
     std::vector<uint32_t> generate_sampled_from_logits(uint32_t count,
-                                                       const SamplingParams& params);
+                                                       const SamplingParams& params,
+                                                       uint32_t eos = UINT32_MAX);
 
     // Streaming generation. `sink(token)` is called for each committed,
     // non-EOS token in order; return false from the sink to cancel (client
     // disconnect). Generation stops at EOS (StopCause::Eos, the EOS token is
     // not passed to the sink), when `count` tokens have been emitted
     // (StopCause::MaxTokens), or when the sink returns false
-    // (StopCause::Cancelled). Returns the number of tokens passed to the sink.
-    // These mirror the CUDA server's generate(prompt, n_max, eos, on_token)
-    // contract so the two servers report finish_reason identically.
+    // (StopCause::Cancelled). A cancelled batched-MTP stream resets the
+    // engine because a speculative round may already have committed tokens
+    // not accepted by the sink; ingest or restore state before reuse.
+    // Returns the number of tokens accepted by the sink. These mirror the
+    // CUDA server's generate(prompt, n_max, eos, on_token) result semantics.
     enum class StopCause { MaxTokens, Eos, Cancelled };
     using TokenSink = std::function<bool(uint32_t)>;
     uint32_t stream_from_pending(uint32_t pending, uint32_t count, uint32_t eos,
@@ -57,9 +169,109 @@ class MetalEngine {
     uint32_t stream_sampled_from_logits(uint32_t count, uint32_t eos,
                                         const SamplingParams& params,
                                         const TokenSink& sink, StopCause& cause);
+    // Commit decoder-control tokens through recurrent/KV state and return the
+    // next greedy pending token. The whole sequence is validated before the
+    // first step, so range/context failures leave engine state unchanged.
+    uint32_t force_tokens(const uint32_t* tokens, uint32_t count);
 
+
+    // Scheduling-quantum surface (multislot Phase 1,
+    // docs/metal/plans/2026-07-15-multislot-phase1.md): each call submits bounded
+    // GPU work so a serving scheduler can interleave engines on one Shared.
+    //
+    // prefill_chunk encodes 2..PREFILL_CHUNK_MAX prompt tokens through the
+    // layer-major chunk path without producing logits. Chunk-boundary
+    // placement is quality-neutral (--chunk-parity gate: widths 17/48/96
+    // bit-identical to 12), so the caller picks any width per call; the
+    // final prompt token still goes through step() to produce logits and
+    // the pending token, exactly like prefill()'s serial tail.
+    void prefill_chunk(const uint32_t* tokens, uint32_t count);
+    static constexpr uint32_t prefill_chunk_max() { return PREFILL_CHUNK_MAX; }
+    // One MTP draft/verify/commit round (one scheduling quantum). Appends
+    // the committed tokens (always starting with `pending`) to `committed`;
+    // the caller emits them and stops at `eos` itself — tokens after an EOS
+    // were already encoded when the verify chunk ran, exactly as in the
+    // streaming commit loop. Adapts live_width in place (callers initialize
+    // it to min(width, 4)) and returns the next pending token. When context
+    // or `remaining` (>= 2, bounds committed tokens) leaves no room to
+    // verify, falls back to one serial step — skipped when `pending` is EOS
+    // so a finished stream never encodes past its end.
+    uint32_t mtp_round(uint32_t pending, uint32_t remaining, uint32_t eos, uint32_t width,
+                       uint32_t& live_width, std::vector<uint32_t>& committed);
+    // Sampled MTP quantum (docs/metal/plans/2026-07-21-metal-sampled-mtp.md):
+    // same greedy MTP drafts + batched verify as mtp_round, but the accept
+    // tail is Leviathan/Chen rejection sampling against the served target
+    // (temperature/top_p/top_k) and the next pending is sampled, not argmax'd.
+    // Request-owned rng (like sample_from_logits). Greedy mtp_round stays
+    // bitwise-untouched. Callers should use temperature > 0; at temperature 0
+    // the walk degenerates to a delta-at-argmax accept that is not the
+    // equality path (prefer mtp_round).
+    uint32_t mtp_sample_round(uint32_t pending, uint32_t remaining, uint32_t eos,
+                              uint32_t width, uint32_t& live_width,
+                              const SamplingParams& params, std::mt19937_64& rng,
+                              std::vector<uint32_t>& committed);
+    // Sample one token from the current logits; the sampled-decode quantum
+    // is sample_from_logits + step under one GPU lease. The RNG belongs to
+    // the request, not the engine, so interleaved slots stay reproducible.
+    uint32_t sample_from_logits(const SamplingParams& params, std::mt19937_64& rng);
     std::shared_ptr<Snapshot> capture_state();
     void restore_state(const Snapshot& snapshot);
+    // Prefix snapshots to disk (docs/metal/plans/2026-07-16-prefix-snapshots.md,
+    // Phase 1): the capture/restore composition streamed through host
+    // memory with plain file I/O (no mmap — ds4's lesson). save writes
+    // path.tmp then renames; load validates the whole file structure
+    // (magic, artifact identity, kv dtype, position, every blob length)
+    // before the first GPU write, so a rejected file never leaves mixed
+    // state. tokens are prefix metadata for the Phase-2 server keying.
+    // logits_resident=false marks a snapshot taken mid-prefill (chunk path):
+    // its state is exact but the resident logits row is stale, so a resume
+    // may continue ingestion from token[position] onward but must never
+    // derive a pending token from the stored logits.
+    // Optional wrapper around each backend operation. Serving uses this to
+    // lease the shared command queue only for device transfers; file writes
+    // and durability syncs stay outside the lease.
+    using DeviceLease = std::function<void(const std::function<void()>&)>;
+    using LoadCheckpoint = std::function<void()>;
+    void save_state(const std::string& path, const uint32_t* tokens, uint32_t token_count,
+                    bool logits_resident = true, const DeviceLease& with_device = {});
+    uint32_t load_state(const std::string& path,const DeviceLease& with_device = {},
+                        const LoadCheckpoint& checkpoint = {}); // returns restored position
+    // Descriptor forms keep metadata inspection and restore pinned to one
+    // inode. The caller retains source_fd; diagnostics use label only.
+    uint32_t load_state_fd(int source_fd,const std::string& label,
+                           const std::vector<uint32_t>* expected_tokens = nullptr,
+                           const DeviceLease& with_device = {},
+                           const LoadCheckpoint& checkpoint = {});
+    // Header-only inspection for prefix keying (server): position, stored
+    // token ids, and the logits-resident flag. Validates magic only — the
+    // full structural validation happens on load_state.
+    struct SnapshotInfo { uint32_t position = 0; bool logits_resident = true;
+                          std::vector<uint32_t> tokens; };
+    static SnapshotInfo peek_snapshot(const std::string& path);
+    static SnapshotInfo peek_snapshot_fd(int source_fd,
+                                         const std::string& label);
+    // Re-run the resident-logits argmax (same GPU kernel as prompt
+    // ingestion) so generation after load_state resumes byte-identically.
+    uint32_t pending_from_logits();
+    const unsigned char* snapshot_identity();   // 20-byte SHA1, whole mapping, cached
+    // State-producing backend/shader configuration. Persistent snapshots
+    // must match this digest in both their deep header and server namespace.
+    std::array<unsigned char,20> snapshot_runtime_identity() const;
+
+    // Constrained tool decoding (BasicToolConstrainer engine surface): a
+    // request-scoped device pool of uint32 legal-token bitsets. The server
+    // resets the pool and invalidates its host-id map when a slot is assigned;
+    // ids therefore remain stable only within that request. mask_pool_add
+    // uploads one mask and returns its slot (-1 when the request exceeds the
+    // cap); set_tool_constraint selects the active slot (-1 disengages).
+    // The active mask is applied to logits inside encode_token, before argmax,
+    // so greedy decode, top-k extraction, and CPU sampling see only legal
+    // tokens. Serial decode only; Metal does not wire MTP verify-lane masks.
+    static constexpr int MASK_POOL_CAP = 64;
+    int mask_pool_used = 0;
+    int mask_pool_add(const void* bits);
+    void reset_mask_pool();
+    void set_tool_constraint(int mask_id);
     static constexpr uint32_t vocabulary_size() { return 248320; }
     uint32_t position() const { return position_; }
     SpecStats last_spec_stats() const { return last_spec_stats_; }
@@ -67,6 +279,20 @@ class MetalEngine {
     bool used_per_tensor_upload() const { return per_tensor_upload_; }
     bool chunked_prefill() const { return chunked_prefill_; }
     void set_chunked_prefill(bool enabled);
+    // True when Q27_METAL_KV_FP16_CELLS armed production fp16 exception
+    // side caches on this engine. Snapshots carry the side rows (v2,
+    // docs/metal/plans/2026-07-17-kv-except-snapshot-v2.md); the head masks are
+    // the snapshot-config identity — a snapshot only restores into an
+    // engine with the exact same cell list, and the server keys its disk
+    // store off them so mismatched configs miss instead of rejecting.
+    bool kv_fp16_except() const { return kv_fp16_except_; }
+    const uint8_t* kv_fp16_head_masks() const { return kv_fp16_head_masks_; }
+    bool gpu_sample_enabled() const { return gpu_sample_; }
+    bool resident_enabled() const { return resident_; }
+    // Side-cache codec (Q27_METAL_KV_CELLS_CODEC): 0 = fp16, 1 = e4m3
+    // (hot-cells arm, 2026-07-17-kv-e4m3-hot-cells.md). Part of the
+    // snapshot-config identity and the server's disk-store tag.
+    uint32_t kv_side_codec() const { return kv_fp16_side_codec_; }
 
   private:
     static constexpr uint32_t N_LAYER = 64;
@@ -82,7 +308,10 @@ class MetalEngine {
     static constexpr uint32_t GDN_QK_HEADS = 16;
     static constexpr uint32_t GDN_DIM = 128;
     static constexpr uint32_t VOCAB = 248320;
-    static constexpr uint32_t CHUNK_MAX = 12;
+    static constexpr uint32_t CHUNK_MAX = 12;          // MTP verify / NLL / KL width
+    static constexpr uint32_t PREFILL_CHUNK_MAX = 96;  // prompt-ingestion width (8x12)
+    static constexpr uint32_t TOPK_CAPACITY = 1024;
+    static constexpr uint32_t RESIDENT_MAX = 8;
     static constexpr float EPS = 1e-6f;
     static constexpr float FREQ_BASE = 1e7f;
 
@@ -93,15 +322,37 @@ class MetalEngine {
         std::shared_ptr<BackendBuffer> v_cache;
     };
 
-    Model model_;
-    MetalBackend backend_;
+    std::shared_ptr<Shared> shared_;
+    Model& model_;
+    MetalBackend& backend_;
     uint32_t max_context_;
     bool turbo3_kv_;
     bool per_tensor_upload_ = false;
+    // Production KV fp16 exception cells
+    // (docs/metal/plans/2026-07-17-kv-except-production.md): per masked head, a
+    // kv_heads=1 fp16 side cache in the turbo3 WHT domain; the head's
+    // query-head window is re-attended f16 against it, overwriting the
+    // production dispatch's output rows. Parsed from
+    // Q27_METAL_KV_FP16_CELLS (census cell numbers, per-head K+V pairs
+    // required) in the constructor; turbo3 engines only (ignored with a
+    // note on fp16 engines — those cells are already fp16). Indexed by
+    // attn_idx = layer/4. Bytes ride engine_cache_bytes_.
+    struct KvFp16Side { uint32_t head; std::shared_ptr<BackendBuffer> k, v; };
+    std::array<std::vector<KvFp16Side>, 16> kv_fp16_side_;
+    bool kv_fp16_except_ = false;
+    uint8_t kv_fp16_head_masks_[16] = {};   // snapshot-config identity (bit = head)
+    uint32_t kv_fp16_side_codec_ = 0;       // 0 fp16, 1 e4m3 side stores
+    uint64_t engine_cache_bytes_ = 0;
+    // Blocked-GQA softmax partials, engine-owned (audit E2): allocated once
+    // in the constructor at gqa_partial_peak, GPU-private, freed with the
+    // engine. Passed into every backend attention call.
+    std::shared_ptr<BackendBuffer> gqa_partials_;
     uint32_t position_ = 0;
     bool logits_resident_ = false;
+    // True only when MTP KV rows [0, position_) match the main-model state.
+    bool mtp_cache_valid_ = false;
     SpecStats last_spec_stats_;
-    std::unordered_map<std::string, BackendTensor> weights_;
+    std::unordered_map<std::string, BackendTensor>& weights_;
     std::vector<LayerState> layers_;
 
     std::shared_ptr<BackendBuffer> h_, x1_, y_;
@@ -109,6 +360,16 @@ class MetalEngine {
     std::shared_ptr<BackendBuffer> qkv_, z_, alpha_, beta_raw_, g_, beta_, conv_out_;
     std::shared_ptr<BackendBuffer> delta_out_, gated_out_;
     std::shared_ptr<BackendBuffer> ffn_gate_, ffn_up_, logits_, token_out_;
+    // GPU-assisted sampling: top-k candidate over-set staging
+    // (Q27_METAL_GPU_SAMPLE=0 forces the full-logits readback path).
+    std::shared_ptr<BackendBuffer> topk_values_, topk_indices_, topk_count_;
+    bool gpu_sample_ = true;
+    std::shared_ptr<BackendBuffer> mask_pool_;   // lazy: MASK_POOL_CAP bitsets
+    int active_mask_ = -1;
+    // GPU-resident greedy decode: K chained steps per command buffer, token
+    // ids archived device-side (Q27_METAL_RESIDENT=0 opts out).
+    std::shared_ptr<BackendBuffer> token_ring_;
+    bool resident_ = true;
     std::shared_ptr<BackendBuffer> mtp_embed_norm_, mtp_hidden_norm_, mtp_concat_;
     std::shared_ptr<BackendBuffer> mtp_x_, mtp_hidden_out_, mtp_logits_, mtp_k_cache_, mtp_v_cache_;
     BackendQuantized q5120_, q6144_, q10240_, q17408_;
@@ -127,34 +388,37 @@ class MetalEngine {
     // accepted prefix, so no checkpoint, restore, or commit re-encode exists.
     // ctargets_/cnll_ also serve teacher-forced NLL quality gates.
     std::shared_ptr<BackendBuffer> cfinal_, clogits_, cpred_;
+    std::shared_ptr<BackendBuffer> wide_head_stage_;   // lazy, CHUNK_MAX x N_EMBD f32
     std::shared_ptr<BackendBuffer> ctargets_, cnll_;
     std::vector<std::shared_ptr<BackendBuffer>> park_qkv_, park_g_, park_beta_;
     std::shared_ptr<BackendBuffer> discard_recurrent_, discard_ring_;
 
-    // The q4s contract requires the MTP layer; retained as an explicit gate at
-    // call sites so missing state fails closed if construction ever changes.
+    // The q4s contract requires the MTP layer; call sites still fail closed.
     bool has_mtp_ = true;
 
     std::shared_ptr<BackendBuffer> alloc_f32(uint64_t count);
+    void initialize_mtp_sentinel();
     const BackendTensor& weight(const std::string& name) const;
     const BackendTensor& layer_weight(uint32_t layer, const char* leaf) const;
     static bool attention_layer(uint32_t layer) { return layer % 4 == 3; }
 
     void validate_architecture() const;
+    uint32_t sample_next(const SamplingParams& params, std::mt19937_64& random);
+    uint32_t decode_resident(uint32_t pending, uint32_t* out, uint32_t k);
     void project(const BackendTensor& w, const BackendBuffer& x_float,
                  const BackendQuantized& xq, BackendBuffer& out);
     void project_pair(const BackendTensor& a, BackendBuffer& a_out,
                       const BackendTensor& b, BackendBuffer& b_out,
                       const BackendBuffer& x_float, const BackendQuantized& xq);
     void gdn_block(uint32_t layer);
-    void attention_block(uint32_t layer);
+    void attention_block(uint32_t layer, uint32_t pos);
     void ffn(uint32_t layer);
-    void encode_token(uint32_t token, bool produce_logits);
+    void encode_token(uint32_t token, bool produce_logits, bool token_from_device = false,
+                      uint32_t pos_offset = 0);
     void gdn_chunk(uint32_t layer, uint32_t count, bool verify);
     void attention_chunk(uint32_t layer, uint32_t count);
     void ffn_chunk(uint32_t layer, uint32_t count);
     void chunk_forward(const uint32_t* tokens, uint32_t count, bool verify = false);
-    void encode_chunk(const uint32_t* tokens, uint32_t count);
     static uint32_t gdn_slot(uint32_t layer) { return layer - (layer + 1) / 4; }
     void gdn_replay(uint32_t count);
     std::vector<uint32_t> generate_mtp_batched(uint32_t pending, uint32_t count,

--- a/src/metal/metal_server.cpp
+++ b/src/metal/metal_server.cpp
@@ -1,0 +1,4425 @@
+#include "metal_engine.h"
+#include "disk_snapshot_store.h"
+#include "stream_format.h"
+#include "serving_policy.h"
+
+#include "../tokenizer.h"
+#include "../toolconstrain.h"
+#include <cerrno>
+#include "../../third_party/httplib.h"
+#include "../../third_party/json.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <filesystem>
+#include <functional>
+#include <fstream>
+#include <fcntl.h>
+#include <list>
+#include <limits>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <random>
+#include <set>
+#include <unordered_set>
+#include <stdexcept>
+#include <sys/stat.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+#include <CommonCrypto/CommonDigest.h>
+#include <mach-o/dyld.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+using json = nlohmann::json;
+
+namespace {
+
+std::string file_sha1(const std::string& path) {
+    std::ifstream f(path,std::ios::binary);
+    if(!f) throw std::runtime_error("cannot hash file: "+path);
+    std::vector<unsigned char> bytes((std::istreambuf_iterator<char>(f)),{});
+    unsigned char digest[CC_SHA1_DIGEST_LENGTH];
+    CC_SHA1(bytes.data(),(CC_LONG)bytes.size(),digest);
+    static const char hex[]="0123456789abcdef";
+    std::string out(40,'0');
+    for(int i=0;i<CC_SHA1_DIGEST_LENGTH;i++) {
+        out[2*i]=hex[digest[i]>>4]; out[2*i+1]=hex[digest[i]&15];
+    }
+    return out;
+}
+
+
+void mapping_sha1(const q27::Model& model,unsigned char digest[CC_SHA1_DIGEST_LENGTH]) {
+    CC_SHA1_CTX ctx;
+    CC_SHA1_Init(&ctx);
+    const auto* bytes=static_cast<const unsigned char*>(model.mapping_base());
+    const uint64_t size=model.mapping_size();
+    for(uint64_t offset=0;offset<size;) {
+        const CC_LONG chunk=(CC_LONG)std::min<uint64_t>(256u<<20,size-offset);
+        CC_SHA1_Update(&ctx,bytes+offset,chunk);
+        offset+=chunk;
+    }
+    CC_SHA1_Final(digest,&ctx);
+}
+
+std::string executable_sha1() {
+    uint32_t n=0;
+    _NSGetExecutablePath(nullptr,&n);
+    std::vector<char> path(n+1);
+    if(_NSGetExecutablePath(path.data(),&n)!=0)
+        throw std::runtime_error("cannot resolve server executable");
+    return file_sha1(path.data());
+}
+
+
+std::pair<int,std::string> open_private_trace_file(const std::string& input) {
+    std::error_code ec;
+    const std::filesystem::path requested=
+        std::filesystem::absolute(std::filesystem::path(input),ec).lexically_normal();
+    if(ec || !requested.is_absolute() || requested.filename().empty())
+        throw std::runtime_error("invalid --trace path: "+input);
+
+    int dirfd=::open("/",O_RDONLY|O_DIRECTORY|O_CLOEXEC);
+    if(dirfd<0) throw std::runtime_error("cannot open --trace root: "+requested.string());
+    for(const auto& component:requested.parent_path().relative_path()) {
+        const std::string name=component.string();
+        if(name.empty() || name=="." || name=="..") {
+            ::close(dirfd);
+            throw std::runtime_error("invalid --trace path: "+input);
+        }
+        const int next=::openat(dirfd,name.c_str(),
+                                O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+        if(next<0) {
+            ::close(dirfd);
+            throw std::runtime_error("cannot open --trace directory: "+requested.string());
+        }
+        ::close(dirfd);
+        dirfd=next;
+    }
+    const int fd=::openat(dirfd,requested.filename().c_str(),
+                          O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC|O_NOFOLLOW,0600);
+    ::close(dirfd);
+    if(fd<0) throw std::runtime_error("cannot open --trace path: "+requested.string());
+    return {fd,requested.string()};
+}
+
+uint32_t parse_u32(const std::string& text, const char* option) {
+    if (text.empty() || text[0]=='-') throw std::runtime_error(std::string("invalid ")+option);
+    size_t used=0; unsigned long long value=std::stoull(text,&used,10);
+    if(used!=text.size() || value>UINT32_MAX) throw std::runtime_error(std::string("invalid ")+option);
+    return (uint32_t)value;
+}
+
+float parse_float(const std::string& text, const char* option) {
+    if (text.empty()) throw std::runtime_error(std::string("invalid ")+option);
+    // stof parses "nan"/"inf" successfully -- reject non-finite here so the
+    // range checks at the call sites cannot be bypassed.
+    size_t used=0; float value=std::stof(text,&used);
+    if(used!=text.size() || !std::isfinite(value)) throw std::runtime_error(std::string("invalid ")+option);
+    return value;
+}
+
+// Served sampling defaults, resolved once in main from
+// --temperature-default / --top-p-default / --top-k-default (flag wins; env
+// twins Q27_METAL_{TEMPERATURE,TOP_P,TOP_K}_DEFAULT). They apply only when a
+// request OMITS the field -- explicit client values always win. With neither
+// flag nor env they hold the shipped greedy values (0 / 1 / 0), so the
+// greedy path stays bitwise. temp>0 keeps MTP when --mtp is set (sampled
+// rejection-accept path). Tool
+// constraining stays greedy-only. Trace logs effective sampling per request.
+float sampling_default_temperature=0.0f;
+float sampling_default_top_p=1.0f;
+uint32_t sampling_default_top_k=0;
+
+
+std::vector<uint32_t> to_u32(const std::vector<int>& ids) {
+    std::vector<uint32_t> result; result.reserve(ids.size());
+    for(int id:ids) { if(id<0) throw std::runtime_error("tokenizer returned a negative id"); result.push_back((uint32_t)id); }
+    return result;
+}
+
+std::string text_content(const json& content) {
+    if(content.is_string()) return content.get<std::string>();
+    std::string out;
+    // jstr, not value(): inside a content ARRAY the established rule is
+    // skip-the-malformed-part (the is_object guard above), not reject the whole
+    // request. value() throws on a part whose "type"/"text" is present but
+    // null or non-string, which would 400 a request the is_object guard was
+    // written to tolerate. Upstream 1a15ff8 made the same swap on the CUDA arm.
+    // Non-text parts are intentionally omitted on this text-only backend,
+    // matching CUDA bridge compatibility and preserving replayable mixed
+    // assistant/tool history instead of rejecting the whole prior turn.
+    if(content.is_array()) for(const auto& part:content) {
+        if(!part.is_object()) continue;
+        const std::string type=q27::jstr(part,"type");
+        if(type=="text" || type=="input_text" || type=="output_text") out+=q27::jstr(part,"text");
+    }
+    return out;
+}
+
+// OpenAI chat messages -> Msg list for chatml_prompt (which merges the tools
+// preamble into the system message, replacing the manual merge that lived
+// here). Beyond-CUDA: src/server.cu's chat endpoint is text-only by design
+// (its structured tool paths are /v1/messages and /v1/responses), but pi.dev
+// speaks openai-completions, so this endpoint must round-trip tool traffic —
+// assistant.tool_calls arrays and role:"tool" results are reconstructed to
+// the model's <tool_call>/<tool_response> markers (agentic-parity round,
+// docs/metal/plans/2026-07-17-metal-agentic-parity.md).
+std::vector<q27::Msg> openai_msgs(const json& body) {
+    std::vector<q27::Msg> msgs;
+    if(body.contains("system")) {
+        std::string system=text_content(body["system"]);
+        if(!system.empty()) msgs.push_back({"system",system});
+    }
+    if(!body.contains("messages") || !body["messages"].is_array())
+        throw std::runtime_error("messages must be an array");
+    for(const auto& message:body["messages"]) {
+        if(!message.is_object()) continue;
+        std::string role=q27::jstr(message,"role");
+        if(role=="developer") role="system";
+        std::string content=message.contains("content")?text_content(message["content"]):"";
+        if(role.empty()) continue;
+        if(role=="tool") {
+            msgs.push_back({"user",q27::tool_response_text(content)});
+            continue;
+        }
+        if(role=="assistant" && message.contains("tool_calls") && message["tool_calls"].is_array()) {
+            for(const auto& c:message["tool_calls"]) {
+                if(!c.is_object() || !c.contains("function") || !c["function"].is_object()) continue;
+                const json& fn=c["function"];
+                // OpenAI carries arguments as a JSON-encoded STRING; tolerate
+                // an object too (some clients send it pre-parsed).
+                json args=json::object();
+                if(fn.contains("arguments")) {
+                    if(fn["arguments"].is_string()) {
+                        try { args=json::parse(fn["arguments"].get<std::string>()); }
+                        catch(...) { args=fn["arguments"]; }
+                    } else args=fn["arguments"];
+                }
+                if(!content.empty() && content.back()!='\n') content+="\n";
+                content+=q27::tool_call_text(q27::jstr(fn,"name"),args);
+            }
+        }
+        msgs.push_back({role,content});
+    }
+    // Merge consecutive same-role messages (a run of tool results becomes one
+    // user block), matching the CUDA responses handler's merge.
+    std::vector<q27::Msg> merged;
+    for(auto& m:msgs) {
+        if(!merged.empty() && merged.back().role==m.role) merged.back().content+="\n"+m.content;
+        else merged.push_back(std::move(m));
+    }
+    if(merged.empty()) throw std::runtime_error("messages are empty");
+    if(merged[0].role=="system") q27::normalize_cc_billing_header(merged[0].content);
+    return merged;
+}
+
+struct ResponsesPromptInput {
+    json tools = json::array();
+    std::set<std::string> custom_names;
+    q27::ToolChoice choice;
+    std::vector<std::string> tool_names;
+    std::set<std::string> allowed_hosted_names;
+    std::vector<q27::Msg> messages;
+};
+
+bool responses_tool_allowed(const std::string& name,
+                            const std::set<std::string>& allowed_registered,
+                            const std::set<std::string>& allowed_hosted) {
+    return allowed_registered.count(name) || allowed_hosted.count(name);
+}
+
+
+// Normalize Responses input once so prompt rendering and tool eligibility
+// consume the same canonical request representation.
+ResponsesPromptInput responses_prompt_input(const json& body) {
+    ResponsesPromptInput out;
+    std::set<std::string> hosted_names;
+    std::set<std::string> function_names;
+    std::set<std::string> expanded_tool_names;
+    bool duplicate_tool_name=false;
+    if(body.contains("tools") && body["tools"].is_array())
+        for(const auto& t:body["tools"]) {
+            if(!t.is_object()) continue;
+            const std::string ty=q27::jstr(t,"type");
+            if(t.contains("function") && t["function"].is_object()) {
+                const std::string name=q27::jstr(t["function"],"name");
+                if(!name.empty()) {
+                    function_names.insert(name);
+                    if(!expanded_tool_names.insert(name).second) duplicate_tool_name=true;
+                    out.tools.push_back(t);
+                }
+            } else if(ty=="function") {
+                const std::string name=q27::jstr(t,"name");
+                if(!name.empty()) {
+                    function_names.insert(name);
+                    if(!expanded_tool_names.insert(name).second) duplicate_tool_name=true;
+                    out.tools.push_back({{"type","function"},
+                        {"function",{{"name",name},
+                                     {"description",q27::jstr(t,"description")},
+                                     {"parameters",t.contains("parameters")?t["parameters"]
+                                                                           :json::object()}}}});
+                }
+            } else if(ty=="custom") {
+                const std::string name=q27::jstr(t,"name");
+                if(!name.empty()) {
+                    out.custom_names.insert(name);
+                    if(!expanded_tool_names.insert(name).second) duplicate_tool_name=true;
+                    out.tools.push_back({{"type","function"},
+                        {"function",{{"name",name},
+                                     {"description",q27::jstr(t,"description")},
+                                     {"parameters",{{"type","object"},
+                                         {"properties",{{"input",{{"type","string"},
+                                             {"description","The complete raw input text for this tool."}}}}},
+                                         {"required",json::array({"input"})}}}}}});
+                }
+            // Optional hosted capabilities are client-side and may be skipped
+            // under auto/none. A required unmodeled type is rejected below
+            // when it cannot map to any locally supported call name.
+            } else if(!ty.empty()) {
+                if(!hosted_names.insert(ty).second) duplicate_tool_name=true;
+                if(ty=="shell")
+                    for(auto tool:q27::responses_shell_prompt_tools()) {
+                        const std::string name=tool["function"]["name"].get<std::string>();
+                        if(!expanded_tool_names.insert(name).second) duplicate_tool_name=true;
+                        out.tools.push_back(std::move(tool));
+                    }
+            }
+        }
+    if(duplicate_tool_name)
+        throw std::runtime_error("ambiguous duplicate Responses tool name");
+    if(q27::responses_tool_names_ambiguous(function_names,out.custom_names,hosted_names))
+        throw std::runtime_error("ambiguous duplicate Responses tool name");
+
+    q27::validate_responses_tool_choice_declarations(
+        body, function_names, out.custom_names, hosted_names);
+    json selection_body=body;
+    selection_body["tools"]=out.tools;
+    out.choice=q27::parse_responses_tool_choice(selection_body);
+    q27::apply_openai_parallel_tool_calls(body,out.choice);
+    if(out.choice.invalid) throw std::runtime_error("invalid tool_choice or parallel_tool_calls");
+
+    std::set<std::string> registered_names;
+    for(const auto& tool:out.tools)
+        registered_names.insert(tool["function"]["name"].get<std::string>());
+    std::set<std::string> declared_names=registered_names;
+    declared_names.insert(hosted_names.begin(),hosted_names.end());
+    if(!out.choice.forced_name.empty() && !declared_names.count(out.choice.forced_name))
+        throw std::runtime_error("tool_choice names a tool not present in tools");
+    for(const auto& name:out.choice.allowed_names)
+        if(!declared_names.count(name))
+            throw std::runtime_error("tool_choice names a tool not present in tools");
+    if(out.choice.mode==q27::ToolChoice::FORCED && declared_names.empty())
+        throw std::runtime_error("tool_choice requires at least one valid tool");
+
+    auto allow_hosted_type=[&](const std::string& type){
+        q27::add_responses_hosted_call_names(out.allowed_hosted_names,type);
+    };
+    if(out.choice.mode!=q27::ToolChoice::NONE) {
+        if(!out.choice.forced_name.empty()) {
+            if(hosted_names.count(out.choice.forced_name))
+                allow_hosted_type(out.choice.forced_name);
+        } else if(!out.choice.allowed_names.empty()) {
+            for(const auto& name:out.choice.allowed_names)
+                if(hosted_names.count(name)) allow_hosted_type(name);
+        } else for(const auto& type:hosted_names) allow_hosted_type(type);
+    }
+    q27::ToolChoice registered_choice=
+        q27::responses_registered_tool_choice(out.choice,hosted_names);
+    q27::OpenAIToolSelection selected=q27::select_openai_tools(selection_body,registered_choice);
+    out.tools=std::move(selected.tools);
+    out.tool_names=std::move(selected.names);
+    if(out.choice.mode==q27::ToolChoice::FORCED && out.tool_names.empty() &&
+       out.allowed_hosted_names.empty())
+        throw std::runtime_error("tool_choice requires at least one locally supported tool");
+    const std::set<std::string> eligible(out.tool_names.begin(),out.tool_names.end());
+    for(auto it=out.custom_names.begin();it!=out.custom_names.end();)
+        if(!eligible.count(*it)) it=out.custom_names.erase(it);
+        else ++it;
+    if(body.contains("instructions") && body["instructions"].is_string())
+        out.messages.push_back({"system",body["instructions"]});
+    if(body.contains("input")) {
+        if(body["input"].is_string()) out.messages.push_back({"user",body["input"]});
+        else if(body["input"].is_array())
+            for(const auto& item:body["input"]) {
+                if(!item.is_object()) continue;
+                const std::string type=q27::jstr(item,"type","message");
+                if(type=="message") {
+                    std::string role=q27::jstr(item,"role","user");
+                    if(role=="developer") role="system";
+                    out.messages.push_back({role,item.contains("content")?
+                        text_content(item["content"]):""});
+                } else if(type=="function_call" || type=="custom_tool_call") {
+                    json args;
+                    if(type=="function_call") {
+                        try { args=json::parse(q27::jstr(item,"arguments","{}")); }
+                        catch(...) { args=q27::jstr(item,"arguments"); }
+                    } else args={{"input",q27::jstr(item,"input")}};
+                    out.messages.push_back({"assistant",
+                        q27::tool_call_text(q27::jstr(item,"name"),args)});
+                } else if(type=="function_call_output" || type=="custom_tool_call_output") {
+                    std::string value;
+                    if(item.contains("output"))
+                        value=item["output"].is_string()?item["output"].get<std::string>()
+                                                        :text_content(item["output"]);
+                    out.messages.push_back({"user",q27::tool_response_text(value)});
+                }
+                // Reasoning items in history are intentionally dropped.
+            }
+    }
+    if(out.messages.empty()) throw std::runtime_error("input is empty");
+    std::vector<q27::Msg> merged;
+    for(auto& message:out.messages) {
+        if(!merged.empty() && merged.back().role==message.role)
+            merged.back().content+="\n"+message.content;
+        else merged.push_back(std::move(message));
+    }
+    out.messages=std::move(merged);
+    return out;
+}
+
+// Unique-ish ids for tool_use/tool_calls blocks: agent clients key results
+// to call ids, so a fixed string would collide across turns.
+std::atomic<long> req_counter{0};
+
+
+
+
+// OpenAI `stop` (string or array of strings) / Anthropic `stop_sequences`
+// (array). Empty strings are dropped -- they would match at every position.
+std::vector<std::string> parse_stops(const json& body,const char* key,
+                                     bool openai_count_limit=false) {
+    std::vector<std::string> out;
+    if(!body.contains(key)) return out;
+    const json& s=body[key];
+    if(s.is_string()) { auto v=s.get<std::string>(); if(!v.empty()) out.push_back(std::move(v)); }
+    else if(s.is_array()) for(const auto& e:s)
+        if(e.is_string()) { auto v=e.get<std::string>(); if(!v.empty()) out.push_back(std::move(v)); }
+    q27::validate_stop_sequences(out,openai_count_limit);
+    return out;
+}
+
+class PrefixCache {
+  public:
+    explicit PrefixCache(size_t capacity):capacity_(capacity){}
+
+    bool restore(q27::MetalEngine& engine,const std::vector<uint32_t>& prompt,bool mtp,
+                 size_t& matched,uint32_t& pending) {
+        auto best=entries_.end(); size_t best_len=0;
+        for(auto it=entries_.begin();it!=entries_.end();++it) {
+            if(it->mtp!=mtp || it->tokens.size()>prompt.size() ||
+               it->tokens.size()<=best_len) continue;
+            if(std::equal(it->tokens.begin(),it->tokens.end(),prompt.begin())) {
+                best=it; best_len=it->tokens.size();
+            }
+        }
+        if(best==entries_.end()) return false;
+        engine.restore_state(*best->snapshot); pending=best->pending; matched=best_len;
+        entries_.splice(entries_.begin(),entries_,best);
+        return true;
+    }
+
+    bool prepare_insert(const std::vector<uint32_t>& tokens,bool mtp) {
+        if(!capacity_) return false;
+        for(auto it=entries_.begin();it!=entries_.end();) {
+            if(it->mtp==mtp && it->tokens==tokens) it=entries_.erase(it);
+            else ++it;
+        }
+        while(entries_.size()>=capacity_) entries_.pop_back();
+        return true;
+    }
+
+    void insert(std::vector<uint32_t> tokens,bool mtp,uint32_t pending,
+                std::shared_ptr<q27::MetalEngine::Snapshot> snapshot) {
+        entries_.push_front({std::move(tokens),mtp,pending,std::move(snapshot)});
+    }
+  private:
+    struct Entry { std::vector<uint32_t> tokens; bool mtp; uint32_t pending; std::shared_ptr<q27::MetalEngine::Snapshot> snapshot; };
+    size_t capacity_; std::list<Entry> entries_;
+};
+
+// Disk snapshot store now lives in disk_snapshot_store.h (extracted so the
+// T1 eviction gate drives the REAL store offline; the peek adapter below
+// bridges SnapPeekInfo to q27::MetalEngine::SnapshotInfo).
+static SnapPeekInfo snap_peek_adapter(int fd,const std::string& path) {
+    const q27::MetalEngine::SnapshotInfo i=q27::MetalEngine::peek_snapshot_fd(fd,path);
+    SnapPeekInfo o; o.position=i.position; o.logits_resident=i.logits_resident; o.tokens=i.tokens;
+    return o;
+}
+// SHA1 token-key hash for DiskSnapshotStore (production); injected so the
+// store header stays platform-crypto-free.
+static void snap_hash_sha1(const uint32_t* tokens,uint32_t count,char out_hex[41]) {
+    unsigned char sha[20];
+    CC_SHA1(tokens,(CC_LONG)(count*4),sha);
+    for(int i=0;i<20;i++) snprintf(out_hex+2*i,3,"%02x",sha[i]);
+    out_hex[40]='\0';
+}
+
+// Whole-session trace stream (triage I2, docs/plans/2026-07-17-ds4-product-
+// triage.md): one JSONL stream of the events the parity rounds kept having
+// to reconstruct by hand from scattered logs — rendered prompts, snapshot /
+// prefix-cache decisions, tool-parser recoveries, cancellations, error
+// answers. Diagnostic switch only (ds4 flag rule): off by default, zero
+// semantic effect when on. Every line carries wall `ts` plus monotonic
+// `tms` (ms since open) so two-slot interleavings reconstruct exactly.
+struct TraceLog {
+    void open(const std::string& path) {
+        auto [fd,opened_path]=open_private_trace_file(path);
+        struct stat st{};
+        if(::fstat(fd,&st)!=0 || !S_ISREG(st.st_mode)) {
+            ::close(fd);
+            throw std::runtime_error("--trace path is not a regular file: "+opened_path);
+        }
+        if(::fchmod(fd,0600)!=0) {
+            ::close(fd);
+            throw std::runtime_error("cannot secure --trace path: "+opened_path);
+        }
+        f_=::fdopen(fd,"a");
+        if(!f_) {
+            ::close(fd);
+            throw std::runtime_error("cannot wrap --trace path: "+path);
+        }
+    }
+    bool enabled() const { return f_!=nullptr; }
+    bool healthy() const { return f_!=nullptr && healthy_.load(std::memory_order_acquire); }
+    void event(json j) noexcept {
+        if(!f_) return;
+        try {
+            j["ts"]=(long)std::time(nullptr);
+            std::lock_guard<std::mutex> lk(m_);
+            j["tms"]=(long)std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now()-t0_).count();
+            const std::string s=j.dump();
+            if(fwrite(s.data(),1,s.size(),f_)!=s.size() ||
+               fputc('\n',f_)==EOF || fflush(f_)!=0)
+                healthy_.store(false,std::memory_order_release);
+        } catch(...) { healthy_.store(false,std::memory_order_release); }
+    }
+  private:
+    FILE* f_=nullptr; std::mutex m_;
+    std::atomic<bool> healthy_{true};
+    const std::chrono::steady_clock::time_point t0_=std::chrono::steady_clock::now();
+};
+
+// Trace prompt payloads cap at 64 KB (ctx-limit test prompts run ~1 MB);
+// truncation is recorded, never silent.
+inline json trace_text(const std::string& s) {
+    if(s.size()<=65536) return json(s);
+    return json({{"truncated",true},{"bytes",(uint64_t)s.size()},{"head",s.substr(0,65536)}});
+}
+
+// Exact token-prefix evidence for recurrence economics. The bounded head is
+// a conservative lower bound: matches beyond 8192 are intentionally not
+// credited rather than inferred from shared prompt bytes.
+inline json trace_token_head(const std::vector<uint32_t>& ids) {
+    const size_t n=std::min<size_t>(ids.size(),8192);
+    json out=json::array();
+    for(size_t i=0;i<n;i++) out.push_back(ids[i]);
+    return out;
+}
+
+struct Runtime {
+    q27::Tokenizer tokenizer;
+    std::string model_path;
+    std::shared_ptr<q27::MetalEngine::Shared> shared;
+    // One request slot = one engine on the shared mapping plus its private
+    // prefix cache, scheduling phase, and constraint device-pool map (each
+    // engine owns its own mask pool, so host mask id -> pool slot is
+    // per-slot state; the host-side mask cache stays shared).
+    struct Slot {
+        q27::MetalEngine engine;
+        PrefixCache cache;
+        std::vector<int> host2dev;
+        bool busy=false;
+        enum class Phase { Idle, Prefill, Decode, Verify } phase=Phase::Idle;
+        Slot(std::shared_ptr<q27::MetalEngine::Shared> s,uint32_t ctx,bool turbo3,size_t entries)
+            :engine(std::move(s),ctx,turbo3),cache(entries) {}
+    };
+    std::vector<std::unique_ptr<Slot>> slots;
+    uint32_t mtp_width;
+    uint32_t context;
+    bool model_has_mtp=false;
+    bool model_chunked_prefill=false;
+
+    // Lock order (multislot Phase 1 contract, docs/plans/2026-07-15-
+    // multislot-phase1.md): route_ before lease_ — and in fact the two are
+    // never held together. route_ guards slot assignment, phases, waiter
+    // count, and wait stats, and is never held across GPU work; lease_
+    // serializes every engine call (slots alias one Shared command queue)
+    // and is held for one scheduling quantum at a time.
+    //
+    // The lease is a FIFO ticket lock, not a plain mutex: std::mutex makes
+    // no fairness promise, and a tight decode loop (release, deliver,
+    // reacquire) starves the other slot for a whole generation under it
+    // (measured 5.5 s gate wait on the first two-slot run). Ticket order
+    // caps the wait at one active quantum, which is the Phase 1 guarantee.
+    struct ClientGone {};
+    struct Lease {
+        std::mutex m;
+        std::condition_variable cv;
+        uint64_t next=0, serving=0;
+        std::set<uint64_t> cancelled;
+
+        void retire_locked(uint64_t ticket) {
+            if(ticket==serving) {
+                serving++;
+                while(cancelled.erase(serving)) serving++;
+            } else {
+                cancelled.insert(ticket);
+            }
+        }
+
+        struct Guard {
+            Lease* l=nullptr;
+            uint64_t ticket=0;
+            Guard()=default;
+            explicit Guard(Lease& lease,
+                           const std::function<void()>& checkpoint={})
+                :l(&lease) {
+                std::unique_lock<std::mutex> lk(l->m);
+                ticket=l->next++;
+                auto check_live=[&] {
+                    if(!checkpoint) return;
+                    lk.unlock();
+                    try {
+                        checkpoint();
+                    } catch(...) {
+                        lk.lock();
+                        l->retire_locked(ticket);
+                        l=nullptr;
+                        lk.unlock();
+                        lease.cv.notify_all();
+                        throw;
+                    }
+                    lk.lock();
+                };
+                while(l->serving!=ticket) {
+                    check_live();
+                    if(l->serving==ticket) break;
+                    l->cv.wait_for(lk,std::chrono::milliseconds(100));
+                }
+                check_live();
+            }
+            Guard(Guard&& o) noexcept :l(o.l),ticket(o.ticket) { o.l=nullptr; }
+            Guard& operator=(Guard&&)=delete;
+            Guard(const Guard&)=delete;
+            Guard& operator=(const Guard&)=delete;
+            ~Guard() {
+                if(!l) return;
+                { std::lock_guard<std::mutex> lk(l->m); l->retire_locked(ticket); }
+                l->cv.notify_all();
+            }
+        };
+    };
+    std::mutex route_;
+    std::condition_variable slot_free_;
+    Lease lease_;
+    // Serializes poison recovery. recovering_ is guarded by route_ and keeps
+    // queued requests from claiming an engine while the shared backend and
+    // every attached slot are replaced.
+    std::mutex recovery_;
+    bool recovering_=false;
+    std::string recovery_failure_;
+    // Slot admission is ticketed so newly arriving handlers cannot barge past
+    // awakened waiters; requests wait in arrival order until a slot is free.
+    uint64_t slot_next_=0, slot_serving_=0;
+    uint32_t queue_waiters=0;
+    std::set<uint64_t> cancelled_slot_tickets_;
+    static constexpr uint32_t QUEUE_MAX=8;
+    // Engine failures during generation are server bugs, not request bugs:
+    // Anthropic defines api_error (500) for them, and retrying clients treat
+    // 500 as transient while 400 is fatal. Handlers wrap only run(); parse,
+    // validation, and overflow errors are raised before it. Known coarseness:
+    // the rare post-restore "prompt exceeds context" inside run() uses 500.
+    struct ServerOverloaded : std::runtime_error { using std::runtime_error::runtime_error; };
+    struct EngineError : std::runtime_error { using std::runtime_error::runtime_error; };
+    // Innermost lock: guards the shared host-side ToolMaskCache (mask
+    // construction simulates the whole vocabulary on a miss). Order:
+    // route_ | lease_ -> mask_mutex_; never the reverse.
+    std::mutex mask_mutex_;
+    // Wait accounting bucketed by what the competing traffic was doing at
+    // arrival (idle/prefill/decode/verify), guarded by route_. Queue wait is
+    // arrival-to-slot admission; gate wait is admission-to-first GPU lease.
+    struct WaitStats { uint64_t n=0; double sum_ms=0, max_ms=0; };
+    std::map<std::string,WaitStats> queue_wait_stats, gate_wait_stats;
+    // Speculation ground truth for the multislot MTP gates: a quantum round
+    // committing >1 token proves accepted drafts, so committed > rounds is
+    // the nonzero-speculation assert's unfakeable signal (vacuous-gate rule).
+    std::atomic<uint64_t> spec_rounds_total{0}, spec_committed_total{0};
+    bool constrain_tools=false;
+    // Server thinking profile (upstream v0.4.0 parity): the DEFAULT is
+    // no-think — prompts render the closed empty think block so the model
+    // answers directly (the qwen36 think-forever pathology makes forced
+    // traces a serving hazard; upstream's README documents the same
+    // default for speed). --think flips the profile to prefilling an open
+    // think tag. Either way, per-request fields override (resolve_think).
+    std::vector<std::string> vocab_bytes_v;
+    q27::ToolMaskCache mask_cache;
+    DiskSnapshotStore snapstore{&snap_peek_adapter,&snap_hash_sha1};
+    TraceLog trace;
+    std::string model_name,model_sha1_cache,boot_id,server_sha1,tokenizer_name,tokenizer_sha1;
+    json serving_identity_cache;
+    bool snapshot_spine_pin_config=false;
+    std::string os_sysname,os_release,os_machine;
+    bool turbo3_kv=false;
+    std::atomic<bool> test_fail_after_snapshot_publish{false};
+    size_t prefix_entries_config=0;
+    uint64_t snapshot_max_bytes_config=0;
+    uint32_t max_tokens_default_config=0;
+    bool think_default=false;   // --think; see the profile comment above
+    std::mutex model_identity_mu;
+    // Auto-snapshot threshold in prompt tokens (0 = hint-only); set with
+    // the snapshot store, meaningful only when snapstore.enabled().
+    size_t snap_auto_min=0;
+
+    // Expensive (~2 s for T2), opt-in through /health?identity=1. This is
+    // SHA1 over the resident mmap itself (snapshot identity), so an atomic
+    // pathname replacement cannot relabel outputs from the old inode.
+    std::string resident_model_sha1() {
+        std::shared_ptr<q27::MetalEngine::Shared> resident;
+        {
+            std::lock_guard<std::mutex> route_lock(route_);
+            if(!recovery_failure_.empty()) throw std::runtime_error(recovery_failure_);
+            resident=shared;
+        }
+        std::lock_guard<std::mutex> lock(model_identity_mu);
+        if(model_sha1_cache.empty()) {
+            unsigned char digest[CC_SHA1_DIGEST_LENGTH];
+            mapping_sha1(resident->model,digest);
+            static const char hex[]="0123456789abcdef";
+            model_sha1_cache.resize(40);
+            for(int i=0;i<20;i++) {
+                model_sha1_cache[2*i]=hex[digest[i]>>4];
+                model_sha1_cache[2*i+1]=hex[digest[i]&15];
+            }
+        }
+        return model_sha1_cache;
+    }
+
+    json build_serving_identity() {
+        const auto& e=slots.front()->engine;
+        std::string cell_masks;
+        static const char hex[]="0123456789abcdef";
+        for(int i=0;i<16;i++) {
+            const uint8_t m=e.kv_fp16_head_masks()[i];
+            cell_masks+=hex[m>>4]; cell_masks+=hex[m&15];
+        }
+        return {{"identity_schema",3},{"server_sha1",server_sha1},
+                {"platform",{{"sysname",os_sysname},{"release",os_release},{"machine",os_machine},
+                    {"metal_device",shared->backend.name()}}},
+                {"shader_abi",q27::MetalBackend::shader_abi_tag()},
+                {"shader_sha1",shared->backend.shader_source_sha1()},
+                {"protocol",{{"context",context},{"kv",turbo3_kv?"turbo3":"fp16"},
+                    {"mtp",mtp_width},{"slots",slots.size()},
+                    {"prefix_entries",prefix_entries_config},{"constrain_tools",constrain_tools},
+                    {"snapshots",snapstore.enabled()},{"snapshot_auto_min",snap_auto_min},
+                    {"snapshot_max_bytes",snapshot_max_bytes_config},
+                    {"snapshot_spine_pin",snapshot_spine_pin_config},
+                    {"max_tokens_default",max_tokens_default_config},
+                    {"think_default",think_default},
+                    {"sampling_default",{{"temperature",sampling_default_temperature},
+                        {"top_p",sampling_default_top_p},{"top_k",sampling_default_top_k}}},
+                    {"kv_fp16_except",e.kv_fp16_except()},{"kv_fp16_cell_masks",cell_masks},
+                    {"kv_side_codec",e.kv_fp16_except()?(e.kv_side_codec()?"e4m3":"fp16"):"none"},
+                    {"gemm_half",shared->backend.gemm_half_enabled()},
+                    {"gqa_tile",shared->backend.gqa_tile()},{"gqa_block",shared->backend.gqa_block()},
+                    {"gqa_threshold",shared->backend.gqa_threshold()},
+                    {"gpu_sample",e.gpu_sample_enabled()},{"resident",e.resident_enabled()},
+                    {"bare_system",getenv("Q27_BARE")!=nullptr},{"tool_strict",q27::tool_strict()},
+                    {"tokenizer",tokenizer_name},{"tokenizer_sha1",tokenizer_sha1}}}};
+    }
+
+    std::string health_status() {
+        std::lock_guard<std::mutex> route_lock(route_);
+        if(!recovery_failure_.empty()) return "error";
+        return recovering_?"recovering":"ok";
+    }
+
+    json serving_identity() {
+        std::lock_guard<std::mutex> route_lock(route_);
+        json out=serving_identity_cache;
+        out["backend_state"]=recovery_failure_.empty()?
+            (recovering_?"recovering":"ok"):"error";
+        return out;
+    }
+
+    // Serving knobs promoted to CLI flags (homebrew Phase-2 pre-tag):
+    // budget_mb / snapshot_dir / snapshot_max_mb / snapshot_auto carry the
+    // parsed flag values, already range-validated in main; the sentinel
+    // (0 / empty / 0 / -1) means "flag absent, fall back to the env twin".
+    // An explicit flag always wins over the env.
+    Runtime(const std::string& model,const std::string& tok,uint32_t ctx,bool turbo3,
+            uint32_t width,size_t cache_entries,bool constrain,
+            uint32_t slot_count,uint32_t budget_mb,const std::string& snapshot_dir,
+            uint32_t snapshot_max_mb,long long snapshot_auto,uint32_t max_tokens_default,
+            int spine_pin,bool think_srv)
+        :tokenizer(tok),model_path(model),mtp_width(width),context(ctx),
+         constrain_tools(constrain),turbo3_kv(turbo3),prefix_entries_config(cache_entries),
+         max_tokens_default_config(max_tokens_default),think_default(think_srv) {
+        // Server identity (homebrew plan Q2): /health and the boot trace name
+        // the resident artifact so wrapper/clients can tell what's loaded.
+        model_name=std::filesystem::path(model).filename().string();
+#if Q27_METAL_TEST_FAILPOINTS
+        test_fail_after_snapshot_publish.store(
+            getenv("Q27_METAL_FAIL_AFTER_SNAPSHOT_PUBLISH")!=nullptr,
+            std::memory_order_relaxed);
+#endif
+        tokenizer_name=std::filesystem::path(tok).filename().string();
+        struct utsname un{};
+        if(::uname(&un)!=0) throw std::runtime_error("cannot read host identity");
+        os_sysname=un.sysname; os_release=un.release; os_machine=un.machine;
+        server_sha1=executable_sha1();
+        tokenizer_sha1=file_sha1(tok);
+        {
+            std::random_device rd;
+            uint64_t x=((uint64_t)rd()<<32)^rd()^
+                (uint64_t)std::chrono::high_resolution_clock::now().time_since_epoch().count();
+            char buf[17]; std::snprintf(buf,sizeof buf,"%016llx",(unsigned long long)x);
+            boot_id=buf;
+        }
+        if(tokenizer.vocab_size()!=q27::MetalEngine::vocabulary_size())
+            throw std::runtime_error("tokenizer/model vocabulary mismatch");
+        shared=q27::MetalEngine::open_shared(model);
+        // G6 admission budget (hoisted 2026-07-22 for --ctx auto): the
+        // device serving envelope every slot's KV + fixed state + snapshot
+        // capacity must fit. Default = half the recommended working set
+        // (the engine KV check's convention); --budget-mb flag wins over
+        // the env twin. See the admission loop below for the full comment.
+        const char* budget_env=getenv("Q27_METAL_BUDGET_MB");
+        uint64_t budget=shared->backend.recommended_working_set_size()/2;
+        if(budget_mb) budget=(uint64_t)budget_mb*1024ull*1024ull; // --budget-mb, validated at parse
+        else if(budget_env) {
+            // Fail loud on a malformed override: "-1" through strtoull would
+            // wrap to an effectively unlimited budget and bypass the gate.
+            char* end=nullptr; errno=0;
+            const unsigned long long mb=strtoull(budget_env,&end,10);
+            if(errno || end==budget_env || *end || !mb || mb>(1ull<<24))
+                throw std::runtime_error("Q27_METAL_BUDGET_MB must be an integer 1..16777216");
+            budget=(uint64_t)mb*1024ull*1024ull;
+        }
+        const bool budget_overridden=budget_mb || budget_env;
+        const uint64_t configured_budget=budget;
+        if(budget_overridden) shared->cache_budget=configured_budget;
+        if(ctx==0) {
+            // --ctx auto (upstream v0.4.0 parity; the default): size each
+            // slot's window to what the DEVICE can actually serve. The
+            // budget is the SMALLER of the admission-policy ceiling
+            // (working_set/2 or --budget-mb) and the measured free envelope:
+            // recommended - allocated-after-weights + a bounded 2 GB
+            // overcommit allowance (macOS pages/compresses gracefully past
+            // recommended; every supported legacy config lives inside this)
+            // - a 1 GB activation/desktop reserve. Sizing to the raw policy
+            // ceiling OOMs the command queue on the 24 GB + official-tier
+            // reality: weights (17 GB) and KV share one working set.
+            const uint64_t recommended=shared->backend.recommended_working_set_size();
+            const uint64_t allocated=shared->backend.current_allocated_size();
+            // currentAllocatedSize does NOT price the mapped artifact (the
+            // weights ride the file mapping), so charge the artifact bytes
+            // explicitly — the OOM at the raw policy ceiling was weights
+            // (17 GB) and KV sharing one working set.
+            const uint64_t artifact_bytes=(uint64_t)shared->model.mapping_size();
+            const uint64_t used=artifact_bytes+allocated;
+            const uint64_t measured=recommended>used?recommended-used:0;
+            const uint64_t envelope=measured+(3ull<<30);
+            const uint64_t policy_budget=budget;
+            uint64_t kv_budget=std::min(budget,envelope);
+            kv_budget=kv_budget>(1ull<<30)?kv_budget-(1ull<<30):0;
+            // The admission loop below shares the measured envelope when
+            // auto (policy budget stays for explicit --ctx): solver and
+            // admission must not disagree about what fits.
+            budget=kv_budget;
+            // The admission charge (KV reservation + fixed engine state +
+            // per-entry snapshot capacity — a snapshot is KV CONTENT, so it
+            // scales with ctx too) is exactly linear in ctx. The engine's
+            // allocation-free estimator solves slope + intercept without
+            // briefly violating an explicit budget through probe engines.
+            const uint32_t p1=1024,p2=8192;
+            const uint64_t t1=q27::MetalEngine::serving_reservation_bytes(
+                *shared,p1,turbo3,cache_entries);
+            const uint64_t t2=q27::MetalEngine::serving_reservation_bytes(
+                *shared,p2,turbo3,cache_entries);
+            const double slope=(double)(t2-t1)/(double)(p2-p1);
+            const uint64_t intercept=t1-(uint64_t)(slope*p1);
+            // Degrade like the admission loop promises: if the requested
+            // slot count cannot each hold the floor, solve again for fewer
+            // slots so slot 0 always remains serviceable.
+            uint64_t solved=0; uint32_t split=slot_count?slot_count:1;
+            for(uint32_t n=split; ; --n) {
+                const uint64_t slot_budget=kv_budget/n;
+                // Safety margin: slope rounding and block-aligned snapshot
+                // sizing must never push the solved charge past budget.
+                const uint64_t margin=std::max<uint64_t>(64ull<<20,slot_budget/64);
+                const uint64_t usable=slot_budget>margin?slot_budget-margin:0;
+                solved=usable>intercept?(uint64_t)((usable-intercept)/slope):0;
+                if(solved>=8192 || n==1) { split=n; break; }
+            }
+            if(solved>262144) solved=262144;   // model-family position cap
+            // Preserve the legacy 8192 target when it fits, but auto sizing
+            // must remain inside the actual serving envelope. Very small
+            // envelopes either take the largest positive context or fail
+            // before any engine allocation when even context 1 cannot fit.
+            if(solved<8192) {
+                if(!solved) {
+                    const uint64_t minimum=q27::MetalEngine::serving_reservation_bytes(
+                        *shared,1,turbo3,cache_entries);
+                    if(minimum>kv_budget) {
+                        const uint64_t need_mb=(minimum+1048575)/1048576;
+                        const uint64_t have_mb=kv_budget/1048576;
+                        throw std::runtime_error("--ctx auto: serving envelope cannot fit even "
+                            "a one-token context ("+std::to_string(need_mb)+
+                            " MB required > "+std::to_string(have_mb)+" MB budget)");
+                    }
+                    solved=1;
+                }
+                fprintf(stderr,"q27 Metal server: --ctx auto: serving envelope constrains "
+                        "context to %llu tokens (legacy target 8192)\n",
+                        (unsigned long long)solved);
+            }
+            ctx=(uint32_t)solved;
+            context=ctx;
+            fprintf(stderr,"q27 Metal server: --ctx auto: %u tokens per slot "
+                    "(%.0f charged bytes/token incl snapshot + %.1f MB fixed; "
+                    "KV budget %.0f MB [policy %.0f MB, free %.0f MB + 3072 MB overcommit - 1024 MB reserve] "
+                    "sized for %u of %u requested slot%s)\n",
+                    ctx,slope,intercept/1048576.0,kv_budget/1048576.0,
+                    policy_budget/1048576.0,measured/1048576.0,
+                    split,slot_count,slot_count==1?"":"s");
+        }
+        const uint64_t planned_per_slot=q27::MetalEngine::serving_reservation_bytes(
+            *shared,ctx,turbo3,cache_entries);
+        if(planned_per_slot>budget) {
+            const uint64_t need_mb=(planned_per_slot+1048575)/1048576;
+            const uint64_t have_mb=budget/1048576;
+            throw std::runtime_error("serving budget cannot fit one slot ("+
+                std::to_string(need_mb)+" MB required > "+
+                std::to_string(have_mb)+" MB budget)");
+        }
+        slots.push_back(std::make_unique<Slot>(shared,ctx,turbo3,cache_entries));
+        model_has_mtp=slots.front()->engine.has_mtp();
+        model_chunked_prefill=slots.front()->engine.chunked_prefill();
+
+        // Snapshot v2 (2026-07-17-kv-except-snapshot-v2.md): exception
+        // engines snapshot like any other — side rows ride every surface
+        // and snapshot_bytes() prices them, so no capacity override exists
+        // anymore. Informational note only.
+        if(slots.front()->engine.kv_fp16_except())
+            fprintf(stderr,"q27 Metal server: KV exception cells active (Q27_METAL_KV_FP16_CELLS, side codec %s); side caches ride prefix/disk snapshots (v2)\n",
+                    slots.front()->engine.kv_side_codec()?"e4m3":"fp16");
+        // G6 admission (docs/metal/plans/2026-07-16-g6-admission.md): every
+        // slot must fit the FULL footprint — KV + per-engine GQA partials,
+        // fixed state, and snapshot capacity — against the selected device
+        // budget (--budget-mb, Q27_METAL_BUDGET_MB, or the default half of
+        // recommended working set). The engine's KV-only check remains
+        // underneath as defense in depth.
+        const q27::MetalEngine& e0=slots[0]->engine;
+        const uint64_t per_slot=e0.kv_reserved_bytes()
+                               +q27::MetalEngine::fixed_state_bytes(e0.chunked_prefill(),e0.has_mtp())
+                               +(uint64_t)cache_entries*e0.snapshot_bytes();
+        if(per_slot!=planned_per_slot)
+            throw std::runtime_error("q27 Metal: serving footprint estimator drift");
+        for(uint32_t s=1;s<slot_count;s++) {
+            const uint64_t need=(uint64_t)(slots.size()+1)*per_slot;
+            if(need>budget) {
+                fprintf(stderr,"multislot: slot %u admission rejected: %.0f MB needed "
+                        "(%zu+1 slots x %.0f MB/slot incl partials) > %.0f MB budget%s; "
+                        "serving with %zu slot(s)\n",
+                        s,need/1048576.0,slots.size(),per_slot/1048576.0,
+                        budget/1048576.0,
+                        budget_mb?" (--budget-mb)":(budget_env?" (Q27_METAL_BUDGET_MB)":""),slots.size());
+                break;
+            }
+            try { slots.push_back(std::make_unique<Slot>(shared,ctx,turbo3,cache_entries)); }
+            catch(const std::exception& e) {
+                fprintf(stderr,"multislot: slot %u admission failed (%s); serving with %zu slot(s)\n",
+                        s,e.what(),slots.size());
+                break;
+            }
+        }
+        // Prefix snapshots Phase 2: opt-in via --snapshot-dir (env fallback
+        // Q27_METAL_SNAPSHOT_DIR); budget via --snapshot-max-mb /
+        // Q27_METAL_SNAPSHOT_MAX_MB (validated, fail-loud, same class as
+        // the admission budget; default 8192 MB). The artifact identity
+        // hash (~3 s over the 7 GB mapping) is primed HERE, at startup, so
+        // the first hinted request never stalls the lease on it.
+        std::string sdir=snapshot_dir;
+        if(sdir.empty())
+            if(const char* senv=getenv("Q27_METAL_SNAPSHOT_DIR"); senv && *senv) sdir=senv;
+        if(!sdir.empty()) {
+            uint64_t snap_mb=8192;
+            if(snapshot_max_mb) snap_mb=snapshot_max_mb; // --snapshot-max-mb, validated at parse
+            else if(const char* smax=getenv("Q27_METAL_SNAPSHOT_MAX_MB"); smax && *smax) {
+                char* end=nullptr; errno=0;
+                const unsigned long long mb=strtoull(smax,&end,10);
+                if(errno || end==smax || *end || !mb || mb>(1ull<<24))
+                    throw std::runtime_error("Q27_METAL_SNAPSHOT_MAX_MB must be an integer 1..16777216");
+                snap_mb=(uint64_t)mb;
+            }
+            std::error_code ec;
+            std::filesystem::create_directories(sdir,ec);
+            if(ec)
+                throw std::runtime_error("cannot create snapshot dir (--snapshot-dir / Q27_METAL_SNAPSHOT_DIR): "+sdir);
+            // Snapshot contents include prompt tokens and KV state. Secure the
+            // configured leaf itself even when it already existed under a
+            // permissive umask, and reject symlink traversal at the leaf.
+            const int snapshot_dir_fd=::open(sdir.c_str(),O_RDONLY|O_DIRECTORY|O_CLOEXEC|O_NOFOLLOW);
+            if(snapshot_dir_fd<0)
+                throw std::runtime_error("snapshot dir (--snapshot-dir / Q27_METAL_SNAPSHOT_DIR) is not a usable directory: "+sdir);
+            if(::fchmod(snapshot_dir_fd,S_IRWXU)!=0) {
+                const int error=errno;
+                ::close(snapshot_dir_fd);
+                throw std::runtime_error("cannot secure snapshot dir "+sdir+": "+std::strerror(error));
+            }
+            ::close(snapshot_dir_fd);
+            const unsigned char* sha=slots[0]->engine.snapshot_identity();
+            const auto runtime_sha=slots[0]->engine.snapshot_runtime_identity();
+            // Full 160-bit artifact and runtime identities in the tag: a
+            // truncated prefix could collide across models, shader builds,
+            // hardware, or state-producing backend settings and let one
+            // server restore another configuration's numerical state.
+            std::string tag;
+            tag.reserve(104);
+            char hex[3];
+            for(int i=0;i<20;i++) { snprintf(hex,3,"%02x",sha[i]); tag+=hex; }
+            tag+=turbo3?'t':'f';
+            tag+='r';
+            for(unsigned char byte:runtime_sha) {
+                snprintf(hex,3,"%02x",byte);
+                tag+=hex;
+            }
+            if(slots[0]->engine.kv_fp16_except()) {
+                // 'x' = fp16 sides, 'y' = e4m3 sides: codec is config
+                // identity, so the two must miss each other's files.
+                tag+=slots[0]->engine.kv_side_codec()?'y':'x';
+                const uint8_t* masks=slots[0]->engine.kv_fp16_head_masks();
+                tag+=q27::metal_snapshot_head_mask_tag(masks,16);
+            }
+            tag+='-';
+            snapshot_max_bytes_config=snap_mb*1024ull*1024ull;
+            // T1 spine-pin resolution (flag > env > default on):
+            // --snapshot-spine-pin 0/1 wins; else Q27_METAL_SNAPSHOT_SPINE_PIN
+            // (fail-loud like the other snapshot knobs); default 1.
+            bool spin=true;
+            if(spine_pin>=0) spin=(spine_pin!=0);
+            else if(const char* sp=getenv("Q27_METAL_SNAPSHOT_SPINE_PIN"); sp && *sp) {
+                char* end=nullptr; errno=0;
+                const unsigned long long v=strtoull(sp,&end,10);
+                if(errno || end==sp || *end || v>1)
+                    throw std::runtime_error("Q27_METAL_SNAPSHOT_SPINE_PIN must be 0 or 1");
+                spin=(v!=0);
+            }
+            snapshot_spine_pin_config=spin;
+            snapstore.init(sdir,snapshot_max_bytes_config,tag.c_str(),spin);
+            // A restart over an oversized directory must return under budget
+            // without waiting for the next save.
+            snapstore.evict_past_budget();
+            if(!slots[0]->engine.chunked_prefill())
+                fprintf(stderr,"prefix-snapshots: WARNING — no chunked prefill on this device; "
+                        "\"snapshot\" hints are ignored (loads still served)\n");
+            // Auto-snapshot threshold (2026-07-17 T2 prefill finding,
+            // docs/metal/plans/2026-07-17-t2-prefill-throughput.md): chunked
+            // prefill is compute-mature at ~28-40 tok/s on the M4, so a
+            // large agentic prompt (pi ~8.4K tokens, CC larger) costs
+            // minutes of TTFT — and real agent clients never send the
+            // "snapshot" hint. With the snapshot dir already opted in,
+            // prompts at/above the threshold behave as hinted; the existing
+            // covered-prefix skip and LRU budget bound the write traffic.
+            // --snapshot-auto / Q27_METAL_SNAPSHOT_AUTO overrides (tokens;
+            // 0 disables auto).
+            snap_auto_min=4096;
+            if(snapshot_auto>=0) snap_auto_min=(size_t)snapshot_auto; // --snapshot-auto, validated at parse
+            else if(const char* sauto=getenv("Q27_METAL_SNAPSHOT_AUTO"); sauto && *sauto) {
+                char* end=nullptr; errno=0;
+                const unsigned long long v=strtoull(sauto,&end,10);
+                if(errno || end==sauto || *end || v>(1ull<<24))
+                    throw std::runtime_error("Q27_METAL_SNAPSHOT_AUTO must be an integer 0..16777216");
+                snap_auto_min=(size_t)v;
+            }
+            fprintf(stderr,"prefix-snapshots: dir %s, budget %llu MB, auto>=%zu tokens, spine-pin %s, tag %s\n",
+                    sdir.c_str(),(unsigned long long)snap_mb,snap_auto_min,spin?"on":"off",tag.c_str());
+        }
+        if(constrain_tools) {
+            vocab_bytes_v=tokenizer.vocab_bytes();
+            mask_cache.init(&vocab_bytes_v,tokenizer.token_id("</tool_call>"));
+            fprintf(stderr,"constrain-tools: grammar-locked <tool_call> bodies (open=%d close=%d)\n",
+                    tokenizer.token_id("<tool_call>"),tokenizer.token_id("</tool_call>"));
+        }
+        serving_identity_cache=build_serving_identity();
+    }
+
+    // A committed Metal failure poisons the shared command queue and every
+    // engine attached to it. Stop admissions, let in-flight requests unwind,
+    // then replace the mapping/backend and all slots as one generation.
+    // Recovery validates the reopened pathname against the resident mapping:
+    // an atomic deployment must never switch a live boot to different weights.
+    bool recover_backend_if_poisoned() {
+        std::unique_lock<std::mutex> recovery_lock(recovery_);
+        if(shared->backend.healthy()) return false;
+
+        size_t slot_count=0;
+        {
+            std::unique_lock<std::mutex> route_lock(route_);
+            recovering_=true;
+            slot_free_.wait(route_lock,[&]{
+                for(const auto& slot:slots) if(slot->busy) return false;
+                return true;
+            });
+            slot_count=slots.size();
+        }
+
+        std::shared_ptr<q27::MetalEngine::Shared> replacement_shared;
+        std::vector<std::unique_ptr<Slot>> old_slots,replacement_slots;
+        try {
+            unsigned char resident_sha1[CC_SHA1_DIGEST_LENGTH];
+            unsigned char replacement_sha1[CC_SHA1_DIGEST_LENGTH];
+            mapping_sha1(shared->model,resident_sha1);
+            replacement_shared=q27::MetalEngine::open_shared(model_path);
+            replacement_shared->cache_budget=shared->cache_budget;
+            mapping_sha1(replacement_shared->model,replacement_sha1);
+            if(std::memcmp(resident_sha1,replacement_sha1,sizeof resident_sha1)!=0)
+                throw std::runtime_error(
+                    "model artifact changed on disk; refusing in-process Metal recovery");
+            // One boot must retain both its model and shader identities.
+            if(replacement_shared->backend.shader_source_sha1()!=
+               shared->backend.shader_source_sha1())
+                throw std::runtime_error(
+                    "Metal shader source changed on disk; refusing in-process recovery");
+            // Reserve before moving the live vector; allocation failure leaves it intact.
+            replacement_slots.reserve(slot_count);
+        } catch(const std::exception& error) {
+            fprintf(stderr,"Metal backend recovery failed before rebuild: %s\n",error.what());
+            {
+                std::lock_guard<std::mutex> route_lock(route_);
+                recovery_failure_="Metal backend recovery failed before rebuild: ";
+                recovery_failure_+=error.what();
+                recovering_=false;
+            }
+            slot_free_.notify_all();
+            throw;
+        }
+
+        {
+            std::lock_guard<std::mutex> route_lock(route_);
+            old_slots=std::move(slots);
+            shared=replacement_shared;
+        }
+        // Poisoned engines cannot be a rollback target. Release every old
+        // slot and the old shared backend before allocating the replacement
+        // generation, preserving the startup admission memory envelope.
+        old_slots.clear();
+        try {
+            for(size_t i=0;i<slot_count;i++) {
+                replacement_slots.push_back(std::make_unique<Slot>(
+                    replacement_shared,context,turbo3_kv,prefix_entries_config));
+            }
+        } catch(const std::exception& error) {
+            fprintf(stderr,"Metal backend recovery: slot rebuild stopped after %zu/%zu (%s)\n",
+                    replacement_slots.size(),slot_count,error.what());
+            if(replacement_slots.empty() || !replacement_shared->backend.healthy()) {
+                {
+                    std::lock_guard<std::mutex> route_lock(route_);
+                    recovery_failure_="Metal backend recovery could not rebuild a healthy serving slot: ";
+                    recovery_failure_+=error.what();
+                    recovering_=false;
+                }
+                slot_free_.notify_all();
+                throw;
+            }
+            // A partial rebuild is healthy and preferable to taking the
+            // process down. Capacity is reduced until the next restart.
+        }
+        const size_t rebuilt_count=replacement_slots.size();
+        {
+            std::lock_guard<std::mutex> route_lock(route_);
+            shared=std::move(replacement_shared);
+            slots=std::move(replacement_slots);
+            serving_identity_cache["protocol"]["slots"]=slots.size();
+            recovery_failure_.clear();
+            recovering_=false;
+        }
+        slot_free_.notify_all();
+        fprintf(stderr,"Metal backend recovery: rebuilt %zu slot%s after command failure\n",
+                rebuilt_count,rebuilt_count==1?"":"s");
+        trace.event({{"kind","backend_recovery"},{"slots",rebuilt_count}});
+        return true;
+    }
+
+    template<class Fn>
+    decltype(auto) guard_engine(Fn&& fn) {
+        try { return std::forward<Fn>(fn)(); }
+        catch(const ServerOverloaded&) { throw; }
+        catch(const EngineError&) { throw; }
+        catch(const std::exception& error) {
+            std::string message=error.what();
+            try { recover_backend_if_poisoned(); }
+            catch(const std::exception& recovery) {
+                message+="; Metal backend recovery failed: ";
+                message+=recovery.what();
+            }
+            throw EngineError(message);
+        }
+    }
+
+    static const char* phase_name(Slot::Phase p) {
+        switch(p) {
+            case Slot::Phase::Prefill: return "prefill";
+            case Slot::Phase::Decode: return "decode";
+            case Slot::Phase::Verify: return "verify";
+            default: return "idle";
+        }
+    }
+
+    // Prefill width policy (Phase 1 contract): the width is a runtime
+    // policy, not an engine constant. 96 when nothing competes, 48 when the
+    // competing traffic is itself prefilling, 12 when a latency-sensitive
+    // stream (decode/MTP verify) or a queued request is waiting for the GPU.
+    uint32_t quantum_width(const Slot* self) {
+        std::lock_guard<std::mutex> lk(route_);
+        bool other_busy=false, other_latency=false;
+        for(const auto& s:slots) {
+            if(s.get()==self || !s->busy) continue;
+            other_busy=true;
+            if(s->phase!=Slot::Phase::Prefill) other_latency=true;
+        }
+        if(other_latency || queue_waiters>0) return 12;
+        if(other_busy) return 48;
+        return 96;
+    }
+    uint32_t effective_speculation_width(const q27::SamplingParams& sampling,
+                                         bool bounded_reasoning) const {
+        return q27::metal_serving_speculation_width(
+            mtp_width,model_has_mtp,model_chunked_prefill,
+            sampling.temperature>0.0f,getenv("Q27_SAMPLE_PLAIN")!=nullptr,
+            bounded_reasoning);
+    }
+
+    uint32_t prompt_ceiling(const q27::SamplingParams& sampling,
+                            bool bounded_reasoning) const {
+        return q27::metal_max_prompt_tokens(
+            context,effective_speculation_width(sampling,bounded_reasoning));
+    }
+
+
+    // How generation ended. Stop == the model emitted EOS (finish_reason
+    // "stop" / stop_reason "end_turn"); StopSequence == a requested stop
+    // string matched ("stop" / "stop_sequence"); Length == max_tokens hit
+    // ("length" / "max_tokens"); Cancelled == the client disconnected.
+    enum class Finish { Length, Stop, StopSequence, Cancelled };
+    struct Outcome {
+        uint32_t prompt_tokens=0, output_tokens=0;
+        size_t prefix_hit=0;
+        Finish finish=Finish::Length;
+        std::string stop_sequence; // set when finish==StopSequence
+        double queue_wait_ms=0;    // arrival to slot admission
+        double gate_wait_ms=0;     // slot admission to first GPU lease
+        const char* arrival="idle"; // competing slot's phase at arrival
+    };
+
+    struct ThinkControl {
+        q27::ThinkBudgetState* state=nullptr;
+        q27::StreamSplitter* splitter=nullptr;
+        const std::vector<int>* close_ids=nullptr;
+        std::function<bool(const std::string&)> emit_forced;
+    };
+
+    // Invalidate path-keyed metadata on every save attempt. save_state can
+    // atomically rename the new inode and then throw on directory fsync; in
+    // that uncertain-publication case the path may already name new metadata.
+    // Erasing is safe before rename too: the next lookup simply re-peeks the
+    // still-current old file.
+    void save_disk_snapshot(q27::MetalEngine& engine,const std::string& path,
+                            const uint32_t* tokens,uint32_t count,
+                            bool logits_resident,
+                            const std::function<void()>& checkpoint={}) {
+        try {
+            engine.save_state(path,tokens,count,logits_resident,
+                [&](const std::function<void()>& operation) {
+                    if(checkpoint) checkpoint();
+                    Lease::Guard gpu(lease_,checkpoint);
+                    operation();
+                });
+        } catch(...) {
+            snapstore.save_failed(path);
+            throw;
+        }
+        if(checkpoint) checkpoint();
+        snapstore.published(path,tokens,count);
+#if Q27_METAL_TEST_FAILPOINTS
+        if(test_fail_after_snapshot_publish.exchange(false,std::memory_order_relaxed))
+            throw std::runtime_error("injected failure after snapshot publication");
+#endif
+    }
+
+    // Single generation core shared by streaming and non-streaming paths.
+    // `emit(piece)` receives UTF-8-safe, stop-sequence-trimmed text as it is
+    // produced and returns false when the client has gone away.
+    //
+    // Multislot Phase 1: a request claims an idle slot (engine + prefix
+    // cache), then makes progress one scheduling quantum at a time — one
+    // prefill chunk at the policy width, one decode step, or one MTP
+    // draft/verify/commit round per GPU lease — so a concurrent request on
+    // the other slot waits at most one active quantum, never a whole
+    // generation. Text delivery (decode/UTF-8/stop gates/emit) runs outside
+    // the lease: a slow client can stall its own stream, not the GPU.
+    Outcome run(const std::vector<uint32_t>& prompt,uint32_t count,
+                const q27::SamplingParams& sampling,
+                const std::vector<std::string>& stops,
+                const std::function<bool(const std::string&)>& emit,
+                const std::vector<std::string>& tool_names={},
+                bool snapshot_hint=false,
+                const std::string& trace_id="",
+                ThinkControl* think_control=nullptr,
+                bool forced_tool_choice=false,
+                const std::function<bool()>& live={}) {
+        if(prompt.empty()) throw std::runtime_error("prompt is empty");
+        q27::validate_sampling(sampling);
+        // `mtp` (prefill warm + decode path) is resolved after the slot's
+        // engine is bound — it needs has_mtp() so an incompatible artifact
+        // fails closed instead of entering mtp_warm.
+        const bool tracks_reasoning=think_control && think_control->state &&
+            think_control->splitter && think_control->close_ids;
+        const bool bounded_reasoning=tracks_reasoning && think_control->state->limit>=0;
+        const bool sample_plain=getenv("Q27_SAMPLE_PLAIN")!=nullptr;
+        const auto arrive=std::chrono::steady_clock::now();
+
+        // ---- slot acquisition (route_ only; never held across GPU work) ----
+        Slot* slot=nullptr;
+        const char* arrival="idle";
+        {
+            std::unique_lock<std::mutex> lk(route_);
+            if(!recovery_failure_.empty()) throw EngineError(recovery_failure_);
+            for(const auto& s:slots) if(s->busy) arrival=phase_name(s->phase);
+            while(cancelled_slot_tickets_.erase(slot_serving_)) slot_serving_++;
+            if(slot_next_-slot_serving_>=QUEUE_MAX)
+                throw ServerOverloaded("server overloaded: request queue is full");
+            const uint64_t ticket=slot_next_++;
+            struct TurnPass {
+                Runtime& rt;
+                uint64_t ticket;
+                ~TurnPass() {
+                    if(rt.slot_serving_==ticket) {
+                        rt.slot_serving_++;
+                        while(rt.cancelled_slot_tickets_.erase(rt.slot_serving_))
+                            rt.slot_serving_++;
+                    } else {
+                        rt.cancelled_slot_tickets_.insert(ticket);
+                    }
+                    rt.slot_free_.notify_all();
+                }
+            } turn{*this,ticket};
+            queue_waiters++;
+            for(;;) {
+                if(!recovering_ && slot_serving_==ticket) {
+                    if(!recovery_failure_.empty()) break;
+                    bool available=false;
+                    for(const auto& s:slots) if(!s->busy) { available=true; break; }
+                    if(available) break;
+                }
+                if(live) {
+                    lk.unlock();
+                    const bool connected=live();
+                    lk.lock();
+                    if(!connected) {
+                        queue_waiters--;
+                        trace.event({{"kind","cancel"},{"phase","queue"},{"id",trace_id}});
+                        throw ClientGone{};
+                    }
+                }
+                slot_free_.wait_for(lk,std::chrono::milliseconds(100));
+            }
+            queue_waiters--;
+            if(!recovery_failure_.empty())
+                throw EngineError(recovery_failure_);
+            for(const auto& s:slots) if(!s->busy) { slot=s.get(); break; }
+            slot->busy=true;
+            slot->phase=Slot::Phase::Prefill;
+        }
+        struct SlotRelease {
+            Runtime& rt; Slot& s;
+            ~SlotRelease() {
+                {
+                    std::lock_guard<std::mutex> lk(rt.route_);
+                    s.busy=false;
+                    s.phase=Slot::Phase::Idle;
+                    if(!rt.shared->backend.healthy()) rt.recovering_=true;
+                }
+                // notify_all, not notify_one: only the serving ticket's
+                // waiter can proceed. notify_one may wake another ticket that
+                // immediately sleeps again, wedging the queue with an idle slot.
+                rt.slot_free_.notify_all();
+            }
+        } slot_release{*this,*slot};
+        q27::MetalEngine& engine=slot->engine;
+        // Warm MTP whenever the artifact has the layer and we will use it:
+        // greedy MTP, or sampled MTP (not Q27_SAMPLE_PLAIN force-off).
+        const bool mtp=mtp_width!=0 && engine.has_mtp() && !bounded_reasoning &&
+            !(sampling.temperature>0.0f && sample_plain);
+        // Reject the complete request before any prompt token mutates engine
+        // state. Endpoint preflights normally clamp this first; this is the
+        // run-level backstop for internal callers and future routes.
+        if(!q27::metal_generation_fits(prompt.size(),count,context))
+            throw std::runtime_error("generation exceeds context");
+
+
+        // First lease acquisition stamps the gate wait; every engine call
+        // below runs under one of these scoped leases.
+        const auto admitted=std::chrono::steady_clock::now();
+        const double queue_wait_ms=
+            std::chrono::duration<double,std::milli>(admitted-arrive).count();
+        double gate_wait_ms=-1.0;
+        auto checkpoint=[&] {
+            if(live && !live()) {
+                trace.event({{"kind","cancel"},{"phase","prefill"},{"id",trace_id}});
+                throw ClientGone{};
+            }
+        };
+        auto lease_now=[&]()->Lease::Guard {
+            checkpoint();
+            Lease::Guard gpu(lease_,checkpoint);
+            if(gate_wait_ms<0)
+                gate_wait_ms=std::chrono::duration<double,std::milli>(
+                    std::chrono::steady_clock::now()-admitted).count();
+            return gpu;
+        };
+
+        // ---- prompt ingestion, one quantum per chunk ----
+        size_t hit=0; uint32_t pending=0;
+        bool restored=false,disk_loaded=false;
+        auto enforce_snapshot_budget=[&]() noexcept {
+            try {
+                const auto ev=snapstore.evict_past_budget();
+                if(ev.first) trace.event({{"kind","snapshot_evict"},{"id",trace_id},
+                                          {"files",ev.first},{"bytes",ev.second}});
+            } catch(const std::exception& e) {
+                std::fprintf(stderr,"[snapshot-evict] skipped: %s\n",e.what());
+                trace.event({{"kind","snapshot_evict_failed"},{"id",trace_id},
+                             {"error",e.what()}});
+            }
+        };
+        // Disk lookup and validation run without the shared device lease. Each
+        // restore transfer takes one bounded lease; MTP requests stay on the
+        // cold path because lane warming state is not snapshotted in this phase.
+        DiskSnapshotStore::Match disk_match;
+        checkpoint();
+        if(!mtp && snapstore.enabled()) disk_match=snapstore.best_match(prompt);
+        const bool disk_ok=(bool)disk_match;
+        const uint32_t disk_len=disk_ok?(uint32_t)disk_match.info.tokens.size():0;
+        auto snapshot_checkpoint=checkpoint;
+        {
+            auto gpu=lease_now();
+            // A slot's constraint masks are request-scoped. Reset both the
+            // device allocator and its host cache map before any restore or
+            // prefill so varied tool schemas cannot exhaust a long-lived slot.
+            engine.reset_mask_pool();
+            slot->host2dev.clear();
+            restored=slot->cache.restore(engine,prompt,mtp,hit,pending);
+            if(!restored) { engine.reset(); hit=0; }
+        }
+        // The deeper prefix wins across tiers. Validation completes before the
+        // first device write; pass-2 failures leave indeterminate state and
+        // therefore fall back through a leased reset/restore below.
+        if(disk_ok && disk_len>hit) {
+            try {
+                snapshot_checkpoint();
+                engine.load_state_fd(disk_match.fd,disk_match.path,&disk_match.info.tokens,
+                    [&](const std::function<void()>& operation) {
+                        snapshot_checkpoint();
+                        auto gpu=lease_now();
+                        operation();
+                    },snapshot_checkpoint);
+                disk_loaded=true;
+                hit=disk_len;
+                if(hit==prompt.size()) {
+                    auto gpu=lease_now();
+                    pending=engine.pending_from_logits();
+                    restored=true;
+                }
+                snapstore.hits++;
+            } catch(const std::exception&) {
+                // Command failures poison the shared backend, not the
+                // snapshot. Let guard_engine rebuild it and retain the entry.
+                if(!shared->backend.healthy()) throw;
+                try {
+                    snapstore.reject(disk_match.path,disk_match.fd);
+                } catch(const std::exception& cleanup_error) {
+                    std::fprintf(stderr,"[snapshot-reject] cleanup skipped: %s\n",cleanup_error.what());
+                    trace.event({{"kind","snapshot_reject_cleanup_error"},
+                                 {"path",disk_match.path},{"error",cleanup_error.what()}});
+                }
+                {
+                    auto gpu=lease_now();
+                    engine.reset(); hit=0; pending=0;
+                    restored=slot->cache.restore(engine,prompt,mtp,hit,pending);
+                    if(!restored) { engine.reset(); hit=0; pending=0; }
+                }
+            }
+        }
+        if((uint64_t)engine.position()+(prompt.size()-hit)>context)
+            throw std::runtime_error("prompt exceeds context");
+        trace.event({{"kind","prefix"},{"id",trace_id},
+                     {"tier",hit==0?"cold":(disk_loaded?"disk":"memory")},
+                     {"hit",(uint64_t)hit},{"prompt_tokens",(uint64_t)prompt.size()}});
+        // Hinted save target: a stable boundary — trim a 32-token tail
+        // (the question-specific suffix) and align down to a 96-token
+        // prefill-chunk boundary. Reached exactly by capping one chunk's
+        // width; skipped when the restored prefix already covers it.
+        //
+        // Auto-save (snap_auto_min) rides the same machinery. Same-key writers
+        // use private temporary inodes; because the token key fixes the saved
+        // state, the last atomic rename wins with equivalent content. Snapshot
+        // filesystem writes and durability syncs run without the device lease;
+        // each 16 MiB device transfer takes one FIFO lease quantum. A
+        // non-repeating large-prompt workload still pays one ~1.3 GB write per
+        // unique prefix, so churn-sensitive deployments set
+        // Q27_METAL_SNAPSHOT_AUTO=0 (hint-only).
+        size_t save_at=0;
+        const bool snap_wanted=snapshot_hint ||
+                               (snap_auto_min && prompt.size()>=snap_auto_min);
+        if(snap_wanted && !mtp && snapstore.enabled() && engine.chunked_prefill() &&
+           prompt.size()>32+96) {
+            const size_t target=(prompt.size()-32)/96*96;
+            if(target>hit) save_at=target;
+        }
+        std::vector<uint32_t> suffix(prompt.begin()+hit,prompt.end());
+        if(!suffix.empty()) {
+            if(mtp || !engine.chunked_prefill()) {
+                // Token-serial prefill still obeys the shared scheduling
+                // quantum: one bounded command batch per lease. This keeps
+                // serial MTP and older-device prompts from monopolizing the GPU
+                // for their entire prompt.
+                size_t i=0;
+                while(i<suffix.size()) {
+                    const uint32_t take=(uint32_t)std::min<size_t>(
+                        q27::MetalEngine::serial_prefill_chunk_max(),suffix.size()-i);
+                    const bool final_chunk=i+take==suffix.size();
+                    {
+                        auto gpu=lease_now();
+                        const uint32_t next=engine.prefill_serial_chunk(
+                            suffix.data()+i,take,mtp,final_chunk);
+                        if(final_chunk) pending=next;
+                    }
+                    i+=take;
+                }
+            } else {
+                size_t i=0;
+                const size_t chunkable=suffix.size()-1;
+                while(chunkable-i>=2) {
+                    const uint32_t width=quantum_width(slot);
+                    uint32_t take=(uint32_t)std::min<size_t>(width,chunkable-i);
+                    if(save_at && hit+i<save_at) {
+                        // prefill_chunk takes 2..96 tokens. A one-token gap to
+                        // the boundary cannot be reached by capping, so skip
+                        // the best-effort save rather than failing the request.
+                        if(save_at-(hit+i)==1) save_at=0;
+                        else take=(uint32_t)std::min<size_t>(take,save_at-(hit+i));
+                    }
+                    {
+                        auto gpu=lease_now();
+                        engine.prefill_chunk(suffix.data()+i,take);
+                    }
+                    i+=take;
+                    if(save_at && hit+i==save_at) {
+                        // Mid-prefill state is exact but the logits row is
+                        // stale — recorded in the file so a same-length
+                        // request can never derive a pending token from it.
+                        const std::string path=snapstore.path_for(
+                            prompt.data(),(uint32_t)save_at);
+                        bool published=false;
+                        try {
+                            published=snapstore.with_publication_lock(path,[&] {
+                                if(snapstore.exact_resident(
+                                        prompt.data(),(uint32_t)save_at)) return false;
+                                save_disk_snapshot(engine,path,prompt.data(),
+                                                   (uint32_t)save_at,false,snapshot_checkpoint);
+                                return true;
+                            });
+                        } catch(const std::exception& e) {
+                            // Automatic/hinted persistence is an optimization,
+                            // not part of inference correctness. Keep ordinary
+                            // filesystem failures off the response path, but a
+                            // poisoned backend must still reach guard_engine so
+                            // every slot is rebuilt before the next request.
+                            if(!shared->backend.healthy()) throw;
+                            fprintf(stderr,"[snapshot-save] skipped: %s\n",e.what());
+                            trace.event({{"kind","snapshot_save_failed"},{"id",trace_id},
+                                         {"len",(uint64_t)save_at},{"error",e.what()}});
+                        }
+                        enforce_snapshot_budget();
+                        if(published) {
+                            snapstore.saves++;
+                            trace.event({{"kind","snapshot_save"},{"id",trace_id},
+                                         {"len",(uint64_t)save_at},
+                                         {"mode",snapshot_hint?"hint":"auto"}});
+                        }
+                        save_at=0;
+                    }
+                }
+                // Serial tail: at most one leftover chunkable token plus the
+                // final token, which produces the logits and pending id —
+                // mirrors MetalEngine::prefill()'s tail exactly.
+                for(;i<suffix.size();i++) {
+                    auto gpu=lease_now();
+                    pending=engine.step(suffix[i]);
+                }
+            }
+        }
+        // Cache the prompt state before generation mutates it. One entry costs
+        // about 151 MiB for GDN state, so the default capacity is deliberately 1.
+        // prepare_insert can release an evicted snapshot's GPU buffers, so it
+        // stays under the lease alongside capture_state.
+        {
+            auto gpu=lease_now();
+            if(slot->cache.prepare_insert(prompt,mtp))
+                slot->cache.insert(prompt,mtp,pending,engine.capture_state());
+        }
+        {
+            std::lock_guard<std::mutex> lk(route_);
+            slot->phase = mtp ? Slot::Phase::Verify : Slot::Phase::Decode;
+            WaitStats& qs=queue_wait_stats[arrival];
+            qs.n++; qs.sum_ms+=queue_wait_ms; qs.max_ms=std::max(qs.max_ms,queue_wait_ms);
+            WaitStats& gs=gate_wait_stats[arrival];
+            gs.n++; gs.sum_ms+=std::max(gate_wait_ms,0.0); gs.max_ms=std::max(gs.max_ms,gate_wait_ms);
+        }
+
+        // token -> decode -> UTF-8 boundary gate -> stop-sequence holdback ->
+        // emit, all outside the GPU lease. A failed emit cancels generation;
+        // a completed stop sequence records its own terminal reason.
+        q27::Utf8Gate ugate;
+        q27::StopBuffer stopbuf(stops);
+        const uint32_t eos_id=(uint32_t)tokenizer.eos();
+        bool client_gone=false, stop_hit=false;
+        uint32_t produced=0;
+        q27::MetalEngine::StopCause cause=q27::MetalEngine::StopCause::MaxTokens;
+        struct BudgetTask {
+            bool sampling=false;
+            bool accept_one=false;
+            bool public_budget_reduced=false;
+            bool budget_cancelled=false;
+            bool budget_truncated=false;
+            uint32_t n_max;
+            uint32_t& emitted;
+            const std::vector<int>* forced=nullptr;
+
+            BudgetTask(uint32_t cap,uint32_t& done,bool sampled)
+                : sampling(sampled),n_max(cap),emitted(done) {}
+            void force(const std::vector<int>& ids) { forced=&ids; accept_one=true; }
+            bool force_from_public_budget(const std::vector<int>& ids) {
+                const uint32_t cost=(uint32_t)ids.size();
+                public_budget_reduced=true;
+                if(n_max-emitted<=cost) {
+                    budget_cancelled=true;
+                    budget_truncated=true;
+                    return false;
+                }
+                n_max-=cost;
+                force(ids);
+                return true;
+            }
+            void release_accept_one() { if(!forced) accept_one=false; }
+        } budget_task(count,produced,sampling.temperature>0.0f);
+        auto queue_reasoning_close=[&](q27::ThinkBudgetAction action) {
+            if(action==q27::ThinkBudgetAction::FORCE_RESERVED)
+                budget_task.force(*think_control->close_ids);
+            else if(action==q27::ThinkBudgetAction::FORCE_PUBLIC)
+                budget_task.force_from_public_budget(*think_control->close_ids);
+        };
+        auto apply_forced=[&](bool consume_current,uint32_t current)->bool {
+            const std::vector<int>* ids=budget_task.forced;
+            if(!ids) return true;
+            budget_task.forced=nullptr;
+            // Stop-sequence holdback precedes the channel splitter in this
+            // runtime. Flush any visible prefix before the hidden close so
+            // reasoning bytes cannot be reclassified as answer text after
+            // the forced channel transition.
+            bool boundary_stopped=false;
+            std::string boundary=stopbuf.feed(ugate.flush(),boundary_stopped);
+            bool flush_stopped=false;
+            boundary+=stopbuf.flush(&flush_stopped);
+            boundary_stopped=boundary_stopped || flush_stopped;
+            if(!boundary.empty() && !emit(boundary)) {
+                client_gone=true;
+                cause=q27::MetalEngine::StopCause::Cancelled;
+                return false;
+            }
+            if(boundary_stopped) {
+                stop_hit=true;
+                cause=q27::MetalEngine::StopCause::Cancelled;
+                return false;
+            }
+            {
+                auto gpu=lease_now();
+                if(consume_current) pending=engine.step(current);
+                for(int id:*ids) {
+                    const uint32_t forced=(uint32_t)id;
+                    pending=engine.force_tokens(&forced,1);
+                }
+            }
+            for(int id:*ids) {
+                const q27::StreamSplitter::Chan before=think_control->splitter->chan;
+                const std::string safe=ugate.feed(tokenizer.decode_one(id));
+                if(!safe.empty() && think_control && think_control->emit_forced &&
+                   !think_control->emit_forced(safe)) {
+                    client_gone=true;
+                    cause=q27::MetalEngine::StopCause::Cancelled;
+                    return false;
+                }
+                think_control->state->observe(before,think_control->splitter->chan,true);
+            }
+            budget_task.release_accept_one();
+            return true;
+        };
+        if(bounded_reasoning) {
+            queue_reasoning_close(think_control->state->start(think_control->splitter->chan));
+            if(!apply_forced(false,0)) client_gone=true;
+        }
+        auto deliver=[&](uint32_t token)->bool {
+            if(live && !live()) {
+                client_gone=true;
+                cause=q27::MetalEngine::StopCause::Cancelled;
+                return false;
+            }
+            const q27::StreamSplitter::Chan before=tracks_reasoning
+                ? think_control->splitter->chan : q27::StreamSplitter::TEXT;
+            bool stopped=false;
+            std::string safe=stopbuf.feed(ugate.feed(tokenizer.decode_one((int)token)),stopped);
+            if(!emit(safe)) { client_gone=true; cause=q27::MetalEngine::StopCause::Cancelled; return false; }
+            if(!stopped && tracks_reasoning) {
+                think_control->state->observe(before,think_control->splitter->chan);
+                queue_reasoning_close(
+                    think_control->state->finish_round(think_control->splitter->chan));
+            }
+            produced++;
+            if(stopped) { stop_hit=true; cause=q27::MetalEngine::StopCause::Cancelled; return false; }
+            return !budget_task.budget_cancelled;
+        };
+        // Constrained tool decoding: trigger detection + grammar feeding on
+        // the serial token stream (rounds are single tokens on this path, so
+        // the CUDA engage-lag truncation degenerates to plain sequencing: the
+        // constraint set here masks the NEXT token's logits inside step()).
+        q27::BasicToolConstrainer<q27::MetalEngine,q27::Tokenizer> tc;
+        tc.eng=&engine; tc.tok=&tokenizer; tc.cache=&mask_cache; tc.host2dev=&slot->host2dev;
+        tc.enabled=q27::metal_tool_constraint_enabled(
+            constrain_tools,!tool_names.empty(),sampling.temperature==0.0f,
+            effective_speculation_width(sampling,bounded_reasoning),forced_tool_choice);
+        {
+            auto gpu=lease_now();
+            tc.begin(tool_names);
+        }
+        // Scope-exit constraint cleanup: runs on normal return, client
+        // disconnect, and engine exceptions alike, and never throws (a
+        // cleanup failure must not mask the original exception). Both resets
+        // are host-only state on this request's still-owned slot, so taking
+        // the shared GPU lease here would only make cancellation block.
+        struct ConstraintCleanup {
+            q27::BasicToolConstrainer<q27::MetalEngine,q27::Tokenizer>& tc;
+            q27::MetalEngine& engine;
+            ~ConstraintCleanup() {
+                try {
+                    tc.end();
+                    engine.set_tool_constraint(-1);
+                } catch(...) {}
+            }
+        } constraint_cleanup{tc,engine};
+
+        // ---- generation, one quantum per lease ----
+        // Sampled MTP (temp>0 + --mtp + has_mtp): rejection-sample accept on
+        // greedy drafts. Q27_SAMPLE_PLAIN=1 forces the slow plain sample path
+        // for distribution A/B. Artifacts without MTP fall through to plain.
+        if(client_gone) {
+            // Initial forced-control delivery observed a disconnected client.
+        } else if(sampling.temperature>0.0f && mtp_width!=0 && engine.has_mtp() &&
+                  engine.chunked_prefill() && !sample_plain && !bounded_reasoning) {
+            std::mt19937_64 rng(sampling.seed);
+            {
+                // Prefill left a greedy pending; first emitted token is sampled.
+                auto gpu=lease_now();
+                pending=engine.sample_from_logits(sampling,rng);
+            }
+            uint32_t live_width=std::min(mtp_width,4u);
+            std::vector<uint32_t> committed;
+            bool stopped=false;
+            while(!stopped && produced<budget_task.n_max) {
+                if(produced+1==budget_task.n_max) {
+                    if(pending!=eos_id) deliver(pending);
+                    else cause=q27::MetalEngine::StopCause::Eos;
+                    break;
+                }
+                committed.clear();
+                {
+                    auto gpu=lease_now();
+                    pending=engine.mtp_sample_round(pending,budget_task.n_max-produced,eos_id,mtp_width,
+                                                    live_width,sampling,rng,committed);
+                }
+                spec_rounds_total.fetch_add(1,std::memory_order_relaxed);
+                spec_committed_total.fetch_add(committed.size(),std::memory_order_relaxed);
+                for(uint32_t token:committed) {
+                    if(token==eos_id) { cause=q27::MetalEngine::StopCause::Eos; stopped=true; break; }
+                    if(!deliver(token)) { stopped=true; break; }
+                }
+            }
+        } else if(sampling.temperature>0.0f) {
+            std::mt19937_64 rng(sampling.seed);
+            while(produced<budget_task.n_max) {
+                uint32_t token;
+                {
+                    auto gpu=lease_now();
+                    token=engine.sample_from_logits(sampling,rng);
+                }
+                if(token==eos_id) { cause=q27::MetalEngine::StopCause::Eos; break; }
+                if(!deliver(token)) break;
+                if(budget_task.forced) {
+                    if(!apply_forced(true,token)) break;
+                    continue;
+                }
+                if(produced==budget_task.n_max) break;
+                auto gpu=lease_now();
+                engine.step(token);
+            }
+        } else if(mtp && engine.chunked_prefill()) {
+            uint32_t live_width=std::min(mtp_width,4u);
+            std::vector<uint32_t> committed;
+            bool stopped=false;
+            while(!stopped && produced<budget_task.n_max) {
+                if(produced+1==budget_task.n_max) {
+                    if(pending!=eos_id) deliver(pending);
+                    else cause=q27::MetalEngine::StopCause::Eos;
+                    break;
+                }
+                committed.clear();
+                {
+                    auto gpu=lease_now();
+                    pending=engine.mtp_round(pending,budget_task.n_max-produced,eos_id,mtp_width,
+                                             live_width,committed);
+                }
+                spec_rounds_total.fetch_add(1,std::memory_order_relaxed);
+                spec_committed_total.fetch_add(committed.size(),std::memory_order_relaxed);
+                for(uint32_t token:committed) {
+                    if(token==eos_id) { cause=q27::MetalEngine::StopCause::Eos; stopped=true; break; }
+                    if(!deliver(token)) { stopped=true; break; }
+                }
+            }
+        } else {
+            // Serial greedy walk (also the constrained-decode path): emit the
+            // pending token, then each step yields the next. The constraint
+            // ops for the token just emitted run under the same lease as the
+            // step they mask, exactly as the old in-sink sequencing did.
+            while(produced<budget_task.n_max) {
+                if(pending==eos_id) { cause=q27::MetalEngine::StopCause::Eos; break; }
+                const uint32_t current=pending;
+                if(!deliver(current)) break;
+                if(budget_task.forced) {
+                    if(!apply_forced(true,current)) break;
+                    continue;
+                }
+                if(produced==budget_task.n_max) break;
+                if(tc.enabled && tc.active) {
+                    // Pre-materialize the advanced state's mask outside the
+                    // lease: ToolMaskCache::get simulates the whole vocabulary
+                    // on a miss and must not extend the other slot's wait. This
+                    // uses the same peek-advance shape as the CUDA flow. The
+                    // engage path still builds its entry mask under the lease,
+                    // once per tool call.
+                    q27::ToolGrammar peek=tc.tg;
+                    bool ok=true;
+                    for(char c:tokenizer.decode_one((int)current))
+                        if(!peek.advance(c)) { ok=false; break; }
+                    if(ok && !peek.closed()) {
+                        std::lock_guard<std::mutex> mk(mask_mutex_);
+                        mask_cache.get(peek);
+                    }
+                }
+                auto gpu=lease_now();
+                if(tc.enabled) {
+                    // mask_mutex_ inside the lease guards the shared host
+                    // cache against a concurrent slot's prewarm above.
+                    std::lock_guard<std::mutex> mk(mask_mutex_);
+                    const int tid=(int)current;
+                    tc.scan_round(&tid,1);
+                    tc.on_id(tid);
+                    // Restage the advanced grammar state's mask: on_id moves
+                    // tc.tg but stages nothing, so otherwise every step after
+                    // the first constrained token uses the prior legal set.
+                    if(tc.active) tc.apply(tc.tg);
+                }
+                pending=engine.step(current);
+            }
+        }
+        // Flush the boundary gates: a dangling multi-byte tail becomes U+FFFD;
+        // a provisional stop match resolves now that no earlier prefix can
+        // complete, otherwise held-back prefix text is real output.
+        if(!client_gone && !stop_hit) {
+            bool stopped=false;
+            std::string tail=stopbuf.feed(ugate.flush(),stopped);
+            bool flush_stopped=false;
+            tail+=stopbuf.flush(&flush_stopped);
+            stopped=stopped || flush_stopped;
+            if(!tail.empty() && !emit(tail)) client_gone=true;
+            if(stopped && !client_gone) stop_hit=true;
+        }
+
+        Outcome out;
+        out.prompt_tokens=(uint32_t)prompt.size();
+        out.output_tokens=produced;
+        out.prefix_hit=hit;
+        out.queue_wait_ms=queue_wait_ms;
+        out.gate_wait_ms=std::max(gate_wait_ms,0.0);
+        out.arrival=arrival;
+        if(client_gone) {
+            out.finish=Finish::Cancelled;
+            trace.event({{"kind","cancel"},{"phase","generate"},{"id",trace_id}});
+        }
+        else if(stop_hit) {
+            out.finish=Finish::StopSequence;
+            if(stopbuf.matched>=0 && stopbuf.matched<(int)stops.size())
+                out.stop_sequence=stops[stopbuf.matched];
+        } else if(cause==q27::MetalEngine::StopCause::Eos) out.finish=Finish::Stop;
+        else out.finish=Finish::Length;
+        return out;
+    }
+};
+
+const char* trace_finish(Runtime::Finish f) {
+    switch(f) {
+        case Runtime::Finish::Length: return "length";
+        case Runtime::Finish::StopSequence: return "stop_sequence";
+        case Runtime::Finish::Cancelled: return "cancelled";
+        default: return "eos";
+    }
+}
+const char* openai_finish(Runtime::Finish f) {
+    switch(f) {
+        case Runtime::Finish::Length: return "length";
+        default: return "stop"; // Stop (eos), StopSequence, and Cancelled
+    }
+}
+const char* anthropic_stop(Runtime::Finish f) {
+    switch(f) {
+        case Runtime::Finish::Length: return "max_tokens";
+        case Runtime::Finish::StopSequence: return "stop_sequence";
+        default: return "end_turn"; // Stop (eos) and Cancelled
+    }
+}
+
+q27::SamplingParams sampling_params(const json& body) {
+    q27::SamplingParams result;
+    result.temperature=sampling_default_temperature;
+    result.top_p=sampling_default_top_p;
+    result.top_k=sampling_default_top_k;
+    // Present-but-null falls back to the served default rather than throwing;
+    // clients commonly send null-valued fields and max_tokens accepts the same
+    // shape below. Any other non-number type is malformed and must be rejected
+    // instead of silently serving a default the client did not request.
+    if(body.contains("temperature")) {
+        const json& v=body["temperature"];
+        if(!v.is_null()) {
+            if(!v.is_number()) throw std::runtime_error("invalid temperature");
+            result.temperature=v.get<float>();
+        }
+    }
+    if(body.contains("top_p")) {
+        const json& v=body["top_p"];
+        if(!v.is_null()) {
+            if(!v.is_number()) throw std::runtime_error("invalid top_p");
+            result.top_p=v.get<float>();
+        }
+    }
+    if(body.contains("top_k")) {
+        const json& v=body["top_k"];
+        if(!v.is_null()) {
+            // Integer type required: a JSON float would silently truncate and
+            // a negative value would wrap to a huge unsigned integer.
+            if(!v.is_number_integer() && !v.is_number_unsigned())
+                throw std::runtime_error("invalid top_k");
+            const long long k=v.get<long long>();
+            if(k<0 || (unsigned long long)k>UINT32_MAX)
+                throw std::runtime_error("invalid top_k");
+            result.top_k=(uint32_t)k;
+        }
+    }
+    result.seed=0;
+    if(body.contains("seed")) {
+        const json& v=body["seed"];
+        if(!v.is_null()) {
+            if(v.is_number_unsigned()) result.seed=v.get<uint64_t>();
+            else if(v.is_number_integer()) {
+                const long long s=v.get<long long>();
+                if(s<0) throw std::runtime_error("invalid seed");
+                result.seed=(uint64_t)s;
+            } else throw std::runtime_error("invalid seed");
+        }
+    }
+    q27::validate_sampling(result);
+    return result;
+}
+
+// Per-endpoint defaults mirror the CUDA server:
+// /v1/messages 1024, OpenAI completions/chat 256, responses 4096.
+// --max-tokens-default (flag wins; env fallback Q27_METAL_MAX_TOKENS_DEFAULT)
+// overrides all of them for requests that omit max_tokens (or send null):
+// pi.dev sends max_tokens:null, and the
+// CUDA-parity 256 truncates real agent turns mid-answer ("maximum output
+// token limit", 2026-07-17). Explicit client values always win; the
+// context preflight still clamps to the remaining window.
+// Set once in main (before the server accepts) from --max-tokens-default;
+// 0 = flag absent.
+long long max_tokens_default_flag=0;
+// Null/absent -> default; wrong-typed -> a CALLER-NAMED error. json_i64_or
+// lets nlohmann's raw exception text escape, so a wrong-typed max_tokens
+// answered the client with
+//   "[json.exception.type_error.302] type must be number, but is string"
+// inside the invalid_request_error envelope -- library internals leaking into
+// a public API error, and inconsistent with the sibling fields resolved two
+// functions up, which already say "invalid temperature" / "invalid top_k"
+// (found by the 2026-07-25 serving gate). Numerically integral JSON floats
+// such as 4096.0 remain valid, but fractional token counts are rejected
+// rather than silently truncated.
+long long int_field_or(const json& body,const char* key,long long dflt) {
+    const auto it=body.find(key);
+    if(it==body.end() || it->is_null()) return dflt;
+    if(!it->is_number()) throw std::runtime_error(std::string("invalid ")+key);
+    const double v=it->get<double>();
+    // Downstream decode-limit helpers use int. Validate before narrowing so
+    // accepted wire values cannot wrap negative and silently become zero.
+    if(!(v>=0.0) || v>(double)std::numeric_limits<int>::max())
+        throw std::runtime_error(std::string("invalid ")+key);
+    const long long integral=(long long)v;
+    if((double)integral!=v) throw std::runtime_error(std::string("invalid ")+key);
+    return integral;
+}
+
+enum class TokenLimitApi { Legacy, Chat, Responses };
+
+uint32_t max_tokens(const json& body,long long dflt,
+                    TokenLimitApi api=TokenLimitApi::Legacy) {
+    if(max_tokens_default_flag>0) dflt=max_tokens_default_flag; // resolved flag/env value
+    long long value=int_field_or(body,"max_output_tokens",dflt);
+    value=int_field_or(body,"max_tokens",value);
+    // Each endpoint's official field wins over accepted foreign/legacy aliases.
+    if(api==TokenLimitApi::Chat)
+        value=int_field_or(body,"max_completion_tokens",value);
+    else if(api==TokenLimitApi::Responses)
+        value=int_field_or(body,"max_output_tokens",value);
+    if(value<0 || value>std::numeric_limits<int>::max())
+        throw std::runtime_error("invalid max_tokens");
+    return (uint32_t)value;
+}
+
+// jbool, not value(): `{"stream": null}` is how a large share of
+// OpenAI-compatible request builders (LangChain/LiteLLM class) spell "unset",
+// and value() throws type_error.302 on a present-but-null key -- which
+// guarded() turns into a 400 invalid_request_error for a request that was
+// fine on the wire. sampling_params/max_tokens already treated null as
+// absent; `stream` and `prompt` were the two scalars that missed the rule
+// (upstream 1a15ff8 fixed the same class on the CUDA arm).
+//
+// DELIBERATE DIVERGENCE from upstream's jnum/jint on temperature/top_p/top_k/
+// seed/max_tokens: those stay strict here. Null tolerance is intentional;
+// wrong-type tolerance is not, because it would serve a request whose sampling
+// settings the client believes were honored.
+bool wants_stream(const json& body) { return q27::jbool(body,"stream",false); }
+
+long unix_now() { return (long)std::time(nullptr); }
+
+void json_response(httplib::Response& response,const json& value,int status=200) {
+    response.status=status;
+    response.set_content(value.dump(-1,' ',false,json::error_handler_t::replace),"application/json");
+}
+
+} // namespace
+
+static int mark_supervisor_lock_close_on_exec() {
+    const char* value = std::getenv("Q27_SUPERVISOR_LOCK_FD");
+    char* end = nullptr;
+    long parsed;
+    int flags;
+    if (!value || !*value) return 0;
+    errno = 0;
+    parsed = std::strtol(value, &end, 10);
+    if (errno || !end || *end || parsed < 0 || parsed > 0x7fffffffL) {
+        std::fprintf(stderr, "q27-metal-server: invalid supervisor lock descriptor\n");
+        return -1;
+    }
+    flags = fcntl(static_cast<int>(parsed), F_GETFD);
+    if (flags < 0 ||
+        fcntl(static_cast<int>(parsed), F_SETFD, flags | FD_CLOEXEC) != 0) {
+        std::fprintf(stderr,
+                     "q27-metal-server: cannot protect supervisor lock descriptor: %s\n",
+                     std::strerror(errno));
+        return -1;
+    }
+    (void)unsetenv("Q27_SUPERVISOR_LOCK_FD");
+    return 0;
+}
+
+int main(int argc,char** argv) {
+    if (mark_supervisor_lock_close_on_exec() != 0) return 2;
+    if(argc<3) {
+        fprintf(stderr,"usage: %s model.q27 tokenizer.tok [--host 127.0.0.1] [--port 8080] [--ctx N|auto] [--mtp 2..12] [--kv fp16|turbo3] [--prefix-entries N] [--constrain-tools] [--think] [--request-think] [--think-budget N] [--slots N] [--trace path]\n"
+                       "       [--snapshot-dir path] [--snapshot-max-mb 1..16777216] [--snapshot-auto 0..16777216] [--snapshot-spine-pin 0|1] [--max-tokens-default N] [--budget-mb 1..16777216]\n"
+                       "       [--temperature-default T] [--top-p-default P] [--top-k-default K] [--api-key KEY] [--api-key-file path]\n"
+                       "       (the snapshot/max-tokens/budget/sampling-default flags fall back to their env twins Q27_METAL_{SNAPSHOT_DIR,SNAPSHOT_MAX_MB,SNAPSHOT_AUTO,SNAPSHOT_SPINE_PIN,MAX_TOKENS_DEFAULT,BUDGET_MB,TEMPERATURE_DEFAULT,TOP_P_DEFAULT,TOP_K_DEFAULT}; an explicit flag wins)\n",argv[0]);
+        return 1;
+    }
+    try {
+        std::string model=argv[1],tok=argv[2],host="127.0.0.1";
+        std::string trace_path,snapshot_dir;
+        uint32_t port=8080,context=0,width=0,prefix_entries=1,slot_count=2;
+        // Shipped-semantics knobs as flags (homebrew Phase-2 pre-tag);
+        // sentinel = flag absent, Runtime falls back to the env twin.
+        // snapshot_auto keeps a signed sentinel because 0 is meaningful
+        // (hint-only saves).
+        uint32_t budget_mb=0,snapshot_max_mb=0,max_tokens_default=0;
+        bool think_default=false;   // --think flips the server profile (default no-think)
+        // --request-think (upstream 0a1b21f parity): honor the request's
+        // thinking fields. OFF by default -- without it, enable_thinking /
+        // chat_template_kwargs / Anthropic `thinking` are IGNORED and the boot
+        // profile stands. Closes the footgun where a benchmark or client that
+        // sends enable_thinking:true (many do) silently flips a no-think
+        // server into thinking mode. NOTE: this is a behavior change for the
+        // Metal arm, which honored those fields unconditionally through
+        // v0.6.1; pass --request-think to keep the old behavior.
+        bool req_think=false;
+        // Reasoning-token cap whenever a THINK channel is active. -1 uses
+        // half the request token cap, 0 disables the cap, positive is absolute.
+        int think_budget_flag=-1;
+        // Sampling-default sentinels double as "flag absent" (-1 / 0 /
+        // UINT32_MAX are all outside the valid ranges); with neither flag
+        // nor env the resolved values are the shipped greedy defaults.
+        float temperature_default=-1.0f, top_p_default=0.0f;
+        uint32_t top_k_default=UINT32_MAX;
+        long long snapshot_auto=-1;
+        int spine_pin=-1;   // -1 = unset (env/default); 0/1 explicit flag
+        bool turbo3=false; bool constrain_tools=false;
+        // Opt-in Bearer/x-api-key authentication on serving endpoints. Empty
+        // means authentication is disabled.
+        std::vector<std::string> api_keys;
+        for(int i=3;i<argc;i++) {
+            std::string arg=argv[i];
+            if(arg=="--host" && i+1<argc) host=argv[++i];
+            else if(arg=="--port" && i+1<argc) port=parse_u32(argv[++i],"--port");
+            else if(arg=="--ctx" && i+1<argc) {
+                const char* v=argv[++i];
+                if(!strcmp(v,"auto")) context=0;   // sentinel: resolve in Runtime
+                else {
+                    context=parse_u32(v,"--ctx");
+                    // 0 is the auto sentinel, so reject a numeric 0 here.
+                    // Reinterpreting it as auto would allocate a hardware-
+                    // dependent window for an invalid explicit configuration.
+                    if(!context || context>262144)
+                        throw std::runtime_error("--ctx must be 1..262144 or auto");
+                }
+            }
+            else if(arg=="--mtp" && i+1<argc) width=parse_u32(argv[++i],"--mtp");
+            else if(arg=="--prefix-entries" && i+1<argc) prefix_entries=parse_u32(argv[++i],"--prefix-entries");
+            else if(arg=="--slots" && i+1<argc) slot_count=parse_u32(argv[++i],"--slots");
+            else if(arg=="--kv" && i+1<argc) { std::string mode=argv[++i]; if(mode=="turbo3")turbo3=true; else if(mode!="fp16")throw std::runtime_error("invalid --kv"); }
+            else if(arg=="--constrain-tools") constrain_tools=true;
+            else if(arg=="--think") think_default=true;
+            else if(arg=="--request-think") req_think=true;
+            else if(arg=="--think-budget" && i+1<argc) {
+                const uint32_t value=parse_u32(argv[++i],"--think-budget");
+                if(value>(uint32_t)std::numeric_limits<int>::max())
+                    throw std::runtime_error("--think-budget must be 0..2147483647");
+                think_budget_flag=(int)value;
+            }
+            else if(arg=="--trace" && i+1<argc) trace_path=argv[++i];
+            else if(arg=="--snapshot-dir" && i+1<argc) { snapshot_dir=argv[++i]; if(snapshot_dir.empty()) throw std::runtime_error("invalid --snapshot-dir"); }
+            // The env twins reject 0 as malformed, and 0 here would silently
+            // collapse into the "flag absent" sentinel — so it fails loud
+            // in-branch (post-loop checks can no longer tell 0 from unset).
+            else if(arg=="--snapshot-max-mb" && i+1<argc) { snapshot_max_mb=parse_u32(argv[++i],"--snapshot-max-mb"); if(!snapshot_max_mb||snapshot_max_mb>(1u<<24)) throw std::runtime_error("--snapshot-max-mb must be an integer 1..16777216"); }
+            else if(arg=="--snapshot-auto" && i+1<argc) { snapshot_auto=parse_u32(argv[++i],"--snapshot-auto"); if(snapshot_auto>(1ll<<24)) throw std::runtime_error("--snapshot-auto must be an integer 0..16777216"); }
+            else if(arg=="--max-tokens-default" && i+1<argc) { max_tokens_default=parse_u32(argv[++i],"--max-tokens-default"); if(!max_tokens_default) throw std::runtime_error("--max-tokens-default must be >= 1"); }
+            else if(arg=="--temperature-default" && i+1<argc) { temperature_default=parse_float(argv[++i],"--temperature-default"); if(temperature_default<0.0f) throw std::runtime_error("--temperature-default must be >= 0"); }
+            else if(arg=="--top-p-default" && i+1<argc) { top_p_default=parse_float(argv[++i],"--top-p-default"); if(top_p_default<=0.0f||top_p_default>1.0f) throw std::runtime_error("--top-p-default must be in (0,1]"); }
+            else if(arg=="--top-k-default" && i+1<argc) { top_k_default=parse_u32(argv[++i],"--top-k-default"); if(top_k_default==UINT32_MAX) throw std::runtime_error("invalid --top-k-default"); }
+            else if(arg=="--budget-mb" && i+1<argc) { budget_mb=parse_u32(argv[++i],"--budget-mb"); if(!budget_mb||budget_mb>(1u<<24)) throw std::runtime_error("--budget-mb must be an integer 1..16777216"); }
+            // Range-check the UNSIGNED value BEFORE narrowing to int. The
+            // old `(int)parse_u32(...)` then `>N` order let anything in
+            // [2^31, 2^32) cast to a negative int and sail past the bound, so
+            // `--snapshot-spine-pin 3000000000` was silently accepted and then
+            // read as "unset" -- an operator pinning the spine could get the
+            // opposite of what they asked for, with no diagnostic.
+            else if(arg=="--snapshot-spine-pin" && i+1<argc) {
+                const uint32_t v=parse_u32(argv[++i],"--snapshot-spine-pin");
+                if(v>1) throw std::runtime_error("--snapshot-spine-pin must be 0 or 1");
+                spine_pin=(int)v;
+            }
+            // Auth config is fail-LOUD in both directions (upstream 1a15ff8
+            // item 4). An empty key can never authenticate anything --
+            // api_key_valid rejects an empty `provided` before comparing --
+            // so accepting one stands up a server that 401s every request;
+            // and a key FILE that opens but yields nothing usable stands up a
+            // server with auth silently OFF, the opposite of what the
+            // operator asked for. Refuse both at boot rather than serve a
+            // configuration nobody wanted.
+            else if(arg=="--api-key" && i+1<argc) {
+                if(!argv[++i][0]) throw std::runtime_error("--api-key: empty key (an empty key can never match)");
+                api_keys.push_back(argv[i]);
+            }
+            else if(arg=="--api-key-file" && i+1<argc) {
+                const size_t before=api_keys.size();
+                if(!q27::load_api_key_file(argv[++i],&api_keys))
+                    throw std::runtime_error(std::string("--api-key-file ")+argv[i]+": could not open");
+                if(api_keys.size()==before)
+                    throw std::runtime_error(std::string("--api-key-file ")+argv[i]+
+                        ": no keys found (every line blank or a #comment) -- refusing to start "
+                        "with auth silently disabled");
+            }
+            else throw std::runtime_error("unknown/incomplete argument: "+arg);
+        }
+        // Q27_API_KEY: a second, additive source (not exclusive with the CLI
+        // flags -- all configured keys are valid simultaneously, matching
+        // --api-key-file's multi-key semantics). Preferred where CLI args are
+        // visible via `ps` but the orchestrator's secret store is not.
+        // The `envkey[0]` test is load-bearing, not defensive tidiness:
+        // api_key_valid's constant-time property documents "an empty KEY is
+        // never configured" as an INVARIANT its callers must uphold (it fast-
+        // paths an empty `provided` without comparing). An empty Q27_API_KEY
+        // must therefore be dropped here, exactly as --api-key refuses one
+        // above. Do not relax either check.
+        if(const char* envkey=getenv("Q27_API_KEY"); envkey && envkey[0]) api_keys.push_back(envkey);
+        if(port<=0 || port>65535) throw std::runtime_error("--port must be between 1 and 65535");
+        if(width && (width<2 || width>12)) throw std::runtime_error("MTP width must be 2..12");
+        // Bounded so entries * snapshot_bytes() cannot wrap uint64 in the
+        // per-slot charge. Side-inclusive snapshots at maximum context put
+        // the wrap within uint32 range; 4096 entries exceeds real deployments.
+        if(prefix_entries>4096) throw std::runtime_error("--prefix-entries must be 0..4096");
+        if(constrain_tools && width) throw std::runtime_error("--constrain-tools requires serial decode; drop --mtp (verify-lane masks are not wired on Metal)");
+        // The latency guarantee (wait <= one active quantum) holds with one
+        // competing slot. More than two requires extending the scheduler and
+        // width/statistics model first.
+        if(slot_count<1 || slot_count>2) throw std::runtime_error("--slots must be 1..2 in multislot Phase 1");
+        if(!max_tokens_default)
+            if(const char* e=getenv("Q27_METAL_MAX_TOKENS_DEFAULT"); e && *e) {
+                max_tokens_default=parse_u32(e,"Q27_METAL_MAX_TOKENS_DEFAULT");
+                if(!max_tokens_default)
+                    throw std::runtime_error("Q27_METAL_MAX_TOKENS_DEFAULT must be >= 1");
+            }
+        if(max_tokens_default>(uint32_t)std::numeric_limits<int>::max())
+            throw std::runtime_error("max token default must be <= INT_MAX");
+        max_tokens_default_flag=max_tokens_default;
+        if(temperature_default<0.0f)
+            if(const char* e=getenv("Q27_METAL_TEMPERATURE_DEFAULT"); e && *e) {
+                temperature_default=parse_float(e,"Q27_METAL_TEMPERATURE_DEFAULT");
+                if(temperature_default<0.0f) throw std::runtime_error("Q27_METAL_TEMPERATURE_DEFAULT must be >= 0");
+            }
+        if(top_p_default==0.0f)
+            if(const char* e=getenv("Q27_METAL_TOP_P_DEFAULT"); e && *e) {
+                top_p_default=parse_float(e,"Q27_METAL_TOP_P_DEFAULT");
+                if(top_p_default<=0.0f||top_p_default>1.0f) throw std::runtime_error("Q27_METAL_TOP_P_DEFAULT must be in (0,1]");
+            }
+        if(top_k_default==UINT32_MAX)
+            if(const char* e=getenv("Q27_METAL_TOP_K_DEFAULT"); e && *e) {
+                top_k_default=parse_u32(e,"Q27_METAL_TOP_K_DEFAULT");
+                if(top_k_default==UINT32_MAX) throw std::runtime_error("invalid Q27_METAL_TOP_K_DEFAULT");
+            }
+        // Neither flag nor env: the shipped greedy defaults (bitwise unchanged).
+        if(temperature_default<0.0f) temperature_default=0.0f;
+        if(top_p_default==0.0f) top_p_default=1.0f;
+        if(top_k_default==UINT32_MAX) top_k_default=0;
+        sampling_default_temperature=temperature_default;
+        sampling_default_top_p=top_p_default;
+        sampling_default_top_k=top_k_default;
+        if(sampling_default_temperature>0.0f && width)
+            fprintf(stderr,"[sampling-default] temperature default %.4g uses sampled MTP (rejection accept) when --mtp is set; set temperature=0 per-request for greedy MTP\n",
+                    (double)sampling_default_temperature);
+        Runtime runtime(model,tok,context,turbo3,width,prefix_entries,constrain_tools,slot_count,
+                        budget_mb,snapshot_dir,snapshot_max_mb,snapshot_auto,max_tokens_default,spine_pin,
+                        think_default);
+        if(!trace_path.empty()) {
+            runtime.trace.open(trace_path);
+            runtime.trace.event({{"kind","boot"},{"ctx",runtime.context},{"kv",turbo3?"turbo3":"fp16"},
+                                 {"mtp",width},{"slots",runtime.slots.size()},
+                                 {"model",runtime.model_name},{"artifact_sha1",runtime.resident_model_sha1()},
+                                 {"runtime",runtime.serving_identity()},{"boot_id",runtime.boot_id}});
+        }
+        httplib::Server server;
+        // Enough workers reach run() for its finite slot queue to reject
+        // overload; the outer accepted-connection queue is bounded as well.
+        server.new_task_queue=[] { return new httplib::ThreadPool(16,32); };
+        // Existing serving authentication: when keys are configured, every
+        // route except health accepts Bearer or x-api-key credentials.
+        server.set_pre_routing_handler([api_keys](const httplib::Request& req,httplib::Response& r){
+            if(api_keys.empty() || req.path=="/health")
+                return httplib::Server::HandlerResponse::Unhandled;
+            const std::string provided=q27::extract_api_key(req.get_header_value("Authorization"),
+                                                            req.get_header_value("x-api-key"));
+            if(q27::api_key_valid(provided,api_keys))
+                return httplib::Server::HandlerResponse::Unhandled;
+            const bool anthropic_shape=req.path.rfind("/v1/messages",0)==0;
+            r.status=401;
+            if(!anthropic_shape) r.set_header("WWW-Authenticate","Bearer");
+            r.set_content(q27::auth_error_json(anthropic_shape),"application/json");
+            r.set_header("Connection","close");
+            return httplib::Server::HandlerResponse::Handled;
+        });
+        if(!api_keys.empty())
+            fprintf(stderr,"API key authentication enabled (%zu key%s configured)\n",
+                    api_keys.size(),api_keys.size()==1?"":"s");
+        server.Get("/health",[&runtime,&api_keys](const httplib::Request& req,httplib::Response& r){
+            const std::string provided=q27::extract_api_key(
+                req.get_header_value("Authorization"),req.get_header_value("x-api-key"));
+            if(!api_keys.empty() && !q27::api_key_valid(provided,api_keys)) {
+                json_response(r,{{"status",runtime.health_status()}});
+                return;
+            }
+            json body={{"status",runtime.health_status()},{"model",runtime.model_name},{"boot_id",runtime.boot_id},
+                       {"runtime",runtime.serving_identity()},
+                       {"trace",{{"enabled",runtime.trace.enabled()},
+                                 {"healthy",runtime.trace.healthy()}}}};
+            if(req.has_param("identity") && req.get_param_value("identity")=="1") {
+                try { body["artifact_sha1"]=runtime.resident_model_sha1(); }
+                catch(const std::exception&) {
+                    body["artifact_sha1"]=nullptr;
+                    body["identity_error"]="artifact identity unavailable";
+                }
+            }
+            json_response(r,body);
+        });
+        // Queue and gate wait metrics expose multislot scheduling behavior.
+        server.Get("/stats",[&runtime](const httplib::Request&,httplib::Response& r){
+            auto bucket=[](const std::map<std::string,Runtime::WaitStats>& stats){
+                json out=json::object();
+                for(const auto& [phase,ws]:stats)
+                    out[phase]={{"requests",ws.n},
+                                {"mean_ms",ws.n?ws.sum_ms/ws.n:0.0},
+                                {"max_ms",ws.max_ms}};
+                return out;
+            };
+            json gate,queue;
+            size_t slot_count=0;
+            {
+                std::unique_lock<std::mutex> lk(runtime.route_);
+                runtime.slot_free_.wait(lk,[&]{ return !runtime.recovering_; });
+                gate=bucket(runtime.gate_wait_stats);
+                queue=bucket(runtime.queue_wait_stats);
+                slot_count=runtime.slots.size();
+            }
+            json_response(r,{{"slots",slot_count},
+                             {"gate_wait_by_arrival",gate},
+                             {"queue_wait_by_arrival",queue},
+                             {"speculation",{{"rounds",(uint64_t)runtime.spec_rounds_total},
+                                             {"committed",(uint64_t)runtime.spec_committed_total}}},
+                             {"snapshots",{{"enabled",runtime.snapstore.enabled()},
+                                           {"evicted_spine",(uint64_t)runtime.snapstore.evicted_spine},
+                                           {"evicted_leaf",(uint64_t)runtime.snapstore.evicted_leaf}}}});
+        });
+        server.Get("/v1/models",[](const httplib::Request&,httplib::Response& r){
+            json_response(r,{{"object","list"},{"data",json::array({
+                {{"id","q27-metal"},{"object","model"},{"owned_by","q27"}}
+            })}});
+        });
+
+        auto guarded=[&](const char* api,auto handler) {
+            return [&,api,handler](const httplib::Request& request,httplib::Response& response) {
+                const std::string error_id="arrival_metal_"+runtime.boot_id+"_"+
+                    std::to_string((long)req_counter++);
+                runtime.trace.event({{"kind","arrival"},{"api",api},{"id",error_id}});
+                try { handler(json::parse(request.body),response,
+                              request.has_header("x-codex-installation-id") ||
+                              request.has_header("x-codex-turn-metadata"),
+                              request.is_connection_alive); }
+                catch(const Runtime::ClientGone&) {
+                    response.status=499;
+                }
+                catch(const Runtime::ServerOverloaded& e) {
+                    runtime.trace.event({{"kind","error"},{"api",api},{"id",error_id},{"status",503},
+                        {"type","overloaded_error"},{"message",e.what()}});
+                    json_response(response,{{"error",{{"message",e.what()},{"type","overloaded_error"}}}},503);
+                }
+                catch(const Runtime::EngineError& e) {
+                    json_response(response,{{"error",{{"message",e.what()},{"type","api_error"}}}},500);
+                }
+                catch(const std::exception& e) {
+                    runtime.trace.event({{"kind","request"},{"api",api},{"id",error_id},{"validation_error",true}});
+                    runtime.trace.event({{"kind","error"},{"api",api},{"id",error_id},{"status",400},
+                        {"type","invalid_request_error"},{"message",e.what()}});
+                    json_response(response,{{"error",{{"message",e.what()},{"type","invalid_request_error"}}}},400);
+                }
+            };
+        };
+        auto engine_guard=[&](auto&& fn)->decltype(fn()) {
+            return runtime.guard_engine(std::forward<decltype(fn)>(fn));
+        };
+        auto traced_engine=[&](const char* api,const std::string& id,auto&& fn)->decltype(fn()) {
+            try { return engine_guard(std::forward<decltype(fn)>(fn)); }
+            catch(const Runtime::EngineError& e) {
+                runtime.trace.event({{"kind","error"},{"api",api},{"id",id},{"status",500},
+                    {"type","api_error"},{"message",e.what()}});
+                throw;
+            }
+        };
+        // Anthropic endpoints answer in Anthropic's error envelope.
+        auto anthropic_guarded=[&](const char* api,auto handler) {
+            return [&,api,handler](const httplib::Request& request,httplib::Response& response) {
+                const std::string error_id="arrival_metal_"+runtime.boot_id+"_"+
+                    std::to_string((long)req_counter++);
+                runtime.trace.event({{"kind","arrival"},{"api",api},{"id",error_id}});
+                json body;
+                try { body=json::parse(request.body); }
+                catch(...) {
+                    runtime.trace.event({{"kind","request"},{"api",api},{"id",error_id},{"validation_error",true}});
+                    runtime.trace.event({{"kind","error"},{"api",api},{"id",error_id},{"status",400},
+                        {"type","invalid_request_error"},{"message","invalid JSON body"}});
+                    response.status=400;
+                    response.set_content(q27::anthropic_error_json("invalid_request_error","invalid JSON body"),"application/json");
+                    return;
+                }
+                try { handler(body,response,request.is_connection_alive); }
+                catch(const Runtime::ClientGone&) {
+                    response.status=499;
+                }
+                catch(const Runtime::ServerOverloaded& e) {
+                    runtime.trace.event({{"kind","error"},{"api",api},{"id",error_id},{"status",503},
+                        {"type","overloaded_error"},{"message",e.what()}});
+                    response.status=503;
+                    response.set_content(q27::anthropic_error_json("overloaded_error",e.what()),"application/json");
+                }
+                catch(const Runtime::EngineError& e) {
+                    response.status=500;
+                    response.set_content(q27::anthropic_error_json("api_error",e.what()),"application/json");
+                }
+                catch(const std::exception& e) {
+                    runtime.trace.event({{"kind","request"},{"api",api},{"id",error_id},{"validation_error",true}});
+                    runtime.trace.event({{"kind","error"},{"api",api},{"id",error_id},{"status",400},
+                        {"type","invalid_request_error"},{"message",e.what()}});
+                    response.status=400;
+                    response.set_content(q27::anthropic_error_json("invalid_request_error",e.what()),"application/json");
+                }
+            };
+        };
+
+        // Shared context preflight: each endpoint refuses an oversized prompt
+        // in its API's native 400 shape before slot claim / SSE commit.
+        auto prompt_overflow=[&](size_t prompt_tokens,uint32_t& n,uint32_t& maxp,
+                                 const q27::SamplingParams& sampling)->bool {
+            n=std::min(n,q27::metal_max_generation_tokens(prompt_tokens,runtime.context));
+            const uint32_t width=runtime.effective_speculation_width(sampling,false);
+            maxp=q27::metal_max_prompt_tokens_for_request(runtime.context,width,n);
+            return prompt_tokens>maxp;
+        };
+
+        const std::vector<int> think_close_ids=runtime.tokenizer.encode("</think>\n\n");
+        if(think_close_ids.empty())
+            throw std::runtime_error("thinking close template tokenized empty");
+        auto think_prompt_overflow=[&](size_t prompt_tokens,uint32_t requested,
+                                       bool active,const q27::ThinkCfg& cfg,
+                                       const q27::SamplingParams& sampling,
+                                       uint32_t& n,int& budget,uint32_t& maxp)->bool {
+            // Resolve once with the serial reserve before applying any prompt
+            // ceiling. A live budget selects serial decoding in run(), so a
+            // prompt that only exceeds the speculative ceiling is still valid.
+            const uint32_t spec_width=runtime.effective_speculation_width(sampling,true);
+            const int round_reserve=1+(int)spec_width;
+            q27::ThinkDecodeLimits limits=q27::resolve_think_decode_limits(
+                (int)requested,(int)runtime.context,(int)prompt_tokens,round_reserve,
+                (int)think_close_ids.size(),active,cfg,think_budget_flag);
+            // If the cap is inactive or cannot fire, this is an ordinary
+            // request. Use the output-aware path so resident-logit one-token
+            // requests at the context boundary are not rejected.
+            if(limits.budget<0) {
+                n=requested;
+                budget=-1;
+                return prompt_overflow(prompt_tokens,n,maxp,sampling);
+            }
+            const uint32_t ordinary_max=q27::metal_max_prompt_tokens_for_request(
+                runtime.context,spec_width,(uint32_t)limits.n_max);
+            if(prompt_tokens>ordinary_max) { maxp=ordinary_max; return true; }
+            n=(uint32_t)limits.n_max;
+            budget=limits.budget;
+            if(limits.context_ok) return false;
+            maxp=(uint32_t)q27::max_prompt_for_think_decode(
+                (int)requested,(int)runtime.context,round_reserve,(int)ordinary_max,
+                (int)prompt_tokens,(int)think_close_ids.size(),active,cfg,think_budget_flag);
+            return true;
+        };
+
+        // ---- OpenAI /v1/completions (raw continuation; no template, no
+        // tool protocol) ----
+        server.Post("/v1/completions",guarded("completions",[&](const json& body,httplib::Response& r,bool,
+                                                                  const std::function<bool()>& live){
+            auto ids=to_u32(runtime.tokenizer.encode(q27::jstr(body,"prompt")));
+            uint32_t n=max_tokens(body,q27::metal_default_max_tokens(q27::MetalEndpoint::Completions));
+            const q27::SamplingParams sampling=sampling_params(body);
+            const std::vector<std::string> stops=parse_stops(body,"stop",true);
+            const bool include_usage=q27::openai_stream_includes_usage(body);
+            const std::string id="cmpl-metal-"+runtime.boot_id+"-"+std::to_string((long)req_counter++);
+            const long created=unix_now();
+            if(ids.empty()) throw std::runtime_error("prompt is empty");
+            uint32_t maxp=0;
+            if(prompt_overflow(ids.size(),n,maxp,sampling)) {
+                runtime.trace.event({{"kind","request"},{"api","completions"},{"id",id},
+                    {"validation_error",true},{"prompt_tokens",(uint64_t)ids.size()}});
+                runtime.trace.event({{"kind","error"},{"api","completions"},{"status",400},{"type","context_length_exceeded"},
+                    {"id",id},{"prompt_tokens",(uint64_t)ids.size()},{"max",maxp}});
+                json_response(r,{{"error",{{"message",q27::ctx_limit_error_message((int)ids.size(),(int)maxp)},
+                    {"type","invalid_request_error"},{"code","context_length_exceeded"}}}},400);
+                return;
+            }
+            if(runtime.trace.enabled())
+                // q27::jstr(body,"prompt") repeats the encode accessor, so
+                // this event adds no new throw path. jstr does not throw: a
+                // null/non-string prompt reads as absent, encode yields no
+                // ids, and the empty-prompt check above has already returned.
+                runtime.trace.event({{"kind","request"},{"api","completions"},{"id",id},
+                    {"stream",wants_stream(body)},{"prompt_tokens",(uint64_t)ids.size()},
+                    {"max_tokens",n},{"sampling",{{"temperature",sampling.temperature},{"top_p",sampling.top_p},
+                        {"top_k",sampling.top_k},{"seed",sampling.seed}}},{"stops",stops},
+                    {"snapshot",q27::jbool(body,"snapshot",false)},
+                    {"token_head",trace_token_head(ids)},{"rendered",trace_text(q27::jstr(body,"prompt"))}});
+            if(!wants_stream(body)) {
+                std::string text;
+                auto outcome=traced_engine("completions",id,[&]{
+                    return runtime.run(ids,n,sampling,stops,
+                        [&](const std::string& piece){ text+=piece; return true; },
+                        std::vector<std::string>{},q27::jbool(body,"snapshot",false),id,
+                        nullptr,false,live); });
+                if(outcome.finish==Runtime::Finish::Cancelled) { r.status=499; return; }
+                runtime.trace.event({{"kind","outcome"},{"api","completions"},{"id",id},
+                    {"finish",openai_finish(outcome.finish)},{"terminal",trace_finish(outcome.finish)},
+                    {"prompt_tokens",outcome.prompt_tokens},
+                    {"output_tokens",outcome.output_tokens},{"prefix_hit",outcome.prefix_hit}});
+                json_response(r,{{"id",id},{"object","text_completion"},{"created",created},{"model","q27-metal"},
+                    {"choices",json::array({{{"index",0},{"text",text},{"finish_reason",openai_finish(outcome.finish)}}})},
+                    {"usage",{{"prompt_tokens",outcome.prompt_tokens},{"completion_tokens",outcome.output_tokens},
+                              {"total_tokens",outcome.prompt_tokens+outcome.output_tokens}}}});
+                return;
+            }
+            const bool snap_hint=q27::jbool(body,"snapshot",false);
+            r.set_chunked_content_provider("text/event-stream",
+                [&runtime,ids,n,sampling,stops,id,created,snap_hint,include_usage](size_t,httplib::DataSink& sink)->bool {
+                    bool alive=true;
+                    try {
+                        auto emit=[&](const std::string& piece)->bool {
+                            json event=q27::openai_stream_chunk(
+                                false,id,"text_completion",created,"q27-metal",piece);
+                            if(include_usage) event["usage"]=nullptr;
+                            std::string s=q27::sse_data(event);
+                            alive=sink.write(s.data(),s.size());
+                            return alive;
+                        };
+                        if(!emit("")) { sink.done(); return true; }
+                        auto outcome=runtime.guard_engine([&]{
+                            return runtime.run(ids,n,sampling,stops,emit,
+                                std::vector<std::string>{},snap_hint,id,nullptr,false,
+                                [&]{ return sink.is_alive(); });
+                        });
+                        if(outcome.finish==Runtime::Finish::Cancelled) { sink.done(); return false; }
+                        // Terminal chunk with a real finish_reason before [DONE]
+                        // (parity with server.cu security-review fix #7).
+                        json final_event=q27::openai_stream_final_chunk(
+                            false,id,"text_completion",created,"q27-metal",openai_finish(outcome.finish));
+                        if(include_usage) final_event["usage"]=nullptr;
+                        std::string fin=q27::sse_data(final_event);
+                        sink.write(fin.data(),fin.size());
+                        if(include_usage) {
+                            std::string usage=q27::sse_data(q27::openai_stream_usage_chunk(
+                                id,"text_completion",created,"q27-metal",
+                                outcome.prompt_tokens,outcome.output_tokens));
+                            sink.write(usage.data(),usage.size());
+                        }
+                        std::string done=q27::sse_done(); sink.write(done.data(),done.size());
+                        runtime.trace.event({{"kind","outcome"},{"api","completions"},{"id",id},
+                            {"finish",openai_finish(outcome.finish)},{"terminal",trace_finish(outcome.finish)},
+                            {"prompt_tokens",outcome.prompt_tokens},
+                            {"output_tokens",outcome.output_tokens},{"prefix_hit",outcome.prefix_hit}});
+                    } catch(const Runtime::ClientGone&) {
+                        sink.done();
+                        return false;
+                    } catch(const Runtime::ServerOverloaded& e) {
+                        runtime.trace.event({{"kind","error"},{"api","completions"},{"id",id},{"status",503},{"type","overloaded_error"},{"message",e.what()}});
+                        std::string s=q27::sse_data({{"error",{{"message",e.what()},{"type","overloaded_error"}}}});
+                        sink.write(s.data(),s.size());
+                    } catch(const std::exception& e) {
+                        runtime.trace.event({{"kind","error"},{"api","completions"},{"id",id},{"status",500},{"type","api_error"},{"message",e.what()}});
+                        std::string s=q27::sse_data({{"error",{{"message",e.what()},{"type","api_error"}}}});
+                        sink.write(s.data(),s.size());
+                    }
+                    sink.done();
+                    return true;
+                });
+        }));
+
+        // ---- OpenAI /v1/chat/completions ----
+        // Structured tool traffic both directions (agentic-parity round,
+        // docs/metal/plans/2026-07-17-metal-agentic-parity.md): incoming
+        // assistant.tool_calls / role:"tool" via openai_msgs above; outgoing
+        // <tool_call> segments become message.tool_calls (non-streaming) or
+        // one delta.tool_calls chunk per call (streaming) with finish_reason
+        // "tool_calls"; <think> segments go to reasoning_content (llama.cpp
+        // convention) instead of leaking raw into content.
+        server.Post("/v1/chat/completions",guarded("chat",[&](const json& body,httplib::Response& r,bool,
+                                                               const std::function<bool()>& live){
+            q27::ThinkCfg think_cfg=q27::resolve_think_cfg(body,think_default,req_think,-1);
+            bool think_req=think_cfg.enabled;
+            q27::ToolChoice tchoice=q27::parse_tool_choice(body);
+            q27::apply_openai_parallel_tool_calls(body,tchoice);
+            q27::OpenAIToolSelection selected=q27::select_openai_tools(body,tchoice);
+            const json tools=std::move(selected.tools);
+            const std::vector<std::string> declared_tool_names=std::move(selected.names);
+            const std::unordered_set<std::string> allowed_tool_names(
+                declared_tool_names.begin(),declared_tool_names.end());
+            const bool has_tools=!tools.empty();
+            if(tchoice.mode==q27::ToolChoice::FORCED) {
+                think_req=false;
+                think_cfg.budget_set=true;
+                think_cfg.budget=-1;
+            }
+            std::string rendered=q27::chatml_prompt(openai_msgs(body),tools,think_req);
+            if(tchoice.mode==q27::ToolChoice::FORCED) rendered+="<tool_call>\n";
+            auto ids=to_u32(runtime.tokenizer.encode(rendered));
+            const uint32_t requested_n=max_tokens(body,q27::metal_default_max_tokens(q27::MetalEndpoint::Chat),TokenLimitApi::Chat);
+            uint32_t n=requested_n;
+            int think_budget=-1;
+            const q27::SamplingParams sampling=sampling_params(body);
+            const std::vector<std::string> stops=parse_stops(body,"stop",true);
+            const bool include_usage=q27::openai_stream_includes_usage(body);
+            const long rid=req_counter++;
+            const std::string id="chatcmpl-metal-"+runtime.boot_id+"-"+std::to_string(rid);
+            const long created=unix_now();
+            if(ids.empty()) throw std::runtime_error("prompt is empty");
+            uint32_t maxp=0;
+            if(think_prompt_overflow(ids.size(),requested_n,think_req,think_cfg,sampling,
+                                     n,think_budget,maxp)) {
+                runtime.trace.event({{"kind","request"},{"api","chat"},{"id",id},
+                    {"validation_error",true},{"prompt_tokens",(uint64_t)ids.size()}});
+                runtime.trace.event({{"kind","error"},{"api","chat"},{"status",400},{"type","context_length_exceeded"},
+                    {"id",id},{"prompt_tokens",(uint64_t)ids.size()},{"max",maxp}});
+                json_response(r,{{"error",{{"message",q27::ctx_limit_error_message((int)ids.size(),(int)maxp)},
+                    {"type","invalid_request_error"},{"code","context_length_exceeded"}}}},400);
+                return;
+            }
+            const std::vector<std::string> tnames=declared_tool_names;
+            const bool snap_hint=q27::jbool(body,"snapshot",false);
+            if(runtime.trace.enabled())
+                runtime.trace.event({{"kind","request"},{"api","chat"},{"id",id},
+                    {"stream",wants_stream(body)},{"prompt_tokens",(uint64_t)ids.size()},
+                    {"max_tokens",n},{"tools",(uint64_t)tools.size()},
+                    {"sampling",{{"temperature",sampling.temperature},{"top_p",sampling.top_p},
+                        {"top_k",sampling.top_k},{"seed",sampling.seed}}},{"stops",stops},{"tool_names",tnames},
+                    {"snapshot",snap_hint},{"token_head",trace_token_head(ids)},{"rendered",trace_text(rendered)}});
+            if(!wants_stream(body)) {
+                q27::StreamSplitter sp;
+                q27::ThinkBudgetState tb{think_budget};
+                if(tchoice.mode==q27::ToolChoice::FORCED) sp.chan=q27::StreamSplitter::TOOL;
+                else if(think_req) sp.chan=q27::StreamSplitter::THINK;
+                std::vector<std::pair<q27::StreamSplitter::Chan,std::string>> segments;
+                auto route=[&](q27::StreamSplitter::Chan ch,const std::string& t){
+                    if(ch==q27::StreamSplitter::TOOL &&
+                       tchoice.mode==q27::ToolChoice::NONE)
+                        ch=q27::StreamSplitter::TEXT;
+                    if(t.empty()) {
+                        if(ch!=q27::StreamSplitter::TOOL && !segments.empty() &&
+                           segments.back().first==q27::StreamSplitter::TOOL)
+                            segments.emplace_back(ch,std::string());
+                        return;
+                    }
+                    if(!segments.empty() && segments.back().first==ch)
+                        segments.back().second+=t;
+                    else segments.emplace_back(ch,t);
+                };
+                auto feed_piece=[&](const std::string& piece,bool forced)->bool {
+                    for(auto& [ch,t]:sp.feed(piece)) {
+                        if(forced && ch==q27::StreamSplitter::TEXT && q27::strip_ws2(t).empty())
+                            continue;
+                        route(ch,t);
+                    }
+                    return true;
+                };
+                Runtime::ThinkControl think_control{
+                    &tb,&sp,&think_close_ids,
+                    [&](const std::string& piece){ return feed_piece(piece,true); }};
+                auto outcome=traced_engine("chat",id,[&]{
+                    return runtime.run(ids,n,sampling,stops,
+                        [&](const std::string& piece){ return feed_piece(piece,false); },
+                        tnames,snap_hint,id,&think_control,
+                        tchoice.mode==q27::ToolChoice::FORCED,live); });
+                if(outcome.finish==Runtime::Finish::Cancelled) { r.status=499; return; }
+                const bool final_tool_incomplete=
+                    outcome.finish==Runtime::Finish::Length && sp.chan==q27::StreamSplitter::TOOL;
+                for(auto& [ch,t]:sp.flush()) route(ch,t);
+                std::string unclosed_tool=q27::take_unclosed_final_tool_segment(
+                    segments,final_tool_incomplete);
+                auto ordered=q27::resolve_ordered_tool_segments(
+                    segments,has_tools?&tools:nullptr,outcome.finish==Runtime::Finish::Stop,
+                    [&](const std::string& name,size_t accepted) {
+                        return q27::tool_choice_allows_call(
+                            tchoice,allowed_tool_names,name,accepted);
+                    });
+                ordered.text+=unclosed_tool;
+                std::string th=q27::strip_ws2(ordered.reasoning);
+                std::string tx=q27::strip_ws2(ordered.text);
+                std::vector<q27::ToolCall> good=std::move(ordered.calls);
+                if(ordered.recovered) {
+                    fprintf(stderr,"[tool-fallback] %zu bare call(s) recovered (chat nonstream)\n",ordered.recovered);
+                    runtime.trace.event({{"kind","tool_recovery"},{"api","chat"},{"id",id},{"stream",false},{"count",ordered.recovered}});
+                }
+                json tcs=json::array();
+                int ci=0;
+                for(auto& c:good)
+                    tcs.push_back({{"id","call_metal_"+runtime.boot_id+"_"+std::to_string(rid)+"_"+std::to_string(ci++)},
+                                   {"type","function"},
+                                   {"function",{{"name",c.name},{"arguments",c.arguments.dump()}}}});
+                json message={{"role","assistant"},
+                              {"content",(!tcs.empty() && tx.empty())?json(nullptr):json(tx)}};
+                if(!th.empty()) message["reasoning_content"]=th;
+                if(!tcs.empty()) message["tool_calls"]=tcs;
+                if(q27::forced_tool_choice_missing_is_error(
+                       tchoice,!tcs.empty(),outcome.finish==Runtime::Finish::Length))
+                    throw Runtime::EngineError("model produced no eligible tool call for forced tool_choice");
+                const bool calls_complete=!tcs.empty() && !final_tool_incomplete;
+                runtime.trace.event({{"kind","outcome"},{"api","chat"},{"id",id},
+                    {"finish",calls_complete?"tool_calls":openai_finish(outcome.finish)},
+                    {"terminal",trace_finish(outcome.finish)},{"prompt_tokens",outcome.prompt_tokens},{"output_tokens",outcome.output_tokens},
+                    {"prefix_hit",outcome.prefix_hit}});
+                json_response(r,{{"id",id},{"object","chat.completion"},{"created",created},{"model","q27-metal"},
+                    {"choices",json::array({{{"index",0},{"message",message},
+                        {"finish_reason",calls_complete?"tool_calls":openai_finish(outcome.finish)}}})},
+                    {"usage",{{"prompt_tokens",outcome.prompt_tokens},{"completion_tokens",outcome.output_tokens},
+                              {"total_tokens",outcome.prompt_tokens+outcome.output_tokens},
+                              {"reasoning_tokens",tb.used},{"reasoning_budget_exceeded",tb.tripped}}}});
+                return;
+            }
+            r.set_chunked_content_provider("text/event-stream",
+                [&runtime,ids,n,sampling,stops,id,rid,created,tools,has_tools,tnames,allowed_tool_names,snap_hint,think_req,think_budget,tchoice,include_usage,&think_close_ids](size_t,httplib::DataSink& sink)->bool {
+                    bool alive=true;
+                    auto last_wire=std::chrono::steady_clock::now();
+                    auto chunk=[&](const json& delta,const json& finish){
+                        json event={{"id",id},{"object","chat.completion.chunk"},
+                            {"created",created},{"model","q27-metal"},
+                            {"choices",json::array({{{"index",0},{"delta",delta},{"finish_reason",finish}}})}};
+                        if(include_usage) event["usage"]=nullptr;
+                        std::string s=q27::sse_data(event);
+                        if(!sink.write(s.data(),s.size())) alive=false;
+                        else last_wire=std::chrono::steady_clock::now();
+                        return alive;
+                    };
+                    // Empty deltas are legal keepalives while generated output
+                    // is buffered by reasoning or tool-call framing.
+                    auto keepalive=[&]{
+                        if(alive && std::chrono::steady_clock::now()-last_wire>std::chrono::seconds(5))
+                            chunk(json::object(),nullptr);
+                    };
+                    try {
+                        // Opening role delta (OpenAI streaming convention);
+                        // also the client-gone probe before generation starts.
+                        if(!chunk({{"role","assistant"},{"content",""}},nullptr)) { sink.done(); return true; }
+                        q27::StreamSplitter sp;
+                        q27::ThinkBudgetState tb{think_budget};
+                        if(tchoice.mode==q27::ToolChoice::FORCED) sp.chan=q27::StreamSplitter::TOOL;
+                        else if(think_req) sp.chan=q27::StreamSplitter::THINK;
+                        std::string tool_buf,text_accum;
+                        size_t bare_scan_offset=0;
+                        int tool_counter=0;
+                        bool any_call=false,all_calls_clean=true,reject_stream_call=false;
+                        auto emit_call=[&](const q27::ToolCall& c,bool raw_already_streamed=false){
+                if(!q27::tool_choice_allows_call(
+                    tchoice,allowed_tool_names,c.name,any_call?1u:0u)) {
+                                if(!raw_already_streamed) chunk({{"content",c.raw}},nullptr);
+                                return;
+                            }
+                            any_call=true;
+                            chunk({{"tool_calls",json::array({{{"index",tool_counter},
+                                {"id","call_metal_"+runtime.boot_id+"_"+std::to_string(rid)+"_"+std::to_string(tool_counter)},
+                                {"type","function"},
+                                {"function",{{"name",c.name},{"arguments",c.arguments.dump()}}}}})}},nullptr);
+                            tool_counter++;
+                        };
+                        auto recover_bare=[&](bool allow_repair){
+                            if(!has_tools || bare_scan_offset>=text_accum.size()) return;
+                            const std::string raw=text_accum.substr(bare_scan_offset);
+                            bare_scan_offset=text_accum.size();
+                            std::string pre;
+                            auto bcs=q27::parse_bare_tool_calls(raw, &pre, &tools, true, allow_repair);
+                            size_t recovered=0;
+                            for(const auto& bc:bcs) {
+                                const bool before=any_call;
+                                emit_call(bc,true);
+                                if(!before && any_call) recovered++;
+                            }
+                            if(recovered) {
+                                fprintf(stderr,"[tool-fallback] %zu bare call(s) recovered (chat stream)\n",recovered);
+                                runtime.trace.event({{"kind","tool_recovery"},{"api","chat"},{"id",id},
+                                                     {"stream",true},{"count",recovered}});
+                            }
+                        };
+                        auto emit_tool=[&](){
+                            auto c=q27::parse_tool_call(q27::strip_ws2(tool_buf));
+                            tool_buf.clear();
+                            if(!c.ok) { // malformed: surface as text so nothing is lost
+                                text_accum+=c.raw;
+                                chunk({{"content",c.raw}},nullptr);
+                                return;
+                            }
+                            emit_call(c);
+                        };
+                        auto emit_tool_raw=[&](){
+                            if(tool_buf.empty()) return;
+                            text_accum+=tool_buf;
+                            chunk({{"content",tool_buf}},nullptr);
+                            tool_buf.clear();
+                        };
+                        // Incremental argument streaming (pre-registered
+                        // 2026-07-17-incremental-tool-call-streaming.md):
+                        // wrapped calls stream production-shape as they
+                        // generate; deviant heads fall back to the buffered
+                        // emit_tool recovery path above, raw byte-exact.
+                        q27::ToolCallStreamer ts;
+                        auto tool_frag_chunk=[&](const std::string& frag){
+                            if(frag.empty()) return;
+                            chunk({{"tool_calls",json::array({{{"index",tool_counter},
+                                {"function",{{"arguments",frag}}}}})}},nullptr);
+                        };
+                        auto recover_trail=[&](const std::string& raw,bool allow_repair){
+                            const std::string tr=q27::strip_ws2(raw);
+                            if(tr.empty()) return;
+                            std::string pre,residual;
+                            auto bcs=q27::parse_bare_tool_calls(tr, &pre, &tools, true, allow_repair, &residual);
+                            if(!residual.empty()) { text_accum+=residual; chunk({{"content",residual}},nullptr); }
+                            if(!bcs.empty()) {
+                                fprintf(stderr,"[tool-stream] %zu trailing call(s) recovered after streamed call\n",bcs.size());
+                                runtime.trace.event({{"kind","tool_recovery"},{"api","chat"},{"id",id},
+                                    {"stream",true},{"trailing",true},{"count",bcs.size()}});
+                                for(const auto& bc:bcs) emit_call(bc);
+                            } else if(residual.empty() && tr.find_first_not_of("}] \t\r\n")!=std::string::npos) {
+                                text_accum+=tr; chunk({{"content",tr}},nullptr);
+                            }
+                        };
+                        auto close_tool=[&](bool allow_repair=true,bool wrapper_incomplete=false){
+                            if(!ts.active()) return;
+                            std::string tail;
+                            const bool clean=ts.finalize(&tail,allow_repair);
+                            if(reject_stream_call) {
+                                std::string rejected=ts.raw;
+                                const std::string trailing=ts.trail();
+                                if(!trailing.empty() && trailing.size()<=rejected.size() &&
+                                   rejected.compare(rejected.size()-trailing.size(),trailing.size(),trailing)==0)
+                                    rejected.resize(rejected.size()-trailing.size());
+                                if(!rejected.empty()) chunk({{"content",rejected}},nullptr);
+                                recover_trail(trailing,allow_repair);
+                                reject_stream_call=false;
+                                ts.reset();
+                                return;
+                            }
+                            if(ts.invalid()) {
+                                // Streaming is irreversible: the opener and
+                                // prior argument deltas are already on wire.
+                                // Do not duplicate them as raw buffered text;
+                                // mark the call unclean so the terminal reason
+                                // remains stop/length and clients do not execute.
+                                all_calls_clean=false;
+                                tool_counter++; // opener/index was already emitted
+                                recover_trail(ts.trail(),false);
+                            } else if(ts.opened) {
+                                tool_frag_chunk(tail);
+                                if(!clean || wrapper_incomplete) {
+                                    all_calls_clean=false;
+                                    fprintf(stderr,"[tool-stream] streamed call closed "
+                                            "unbalanced (production semantics, sent as-is)\n");
+                                }
+                                tool_counter++;
+                                // A wrapper can pack more than one call: bytes
+                                // after the streamed call's arguments closed
+                                // are not framing. Recover them through the
+                                // bare-call chain and emit whole (review
+                                // 2026-07-17: the DONE-state byte drop lost
+                                // every call after the first, silently).
+                                recover_trail(ts.trail(),allow_repair);
+                            } else {
+                                tool_buf=ts.raw;
+                                if(wrapper_incomplete) emit_tool_raw();
+                                else emit_tool();
+                            }
+                            ts.reset();
+                        };
+                        auto emit_seg=[&](q27::StreamSplitter::Chan ch,const std::string& t){
+                            if(ch==q27::StreamSplitter::TOOL) {
+                                if(tool_buf.empty() && !ts.active()) recover_bare(false);
+                                if(tchoice.mode==q27::ToolChoice::NONE) {
+                                    text_accum+=t;
+                                    chunk({{"content",t}},nullptr);
+                                    return;
+                                }
+                                if(q27::tool_strict() || !tchoice.forced_name.empty()) {
+                                    tool_buf+=t;
+                                    return;
+                                }
+                                bool opened=false;
+                                const std::string frag=ts.feed(t,&opened);
+                                if(opened) {
+                                    reject_stream_call=!q27::tool_choice_allows_call(
+                                        tchoice,allowed_tool_names,ts.name,any_call?1u:0u);
+                                    if(!reject_stream_call) {
+                                        any_call=true;
+                                        chunk({{"tool_calls",json::array({{{"index",tool_counter},
+                                            {"id","call_metal_"+runtime.boot_id+"_"+std::to_string(rid)+"_"+std::to_string(tool_counter)},
+                                            {"type","function"},
+                                            {"function",{{"name",ts.name},{"arguments",""}}}}})}},nullptr);
+                                    }
+                                }
+                                if(!reject_stream_call) tool_frag_chunk(frag);
+                                return;
+                            }
+                            if(!tool_buf.empty()) emit_tool();
+                            close_tool();
+                            if(t.empty()) return;
+                            if(ch==q27::StreamSplitter::THINK) chunk({{"reasoning_content",t}},nullptr);
+                            else { text_accum+=t; chunk({{"content",t}},nullptr); }
+                        };
+                        auto feed_piece=[&](const std::string& piece,bool forced)->bool {
+                            for(auto& [ch,t]:sp.feed(piece)) {
+                                if(forced && ch==q27::StreamSplitter::TEXT && q27::strip_ws2(t).empty())
+                                    continue;
+                                emit_seg(ch,t);
+                            }
+                            return alive;
+                        };
+                        Runtime::ThinkControl think_control{
+                            &tb,&sp,&think_close_ids,
+                            [&](const std::string& piece){ return feed_piece(piece,true); }};
+                        auto outcome=runtime.guard_engine([&]{
+                            return runtime.run(ids,n,sampling,stops,
+                                [&](const std::string& piece)->bool {
+                                    feed_piece(piece,false);
+                                    keepalive();
+                                    return alive;
+                                },tnames,snap_hint,id,&think_control,
+                                tchoice.mode==q27::ToolChoice::FORCED,
+                                [&]{ return sink.is_alive(); });
+                        });
+                        if(outcome.finish==Runtime::Finish::Cancelled) { sink.done(); return false; }
+                        const bool final_tool_incomplete=
+                            outcome.finish==Runtime::Finish::Length && sp.chan==q27::StreamSplitter::TOOL;
+                        for(auto& [ch,t]:sp.flush()) emit_seg(ch,t);
+                        close_tool(outcome.finish==Runtime::Finish::Stop,final_tool_incomplete);
+                        if(!tool_buf.empty()) {
+                            if(final_tool_incomplete) emit_tool_raw();
+                            else emit_tool();
+                        }
+                        if(!final_tool_incomplete)
+                            recover_bare(outcome.finish==Runtime::Finish::Stop);
+                        // A malformed streamed opener is already on the wire. Buffered
+                        // recovery can ignore it; streaming cannot safely advertise a
+                        // tool-call terminal, so forced mode must fail closed.
+                        if(q27::forced_tool_choice_missing_is_error(
+                               tchoice,any_call && all_calls_clean,
+                               outcome.finish==Runtime::Finish::Length))
+                            throw Runtime::EngineError(
+                                "model produced no eligible tool call for forced tool_choice");
+                        const bool calls_complete=any_call && all_calls_clean &&
+                            !final_tool_incomplete;
+                        chunk(json::object(),calls_complete?"tool_calls":openai_finish(outcome.finish));
+                        if(include_usage) {
+                            std::string usage=q27::sse_data(q27::openai_stream_usage_chunk(
+                                id,"chat.completion.chunk",created,"q27-metal",
+                                outcome.prompt_tokens,outcome.output_tokens));
+                            sink.write(usage.data(),usage.size());
+                        }
+                        std::string done=q27::sse_done(); sink.write(done.data(),done.size());
+                        runtime.trace.event({{"kind","outcome"},{"api","chat"},{"id",id},
+                            {"finish",calls_complete?"tool_calls":openai_finish(outcome.finish)},
+                            {"terminal",trace_finish(outcome.finish)},{"prompt_tokens",outcome.prompt_tokens},{"output_tokens",outcome.output_tokens},
+                            {"prefix_hit",outcome.prefix_hit}});
+                    } catch(const Runtime::ClientGone&) {
+                        sink.done();
+                        return false;
+                    } catch(const Runtime::ServerOverloaded& e) {
+                        runtime.trace.event({{"kind","error"},{"api","chat"},{"id",id},{"status",503},{"type","overloaded_error"},{"message",e.what()}});
+                        std::string s=q27::sse_data({{"error",{{"message",e.what()},{"type","overloaded_error"}}}});
+                        sink.write(s.data(),s.size());
+                    } catch(const std::exception& e) {
+                        runtime.trace.event({{"kind","error"},{"api","chat"},{"id",id},{"status",500},{"type","api_error"},{"message",e.what()}});
+                        std::string s=q27::sse_data({{"error",{{"message",e.what()},{"type","api_error"}}}});
+                        sink.write(s.data(),s.size());
+                    }
+                    sink.done();
+                    return true;
+                });
+        }));
+
+        // ---- Anthropic /v1/messages ----
+        // Full agentic parity with src/server.cu:1087-1439 (2026-07-17 round):
+        // request mapping via anthropic_msgs/anthropic_tools_json (incoming
+        // tool_use/tool_result/thinking reconstructed, billing header
+        // normalized), StreamSplitter output routing into thinking / text /
+        // tool_use content blocks with input_json_delta streaming, bare-call
+        // recovery, stop_reason "tool_use", and the "prompt is too long"
+        // context refusal Claude Code keys compaction off.
+
+        // CC calls count_tokens before compaction decisions; a 404 means it
+        // estimates blind. Count = exactly what /v1/messages prefills for the
+        // same body. CPU-only: no slot, no GPU lease.
+        server.Post("/v1/messages/count_tokens",anthropic_guarded("count_tokens",[&](const json& body,httplib::Response& r,
+                                                                                       const std::function<bool()>&){
+            const std::string id="count_metal_"+runtime.boot_id+"_"+
+                std::to_string((long)req_counter++);
+            if(!body.contains("messages") || !body["messages"].is_array() ||
+               body["messages"].empty()) {
+                runtime.trace.event({{"kind","request"},{"api","count_tokens"},{"id",id},{"validation_error",true}});
+                runtime.trace.event({{"kind","error"},{"api","count_tokens"},{"id",id},{"status",400},
+                    {"type","invalid_request_error"},{"message","messages: non-empty array required"}});
+                r.status=400;
+                r.set_content(q27::anthropic_error_json("invalid_request_error","messages: non-empty array required"),
+                              "application/json");
+                return;
+            }
+            const q27::ToolChoice tchoice=q27::parse_anthropic_tool_choice(body);
+            json all_tools=q27::anthropic_tools_json(body);
+            json normalized={{"tools",all_tools}};
+            q27::OpenAIToolSelection selected=q27::select_openai_tools(normalized,tchoice);
+            const json unavailable=q27::unselected_openai_tools(all_tools,selected);
+            const q27::ThinkCfg think_cfg=q27::resolve_think_cfg(
+                body,think_default,req_think,-1);
+            q27::validate_anthropic_tool_choice_thinking(tchoice,think_cfg);
+            bool think_req=think_cfg.enabled;
+            if(tchoice.mode==q27::ToolChoice::FORCED) think_req=false;
+            std::string rendered=q27::chatml_prompt(
+                q27::anthropic_msgs(body),selected.tools,think_req,nullptr,nullptr,
+                q27::anthropic_tool_choice_instruction(tchoice),&unavailable);
+            if(tchoice.mode==q27::ToolChoice::FORCED) rendered+="<tool_call>\n";
+            const long input_tokens=(long)runtime.tokenizer.encode(rendered).size();
+            if(runtime.trace.enabled())
+                runtime.trace.event({{"kind","request"},{"api","count_tokens"},{"id",id},
+                    {"prompt_tokens",(uint64_t)input_tokens},{"rendered",trace_text(rendered)}});
+            json_response(r,{{"input_tokens",input_tokens}});
+            runtime.trace.event({{"kind","outcome"},{"api","count_tokens"},{"id",id},
+                                 {"finish","counted"},{"output_tokens",0}});
+        }));
+
+        server.Post("/v1/messages",anthropic_guarded("messages",[&](const json& body,httplib::Response& r,
+                                                                     const std::function<bool()>& live){
+            if(!body.contains("messages") || !body["messages"].is_array() ||
+               body["messages"].empty()) {
+                r.status=400;
+                r.set_content(q27::anthropic_error_json("invalid_request_error",
+                    "messages: non-empty array required"),"application/json");
+                return;
+            }
+            const q27::ToolChoice tchoice=q27::parse_anthropic_tool_choice(body);
+            json all_tools=q27::anthropic_tools_json(body);
+            json normalized={{"tools",all_tools}};
+            q27::OpenAIToolSelection selected=q27::select_openai_tools(normalized,tchoice);
+            const json unavailable=q27::unselected_openai_tools(all_tools,selected);
+            const json tools=std::move(selected.tools);
+            const std::vector<std::string> tnames=std::move(selected.names);
+            const std::unordered_set<std::string> allowed_tool_names(
+                tnames.begin(),tnames.end());
+            q27::ThinkCfg think_cfg=q27::resolve_think_cfg(body,think_default,req_think,-1);
+            q27::validate_anthropic_tool_choice_thinking(tchoice,think_cfg);
+            bool think_req=think_cfg.enabled;
+            if(tchoice.mode==q27::ToolChoice::FORCED) {
+                think_req=false;
+                think_cfg.budget_set=true;
+                think_cfg.budget=-1;
+            }
+            std::string rendered=q27::chatml_prompt(
+                q27::anthropic_msgs(body),tools,think_req,nullptr,nullptr,
+                q27::anthropic_tool_choice_instruction(tchoice),&unavailable);
+            if(tchoice.mode==q27::ToolChoice::FORCED) rendered+="<tool_call>\n";
+            auto ids=to_u32(runtime.tokenizer.encode(rendered));
+            const uint32_t requested_n=max_tokens(body,q27::metal_default_max_tokens(q27::MetalEndpoint::Messages));
+            uint32_t n=requested_n;
+            int think_budget=-1;
+            const q27::SamplingParams sampling=sampling_params(body);
+            const std::vector<std::string> stops=parse_stops(body,"stop_sequences");
+            const long rid=req_counter++;
+            const std::string mid="msg_metal_"+runtime.boot_id+"_"+std::to_string(rid);
+            if(ids.empty()) throw std::runtime_error("prompt is empty");
+            uint32_t maxp=0;
+            if(think_prompt_overflow(ids.size(),requested_n,think_req,think_cfg,sampling,
+                                     n,think_budget,maxp)) {
+                fprintf(stderr,"[ctx-limit] prompt=%zu max=%u -> 400\n",ids.size(),maxp);
+                runtime.trace.event({{"kind","request"},{"api","messages"},{"id",mid},
+                    {"validation_error",true},{"prompt_tokens",(uint64_t)ids.size()}});
+                runtime.trace.event({{"kind","error"},{"api","messages"},{"status",400},{"type","context_length_exceeded"},
+                    {"id",mid},{"prompt_tokens",(uint64_t)ids.size()},{"max",maxp}});
+                r.status=400;
+                r.set_content(q27::anthropic_error_json("invalid_request_error",
+                    q27::ctx_limit_error_message((int)ids.size(),(int)maxp)),"application/json");
+                return;
+            }
+            const bool has_tools=!tools.empty();
+            const bool snap_hint=q27::jbool(body,"snapshot",false);
+            if(runtime.trace.enabled())
+                runtime.trace.event({{"kind","request"},{"api","messages"},{"id",mid},
+                    {"stream",wants_stream(body)},{"prompt_tokens",(uint64_t)ids.size()},
+                    {"max_tokens",n},{"tools",(uint64_t)(has_tools?tools.size():0)},
+                    {"sampling",{{"temperature",sampling.temperature},{"top_p",sampling.top_p},
+                        {"top_k",sampling.top_k},{"seed",sampling.seed}}},{"stops",stops},{"tool_names",tnames},
+                    {"snapshot",snap_hint},{"token_head",trace_token_head(ids)},{"rendered",trace_text(rendered)}});
+            if(!wants_stream(body)) {
+                q27::StreamSplitter sp;
+                q27::ThinkBudgetState tb{think_budget};
+                if(tchoice.mode==q27::ToolChoice::FORCED) sp.chan=q27::StreamSplitter::TOOL;
+                else if(think_req) sp.chan=q27::StreamSplitter::THINK;
+                std::vector<std::pair<q27::StreamSplitter::Chan,std::string>> segments;
+                auto route=[&](q27::StreamSplitter::Chan ch,const std::string& t){
+                    if(ch==q27::StreamSplitter::TOOL &&
+                       tchoice.mode==q27::ToolChoice::NONE)
+                        ch=q27::StreamSplitter::TEXT;
+                    if(t.empty()) {
+                        if(ch!=q27::StreamSplitter::TOOL && !segments.empty() &&
+                           segments.back().first==q27::StreamSplitter::TOOL)
+                            segments.emplace_back(ch,std::string());
+                        return;
+                    }
+                    if(!segments.empty() && segments.back().first==ch)
+                        segments.back().second+=t;
+                    else segments.emplace_back(ch,t);
+                };
+                auto feed_piece=[&](const std::string& piece,bool forced)->bool {
+                    for(auto& [ch,t]:sp.feed(piece)) {
+                        if(forced && ch==q27::StreamSplitter::TEXT && q27::strip_ws2(t).empty())
+                            continue;
+                        route(ch,t);
+                    }
+                    return true;
+                };
+                Runtime::ThinkControl think_control{
+                    &tb,&sp,&think_close_ids,
+                    [&](const std::string& piece){ return feed_piece(piece,true); }};
+                auto outcome=traced_engine("messages",mid,[&]{
+                    return runtime.run(ids,n,sampling,stops,
+                        [&](const std::string& piece){ return feed_piece(piece,false); },
+                        tnames,snap_hint,mid,&think_control,
+                        tchoice.mode==q27::ToolChoice::FORCED,live); });
+                if(outcome.finish==Runtime::Finish::Cancelled) { r.status=499; return; }
+                const bool final_tool_incomplete=
+                    outcome.finish==Runtime::Finish::Length && sp.chan==q27::StreamSplitter::TOOL;
+                for(auto& [ch,t]:sp.flush()) route(ch,t);
+                std::string unclosed_tool=q27::take_unclosed_final_tool_segment(
+                    segments,final_tool_incomplete);
+                auto ordered=q27::resolve_ordered_tool_segments(
+                    segments,has_tools?&tools:nullptr,outcome.finish==Runtime::Finish::Stop,
+                    [&](const std::string& name,size_t accepted) {
+                        return q27::tool_choice_allows_call(
+                            tchoice,allowed_tool_names,name,accepted);
+                    });
+                ordered.text+=unclosed_tool;
+                json content=json::array();
+                std::string th=q27::strip_ws2(ordered.reasoning);
+                std::string tx=q27::strip_ws2(ordered.text);
+                if(!th.empty())
+                    content.push_back({{"type","thinking"},{"thinking",th},{"signature","q27-local"}});
+                std::vector<q27::ToolCall> good=std::move(ordered.calls);
+                if(ordered.recovered) {
+                    fprintf(stderr,"[tool-fallback] %zu bare call(s) recovered (nonstream)\n",ordered.recovered);
+                    runtime.trace.event({{"kind","tool_recovery"},{"api","messages"},{"id",mid},{"stream",false},{"count",ordered.recovered}});
+                }
+                const bool any_call=!good.empty();
+                if(!tx.empty() || (!any_call && th.empty()))
+                    content.push_back({{"type","text"},{"text",tx}});
+                int ci=0;
+                for(auto& c:good)
+                    content.push_back({{"type","tool_use"},
+                        {"id","toolu_metal_"+runtime.boot_id+"_"+std::to_string(rid)+"_"+std::to_string(ci++)},
+                        {"name",c.name},{"input",c.arguments}});
+                if(q27::forced_tool_choice_missing_is_error(
+                       tchoice,any_call,outcome.finish==Runtime::Finish::Length))
+                    throw Runtime::EngineError("model produced no eligible tool call for forced tool_choice");
+                const bool calls_complete=any_call && !final_tool_incomplete;
+                json out={{"id",mid},{"type","message"},{"role","assistant"},{"model","q27-metal"},
+                    {"content",content},
+                    {"stop_reason",calls_complete?"tool_use":anthropic_stop(outcome.finish)},
+                    {"stop_sequence",outcome.finish==Runtime::Finish::StopSequence?json(outcome.stop_sequence):json(nullptr)},
+                    {"usage",{{"input_tokens",outcome.prompt_tokens},{"output_tokens",outcome.output_tokens},
+                              {"reasoning_tokens",tb.used},{"reasoning_budget_exceeded",tb.tripped}}}};
+                if(outcome.prefix_hit) out["q27_prefix_hit"]=(uint64_t)outcome.prefix_hit;
+                runtime.trace.event({{"kind","outcome"},{"api","messages"},{"id",mid},
+                    {"finish",calls_complete?"tool_use":anthropic_stop(outcome.finish)},
+                    {"terminal",trace_finish(outcome.finish)},{"prompt_tokens",outcome.prompt_tokens},{"output_tokens",outcome.output_tokens},
+                    {"prefix_hit",outcome.prefix_hit}});
+                json_response(r,out);
+                return;
+            }
+            r.set_chunked_content_provider("text/event-stream",
+                [&runtime,ids,n,sampling,stops,mid,rid,tools,has_tools,tnames,allowed_tool_names,snap_hint,think_req,think_budget,tchoice,&think_close_ids](size_t,httplib::DataSink& sink)->bool {
+                    bool alive=true;
+                    auto last_wire=std::chrono::steady_clock::now();
+                    auto ev=[&](const char* name,const json& j){
+                        std::string s=q27::sse_event(name,j);
+                        if(!sink.write(s.data(),s.size())) alive=false;
+                        else last_wire=std::chrono::steady_clock::now();
+                        return alive;
+                    };
+                    // Block bookkeeping mirrors server.cu's streaming handler:
+                    // lazily opened think/text blocks, tool_use blocks emitted
+                    // whole (start + one input_json_delta + stop) when a tool
+                    // segment closes.
+                    int block_counter=0,tool_counter=0,idx=-1,chan_open=-1;
+                    bool any=false,any_call=false,all_calls_clean=true,reject_stream_call=false;
+                    q27::StreamSplitter sp;
+                    q27::ThinkBudgetState tb{think_budget};
+                    if(tchoice.mode==q27::ToolChoice::FORCED) sp.chan=q27::StreamSplitter::TOOL;
+                    else if(think_req) sp.chan=q27::StreamSplitter::THINK;
+                    std::string tool_buf,text_accum;
+                    size_t bare_scan_offset=0;
+                    auto close_block=[&](){
+                        if(idx<0) return;
+                        if(chan_open==1)
+                            ev("content_block_delta",{{"type","content_block_delta"},{"index",idx},
+                                {"delta",{{"type","signature_delta"},{"signature","q27-local"}}}});
+                        ev("content_block_stop",{{"type","content_block_stop"},{"index",idx}});
+                        idx=-1;
+                    };
+                    auto open_block=[&](int chan){
+                        if(idx>=0 && chan_open!=chan) close_block();
+                        if(idx<0) {
+                            idx=block_counter++;
+                            json cb=chan==1?json{{"type","thinking"},{"thinking",""}}
+                                           :json{{"type","text"},{"text",""}};
+                            ev("content_block_start",{{"type","content_block_start"},
+                                {"index",idx},{"content_block",cb}});
+                            chan_open=chan;
+                            any=true;
+                        }
+                    };
+                    auto eligible_name=[&](const std::string& name){
+                        return q27::tool_choice_allows_call(
+                            tchoice,allowed_tool_names,name,any_call?1u:0u);
+                    };
+                    auto emit_raw=[&](const std::string& raw){
+                        if(raw.empty()) return;
+                        open_block(0);
+                        text_accum+=raw;
+                        ev("content_block_delta",{{"type","content_block_delta"},{"index",idx},
+                            {"delta",{{"type","text_delta"},{"text",raw}}}});
+                    };
+                    auto emit_tool_block=[&](const q27::ToolCall& call,bool raw_already_streamed){
+                        if(!call.ok || !eligible_name(call.name)) {
+                            if(!raw_already_streamed) emit_raw(call.raw);
+                            return;
+                        }
+                        any=true;
+                        any_call=true;
+                        close_block();
+                        const int ti=block_counter++;
+                        const std::string tid="toolu_metal_"+runtime.boot_id+"_"+std::to_string(rid)+"_"+
+                                              std::to_string(tool_counter++);
+                        ev("content_block_start",{{"type","content_block_start"},{"index",ti},
+                            {"content_block",{{"type","tool_use"},{"id",tid},{"name",call.name},
+                                              {"input",json::object()}}}});
+                        ev("content_block_delta",{{"type","content_block_delta"},{"index",ti},
+                            {"delta",{{"type","input_json_delta"},
+                                      {"partial_json",q27::sse_dump(call.arguments)}}}});
+                        ev("content_block_stop",{{"type","content_block_stop"},{"index",ti}});
+                    };
+                    auto recover_bare=[&](bool allow_repair){
+                        if(!has_tools || bare_scan_offset>=text_accum.size()) return;
+                        const std::string raw=text_accum.substr(bare_scan_offset);
+                        bare_scan_offset=text_accum.size();
+                        std::string pre;
+                        auto bcs=q27::parse_bare_tool_calls(raw, &pre, &tools, true, allow_repair);
+                        size_t recovered=0;
+                        for(auto& bc:bcs) {
+                            const bool before=any_call;
+                            emit_tool_block(bc,true);
+                            if(!before && any_call) recovered++;
+                        }
+                        if(recovered) {
+                            fprintf(stderr,"[tool-fallback] %zu bare call(s) recovered (stream)\n",recovered);
+                            runtime.trace.event({{"kind","tool_recovery"},{"api","messages"},{"id",mid},
+                                                 {"stream",true},{"count",recovered}});
+                        }
+                    };
+                    auto emit_tool=[&](){
+                        auto c=q27::parse_tool_call(q27::strip_ws2(tool_buf));
+                        tool_buf.clear();
+                        emit_tool_block(c,false);
+                    };
+                    auto emit_tool_raw=[&](){
+                        if(tool_buf.empty()) return;
+                        emit_raw(tool_buf);
+                        tool_buf.clear();
+                    };
+                    // Incremental tool-call argument streaming (2026-07-18
+                    // streaming-parity-messages-responses.md): wrapped calls
+                    // stream production-shape input_json_delta fragments as
+                    // they generate — the SAME ToolCallStreamer proven on
+                    // /v1/chat/completions. Deviant heads fall back to the
+                    // buffered emit_tool path above, raw byte-exact.
+                    q27::ToolCallStreamer ts;
+                    int cur_tool_idx=-1;   // content-block index of the in-flight streamed call
+                    auto close_stream_block=[&](){
+                        if(cur_tool_idx<0) return;
+                        ev("content_block_stop",{{"type","content_block_stop"},{"index",cur_tool_idx}});
+                        cur_tool_idx=-1;
+                    };
+                    auto recover_trail=[&](const std::string& raw,bool allow_repair){
+                        const std::string tr=q27::strip_ws2(raw);
+                        if(tr.empty()) return;
+                        std::string pre,residual;
+                        auto bcs=q27::parse_bare_tool_calls(tr, &pre, &tools, true, allow_repair, &residual);
+                        if(!residual.empty()) {
+                            text_accum+=residual; open_block(0);
+                            ev("content_block_delta",{{"type","content_block_delta"},{"index",idx},
+                                {"delta",{{"type","text_delta"},{"text",residual}}}});
+                        }
+                        if(!bcs.empty()) {
+                            fprintf(stderr,"[tool-stream] %zu trailing call(s) recovered after streamed call\n",bcs.size());
+                            runtime.trace.event({{"kind","tool_recovery"},{"api","messages"},{"id",mid},
+                                {"stream",true},{"trailing",true},{"count",bcs.size()}});
+                            for(auto& bc:bcs) emit_tool_block(bc,false);
+                        } else if(residual.empty() && tr.find_first_not_of("}] \t\r\n")!=std::string::npos) {
+                            text_accum+=tr; open_block(0);
+                            ev("content_block_delta",{{"type","content_block_delta"},{"index",idx},
+                                {"delta",{{"type","text_delta"},{"text",tr}}}});
+                        }
+                    };
+                    auto close_tool=[&](bool allow_repair=true,bool wrapper_incomplete=false){
+                        if(!ts.active()) return;
+                        std::string tail;
+                        const bool clean=ts.finalize(&tail,allow_repair);
+                        if(reject_stream_call) {
+                            std::string rejected=ts.raw;
+                            const std::string trailing=ts.trail();
+                            if(!trailing.empty() && trailing.size()<=rejected.size() &&
+                               rejected.compare(rejected.size()-trailing.size(),trailing.size(),trailing)==0)
+                                rejected.resize(rejected.size()-trailing.size());
+                            emit_raw(rejected);
+                            recover_trail(trailing,allow_repair);
+                            reject_stream_call=false;
+                            ts.reset();
+                            return;
+                        }
+                        if(ts.invalid()) {
+                            // Streaming is irreversible: opener + prior arg
+                            // deltas are already on wire; recover packed trail.
+                            all_calls_clean=false;
+                            close_stream_block();
+                            recover_trail(ts.trail(),false);
+                        } else if(ts.opened) {
+                            if(!tail.empty() && cur_tool_idx>=0)
+                                ev("content_block_delta",{{"type","content_block_delta"},{"index",cur_tool_idx},
+                                    {"delta",{{"type","input_json_delta"},{"partial_json",tail}}}});
+                            if(!clean || wrapper_incomplete) {
+                                all_calls_clean=false;
+                                fprintf(stderr,"[tool-stream] streamed call closed unbalanced or incomplete\n");
+                            }
+                            close_stream_block();
+                            recover_trail(ts.trail(),allow_repair);
+                        } else {
+                            tool_buf=ts.raw;
+                            if(wrapper_incomplete) emit_tool_raw();
+                            else emit_tool();
+                        }
+                        ts.reset();
+                    };
+                    auto emit_seg=[&](q27::StreamSplitter::Chan ch,const std::string& t){
+                        if(ch==q27::StreamSplitter::TOOL) {
+                            if(tool_buf.empty() && !ts.active()) recover_bare(false);
+                            if(tchoice.mode==q27::ToolChoice::NONE) {
+                                emit_raw(t);
+                                return;
+                            }
+                            if(q27::tool_strict() || !tchoice.forced_name.empty()) {
+                                tool_buf+=t;
+                                return;
+                            }
+                            bool opened=false;
+                            const std::string frag=ts.feed(t,&opened);
+                            if(opened) {
+                                reject_stream_call=!eligible_name(ts.name);
+                                if(!reject_stream_call) {
+                                    any_call=true;
+                                    close_block();
+                                    cur_tool_idx=block_counter++;
+                                    const std::string tid="toolu_metal_"+runtime.boot_id+"_"+std::to_string(rid)+"_"+
+                                                          std::to_string(tool_counter++);
+                                    ev("content_block_start",{{"type","content_block_start"},{"index",cur_tool_idx},
+                                        {"content_block",{{"type","tool_use"},{"id",tid},{"name",ts.name},
+                                                          {"input",json::object()}}}});
+                                }
+                            }
+                            if(!reject_stream_call && !frag.empty() && cur_tool_idx>=0)
+                                ev("content_block_delta",{{"type","content_block_delta"},{"index",cur_tool_idx},
+                                    {"delta",{{"type","input_json_delta"},{"partial_json",frag}}}});
+                            return;
+                        }
+                        close_tool();
+                        if(!tool_buf.empty()) emit_tool();
+                        if(t.empty()) return;
+                        const int chan=ch==q27::StreamSplitter::THINK?1:0;
+                        // suppress pure-whitespace text before/between blocks
+                        if(chan==0 && idx<0 && q27::strip_ws2(t).empty()) return;
+                        open_block(chan);
+                        if(chan==0) text_accum+=t;
+                        ev("content_block_delta",{{"type","content_block_delta"},{"index",idx},
+                            {"delta",chan==1?json{{"type","thinking_delta"},{"thinking",t}}
+                                            :json{{"type","text_delta"},{"text",t}}}});
+                    };
+                    auto feed_piece=[&](const std::string& piece,bool forced)->bool {
+                        for(auto& [ch,t]:sp.feed(piece)) {
+                            if(forced && ch==q27::StreamSplitter::TEXT && q27::strip_ws2(t).empty())
+                                continue;
+                            emit_seg(ch,t);
+                        }
+                        return alive;
+                    };
+                    Runtime::ThinkControl think_control{
+                        &tb,&sp,&think_close_ids,
+                        [&](const std::string& piece){ return feed_piece(piece,true); }};
+                    try {
+                        json msg={{"id",mid},{"type","message"},{"role","assistant"},{"model","q27-metal"},
+                            {"content",json::array()},{"stop_reason",nullptr},{"stop_sequence",nullptr},
+                            {"usage",{{"input_tokens",(int)ids.size()},{"output_tokens",0}}}};
+                        // Gate generation on the opening write so a stream that
+                        // is already unwritable never claims an engine slot.
+                        if(!ev("message_start",{{"type","message_start"},{"message",msg}})) {
+                            sink.done();
+                            return true;
+                        }
+                        // Keepalive through silent stretches (see the chat
+                        // twin — queue wait + prefill + tool_buf buffering):
+                        // Anthropic's wire has a documented ping event for
+                        // exactly this.
+                        auto keepalive=[&]{
+                            if(alive && std::chrono::steady_clock::now()-last_wire>std::chrono::seconds(5))
+                                ev("ping",{{"type","ping"}});
+                        };
+                        auto outcome=runtime.guard_engine([&]{
+                            return runtime.run(ids,n,sampling,stops,
+                                [&](const std::string& piece)->bool {
+                                    feed_piece(piece,false);
+                                    keepalive();
+                                    return alive;
+                                },tnames,snap_hint,mid,&think_control,
+                                tchoice.mode==q27::ToolChoice::FORCED,
+                                [&]{ return sink.is_alive(); });
+                        });
+                        if(outcome.finish==Runtime::Finish::Cancelled) { sink.done(); return false; }
+                        const bool final_tool_incomplete=
+                            outcome.finish==Runtime::Finish::Length && sp.chan==q27::StreamSplitter::TOOL;
+                        for(auto& [ch,t]:sp.flush()) emit_seg(ch,t);
+                        close_tool(outcome.finish==Runtime::Finish::Stop,final_tool_incomplete);
+                        if(!tool_buf.empty()) {
+                            if(final_tool_incomplete) emit_tool_raw();
+                            else emit_tool();
+                        }
+                        if(!final_tool_incomplete)
+                            recover_bare(outcome.finish==Runtime::Finish::Stop);
+                        // Unlike buffered recovery, a malformed streamed opener cannot
+                        // be retracted. Do not claim tool_use; forced mode fails closed.
+                        if(q27::forced_tool_choice_missing_is_error(
+                               tchoice,any_call && all_calls_clean,
+                               outcome.finish==Runtime::Finish::Length))
+                            throw Runtime::EngineError(
+                                "model produced no eligible tool call for forced tool_choice");
+                        if(idx<0 && !any && !any_call) { // nothing at all: empty text block for validity
+                            idx=block_counter++;
+                            chan_open=0;
+                            ev("content_block_start",{{"type","content_block_start"},{"index",idx},
+                                {"content_block",{{"type","text"},{"text",""}}}});
+                        }
+                        close_block();
+                        const bool calls_complete=any_call && all_calls_clean &&
+                            !final_tool_incomplete;
+                        ev("message_delta",{{"type","message_delta"},
+                            {"delta",{{"stop_reason",calls_complete?"tool_use":anthropic_stop(outcome.finish)},
+                                      {"stop_sequence",outcome.finish==Runtime::Finish::StopSequence?json(outcome.stop_sequence):json(nullptr)}}},
+                            {"usage",{{"output_tokens",outcome.output_tokens}}}});
+                        ev("message_stop",{{"type","message_stop"}});
+                        runtime.trace.event({{"kind","outcome"},{"api","messages"},{"id",mid},
+                            {"finish",calls_complete?"tool_use":anthropic_stop(outcome.finish)},
+                            {"terminal",trace_finish(outcome.finish)},{"prompt_tokens",outcome.prompt_tokens},{"output_tokens",outcome.output_tokens},
+                            {"prefix_hit",outcome.prefix_hit}});
+                    } catch(const Runtime::ClientGone&) {
+                        sink.done();
+                        return false;
+                    } catch(const Runtime::ServerOverloaded& e) {
+                        runtime.trace.event({{"kind","error"},{"api","messages"},{"id",mid},{"status",503},{"type","overloaded_error"},{"message",e.what()}});
+                        ev("error",{{"type","error"},{"error",{{"type","overloaded_error"},{"message",e.what()}}}});
+                        ev("message_stop",{{"type","message_stop"}});
+                    } catch(const std::exception& e) {
+                        runtime.trace.event({{"kind","error"},{"api","messages"},{"id",mid},{"status",500},{"type","api_error"},{"message",e.what()}});
+                        // An engine failure mid-stream must not leave an open
+                        // tool_use, text, or thinking block before message_stop.
+                        // close_tool covers streamed tool blocks; close_block
+                        // covers text/thinking. Both are no-ops when closed.
+                        try { close_tool(); } catch(...) {}
+                        try { close_block(); } catch(...) {}
+                        // First-class error event; message_stop still follows so
+                        // naive clients get a well-formed stream (server.cu's
+                        // batch-error convention).
+                        ev("error",{{"type","error"},{"error",{{"type","api_error"},{"message",e.what()}}}});
+                        ev("message_stop",{{"type","message_stop"}});
+                    }
+                    sink.done();
+                    return true;
+                });
+        }));
+
+        // ---- OpenAI Responses API (/v1/responses, Codex CLI) ----
+        // Full CUDA port (src/server.cu:1441-1882, residue round
+        // 2026-07-17-responses-parity-residue.md): instructions/input-item
+        // mapping through the chat template (replacing the raw-text
+        // preamble hack), custom freeform tools bridged to one-string-param
+        // functions, hosted tool types skipped never rejected, and
+        // structured function_call / custom_tool_call output items with the
+        // codex 0.143 item lifecycle on the stream (an output_text.delta
+        // without an open item aborts the codex turn). Wire facts from
+        // codex-rs: the client keys off the JSON `type` field; the agent
+        // loop consumes only response.output_item.done items;
+        // response.completed{response:{id}} is the required terminator;
+        // function_call.arguments is a JSON-encoded STRING. 400 is fatal
+        // to codex, 500 retries — tolerate quirks, 500 on bugs.
+        server.Post("/v1/responses",guarded("responses",[&](const json& body,httplib::Response& r,bool codex_compat,
+                                                             const std::function<bool()>& live){
+            (void)codex_compat;
+            const long rn=req_counter++;
+            const std::string resp_id="resp_metal_"+runtime.boot_id+"_"+std::to_string(rn);
+            const std::string msg_id="msg_metal_"+runtime.boot_id+"_"+std::to_string(rn);
+            // Canonicalize every Responses request before rendering.
+            ResponsesPromptInput normalized=responses_prompt_input(body);
+            json tools=std::move(normalized.tools);
+            std::set<std::string> custom_names=std::move(normalized.custom_names);
+            const q27::ToolChoice tchoice=std::move(normalized.choice);
+            const std::vector<std::string> tnames=std::move(normalized.tool_names);
+            const std::set<std::string> allowed_tool_names(tnames.begin(),tnames.end());
+            const std::set<std::string> allowed_hosted_names=
+                std::move(normalized.allowed_hosted_names);
+            std::vector<std::string> grammar_tool_names=tnames;
+            grammar_tool_names.insert(grammar_tool_names.end(),allowed_hosted_names.begin(),
+                                      allowed_hosted_names.end());
+            std::set<std::string> eligible_call_names=allowed_tool_names;
+            eligible_call_names.insert(allowed_hosted_names.begin(),allowed_hosted_names.end());
+            q27::ToolChoice response_choice=tchoice;
+            if(!response_choice.forced_name.empty() &&
+               !eligible_call_names.count(response_choice.forced_name))
+                response_choice.forced_name.clear();
+            std::vector<q27::Msg> merged=std::move(normalized.messages);
+            q27::ThinkCfg think_cfg=q27::resolve_think_cfg(body,think_default,req_think,-1);
+            bool think_req=think_cfg.enabled;
+            if(tchoice.mode==q27::ToolChoice::FORCED) {
+                think_req=false;
+                think_cfg.budget_set=true;
+                think_cfg.budget=-1;
+            }
+            std::string rendered=q27::chatml_prompt(merged,tools,think_req);
+            if(tchoice.mode==q27::ToolChoice::FORCED) rendered+="<tool_call>\n";
+            auto ids=to_u32(runtime.tokenizer.encode(rendered));
+            const uint32_t requested_n=max_tokens(body,q27::metal_default_max_tokens(q27::MetalEndpoint::Responses),TokenLimitApi::Responses);
+            uint32_t n=requested_n;
+            int think_budget=-1;
+            const q27::SamplingParams sampling=sampling_params(body);
+            const std::vector<std::string> stops=parse_stops(body,"stop",true);
+            if(ids.empty()) throw std::runtime_error("input is empty");
+            uint32_t maxp=0;
+            if(think_prompt_overflow(ids.size(),requested_n,think_req,think_cfg,sampling,
+                                     n,think_budget,maxp)) {
+                // context_length_exceeded is fatal-class for codex, correctly
+                runtime.trace.event({{"kind","request"},{"api","responses"},{"id",resp_id},
+                    {"validation_error",true},{"prompt_tokens",(uint64_t)ids.size()}});
+                runtime.trace.event({{"kind","error"},{"api","responses"},{"status",400},{"type","context_length_exceeded"},
+                    {"id",resp_id},{"prompt_tokens",(uint64_t)ids.size()},{"max",maxp}});
+                json_response(r,{{"error",{{"code","context_length_exceeded"}}}},400);
+                return;
+            }
+            const bool snap_hint=q27::jbool(body,"snapshot",false);
+            if(runtime.trace.enabled())
+                runtime.trace.event({{"kind","request"},{"api","responses"},{"id",resp_id},
+                    {"stream",wants_stream(body)},{"prompt_tokens",(uint64_t)ids.size()},
+                    {"max_tokens",n},{"tools",(uint64_t)tools.size()},
+                    {"sampling",{{"temperature",sampling.temperature},{"top_p",sampling.top_p},
+                        {"top_k",sampling.top_k},{"seed",sampling.seed}}},{"stops",stops},{"tool_names",grammar_tool_names},
+                    {"snapshot",snap_hint},{"token_head",trace_token_head(ids)},{"rendered",trace_text(rendered)}});
+            if(!wants_stream(body)) {
+                json items=json::array();
+                int tool_counter=0,message_counter=0,reason_counter=0;
+                std::string think,text,tool_buf,text_accum;
+                bool rejected_tool_wrapper=false,output_tool_tail=false;
+                auto flush_think=[&](bool incomplete_item=false){
+                    std::string th=q27::strip_ws2(think); think.clear();
+                    if(th.empty()) return;
+                    output_tool_tail=false;
+                    items.push_back({{"type","reasoning"},{"id","rs_metal_"+runtime.boot_id+"_"+std::to_string(rn)+"_"+std::to_string(reason_counter++)},
+                        {"status",incomplete_item?"incomplete":"completed"},{"summary",json::array({{{"type","summary_text"},{"text",th}}})},
+                        {"encrypted_content",nullptr}});
+                };
+                auto push_message=[&](const std::string& tx,bool incomplete_item=false){
+                    if(tx.empty()) return;
+                    output_tool_tail=false;
+                    items.push_back({{"type","message"},{"id",msg_id+"_"+std::to_string(message_counter++)},{"role","assistant"},
+                        {"status",incomplete_item?"incomplete":"completed"},
+                        {"content",json::array({{{"type","output_text"},{"text",tx},
+                                                 {"annotations",json::array()}}})}});
+                };
+                auto push_call=[&](const std::string& name,const json& args,bool incomplete_item=false){
+                    if(!responses_tool_allowed(name,allowed_tool_names,allowed_hosted_names) ||
+                       (tchoice.disable_parallel_tool_use && tool_counter)) return false;
+                    output_tool_tail=!incomplete_item;
+                    const int call_index=tool_counter++;
+                    const std::string cid="call_metal_"+runtime.boot_id+"_"+std::to_string(rn)+"_"+std::to_string(call_index);
+                    const std::string iid="fc_metal_"+runtime.boot_id+"_"+std::to_string(rn)+"_"+std::to_string(call_index);
+                    if(custom_names.count(name)) {
+                        std::string input=args.is_object() && args.contains("input") && args["input"].is_string()
+                                              ?args["input"].get<std::string>():args.dump();
+                        items.push_back({{"type","custom_tool_call"},{"id",iid},{"call_id",cid},
+                            {"status",incomplete_item?"incomplete":"completed"},
+                            {"name",name},{"input",input}});
+                    } else
+                        items.push_back({{"type","function_call"},{"id",iid},{"call_id",cid},
+                                         {"status",incomplete_item?"incomplete":"completed"},
+                                         {"name",name},{"arguments",args.dump()}});
+                    return true;
+                };
+                auto flush_text=[&](bool final_turn,bool incomplete_item=false,
+                                     bool incomplete_call=false){
+                    std::string tx=q27::strip_ws2(text); text.clear();
+                    std::string pre,residual;
+                    auto bcs=q27::parse_bare_tool_calls(tx,&pre,
+                                                        tools.empty()?nullptr:&tools,
+                                                        true,
+                                                        final_turn && !incomplete_call,&residual);
+                    if(bcs.empty()) { push_message(tx,incomplete_item); return; }
+                    std::vector<bool> accepted(bcs.size(),false);
+                    size_t accepted_calls=tool_counter;
+                    std::ptrdiff_t last_accepted=-1;
+                    for(size_t i=0;i<bcs.size();i++) {
+                        accepted[i]=bcs[i].ok && q27::tool_choice_allows_call(
+                            response_choice,eligible_call_names,bcs[i].name,
+                            accepted_calls);
+                        if(accepted[i]) {
+                            accepted_calls++;
+                            last_accepted=(std::ptrdiff_t)i;
+                        }
+                    }
+                    size_t cursor=0,recovered=0;
+                    for(size_t i=0;i<bcs.size();i++) {
+                        auto& bc=bcs[i];
+                        const bool segment_incomplete=incomplete_item &&
+                            last_accepted<(std::ptrdiff_t)i;
+                        push_message(tx.substr(cursor,bc.source_begin-cursor),
+                                     segment_incomplete);
+                        cursor=bc.source_end;
+                        if(accepted[i] && push_call(bc.name,bc.arguments,incomplete_call))
+                            recovered++;
+                        else push_message(tx.substr(bc.source_begin,
+                                                    bc.source_end-bc.source_begin),
+                                          segment_incomplete);
+                    }
+                    push_message(tx.substr(cursor),incomplete_item);
+                    if(recovered) {
+                        fprintf(stderr,"[tool-fallback] %zu bare call(s) recovered (resp nonstream)\n",recovered);
+                        runtime.trace.event({{"kind","tool_recovery"},{"api","responses"},{"id",resp_id},
+                                             {"stream",false},{"count",recovered}});
+                    }
+                };
+                auto flush_tool=[&](bool final_turn,bool incomplete_item=false){
+                    auto c=q27::parse_tool_call(q27::strip_ws2(tool_buf)); tool_buf.clear();
+                    if(!c.ok) rejected_tool_wrapper=true;
+                    if(!c.ok || !responses_tool_allowed(c.name,allowed_tool_names,
+                                                       allowed_hosted_names)) { // malformed/ineligible: surface as text
+                        rejected_tool_wrapper=true;
+                        // Recovery runs over malformed wrapper text so a nested
+                        // recoverable call is not lost. Commit it independently
+                        // so prefix trimming cannot drop later model prose.
+                        text+=(text.empty()?"":"\n")+c.raw;
+                        flush_text(final_turn,incomplete_item,incomplete_item); return;
+                    }
+                    if(!push_call(c.name,c.arguments,incomplete_item)) {
+                        rejected_tool_wrapper=true;
+                        text+=(text.empty()?"":"\n")+c.raw;
+                        flush_text(final_turn,incomplete_item,incomplete_item);
+                    }
+                };
+                q27::StreamSplitter sp;
+                bool routed_closed_tool_tail=false;
+                q27::ThinkBudgetState tb{think_budget};
+                if(tchoice.mode==q27::ToolChoice::FORCED) sp.chan=q27::StreamSplitter::TOOL;
+                else if(think_req) sp.chan=q27::StreamSplitter::THINK;
+                auto route=[&](q27::StreamSplitter::Chan ch,const std::string& t){
+                    if(ch==q27::StreamSplitter::TOOL) routed_closed_tool_tail=false;
+                    if(ch==q27::StreamSplitter::TOOL) {
+                        if(tchoice.mode==q27::ToolChoice::NONE) {
+                            text+=t; text_accum+=t; return;
+                        }
+                        if(!think.empty()) flush_think();
+                        if(!text.empty()) flush_text(true);
+                        tool_buf+=t; return;
+                    }
+                    const bool just_closed_tool=!tool_buf.empty();
+                    if(just_closed_tool) flush_tool(false);
+                    routed_closed_tool_tail=q27::responses_closed_tool_tail_after_segment(
+                        routed_closed_tool_tail,just_closed_tool,
+                        ch==q27::StreamSplitter::THINK,t);
+                    // Close pending text before accumulating thinking, using
+                    // the same transition rule as TOOL. Otherwise a
+                    // text→think→text turn interleaves items and corrupts
+                    // output_index ordering.
+                    if(ch==q27::StreamSplitter::THINK) {
+                        if(!text.empty()) flush_text(true);
+                        if(q27::strip_ws2(t).size()) output_tool_tail=false;
+                        think+=t;
+                        return;
+                    }
+                    if(!think.empty()) flush_think();
+                    text+=t; text_accum+=t;
+                };
+                auto feed_piece=[&](const std::string& piece,bool forced)->bool {
+                    for(auto& [ch,t]:sp.feed(piece)) {
+                        if(forced && ch==q27::StreamSplitter::TEXT && q27::strip_ws2(t).empty())
+                            continue;
+                        route(ch,t);
+                    }
+                    return true;
+                };
+                Runtime::ThinkControl think_control{
+                    &tb,&sp,&think_close_ids,
+                    [&](const std::string& piece){ return feed_piece(piece,true); }};
+                Runtime::Outcome outcome=traced_engine("responses",resp_id,[&]{
+                    return runtime.run(ids,n,sampling,stops,
+                        [&](const std::string& piece){ return feed_piece(piece,false); },
+                        grammar_tool_names,snap_hint,resp_id,&think_control,
+                        tchoice.mode==q27::ToolChoice::FORCED,live);
+                });
+                if(outcome.finish==Runtime::Finish::Cancelled) {
+                    runtime.trace.event({{"kind","outcome"},{"api","responses"},{"id",resp_id},
+                        {"finish","cancelled"},{"terminal","cancelled"},{"prompt_tokens",outcome.prompt_tokens},
+                        {"output_tokens",outcome.output_tokens},{"prefix_hit",outcome.prefix_hit}});
+                    r.status=499;
+                    return;
+                }
+                const bool token_limit_reached=outcome.finish==Runtime::Finish::Length;
+                const bool final_tool_closed=sp.chan==q27::StreamSplitter::TEXT &&
+                    sp.hold.empty() && (sp.tool_boundary || routed_closed_tool_tail);
+                for(auto& [ch,t]:sp.flush()) route(ch,t);
+                const bool allow_tool_repair=outcome.finish==Runtime::Finish::Stop;
+                const bool stream_tool_incomplete=token_limit_reached && !final_tool_closed;
+                if(!tool_buf.empty()) flush_tool(allow_tool_repair,stream_tool_incomplete);
+                const std::string final_text=q27::strip_ws2(text);
+                std::string preview_prefix,preview_remaining;
+                const auto preview_calls=q27::parse_bare_tool_calls(final_text, &preview_prefix, tools.empty()?nullptr:&tools, true, allow_tool_repair, &preview_remaining);
+                const bool bare_tool_tail=q27::responses_tool_tail_after_bare_calls(
+                    output_tool_tail,final_text,preview_calls,response_choice,
+                    eligible_call_names,tool_counter);
+                flush_text(allow_tool_repair,token_limit_reached,false);
+                const bool final_tool_incomplete=stream_tool_incomplete && !bare_tool_tail;
+                const bool limit_reached=q27::responses_token_limit_remains(
+                    token_limit_reached,bare_tool_tail,!rejected_tool_wrapper,
+                    final_tool_incomplete);
+                const auto terminal=q27::responses_terminal_state(limit_reached);
+                flush_think(terminal.incomplete);
+                // Truncation exempts a missing forced call even when Codex
+                // compatibility renders that terminal as `completed`.
+                if(q27::forced_tool_choice_missing_is_error(
+                       tchoice,tool_counter!=0,limit_reached))
+                    throw Runtime::EngineError("model produced no eligible tool call for forced tool_choice");
+                std::string all_text;
+                for(const auto& it:items)
+                    if(it.value("type","")=="message" && it.contains("content"))
+                        for(const auto& c:it["content"])
+                            if(c.value("type","")=="output_text") all_text+=c.value("text","");
+                runtime.trace.event({{"kind","outcome"},{"api","responses"},{"id",resp_id},
+                    {"finish",terminal.status},{"terminal",trace_finish(outcome.finish)},
+                    {"prompt_tokens",outcome.prompt_tokens},
+                    {"output_tokens",outcome.output_tokens},{"prefix_hit",outcome.prefix_hit}});
+                json response={{"id",resp_id},{"object","response"},{"model","q27-metal"},{"status",terminal.status},
+                    {"output_text",all_text}, // Metal convenience field, pre-port consumers
+                    {"output",items},
+                    {"usage",{{"input_tokens",outcome.prompt_tokens},{"output_tokens",outcome.output_tokens},
+                              {"output_tokens_details",{{"reasoning_tokens",tb.used},
+                                                         {"reasoning_budget_exceeded",tb.tripped}}},
+                              {"total_tokens",outcome.prompt_tokens+outcome.output_tokens}}}};
+                if(terminal.incomplete)
+                    response["incomplete_details"]={{"reason","max_output_tokens"}};
+                json_response(r,response);
+                return;
+            }
+            r.set_chunked_content_provider("text/event-stream",
+                [&runtime,ids,n,sampling,stops,rn,resp_id,msg_id,tools,custom_names,
+                 grammar_tool_names,allowed_tool_names,allowed_hosted_names,
+                 eligible_call_names,response_choice,snap_hint,think_req,think_budget,
+                 tchoice,&think_close_ids](size_t,httplib::DataSink& sink)->bool {
+                    bool alive=true;
+                    uint64_t sequence_number=0;
+                    auto last_wire=std::chrono::steady_clock::now();
+                    auto ev=[&](json j){
+                        j["sequence_number"]=sequence_number++;
+                        std::string s=q27::sse_event(j.value("type",std::string("x")),j);
+                        if(!sink.write(s.data(),s.size())) alive=false;
+                        else last_wire=std::chrono::steady_clock::now();
+                        return alive;
+                    };
+                    // Item lifecycle state is outside the try so the engine-
+                    // failure path can close an open item and terminate cleanly.
+                    json items=json::array();
+                    int tool_counter=0,out_index=0,msg_index=-1;
+                    int message_counter=0,reason_counter=0;
+                    std::string think,text,tool_buf,bare_pending,bare_probe,active_msg_id;
+                    bool bare_holding=false,bare_mode10=false,bare_input_final=false;
+                    bool tool_calls_clean=true,bare_ordinary_call_seen=false;
+                    bool output_tool_tail=false;
+                    q27::IncrementalBareJsonEnd bare_scan;
+                    q27::JsonStringLexState bare_text_lex;
+                    q27::MarkdownFenceLexState bare_text_fence;
+                    q27::StreamSplitter sp;
+                    q27::ThinkBudgetState tb{think_budget};
+                    if(tchoice.mode==q27::ToolChoice::FORCED) sp.chan=q27::StreamSplitter::TOOL;
+                    else if(think_req) sp.chan=q27::StreamSplitter::THINK;
+                        auto item_done=[&](const json& it){
+                            ev({{"type","response.output_item.done"},{"output_index",out_index++},{"item",it}});
+                            items.push_back(it);
+                        };
+                        auto flush_think=[&](bool incomplete_item=false){
+                            std::string th=q27::strip_ws2(think); think.clear();
+                            if(th.empty()) return;
+                            output_tool_tail=false;
+                            const std::string iid="rs_metal_"+runtime.boot_id+"_"+
+                                std::to_string(rn)+"_"+std::to_string(reason_counter++);
+                            json item={{"type","reasoning"},{"id",iid},
+                                {"status",incomplete_item?"incomplete":"completed"},
+                                {"summary",json::array({{{"type","summary_text"},{"text",th}}})},
+                                {"encrypted_content",nullptr}};
+                            json added=item; added["status"]="in_progress";
+                            ev({{"type","response.output_item.added"},{"output_index",out_index},{"item",added}});
+                            item_done(item);
+                        };
+                        bool rejected_tool_wrapper=false;
+                        // codex 0.143 item lifecycle: a delta needs an OPEN item
+                        // (added + content_part.added), else the turn aborts.
+                        auto open_text=[&]{
+                            if(msg_index>=0) return;
+                            msg_index=out_index;
+                            active_msg_id=msg_id+"_"+std::to_string(message_counter++);
+                            ev({{"type","response.output_item.added"},{"output_index",msg_index},
+                                {"item",{{"type","message"},{"id",active_msg_id},{"role","assistant"},
+                                         {"status","in_progress"},{"content",json::array()}}}});
+                            ev({{"type","response.content_part.added"},{"item_id",active_msg_id},
+                                {"output_index",msg_index},{"content_index",0},
+                                {"part",{{"type","output_text"},{"text",""},{"annotations",json::array()}}}});
+                        };
+                        auto flush_text=[&](bool incomplete_item=false){
+                            if(msg_index<0) { text.clear(); return; }
+                            std::string tx; tx.swap(text);
+                            ev({{"type","response.output_text.done"},{"item_id",active_msg_id},
+                                {"output_index",msg_index},{"content_index",0},{"text",tx}});
+                            ev({{"type","response.content_part.done"},{"item_id",active_msg_id},
+                                {"output_index",msg_index},{"content_index",0},
+                                {"part",{{"type","output_text"},{"text",tx},{"annotations",json::array()}}}});
+                            json it={{"type","message"},{"id",active_msg_id},{"role","assistant"},
+                                {"status",incomplete_item?"incomplete":"completed"},
+                                {"content",json::array({{{"type","output_text"},{"text",tx},
+                                                         {"annotations",json::array()}}})}};
+                            ev({{"type","response.output_item.done"},{"output_index",msg_index},{"item",it}});
+                            items.push_back(it);
+                            out_index=msg_index+1; msg_index=-1; active_msg_id.clear();
+                        };
+                        auto push_call=[&](const std::string& name,const json& args,bool incomplete_item=false){
+                            if(!responses_tool_allowed(name,allowed_tool_names,allowed_hosted_names) ||
+                               (tchoice.disable_parallel_tool_use && tool_counter)) return false;
+                            output_tool_tail=true;
+                            const int call_index=tool_counter++;
+                            const std::string cid="call_metal_"+runtime.boot_id+"_"+std::to_string(rn)+"_"+std::to_string(call_index);
+                            const std::string iid="fc_metal_"+runtime.boot_id+"_"+std::to_string(rn)+"_"+std::to_string(call_index);
+                            json item;
+                            if(custom_names.count(name)) {
+                                std::string input=args.is_object() && args.contains("input") && args["input"].is_string()
+                                                      ?args["input"].get<std::string>():args.dump();
+                                item={{"type","custom_tool_call"},{"id",iid},{"call_id",cid},
+                                    {"status",incomplete_item?"incomplete":"completed"},
+                                    {"name",name},{"input",input}};
+                            } else
+                                item={{"type","function_call"},{"id",iid},{"call_id",cid},
+                                      {"status",incomplete_item?"incomplete":"completed"},
+                                      {"name",name},{"arguments",args.dump()}};
+                            if(incomplete_item) {
+                                // Never advertise a partial call: clients dispatch
+                                // function_call output_item.done regardless of status.
+                                tool_calls_clean=false;
+                                return true;
+                            }
+                            json added=item;
+                            added["status"]="in_progress";
+                            if(added["type"]=="function_call") added["arguments"]="";
+                            else added["input"]="";
+                            ev({{"type","response.output_item.added"},{"output_index",out_index},{"item",added}});
+                            if(item["type"]=="function_call")
+                                ev({{"type","response.function_call_arguments.done"},
+                                    {"item_id",iid},{"output_index",out_index},
+                                    {"name",name},{"arguments",item["arguments"]}});
+                            item_done(item);
+                            return true;
+                        };
+                        auto push_message_done=[&](const std::string& tx,bool incomplete_item=false){
+                            if(tx.empty()) return;
+                            if(q27::strip_ws2(tx).size()) output_tool_tail=false;
+                            const std::string iid=msg_id+"_"+std::to_string(message_counter++);
+                            json item={{"type","message"},{"id",iid},{"role","assistant"},
+                                {"status",incomplete_item?"incomplete":"completed"},
+                                {"content",json::array({{{"type","output_text"},{"text",tx},
+                                                         {"annotations",json::array()}}})}};
+                            ev({{"type","response.output_item.added"},{"output_index",out_index},
+                                {"item",{{"type","message"},{"id",iid},{"role","assistant"},
+                                         {"status","in_progress"},{"content",json::array()}}}});
+                            ev({{"type","response.content_part.added"},{"item_id",iid},
+                                {"output_index",out_index},{"content_index",0},
+                                {"part",{{"type","output_text"},{"text",""},{"annotations",json::array()}}}});
+                            ev({{"type","response.output_text.delta"},{"item_id",iid},
+                                {"output_index",out_index},{"content_index",0},{"delta",tx}});
+                            ev({{"type","response.output_text.done"},{"item_id",iid},
+                                {"output_index",out_index},{"content_index",0},{"text",tx}});
+                            ev({{"type","response.content_part.done"},{"item_id",iid},
+                                {"output_index",out_index},{"content_index",0},
+                                {"part",{{"type","output_text"},{"text",tx},{"annotations",json::array()}}}});
+                            item_done(item);
+                        };
+                        auto flush_tool=[&](bool final_turn,bool incomplete_item=false){
+                            auto c=q27::parse_tool_call(q27::strip_ws2(tool_buf)); tool_buf.clear();
+                            if(!c.ok) {
+                                rejected_tool_wrapper=true;
+                                runtime.trace.event({{"kind","tool_recovery"},{"api","responses"},{"id",resp_id},
+                                    {"stream",true},{"malformed_wrapper",true},{"count",0}});
+                                if(final_turn && !incomplete_item) {
+                                    std::string pre,residual;
+                                    auto bcs=q27::parse_bare_tool_calls(c.raw, &pre, tools.empty()?nullptr:&tools, true, final_turn, &residual);
+                                    if(!bcs.empty()) {
+                                        size_t cursor=0,recovered=0;
+                                        for(auto& bc:bcs) {
+                                            push_message_done(c.raw.substr(cursor,bc.source_begin-cursor),incomplete_item);
+                                            cursor=bc.source_end;
+                                            if(push_call(bc.name,bc.arguments,false)) recovered++;
+                                            else push_message_done(c.raw.substr(bc.source_begin,
+                                                                               bc.source_end-bc.source_begin),incomplete_item);
+                                        }
+                                        push_message_done(c.raw.substr(cursor),incomplete_item);
+                                        if(recovered) {
+                                            fprintf(stderr,"[tool-fallback] %zu truncated wrapped call(s) recovered (resp stream)\n",recovered);
+                                            runtime.trace.event({{"kind","tool_recovery"},{"api","responses"},{"id",resp_id},{"stream",true},{"truncated_wrapper",true},{"count",recovered}});
+                                            return;
+                                        }
+                                    }
+                                }
+                                push_message_done(c.raw,incomplete_item);
+                                return;
+                            }
+                            if(!responses_tool_allowed(c.name,allowed_tool_names,
+                                                       allowed_hosted_names)) {
+                                rejected_tool_wrapper=true;
+                                push_message_done(c.raw,incomplete_item);
+                                return;
+                            }
+                            if(!push_call(c.name,c.arguments,incomplete_item)) {
+                                rejected_tool_wrapper=true;
+                                push_message_done(c.raw,incomplete_item);
+                            }
+                        };
+                        auto emit_text=[&](const std::string& t){
+                            q27::consume_bare_text_context(
+                                bare_text_lex,bare_text_fence,t);
+                            if(msg_index<0 && text.empty() && q27::strip_ws2(t).empty()) return;
+                            if(q27::strip_ws2(t).size()) output_tool_tail=false;
+                            open_text();
+                            text+=t;
+                            ev({{"type","response.output_text.delta"},{"item_id",active_msg_id},
+                                {"output_index",msg_index},{"content_index",0},{"delta",t}});
+                        };
+                        auto emit_recovered=[&](const std::string& source,
+                                                std::vector<q27::ToolCall>& calls,
+                                                bool incomplete_item,
+                                                bool incomplete_call) {
+                            std::vector<bool> accepted(calls.size(),false);
+                            size_t accepted_calls=tool_counter;
+                            std::ptrdiff_t last_accepted=-1;
+                            for(size_t i=0;i<calls.size();i++) {
+                                accepted[i]=calls[i].ok && q27::tool_choice_allows_call(
+                                    response_choice,eligible_call_names,calls[i].name,
+                                    accepted_calls);
+                                if(accepted[i]) {
+                                    accepted_calls++;
+                                    last_accepted=(std::ptrdiff_t)i;
+                                }
+                            }
+                            size_t cursor=0,recovered=0;
+                            for(size_t i=0;i<calls.size();i++) {
+                                auto& bc=calls[i];
+                                emit_text(source.substr(cursor,bc.source_begin-cursor));
+                                cursor=bc.source_end;
+                                const bool segment_incomplete=incomplete_item &&
+                                    last_accepted<(std::ptrdiff_t)i;
+                                if(accepted[i]) {
+                                    if(msg_index>=0) flush_text(segment_incomplete);
+                                    if(push_call(bc.name,bc.arguments,incomplete_call)) {
+                                        recovered++;
+                                        bare_text_lex.reset();
+                                        bare_text_fence.reset();
+                                    } else emit_text(source.substr(
+                                        bc.source_begin,bc.source_end-bc.source_begin));
+                                } else emit_text(source.substr(bc.source_begin,
+                                                               bc.source_end-bc.source_begin));
+                            }
+                            emit_text(source.substr(cursor));
+                            return recovered;
+                        };
+                        auto flush_bare=[&](bool final_turn,bool incomplete_item=false,
+                                           bool incomplete_call=false){
+                            if(!bare_holding) return;
+                            const bool candidate_mode10=bare_mode10;
+                            std::string pre,residual;
+                            auto bcs=q27::parse_bare_tool_calls(bare_pending, &pre, tools.empty()?nullptr:&tools, true, final_turn && !incomplete_call, &residual);
+                            size_t recovered=0;
+                            if(!bcs.empty()) {
+                                recovered=emit_recovered(
+                                    bare_pending,bcs,incomplete_item,incomplete_call);
+                                if(recovered) {
+                                    fprintf(stderr,"[tool-fallback] %zu bare call(s) recovered (resp stream)\n",recovered);
+                                    runtime.trace.event({{"kind","tool_recovery"},{"api","responses"},{"id",resp_id},
+                                                         {"stream",true},{"count",recovered}});
+                                }
+                            } else emit_text(bare_pending);
+                            if(!candidate_mode10 && !bcs.empty())
+                                bare_ordinary_call_seen=true;
+                            bare_pending.clear();
+                            bare_holding=false;
+                            bare_mode10=false;
+                            // A balanced candidate is a JSON classification boundary.
+                            // Preserve any Markdown fence opened by emitted text.
+                            bare_text_lex.reset();
+                        };
+                        auto flush_bare_probe=[&]() {
+                            if(bare_probe.empty()) return;
+                            emit_text(bare_probe);
+                            bare_probe.clear();
+                        };
+                        auto route_bare_text=[&](const std::string& value) {
+                            std::string remaining=std::move(bare_probe);
+                            bare_probe.clear();
+                            remaining+=value;
+                            while(!remaining.empty()) {
+                                if(bare_holding) {
+                                    bare_pending+=remaining;
+                                    remaining.clear();
+                                } else {
+                                    const size_t object_pos=q27::bare_object_position(
+                                        remaining,bare_text_lex,bare_text_fence,
+                                        bare_input_final);
+                                    const size_t mode10_pos=bare_ordinary_call_seen
+                                        ?std::string::npos
+                                        :q27::bare_mode10_signature_position(
+                                            remaining,eligible_call_names,bare_text_lex,
+                                            bare_text_fence,bare_input_final);
+                                    const size_t opener=object_pos==std::string::npos?mode10_pos:
+                                        mode10_pos==std::string::npos?object_pos:
+                                        std::min(object_pos,mode10_pos);
+                                    if(opener==std::string::npos) {
+                                        size_t keep=bare_input_final || bare_ordinary_call_seen
+                                            ?std::string::npos
+                                            :q27::bare_mode10_probe_start(
+                                                remaining,eligible_call_names,bare_text_lex,
+                                                bare_text_fence,false);
+                                        if(!bare_input_final) {
+                                            const size_t inline_keep=
+                                                q27::bare_unresolved_inline_probe_start(
+                                                    remaining,bare_text_lex,bare_text_fence);
+                                            if(inline_keep!=std::string::npos)
+                                                keep=keep==std::string::npos?inline_keep:
+                                                     std::min(keep,inline_keep);
+                                        }
+                                        if(keep==std::string::npos) {
+                                            emit_text(remaining);
+                                        } else {
+                                            emit_text(remaining.substr(0,keep));
+                                            bare_probe=remaining.substr(keep);
+                                        }
+                                        return;
+                                    }
+                                    if(opener) emit_text(remaining.substr(0,opener));
+                                    bare_pending=remaining.substr(opener);
+                                    bare_holding=true;
+                                    bare_mode10=mode10_pos==opener;
+                                    bare_scan.begin(bare_mode10);
+                                    remaining.clear();
+                                }
+                                if(!bare_mode10 &&
+                                   !q27::plausible_bare_tool_prefix(bare_pending)) {
+                                    std::string retry=std::move(bare_pending);
+                                    bare_pending.clear();
+                                    bare_holding=false;
+                                    emit_text(retry.substr(0,1));
+                                    remaining=retry.substr(1);
+                                    continue;
+                                }
+                                const size_t end=bare_scan.advance(bare_pending);
+                                if(end==std::string::npos) return;
+                                std::string trailing=bare_pending.substr(end);
+                                bare_pending.resize(end);
+                                flush_bare(false,false,false);
+                                remaining=std::move(trailing);
+                            }
+                        };
+                        // Incremental tool-call argument streaming (2026-07-18
+                        // streaming-parity-messages-responses.md): wrapped
+                        // calls stream function_call_arguments.delta fragments
+                        // as they generate — the SAME ToolCallStreamer proven
+                        // on /v1/chat/completions and /v1/messages. Deviant
+                        // heads fall back to the buffered flush_tool path,
+                        // raw byte-exact. custom_tool_call stays whole-item.
+                        q27::ToolCallStreamer ts;
+                        int st_idx=-1;             // output_index of in-flight streamed call
+                        std::string st_iid, st_cid, st_acc;  // item/call ids + accumulated args
+                        bool st_custom=false,st_rejected=false;
+                        bool routed_closed_tool_tail=false;
+                        auto st_arg_delta=[&](const std::string& frag){
+                            if(!frag.empty() && st_idx>=0) st_acc+=frag;
+                        };
+                        auto recover_trail=[&](const std::string& raw,bool allow_repair,bool incomplete_item){
+                            const std::string tr=q27::strip_ws2(raw);
+                            if(tr.empty()) return;
+                            std::string pre,residual;
+                            auto bcs=q27::parse_bare_tool_calls(tr, &pre, tools.empty()?nullptr:&tools, true, allow_repair, &residual);
+                            if(!bcs.empty()) {
+                                const size_t recovered=emit_recovered(
+                                    tr,bcs,incomplete_item,incomplete_item);
+                                if(recovered) {
+                                    fprintf(stderr,"[tool-stream] %zu trailing call(s) recovered after streamed call (resp)\n",recovered);
+                                    runtime.trace.event({{"kind","tool_recovery"},{"api","responses"},{"id",resp_id},
+                                                         {"stream",true},{"trailing",true},{"count",recovered}});
+                                }
+                            } else if(!residual.empty() &&
+                                      residual.find_first_not_of("}] \t\r\n")!=std::string::npos)
+                                emit_text(residual);
+                        };
+                        auto close_stream_tool=[&](bool incomplete_item,bool allow_repair=true){
+                            if(!ts.active()) return;
+                            if(st_rejected) {
+                                rejected_tool_wrapper=true;
+                                st_rejected=false;
+                                std::string tail;
+                                (void)ts.finalize(&tail,allow_repair);
+                                std::string rejected=ts.raw;
+                                const std::string trailing=ts.trail();
+                                if(!trailing.empty() && trailing.size()<=rejected.size() &&
+                                   rejected.compare(rejected.size()-trailing.size(),trailing.size(),trailing)==0)
+                                    rejected.resize(rejected.size()-trailing.size());
+                                push_message_done(rejected,incomplete_item);
+                                recover_trail(trailing,allow_repair,incomplete_item);
+                                ts.reset();
+                                return;
+                            }
+                            // Custom tools are buffered rather than streamed.
+                            // Finalize first so a packed second call is split
+                            // from the first item's verbatim body, then recover
+                            // the trail through the ordinary call path.
+                            if(st_custom) {
+                                st_custom=false;
+                                std::string ignored_tail;
+                                (void)ts.finalize(&ignored_tail,allow_repair);
+                                const std::string trailing=ts.trail();
+                                tool_buf=ts.raw;
+                                if(!trailing.empty() && trailing.size()<=tool_buf.size() &&
+                                   tool_buf.compare(tool_buf.size()-trailing.size(),trailing.size(),trailing)==0)
+                                    tool_buf.resize(tool_buf.size()-trailing.size());
+                                flush_tool(false,incomplete_item);
+                                recover_trail(trailing,allow_repair,incomplete_item);
+                                ts.reset();
+                                return;
+                            }
+                            std::string tail;
+                            const bool clean=ts.finalize(&tail,allow_repair);
+                            auto release_stream_index=[&](bool emitted) {
+                                out_index=q27::responses_output_index_after_stream_item(
+                                    out_index,st_idx,emitted);
+                                st_idx=-1; st_iid.clear(); st_cid.clear(); st_acc.clear();
+                            };
+                            if(ts.invalid()) {
+                                tool_calls_clean=false;
+                                release_stream_index(false);
+                                recover_trail(ts.trail(),false,incomplete_item);
+                            } else if(ts.opened) {
+                                st_arg_delta(tail);
+                                bool emitted=false;
+                                if(!clean || incomplete_item) {
+                                    // Do not open an item that cannot reach a
+                                    // terminal state. Codex dispatches every
+                                    // function_call output_item.done even when
+                                    // its status is "incomplete".
+                                    tool_calls_clean=false;
+                                    fprintf(stderr,"[tool-stream] suppressing incomplete function_call item\n");
+                                } else {
+                                    json it={{"type","function_call"},{"id",st_iid},{"call_id",st_cid},
+                                        {"status","completed"},{"name",ts.name},{"arguments",st_acc}};
+                                    ev({{"type","response.output_item.added"},{"output_index",st_idx},
+                                        {"item",{{"type","function_call"},{"id",st_iid},{"call_id",st_cid},
+                                                 {"status","in_progress"},{"name",ts.name},{"arguments",""}}}});
+                                    if(!st_acc.empty())
+                                        ev({{"type","response.function_call_arguments.delta"},
+                                            {"item_id",st_iid},{"output_index",st_idx},{"delta",st_acc}});
+                                    ev({{"type","response.function_call_arguments.done"},
+                                        {"item_id",st_iid},{"output_index",st_idx},
+                                        {"name",ts.name},{"arguments",st_acc}});
+                                    ev({{"type","response.output_item.done"},{"output_index",st_idx},{"item",it}});
+                                    items.push_back(it);
+                                    output_tool_tail=true;
+                                    emitted=true;
+                                }
+                                release_stream_index(emitted);
+                                recover_trail(ts.trail(),allow_repair,incomplete_item);
+                            } else {
+                                tool_buf=ts.raw;
+                                flush_tool(false,incomplete_item);
+                                release_stream_index(false);
+                            }
+                            ts.reset();
+                        };
+                        auto route=[&](q27::StreamSplitter::Chan ch,const std::string& t){
+                            if(ch==q27::StreamSplitter::TOOL) routed_closed_tool_tail=false;
+                            if(ch==q27::StreamSplitter::TOOL) {
+                                if(tchoice.mode==q27::ToolChoice::NONE) {
+                                    flush_bare_probe();
+                                    flush_bare(false);
+                                    if(!think.empty()) flush_think();
+                                    emit_text(t);
+                                    return;
+                                }
+                                flush_bare_probe();
+                                flush_bare(false);
+                                if(!think.empty()) flush_think();
+                                if(!text.empty()) flush_text();
+                                bare_text_lex.reset();
+                                bare_text_fence.reset();
+                                bare_ordinary_call_seen=false;
+                                // Parse incrementally, but hold the item-added
+                                // event and argument deltas until the wrapper is
+                                // complete. That preserves a balanced Responses
+                                // lifecycle on token limits and engine failures
+                                // without advertising an executable partial call.
+                                if(q27::tool_strict()) {
+                                    tool_buf+=t;
+                                    return;
+                                }
+                                bool opened=false;
+                                const std::string frag=ts.feed(t,&opened);
+                                if(opened) {
+                                    if(!responses_tool_allowed(ts.name,allowed_tool_names,
+                                                               allowed_hosted_names) ||
+                                       (tchoice.disable_parallel_tool_use && tool_counter)) {
+                                        st_rejected=true;
+                                    } else if(custom_names.count(ts.name)) {
+                                        st_custom=true;
+                                    } else {
+                                        const int call_index=tool_counter++;
+                                        st_idx=out_index;
+                                        st_cid="call_metal_"+runtime.boot_id+"_"+std::to_string(rn)+"_"+std::to_string(call_index);
+                                        st_iid="fc_metal_"+runtime.boot_id+"_"+std::to_string(rn)+"_"+std::to_string(call_index);
+                                    }
+                                }
+                                if(!frag.empty() && !st_custom && !st_rejected) st_arg_delta(frag);
+                                return;
+                            }
+                            const bool just_closed_tool=ts.active() || !tool_buf.empty();
+                            close_stream_tool(false);
+                            if(!tool_buf.empty()) flush_tool(false);
+                            routed_closed_tool_tail=q27::responses_closed_tool_tail_after_segment(
+                                routed_closed_tool_tail,just_closed_tool,
+                                ch==q27::StreamSplitter::THINK,t);
+                            // A THINK transition must close an open text item,
+                            // just like TOOL. Otherwise flush_think consumes the
+                            // message's output_index and duplicates or reorders
+                            // completion events.
+                            if(ch==q27::StreamSplitter::THINK) {
+                                flush_bare_probe();
+                                flush_bare(false);
+                                if(!text.empty()) flush_text();
+                                bare_text_lex.reset();
+                                bare_text_fence.reset();
+                                bare_ordinary_call_seen=false;
+                                if(q27::strip_ws2(t).size()) output_tool_tail=false;
+                                think+=t; return;
+                            }
+                            if(!think.empty()) flush_think();
+                            // Bare JSON calls arrive on the TEXT channel. Hold
+                            // only a plausible call-shaped object prefix, and
+                            // classify it as soon as its top-level brace closes.
+                            route_bare_text(t);
+                        };
+                        auto feed_piece=[&](const std::string& piece,bool forced)->bool {
+                            for(auto& [ch,t]:sp.feed(piece)) {
+                                if(forced && ch==q27::StreamSplitter::TEXT && q27::strip_ws2(t).empty())
+                                    continue;
+                                route(ch,t);
+                            }
+                            return alive;
+                        };
+                        Runtime::ThinkControl think_control{
+                            &tb,&sp,&think_close_ids,
+                            [&](const std::string& piece){ return feed_piece(piece,true); }};
+                        try {
+                        if(!ev({{"type","response.created"},
+                                {"response",{{"id",resp_id},{"object","response"},{"status","in_progress"}}}})) {
+                            sink.done(); return true;
+                        }
+                        // Keepalive through silent stretches (see the chat
+                        // twin — queue wait + prefill + tool_buf buffering).
+                        // The Responses wire has no ping event; an SSE comment
+                        // line is spec-legal and invisible to eventsource
+                        // parsers.
+                        auto keepalive=[&]{
+                            if(alive && std::chrono::steady_clock::now()-last_wire>std::chrono::seconds(5)) {
+                                const char ka[]=": keepalive\n\n";
+                                if(!sink.write(ka,sizeof(ka)-1)) alive=false;
+                                else last_wire=std::chrono::steady_clock::now();
+                            }
+                        };
+                        Runtime::Outcome outcome=runtime.guard_engine([&]{
+                            return runtime.run(ids,n,sampling,stops,
+                                [&](const std::string& piece)->bool {
+                                    feed_piece(piece,false);
+                                    keepalive();
+                                    return alive;
+                                },grammar_tool_names,snap_hint,resp_id,&think_control,
+                                tchoice.mode==q27::ToolChoice::FORCED,
+                                [&]{ return sink.is_alive(); });
+                        });
+                        if(outcome.finish==Runtime::Finish::Cancelled) {
+                            runtime.trace.event({{"kind","outcome"},{"api","responses"},{"id",resp_id},
+                                {"finish","cancelled"},{"terminal","cancelled"},{"prompt_tokens",outcome.prompt_tokens},
+                                {"output_tokens",outcome.output_tokens},{"prefix_hit",outcome.prefix_hit}});
+                            sink.done();
+                            return false;
+                        }
+                        const bool token_limit_reached=outcome.finish==Runtime::Finish::Length;
+                        const bool final_tool_closed=sp.chan==q27::StreamSplitter::TEXT &&
+                            sp.hold.empty() && (sp.tool_boundary || routed_closed_tool_tail);
+                        for(auto& [ch,t]:sp.flush()) route(ch,t);
+                        const bool allow_tool_repair=outcome.finish==Runtime::Finish::Stop;
+                        const bool stream_tool_incomplete=token_limit_reached && !final_tool_closed;
+                        close_stream_tool(stream_tool_incomplete,allow_tool_repair);
+                        if(!tool_buf.empty()) flush_tool(allow_tool_repair,stream_tool_incomplete);
+                        if(!bare_probe.empty()) {
+                            bare_input_final=true;
+                            std::string final_probe=std::move(bare_probe);
+                            bare_probe.clear();
+                            route_bare_text(final_probe);
+                            bare_input_final=false;
+                        }
+                        std::string preview_prefix,preview_remaining;
+                        std::vector<q27::ToolCall> preview_calls;
+                        if(bare_holding)
+                            preview_calls=q27::parse_bare_tool_calls(bare_pending, &preview_prefix, tools.empty()?nullptr:&tools, true, allow_tool_repair, &preview_remaining);
+                        const bool bare_tool_tail=q27::responses_tool_tail_after_bare_calls(
+                            output_tool_tail,bare_pending,preview_calls,response_choice,
+                            eligible_call_names,tool_counter);
+                        const bool final_tool_incomplete=stream_tool_incomplete && !bare_tool_tail;
+                        const bool limit_reached=q27::responses_token_limit_remains(
+                            token_limit_reached,bare_tool_tail,
+                            tool_calls_clean && !rejected_tool_wrapper,final_tool_incomplete);
+                        const auto terminal=q27::responses_terminal_state(limit_reached);
+                        flush_think(terminal.incomplete);
+                        flush_text(terminal.incomplete);
+                        flush_bare(allow_tool_repair,terminal.incomplete,false);
+                        flush_text(terminal.incomplete);
+                        if(q27::forced_tool_choice_missing_is_error(
+                               tchoice,tool_counter!=0,limit_reached))
+                            throw Runtime::EngineError("model produced no eligible tool call for forced tool_choice");
+                        if(!tool_calls_clean) {
+                            const char* message="model produced an incomplete tool call";
+                            runtime.trace.event({{"kind","error"},{"api","responses"},{"id",resp_id},
+                                {"status",500},{"type","invalid_model_output"},{"error",message}});
+                            ev({{"type","response.failed"},
+                                {"response",{{"id",resp_id},{"object","response"},{"status","failed"},
+                                    {"error",{{"code","invalid_model_output"},{"message",message}}},
+                                    {"output",items}}}});
+                        } else {
+                            runtime.trace.event({{"kind","outcome"},{"api","responses"},{"id",resp_id},
+                                {"finish",terminal.status},{"terminal",trace_finish(outcome.finish)},
+                                {"prompt_tokens",outcome.prompt_tokens},
+                                {"output_tokens",outcome.output_tokens},{"prefix_hit",outcome.prefix_hit}});
+                            json response={{"id",resp_id},{"object","response"},{"model","q27-metal"},
+                                {"status",terminal.status},{"output",items},
+                                {"usage",{{"input_tokens",outcome.prompt_tokens},
+                                          {"input_tokens_details",{{"cached_tokens",0}}},
+                                          {"output_tokens",outcome.output_tokens},
+                                          {"output_tokens_details",{{"reasoning_tokens",tb.used},
+                                                                     {"reasoning_budget_exceeded",tb.tripped}}},
+                                          {"total_tokens",outcome.prompt_tokens+outcome.output_tokens}}}};
+                            if(terminal.incomplete)
+                                response["incomplete_details"]={{"reason","max_output_tokens"}};
+                            ev({{"type",terminal.event},{"response",response}});
+                        }
+                    } catch(const Runtime::ClientGone&) {
+                        sink.done();
+                        return false;
+                    } catch(const Runtime::ServerOverloaded& e) {
+                        runtime.trace.event({{"kind","error"},{"api","responses"},{"id",resp_id},
+                            {"status",503},{"type","overloaded_error"},{"error",e.what()}});
+                        ev({{"type","error"},{"error",{{"type","overloaded_error"},{"message",e.what()}}}});
+                        ev({{"type","response.failed"},
+                            {"response",{{"id",resp_id},{"object","response"},{"status","failed"},
+                                {"error",{{"code","overloaded_error"},{"message",e.what()}}},
+                                {"output",items}}}});
+                    } catch(const std::exception& e) {
+                        runtime.trace.event({{"kind","error"},{"api","responses"},{"id",resp_id},
+                            {"status",500},{"type","api_error"},{"error",e.what()}});
+                        // An engine failure mid-stream must not leave an open
+                        // item lifecycle over a 200 stream. Close any open item;
+                        // flushers emit the done triplet and no-op when closed.
+                        // A pending tool buffer is unreliable and is dropped.
+                        // Keep the first-class api_error event, then terminate
+                        // the stream with response.failed.
+                        try {
+                            for(auto& [ch,t]:sp.flush()) route(ch,t);
+                            close_stream_tool(true,false);
+                            // Close any in-flight streamed function_call so
+                            // the added item gets a matching done (and lands
+                            // in response.output) instead of dangling open.
+                            if(!tool_buf.empty()) flush_tool(false,true);
+                            if(!think.empty()) flush_think(true);
+                            flush_bare_probe();
+                            if(!bare_pending.empty()) {
+                                emit_text(bare_pending);
+                                bare_pending.clear();
+                                bare_holding=false;
+                            }
+                            flush_text(true);
+                        } catch(...) {}
+                        ev({{"type","error"},{"error",{{"type","api_error"},{"message",e.what()}}}});
+                        ev({{"type","response.failed"},
+                            {"response",{{"id",resp_id},{"object","response"},{"status","failed"},
+                                {"error",{{"code","server_error"},{"message",e.what()}}},
+                                {"output",items}}}});
+                    }
+                    sink.done();
+                    return true;
+                });
+        }));
+
+        // SO_REUSEADDR only (upstream e0a1a39 parity; macOS defines
+        // SO_REUSEPORT, so httplib's default_socket_options picks it here
+        // exactly as it does on Linux). SO_REUSEPORT lets a SECOND Metal
+        // server co-bind this port and the kernel then load-balances
+        // connections across both. On this box that is worse than the CUDA
+        // arm's eval-integrity hazard: a second server also loads a second
+        // copy of a ~17 GiB artifact into 24 GiB of unified memory. REUSEADDR
+        // keeps fast rebind after TIME_WAIT without permitting live co-bind,
+        // so the second process fails into the FATAL below instead.
+        server.set_socket_options([](socket_t sock) {
+            int opt=1;
+            setsockopt(sock,SOL_SOCKET,SO_REUSEADDR,reinterpret_cast<const void*>(&opt),sizeof(opt));
+        });
+        // Bind FIRST, announce only on success (upstream e0a1a39 parity).
+        // The old order printed "listening on ..." and the admin token before
+        // listen() had bound anything, so a port squatter produced a startup
+        // log that claimed success, leaked the admin token to stderr, and only
+        // then failed -- operators (and log scrapers) read the first line.
+        if(!server.bind_to_port(host.c_str(),(int)port)) {
+            fprintf(stderr,
+                    "FATAL: cannot bind %s:%u (port already in use? see "
+                    "`lsof -nP -iTCP:%u -sTCP:LISTEN`)\n",host.c_str(),port,port);
+            return 1;
+        }
+        fprintf(stderr,"q27 Metal server listening on http://%s:%u (ctx=%u, kv=%s, mtp=%u, slots=%zu)\n",
+                host.c_str(),port,runtime.context,turbo3?"turbo3":"fp16",width,runtime.slots.size());
+        if(!server.listen_after_bind()) throw std::runtime_error("server listen failed");
+        return 0;
+    } catch(const std::exception& e) { fprintf(stderr,"%s\n",e.what()); return 1; }
+}

--- a/src/metal/q27_kernels.metal
+++ b/src/metal/q27_kernels.metal
@@ -1,4 +1,4 @@
-// Q27_SHADER_ABI 6
+// Q27_SHADER_ABI 13
 //
 // Shaders compile from this file at RUNTIME, so a host binary built before a
 // buffer-binding change silently misbinds against a newer file (this exact
@@ -13,29 +13,15 @@ using namespace metal;
 struct MatvecArgs {
     uint rows;
     uint cols;
-    uint simdgroups;
 };
-struct MatvecPairArgs { uint rows_a; uint rows_b; uint cols; uint simdgroups; };
+struct MatvecPairArgs { uint rows_a; uint rows_b; uint cols; };
 struct MatmulArgs { uint rows; uint cols; uint x_rows; uint simdgroups; };
 
-inline float stable_softplus(float value) {
-    if (value > 20.0f) return value;
-    if (value < -10.0f) return exp(value);
-    return log(1.0f + exp(value));
-}
-
-inline void reduce_row(float sum, device float *out, uint row,
-                       threadgroup float *partial, ushort lane, ushort simdgroup,
-                       uint simdgroups) {
-    sum = simd_sum(sum);
-    if (lane == 0) partial[simdgroup] = sum;
-    threadgroup_barrier(mem_flags::mem_threadgroup);
-
-    if (simdgroup == 0) {
-        float total = lane < simdgroups ? partial[lane] : 0.0f;
-        total = simd_sum(total);
-        if (lane == 0) out[row] = total;
-    }
+// Goldberg's exact-correction log1p tracks CUDA log1pf to about one ulp; MSL
+// has no log1p.
+inline float log1p_f(float t) {
+    const float u = 1.0f + t;
+    return u == 1.0f ? t : log(u) * (t / (u - 1.0f));
 }
 
 kernel void q27_matvec_f32(
@@ -224,7 +210,6 @@ kernel void q27_matvec_t2_g128(
         if (lane == 0 && row0 + r < args.rows) out[row0 + r] = tot;
     }
 }
-
 struct VectorArgs {
     uint n;
     uint groups;
@@ -280,6 +265,40 @@ kernel void q27_embedding_t2(
     out[gid] = float(int(code) - 1) * float(scales[si]);
 }
 
+
+// GPU-resident greedy decode: identical embedding lookups, but the token id
+// comes from the device buffer the previous step's argmax wrote, so chained
+// steps need no CPU sync. There is NO clamp on the id: a corrupt id WOULD
+// read out of bounds. Safety rests entirely on the argmax invariant —
+// argmax only writes ids < n, and mask+argmax degrades to id 0.
+kernel void q27_embedding_q8_dev(
+        device const char *weights [[buffer(0)]],
+        device const half *scales  [[buffer(1)]],
+        device float *out          [[buffer(2)]],
+        device const uint *token   [[buffer(3)]],
+        constant uint &cols        [[buffer(4)]],
+        uint gid [[thread_position_in_grid]]) {
+    if (gid >= cols) return;
+    const ulong wi = (ulong)token[0] * cols + gid;
+    const ulong si = (ulong)token[0] * (cols / 128) + gid / 128;
+    out[gid] = float(weights[wi]) * float(scales[si]);
+}
+
+kernel void q27_embedding_t2_dev(
+        device const uchar *weights [[buffer(0)]],
+        device const half *scales   [[buffer(1)]],
+        device float *out           [[buffer(2)]],
+        device const uint *token    [[buffer(3)]],
+        constant uint &cols         [[buffer(4)]],
+        uint gid [[thread_position_in_grid]]) {
+    if (gid >= cols) return;
+    const ulong wi = (ulong)token[0] * cols + gid;
+    const uint code = (weights[wi >> 2] >> ((wi & 3) * 2)) & 3;
+    const ulong si = (ulong)token[0] * (cols / 128) + gid / 128;
+    out[gid] = float(int(code) - 1) * float(scales[si]);
+}
+
+
 kernel void q27_rmsnorm(
         device const float *x [[buffer(0)]],
         device const float *w [[buffer(1)]],
@@ -313,7 +332,10 @@ kernel void q27_rmsnorm_quantized(
     for(uint block=simdgroup;block<blocks;block+=8) {
         const uint i=block*32+lane; const float v=out[i];
         const float amax=simd_max(abs(v)); const float scale=amax/127.0f;
-        int q=scale>0.0f?int(rint(v/scale)):0; q=clamp(q,-127,127);
+        // Reciprocal-multiply matches CUDA k_quantize_x, keeping one rounding
+        // rule across backends (rint == __float2int_rn under RNE).
+        const float qinv=scale>0.0f?1.0f/scale:0.0f;
+        int q=int(rint(v*qinv)); q=clamp(q,-127,127);
         values[i]=char(q); if(lane==0) scales[block]=scale;
     }
 }
@@ -525,7 +547,8 @@ kernel void q27_gdn_gates(device const float *alpha [[buffer(0)]],
                            uint gid [[thread_position_in_grid]]) {
     if (gid >= heads) return;
     const float value = alpha[gid] + ssm_dt[gid];
-    const float softplus = stable_softplus(value);
+    const float softplus = value > 20.0f ? value
+                         : (value < -16.0f ? exp(value) : log1p_f(exp(value)));
     g[gid] = ssm_a[gid] * softplus;
     beta[gid] = 1.0f / (1.0f + exp(-beta_raw[gid]));
 }
@@ -639,7 +662,10 @@ kernel void q27_quantize_x(device const float *x [[buffer(0)]],
     float v = i < count ? x[i] : 0.0f;
     float amax = simd_max(abs(v));
     float scale = amax / 127.0f;
-    int q = scale > 0.0f ? int(rint(v / scale)) : 0;
+    // Reciprocal-multiply matches CUDA k_quantize_x, keeping one rounding
+    // rule across backends (rint == __float2int_rn under RNE).
+    const float inv = scale > 0.0f ? 1.0f / scale : 0.0f;
+    int q = int(rint(v * inv));
     q = clamp(q, -127, 127);
     if (i < count) values[i] = char(q);
     if (lane == 0) scales[group] = scale;
@@ -717,6 +743,16 @@ kernel void q27_matvec_q8_quantized(device const char *weights [[buffer(0)]],
     if (lane == 0) out[row] = acc;
 }
 
+// PROMOTED 2026-07-17 (docs/plans/2026-07-17-q4-rewrite-round.md candidate A,
+// r4 arm: bench R = 0.957 vs the 0.90 ship line; the prior 1-row-per-simdgroup
+// structure re-issued the full x load per row). 4 rows per simdgroup, each
+// lane's 32-column int8 x-slice and activation scale held in registers, so
+// x-loads, x-scale reads and the reduction chain amortize across rows and the
+// weight stream runs 4 independent load chains. The decode ALU (q27_dot8_q4)
+// is unchanged: per-row dot, scale multiply order and accumulation order match
+// the pre-promotion kernel exactly — byte-identical outputs (gated). Rows past
+// the grid edge clamp to the last row and compute without storing (the T2
+// wide-kernel convention). Dispatch: 32 rows per 256-thread group.
 kernel void q27_matvec_q4_quantized(device const uchar *weights [[buffer(0)]],
                                      device const half *weight_scales [[buffer(1)]],
                                      device const char *x [[buffer(2)]],
@@ -726,39 +762,62 @@ kernel void q27_matvec_q4_quantized(device const uchar *weights [[buffer(0)]],
                                      uint group [[threadgroup_position_in_grid]],
                                      ushort lane [[thread_index_in_simdgroup]],
                                      ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
-    const uint row = group * 8 + simdgroup;
-    if (row >= args.rows) return;
-    device const uint4 *w4x8 = (device const uint4 *)(weights + (ulong)row * (args.cols / 2));
+    const uint row0 = (group * 8 + (uint)simdgroup) * 4;
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
     device const int4 *x16 = (device const int4 *)x;
-    const ulong scale_base = (ulong)row * (args.cols / 64);
-    float acc = 0.0f;
+    const uint sgroups = args.cols / 64;
+    device const uint4 *w[4];
+    ulong sbase[4];
+    for (uint r = 0; r < 4; r++) {
+        const uint row = min(row0 + r, rlast);   // clamped rows compute, don't store
+        w[r] = (device const uint4 *)(weights + (ulong)row * (args.cols / 2));
+        sbase[r] = (ulong)row * sgroups;
+    }
+    // float4 packs the accumulators; simd_sum per component is still 4
+    // cross-lane reductions — the win is issuing them once per row, not
+    // once per (row, x-load).
+    float4 acc = 0.0f;
     const uint chunks = args.cols / 1024;
     for (uint chunk = 0; chunk < chunks; chunk++) {
         const uint idx = chunk * 32 + lane;
-        const uint4 wp = w4x8[idx];
+        // The lane's 32-column x-slice and activation scale load ONCE per
+        // chunk and serve all 4 rows — the amortization the round bought.
         const int4 xp0 = x16[idx * 2];
         const int4 xp1 = x16[idx * 2 + 1];
-        const int dot0 = q27_dot8_q4(wp.x, as_type<char4>(xp0.x), as_type<char4>(xp0.y)) +
-                         q27_dot8_q4(wp.y, as_type<char4>(xp0.z), as_type<char4>(xp0.w));
-        const int dot1 = q27_dot8_q4(wp.z, as_type<char4>(xp1.x), as_type<char4>(xp1.y)) +
-                         q27_dot8_q4(wp.w, as_type<char4>(xp1.z), as_type<char4>(xp1.w));
-        // Same 32-aligned lane layout as the Q8 kernel: one activation-scale
-        // block and one weight-scale group cover the lane's 32 columns.
         const uint c = chunk * 1024 + lane * 32;
-        acc += float(dot0 + dot1) *
-               float(weight_scales[scale_base + c / 64]) * x_scales[c / 32];
+        const float xs = x_scales[c / 32];
+        for (uint r = 0; r < 4; r++) {
+            const uint4 wp = w[r][idx];
+            const int dot0 = q27_dot8_q4(wp.x, as_type<char4>(xp0.x), as_type<char4>(xp0.y)) +
+                             q27_dot8_q4(wp.y, as_type<char4>(xp0.z), as_type<char4>(xp0.w));
+            const int dot1 = q27_dot8_q4(wp.z, as_type<char4>(xp1.x), as_type<char4>(xp1.y)) +
+                             q27_dot8_q4(wp.w, as_type<char4>(xp1.z), as_type<char4>(xp1.w));
+            // Same 32-aligned lane layout as the Q8 kernel: one activation-
+            // scale block and one weight-scale group cover the lane's 32
+            // columns, and the per-lane integer dot stays exact in float:
+            // nibble-8 is in [-8,7], so |dot0 + dot1| <= 32*8*127 = 32512,
+            // well inside float's 2^24 exact-integer range.
+            acc[r] += float(dot0 + dot1) *
+                      float(weight_scales[sbase[r] + c / 64]) * xs;
+        }
     }
+    // Tail (cols % 1024): the 128-column tail, per row.
     for (uint c = chunks * 1024 + lane * 4; c < args.cols; c += 128) {
-        const uchar2 wp = *(device const uchar2 *)(weights + (ulong)row * (args.cols / 2) + c / 2);
         const char4 xp = *(device const char4 *)(x + c);
-        const int dot = (int(wp.x & 15u) - 8) * xp.x + (int(wp.x >> 4) - 8) * xp.y +
-                        (int(wp.y & 15u) - 8) * xp.z + (int(wp.y >> 4) - 8) * xp.w;
-        acc += float(dot) * float(weight_scales[scale_base + c / 64]) * x_scales[c / 32];
+        const float xs = x_scales[c / 32];
+        for (uint r = 0; r < 4; r++) {
+            const uchar2 wp = *(device const uchar2 *)((device const uchar *)w[r] + c / 2);
+            const int dot = (int(wp.x & 15u) - 8) * xp.x + (int(wp.x >> 4) - 8) * xp.y +
+                            (int(wp.y & 15u) - 8) * xp.z + (int(wp.y >> 4) - 8) * xp.w;
+            acc[r] += float(dot) * float(weight_scales[sbase[r] + c / 64]) * xs;
+        }
     }
-    acc = simd_sum(acc);
-    if (lane == 0) out[row] = acc;
+    for (uint r = 0; r < 4; r++) {
+        const float tot = simd_sum(acc[r]);
+        if (lane == 0 && row0 + r < args.rows) out[row0 + r] = tot;
+    }
 }
-
 // 16 sequential LSB-first 2-bit codes per uint; code c contributes (c-1)*x.
 // The integer dot is exact: |dot| <= 16*1*127 = 2032 per uint, 4064 per
 // lane-chunk, well inside float's exact-integer range.
@@ -823,6 +882,35 @@ kernel void q27_matvec_t2_quantized(device const uchar *weights [[buffer(0)]],
     if (lane == 0) out[row] = acc;
 }
 
+// Dual-row ternary dot: unpack each 2-bit code ONCE, MAC into both rows.
+// The packed-dot GEMV is issue-bound on the unpack (shift/mask/sub per
+// code), not on the weight stream, so sharing the unpack — not the bytes —
+// is where an N=2 batch can win. Integer sums are exact and order-
+// independent, so each row's dot equals the single-row kernel's bit for bit.
+inline void q27_dot16_t2_dual(uint packed, int4 xpa, int4 xpb,
+                              thread int& sa, thread int& sb) {
+    const char4 a0 = as_type<char4>(xpa.x), a1 = as_type<char4>(xpa.y);
+    const char4 a2 = as_type<char4>(xpa.z), a3 = as_type<char4>(xpa.w);
+    const char4 b0 = as_type<char4>(xpb.x), b1 = as_type<char4>(xpb.y);
+    const char4 b2 = as_type<char4>(xpb.z), b3 = as_type<char4>(xpb.w);
+    int w;
+    w = int(packed         & 3u) - 1; sa += w * a0.x; sb += w * b0.x;
+    w = int((packed >>  2) & 3u) - 1; sa += w * a0.y; sb += w * b0.y;
+    w = int((packed >>  4) & 3u) - 1; sa += w * a0.z; sb += w * b0.z;
+    w = int((packed >>  6) & 3u) - 1; sa += w * a0.w; sb += w * b0.w;
+    w = int((packed >>  8) & 3u) - 1; sa += w * a1.x; sb += w * b1.x;
+    w = int((packed >> 10) & 3u) - 1; sa += w * a1.y; sb += w * b1.y;
+    w = int((packed >> 12) & 3u) - 1; sa += w * a1.z; sb += w * b1.z;
+    w = int((packed >> 14) & 3u) - 1; sa += w * a1.w; sb += w * b1.w;
+    w = int((packed >> 16) & 3u) - 1; sa += w * a2.x; sb += w * b2.x;
+    w = int((packed >> 18) & 3u) - 1; sa += w * a2.y; sb += w * b2.y;
+    w = int((packed >> 20) & 3u) - 1; sa += w * a2.z; sb += w * b2.z;
+    w = int((packed >> 22) & 3u) - 1; sa += w * a2.w; sb += w * b2.w;
+    w = int((packed >> 24) & 3u) - 1; sa += w * a3.x; sb += w * b3.x;
+    w = int((packed >> 26) & 3u) - 1; sa += w * a3.y; sb += w * b3.y;
+    w = int((packed >> 28) & 3u) - 1; sa += w * a3.z; sb += w * b3.z;
+    w = int((packed >> 30)      ) - 1; sa += w * a3.w; sb += w * b3.w;
+}
 // Tiled simdgroup-matrix GEMM (x_rows 1..12) for chunked prefill and
 // batched MTP verification. A 128-thread threadgroup (4 simdgroups) owns a
 // 32-row x 16-token output tile and walks K in 64-column tiles: weights are
@@ -846,21 +934,23 @@ kernel void q27_matmul_q4_mm(
         device const uchar *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
         device const char *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
         device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
-        uint group [[threadgroup_position_in_grid]],
+        uint2 group [[threadgroup_position_in_grid]],
         uint tid [[thread_index_in_threadgroup]],
         ushort lane [[thread_index_in_simdgroup]],
         ushort sg [[simdgroup_index_in_threadgroup]]) {
     threadgroup float Wt[32 * 64];   // [row within tile][col within K-tile]
     threadgroup float Xt[64 * 16];   // [col within K-tile][token], prescaled
     threadgroup float Sc[4 * 128];   // per-simdgroup flush scratch
-    const uint row0 = group * 32;
+    const uint row0 = group.x * 32;
+    const uint tok0 = group.y * 16;   // 16-token tile (wide-chunk grid)
     if (row0 >= args.rows) return;
     const uint rlast = args.rows - 1;
     // Staging assignments: one weight row / 16 columns and one token /
     // 8 transposed columns per thread.
     const uint wrow = tid / 4, wcb = (tid % 4) * 16;
     device const uchar *wsrc = weights + (ulong)min(row0 + wrow, rlast) * (args.cols / 2);
-    const uint xtok = tid % 16, xcb = (tid / 16) * 8;
+    const uint xloc = tid % 16, xcb = (tid / 16) * 8;   // Xt column is tile-local
+    const uint xtok = tok0 + xloc;                       // device rows are global
     const bool xvalid = xtok < args.x_rows;
     device const char *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * args.cols;
     const uint xsbase = min(xtok, args.x_rows - 1) * (args.cols / 32);
@@ -900,7 +990,7 @@ kernel void q27_matmul_q4_mm(
             const float xs = xvalid ? x_scales[xsbase + (c0 + xcb) / 32] : 0.0f;
             const char4 xa = *(device const char4 *)(xsrc + c0 + xcb);
             const char4 xb = *(device const char4 *)(xsrc + c0 + xcb + 4);
-            threadgroup float *dst = Xt + xcb * 16 + xtok;
+            threadgroup float *dst = Xt + xcb * 16 + xloc;
             dst[0 * 16] = float(xa.x) * xs; dst[1 * 16] = float(xa.y) * xs;
             dst[2 * 16] = float(xa.z) * xs; dst[3 * 16] = float(xa.w) * xs;
             dst[4 * 16] = float(xb.x) * xs; dst[5 * 16] = float(xb.y) * xs;
@@ -927,7 +1017,7 @@ kernel void q27_matmul_q4_mm(
         acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
         acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
     }
-    const uint tokA = lane % 8, tokB = 8 + lane % 8;
+    const uint tokA = tok0 + lane % 8, tokB = tok0 + 8 + lane % 8;
     if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
     if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
     if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
@@ -938,19 +1028,21 @@ kernel void q27_matmul_q8_mm(
         device const char *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
         device const char *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
         device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
-        uint group [[threadgroup_position_in_grid]],
+        uint2 group [[threadgroup_position_in_grid]],
         uint tid [[thread_index_in_threadgroup]],
         ushort lane [[thread_index_in_simdgroup]],
         ushort sg [[simdgroup_index_in_threadgroup]]) {
     threadgroup float Wt[32 * 64];
     threadgroup float Xt[64 * 16];
     threadgroup float Sc[4 * 128];
-    const uint row0 = group * 32;
+    const uint row0 = group.x * 32;
+    const uint tok0 = group.y * 16;   // 16-token tile (wide-chunk grid)
     if (row0 >= args.rows) return;
     const uint rlast = args.rows - 1;
     const uint wrow = tid / 4, wcb = (tid % 4) * 16;
     device const char *wsrc = weights + (ulong)min(row0 + wrow, rlast) * args.cols;
-    const uint xtok = tid % 16, xcb = (tid / 16) * 8;
+    const uint xloc = tid % 16, xcb = (tid / 16) * 8;   // Xt column is tile-local
+    const uint xtok = tok0 + xloc;                       // device rows are global
     const bool xvalid = xtok < args.x_rows;
     device const char *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * args.cols;
     const uint xsbase = min(xtok, args.x_rows - 1) * (args.cols / 32);
@@ -979,7 +1071,7 @@ kernel void q27_matmul_q8_mm(
             const float xs = xvalid ? x_scales[xsbase + (c0 + xcb) / 32] : 0.0f;
             const char4 xa = *(device const char4 *)(xsrc + c0 + xcb);
             const char4 xb = *(device const char4 *)(xsrc + c0 + xcb + 4);
-            threadgroup float *dst = Xt + xcb * 16 + xtok;
+            threadgroup float *dst = Xt + xcb * 16 + xloc;
             dst[0 * 16] = float(xa.x) * xs; dst[1 * 16] = float(xa.y) * xs;
             dst[2 * 16] = float(xa.z) * xs; dst[3 * 16] = float(xa.w) * xs;
             dst[4 * 16] = float(xb.x) * xs; dst[5 * 16] = float(xb.y) * xs;
@@ -1006,7 +1098,7 @@ kernel void q27_matmul_q8_mm(
         acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
         acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
     }
-    const uint tokA = lane % 8, tokB = 8 + lane % 8;
+    const uint tokA = tok0 + lane % 8, tokB = tok0 + 8 + lane % 8;
     if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
     if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
     if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
@@ -1021,19 +1113,21 @@ kernel void q27_matmul_t2_mm(
         device const uchar *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
         device const char *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
         device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
-        uint group [[threadgroup_position_in_grid]],
+        uint2 group [[threadgroup_position_in_grid]],
         uint tid [[thread_index_in_threadgroup]],
         ushort lane [[thread_index_in_simdgroup]],
         ushort sg [[simdgroup_index_in_threadgroup]]) {
     threadgroup float Wt[32 * 64];
     threadgroup float Xt[64 * 16];
     threadgroup float Sc[4 * 128];
-    const uint row0 = group * 32;
+    const uint row0 = group.x * 32;
+    const uint tok0 = group.y * 16;   // 16-token tile (wide-chunk grid)
     if (row0 >= args.rows) return;
     const uint rlast = args.rows - 1;
     const uint wrow = tid / 4, wcb = (tid % 4) * 16;
     device const uchar *wsrc = weights + (ulong)min(row0 + wrow, rlast) * (args.cols / 4);
-    const uint xtok = tid % 16, xcb = (tid / 16) * 8;
+    const uint xloc = tid % 16, xcb = (tid / 16) * 8;   // Xt column is tile-local
+    const uint xtok = tok0 + xloc;                       // device rows are global
     const bool xvalid = xtok < args.x_rows;
     device const char *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * args.cols;
     const uint xsbase = min(xtok, args.x_rows - 1) * (args.cols / 32);
@@ -1069,7 +1163,7 @@ kernel void q27_matmul_t2_mm(
             const float xs = xvalid ? x_scales[xsbase + (c0 + xcb) / 32] : 0.0f;
             const char4 xa = *(device const char4 *)(xsrc + c0 + xcb);
             const char4 xb = *(device const char4 *)(xsrc + c0 + xcb + 4);
-            threadgroup float *dst = Xt + xcb * 16 + xtok;
+            threadgroup float *dst = Xt + xcb * 16 + xloc;
             dst[0 * 16] = float(xa.x) * xs; dst[1 * 16] = float(xa.y) * xs;
             dst[2 * 16] = float(xa.z) * xs; dst[3 * 16] = float(xa.w) * xs;
             dst[4 * 16] = float(xb.x) * xs; dst[5 * 16] = float(xb.y) * xs;
@@ -1096,14 +1190,430 @@ kernel void q27_matmul_t2_mm(
         acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
         acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
     }
-    const uint tokA = lane % 8, tokB = 8 + lane % 8;
+    const uint tokA = tok0 + lane % 8, tokB = tok0 + 8 + lane % 8;
     if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
     if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
     if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
     if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = racc.w;
 }
 
-// ---- Chunked layer-major prefill (2..12 tokens per dispatch) ----
+// Half-staging variant of the T2 chunk GEMM (default path,
+// Q27_METAL_GEMM_HALF=0 opts out; docs/plans/2026-07-15-gemm-half-staging.md
+// variant G′): tiles are half — doubled simdgroup-MMA rate, halved
+// threadgroup traffic — and BOTH operands stay integer-exact in half: trits
+// on the weight side, raw int8 on the activation side. Accumulators are
+// FLOAT (mixed-precision MMA), keeping int8 x trit sums exact to 2^24.
+// Scales fold at the flush instead of at staging: each 64-K staged tile
+// accumulates its two 32-K sub-slabs (the x-scale groups) into separate
+// accumulator pairs, folded into racc in ONE barrier region per tile with
+// component (row, token) scaled by ws(row) * xs(token, sub-slab). (Variant
+// A staged prescaled activations and failed the shape suite; half
+// ACCUMULATION rounds past 2048 — variant B's 32-K half flush moved the
+// 2K NLL +0.4%.)
+// Trit code -> half bit pattern: (c-1) as f16 is one of three constants
+// (code 3 decodes to +2, preserving the arithmetic unpack's behavior for
+// a corrupt pack byte). The MMA roofline measured the unpack/convert
+// chain at 13.5% of the production GEMM (C/Beq, docs/plans/2026-07-16-
+// mma-roofline.md); constructing the bit pattern directly deletes the
+// integer subtract and int->half convert per element — the roofline's
+// ONE authorized targeted round. The staged halves are identical values,
+// so kernel output is bit-identical to the arithmetic unpack (pre/post
+// artifact A/B gates the change).
+constant ushort q27_t2_half_lut[4] = {0xbc00, 0x0000, 0x3c00, 0x4000};
+
+// Byte -> 4 trit halves (little-endian codes): one constant-memory gather
+// replaces four shift/mask/select chains. 2 KB, generated from the 2-bit
+// code map (code 3 -> +2.0h, matching the arithmetic unpack).
+constant half4 q27_t2_half4_lut[256] = {
+    half4(-1.0h, -1.0h, -1.0h, -1.0h),
+    half4(0.0h, -1.0h, -1.0h, -1.0h),
+    half4(1.0h, -1.0h, -1.0h, -1.0h),
+    half4(2.0h, -1.0h, -1.0h, -1.0h),
+    half4(-1.0h, 0.0h, -1.0h, -1.0h),
+    half4(0.0h, 0.0h, -1.0h, -1.0h),
+    half4(1.0h, 0.0h, -1.0h, -1.0h),
+    half4(2.0h, 0.0h, -1.0h, -1.0h),
+    half4(-1.0h, 1.0h, -1.0h, -1.0h),
+    half4(0.0h, 1.0h, -1.0h, -1.0h),
+    half4(1.0h, 1.0h, -1.0h, -1.0h),
+    half4(2.0h, 1.0h, -1.0h, -1.0h),
+    half4(-1.0h, 2.0h, -1.0h, -1.0h),
+    half4(0.0h, 2.0h, -1.0h, -1.0h),
+    half4(1.0h, 2.0h, -1.0h, -1.0h),
+    half4(2.0h, 2.0h, -1.0h, -1.0h),
+    half4(-1.0h, -1.0h, 0.0h, -1.0h),
+    half4(0.0h, -1.0h, 0.0h, -1.0h),
+    half4(1.0h, -1.0h, 0.0h, -1.0h),
+    half4(2.0h, -1.0h, 0.0h, -1.0h),
+    half4(-1.0h, 0.0h, 0.0h, -1.0h),
+    half4(0.0h, 0.0h, 0.0h, -1.0h),
+    half4(1.0h, 0.0h, 0.0h, -1.0h),
+    half4(2.0h, 0.0h, 0.0h, -1.0h),
+    half4(-1.0h, 1.0h, 0.0h, -1.0h),
+    half4(0.0h, 1.0h, 0.0h, -1.0h),
+    half4(1.0h, 1.0h, 0.0h, -1.0h),
+    half4(2.0h, 1.0h, 0.0h, -1.0h),
+    half4(-1.0h, 2.0h, 0.0h, -1.0h),
+    half4(0.0h, 2.0h, 0.0h, -1.0h),
+    half4(1.0h, 2.0h, 0.0h, -1.0h),
+    half4(2.0h, 2.0h, 0.0h, -1.0h),
+    half4(-1.0h, -1.0h, 1.0h, -1.0h),
+    half4(0.0h, -1.0h, 1.0h, -1.0h),
+    half4(1.0h, -1.0h, 1.0h, -1.0h),
+    half4(2.0h, -1.0h, 1.0h, -1.0h),
+    half4(-1.0h, 0.0h, 1.0h, -1.0h),
+    half4(0.0h, 0.0h, 1.0h, -1.0h),
+    half4(1.0h, 0.0h, 1.0h, -1.0h),
+    half4(2.0h, 0.0h, 1.0h, -1.0h),
+    half4(-1.0h, 1.0h, 1.0h, -1.0h),
+    half4(0.0h, 1.0h, 1.0h, -1.0h),
+    half4(1.0h, 1.0h, 1.0h, -1.0h),
+    half4(2.0h, 1.0h, 1.0h, -1.0h),
+    half4(-1.0h, 2.0h, 1.0h, -1.0h),
+    half4(0.0h, 2.0h, 1.0h, -1.0h),
+    half4(1.0h, 2.0h, 1.0h, -1.0h),
+    half4(2.0h, 2.0h, 1.0h, -1.0h),
+    half4(-1.0h, -1.0h, 2.0h, -1.0h),
+    half4(0.0h, -1.0h, 2.0h, -1.0h),
+    half4(1.0h, -1.0h, 2.0h, -1.0h),
+    half4(2.0h, -1.0h, 2.0h, -1.0h),
+    half4(-1.0h, 0.0h, 2.0h, -1.0h),
+    half4(0.0h, 0.0h, 2.0h, -1.0h),
+    half4(1.0h, 0.0h, 2.0h, -1.0h),
+    half4(2.0h, 0.0h, 2.0h, -1.0h),
+    half4(-1.0h, 1.0h, 2.0h, -1.0h),
+    half4(0.0h, 1.0h, 2.0h, -1.0h),
+    half4(1.0h, 1.0h, 2.0h, -1.0h),
+    half4(2.0h, 1.0h, 2.0h, -1.0h),
+    half4(-1.0h, 2.0h, 2.0h, -1.0h),
+    half4(0.0h, 2.0h, 2.0h, -1.0h),
+    half4(1.0h, 2.0h, 2.0h, -1.0h),
+    half4(2.0h, 2.0h, 2.0h, -1.0h),
+    half4(-1.0h, -1.0h, -1.0h, 0.0h),
+    half4(0.0h, -1.0h, -1.0h, 0.0h),
+    half4(1.0h, -1.0h, -1.0h, 0.0h),
+    half4(2.0h, -1.0h, -1.0h, 0.0h),
+    half4(-1.0h, 0.0h, -1.0h, 0.0h),
+    half4(0.0h, 0.0h, -1.0h, 0.0h),
+    half4(1.0h, 0.0h, -1.0h, 0.0h),
+    half4(2.0h, 0.0h, -1.0h, 0.0h),
+    half4(-1.0h, 1.0h, -1.0h, 0.0h),
+    half4(0.0h, 1.0h, -1.0h, 0.0h),
+    half4(1.0h, 1.0h, -1.0h, 0.0h),
+    half4(2.0h, 1.0h, -1.0h, 0.0h),
+    half4(-1.0h, 2.0h, -1.0h, 0.0h),
+    half4(0.0h, 2.0h, -1.0h, 0.0h),
+    half4(1.0h, 2.0h, -1.0h, 0.0h),
+    half4(2.0h, 2.0h, -1.0h, 0.0h),
+    half4(-1.0h, -1.0h, 0.0h, 0.0h),
+    half4(0.0h, -1.0h, 0.0h, 0.0h),
+    half4(1.0h, -1.0h, 0.0h, 0.0h),
+    half4(2.0h, -1.0h, 0.0h, 0.0h),
+    half4(-1.0h, 0.0h, 0.0h, 0.0h),
+    half4(0.0h, 0.0h, 0.0h, 0.0h),
+    half4(1.0h, 0.0h, 0.0h, 0.0h),
+    half4(2.0h, 0.0h, 0.0h, 0.0h),
+    half4(-1.0h, 1.0h, 0.0h, 0.0h),
+    half4(0.0h, 1.0h, 0.0h, 0.0h),
+    half4(1.0h, 1.0h, 0.0h, 0.0h),
+    half4(2.0h, 1.0h, 0.0h, 0.0h),
+    half4(-1.0h, 2.0h, 0.0h, 0.0h),
+    half4(0.0h, 2.0h, 0.0h, 0.0h),
+    half4(1.0h, 2.0h, 0.0h, 0.0h),
+    half4(2.0h, 2.0h, 0.0h, 0.0h),
+    half4(-1.0h, -1.0h, 1.0h, 0.0h),
+    half4(0.0h, -1.0h, 1.0h, 0.0h),
+    half4(1.0h, -1.0h, 1.0h, 0.0h),
+    half4(2.0h, -1.0h, 1.0h, 0.0h),
+    half4(-1.0h, 0.0h, 1.0h, 0.0h),
+    half4(0.0h, 0.0h, 1.0h, 0.0h),
+    half4(1.0h, 0.0h, 1.0h, 0.0h),
+    half4(2.0h, 0.0h, 1.0h, 0.0h),
+    half4(-1.0h, 1.0h, 1.0h, 0.0h),
+    half4(0.0h, 1.0h, 1.0h, 0.0h),
+    half4(1.0h, 1.0h, 1.0h, 0.0h),
+    half4(2.0h, 1.0h, 1.0h, 0.0h),
+    half4(-1.0h, 2.0h, 1.0h, 0.0h),
+    half4(0.0h, 2.0h, 1.0h, 0.0h),
+    half4(1.0h, 2.0h, 1.0h, 0.0h),
+    half4(2.0h, 2.0h, 1.0h, 0.0h),
+    half4(-1.0h, -1.0h, 2.0h, 0.0h),
+    half4(0.0h, -1.0h, 2.0h, 0.0h),
+    half4(1.0h, -1.0h, 2.0h, 0.0h),
+    half4(2.0h, -1.0h, 2.0h, 0.0h),
+    half4(-1.0h, 0.0h, 2.0h, 0.0h),
+    half4(0.0h, 0.0h, 2.0h, 0.0h),
+    half4(1.0h, 0.0h, 2.0h, 0.0h),
+    half4(2.0h, 0.0h, 2.0h, 0.0h),
+    half4(-1.0h, 1.0h, 2.0h, 0.0h),
+    half4(0.0h, 1.0h, 2.0h, 0.0h),
+    half4(1.0h, 1.0h, 2.0h, 0.0h),
+    half4(2.0h, 1.0h, 2.0h, 0.0h),
+    half4(-1.0h, 2.0h, 2.0h, 0.0h),
+    half4(0.0h, 2.0h, 2.0h, 0.0h),
+    half4(1.0h, 2.0h, 2.0h, 0.0h),
+    half4(2.0h, 2.0h, 2.0h, 0.0h),
+    half4(-1.0h, -1.0h, -1.0h, 1.0h),
+    half4(0.0h, -1.0h, -1.0h, 1.0h),
+    half4(1.0h, -1.0h, -1.0h, 1.0h),
+    half4(2.0h, -1.0h, -1.0h, 1.0h),
+    half4(-1.0h, 0.0h, -1.0h, 1.0h),
+    half4(0.0h, 0.0h, -1.0h, 1.0h),
+    half4(1.0h, 0.0h, -1.0h, 1.0h),
+    half4(2.0h, 0.0h, -1.0h, 1.0h),
+    half4(-1.0h, 1.0h, -1.0h, 1.0h),
+    half4(0.0h, 1.0h, -1.0h, 1.0h),
+    half4(1.0h, 1.0h, -1.0h, 1.0h),
+    half4(2.0h, 1.0h, -1.0h, 1.0h),
+    half4(-1.0h, 2.0h, -1.0h, 1.0h),
+    half4(0.0h, 2.0h, -1.0h, 1.0h),
+    half4(1.0h, 2.0h, -1.0h, 1.0h),
+    half4(2.0h, 2.0h, -1.0h, 1.0h),
+    half4(-1.0h, -1.0h, 0.0h, 1.0h),
+    half4(0.0h, -1.0h, 0.0h, 1.0h),
+    half4(1.0h, -1.0h, 0.0h, 1.0h),
+    half4(2.0h, -1.0h, 0.0h, 1.0h),
+    half4(-1.0h, 0.0h, 0.0h, 1.0h),
+    half4(0.0h, 0.0h, 0.0h, 1.0h),
+    half4(1.0h, 0.0h, 0.0h, 1.0h),
+    half4(2.0h, 0.0h, 0.0h, 1.0h),
+    half4(-1.0h, 1.0h, 0.0h, 1.0h),
+    half4(0.0h, 1.0h, 0.0h, 1.0h),
+    half4(1.0h, 1.0h, 0.0h, 1.0h),
+    half4(2.0h, 1.0h, 0.0h, 1.0h),
+    half4(-1.0h, 2.0h, 0.0h, 1.0h),
+    half4(0.0h, 2.0h, 0.0h, 1.0h),
+    half4(1.0h, 2.0h, 0.0h, 1.0h),
+    half4(2.0h, 2.0h, 0.0h, 1.0h),
+    half4(-1.0h, -1.0h, 1.0h, 1.0h),
+    half4(0.0h, -1.0h, 1.0h, 1.0h),
+    half4(1.0h, -1.0h, 1.0h, 1.0h),
+    half4(2.0h, -1.0h, 1.0h, 1.0h),
+    half4(-1.0h, 0.0h, 1.0h, 1.0h),
+    half4(0.0h, 0.0h, 1.0h, 1.0h),
+    half4(1.0h, 0.0h, 1.0h, 1.0h),
+    half4(2.0h, 0.0h, 1.0h, 1.0h),
+    half4(-1.0h, 1.0h, 1.0h, 1.0h),
+    half4(0.0h, 1.0h, 1.0h, 1.0h),
+    half4(1.0h, 1.0h, 1.0h, 1.0h),
+    half4(2.0h, 1.0h, 1.0h, 1.0h),
+    half4(-1.0h, 2.0h, 1.0h, 1.0h),
+    half4(0.0h, 2.0h, 1.0h, 1.0h),
+    half4(1.0h, 2.0h, 1.0h, 1.0h),
+    half4(2.0h, 2.0h, 1.0h, 1.0h),
+    half4(-1.0h, -1.0h, 2.0h, 1.0h),
+    half4(0.0h, -1.0h, 2.0h, 1.0h),
+    half4(1.0h, -1.0h, 2.0h, 1.0h),
+    half4(2.0h, -1.0h, 2.0h, 1.0h),
+    half4(-1.0h, 0.0h, 2.0h, 1.0h),
+    half4(0.0h, 0.0h, 2.0h, 1.0h),
+    half4(1.0h, 0.0h, 2.0h, 1.0h),
+    half4(2.0h, 0.0h, 2.0h, 1.0h),
+    half4(-1.0h, 1.0h, 2.0h, 1.0h),
+    half4(0.0h, 1.0h, 2.0h, 1.0h),
+    half4(1.0h, 1.0h, 2.0h, 1.0h),
+    half4(2.0h, 1.0h, 2.0h, 1.0h),
+    half4(-1.0h, 2.0h, 2.0h, 1.0h),
+    half4(0.0h, 2.0h, 2.0h, 1.0h),
+    half4(1.0h, 2.0h, 2.0h, 1.0h),
+    half4(2.0h, 2.0h, 2.0h, 1.0h),
+    half4(-1.0h, -1.0h, -1.0h, 2.0h),
+    half4(0.0h, -1.0h, -1.0h, 2.0h),
+    half4(1.0h, -1.0h, -1.0h, 2.0h),
+    half4(2.0h, -1.0h, -1.0h, 2.0h),
+    half4(-1.0h, 0.0h, -1.0h, 2.0h),
+    half4(0.0h, 0.0h, -1.0h, 2.0h),
+    half4(1.0h, 0.0h, -1.0h, 2.0h),
+    half4(2.0h, 0.0h, -1.0h, 2.0h),
+    half4(-1.0h, 1.0h, -1.0h, 2.0h),
+    half4(0.0h, 1.0h, -1.0h, 2.0h),
+    half4(1.0h, 1.0h, -1.0h, 2.0h),
+    half4(2.0h, 1.0h, -1.0h, 2.0h),
+    half4(-1.0h, 2.0h, -1.0h, 2.0h),
+    half4(0.0h, 2.0h, -1.0h, 2.0h),
+    half4(1.0h, 2.0h, -1.0h, 2.0h),
+    half4(2.0h, 2.0h, -1.0h, 2.0h),
+    half4(-1.0h, -1.0h, 0.0h, 2.0h),
+    half4(0.0h, -1.0h, 0.0h, 2.0h),
+    half4(1.0h, -1.0h, 0.0h, 2.0h),
+    half4(2.0h, -1.0h, 0.0h, 2.0h),
+    half4(-1.0h, 0.0h, 0.0h, 2.0h),
+    half4(0.0h, 0.0h, 0.0h, 2.0h),
+    half4(1.0h, 0.0h, 0.0h, 2.0h),
+    half4(2.0h, 0.0h, 0.0h, 2.0h),
+    half4(-1.0h, 1.0h, 0.0h, 2.0h),
+    half4(0.0h, 1.0h, 0.0h, 2.0h),
+    half4(1.0h, 1.0h, 0.0h, 2.0h),
+    half4(2.0h, 1.0h, 0.0h, 2.0h),
+    half4(-1.0h, 2.0h, 0.0h, 2.0h),
+    half4(0.0h, 2.0h, 0.0h, 2.0h),
+    half4(1.0h, 2.0h, 0.0h, 2.0h),
+    half4(2.0h, 2.0h, 0.0h, 2.0h),
+    half4(-1.0h, -1.0h, 1.0h, 2.0h),
+    half4(0.0h, -1.0h, 1.0h, 2.0h),
+    half4(1.0h, -1.0h, 1.0h, 2.0h),
+    half4(2.0h, -1.0h, 1.0h, 2.0h),
+    half4(-1.0h, 0.0h, 1.0h, 2.0h),
+    half4(0.0h, 0.0h, 1.0h, 2.0h),
+    half4(1.0h, 0.0h, 1.0h, 2.0h),
+    half4(2.0h, 0.0h, 1.0h, 2.0h),
+    half4(-1.0h, 1.0h, 1.0h, 2.0h),
+    half4(0.0h, 1.0h, 1.0h, 2.0h),
+    half4(1.0h, 1.0h, 1.0h, 2.0h),
+    half4(2.0h, 1.0h, 1.0h, 2.0h),
+    half4(-1.0h, 2.0h, 1.0h, 2.0h),
+    half4(0.0h, 2.0h, 1.0h, 2.0h),
+    half4(1.0h, 2.0h, 1.0h, 2.0h),
+    half4(2.0h, 2.0h, 1.0h, 2.0h),
+    half4(-1.0h, -1.0h, 2.0h, 2.0h),
+    half4(0.0h, -1.0h, 2.0h, 2.0h),
+    half4(1.0h, -1.0h, 2.0h, 2.0h),
+    half4(2.0h, -1.0h, 2.0h, 2.0h),
+    half4(-1.0h, 0.0h, 2.0h, 2.0h),
+    half4(0.0h, 0.0h, 2.0h, 2.0h),
+    half4(1.0h, 0.0h, 2.0h, 2.0h),
+    half4(2.0h, 0.0h, 2.0h, 2.0h),
+    half4(-1.0h, 1.0h, 2.0h, 2.0h),
+    half4(0.0h, 1.0h, 2.0h, 2.0h),
+    half4(1.0h, 1.0h, 2.0h, 2.0h),
+    half4(2.0h, 1.0h, 2.0h, 2.0h),
+    half4(-1.0h, 2.0h, 2.0h, 2.0h),
+    half4(0.0h, 2.0h, 2.0h, 2.0h),
+    half4(1.0h, 2.0h, 2.0h, 2.0h),
+    half4(2.0h, 2.0h, 2.0h, 2.0h),
+};
+
+kernel void q27_matmul_t2_mm_h(
+        device const uchar *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const char *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint2 group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup half Wt[32 * 64];
+    threadgroup half Xt[64 * 16];
+    threadgroup float Sc[4 * 256];
+    const uint row0 = group.x * 32;
+    const uint tok0 = group.y * 16;   // 16-token tile (wide-chunk grid)
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint wrow = tid / 4, wcb = (tid % 4) * 16;
+    device const uchar *wsrc = weights + (ulong)min(row0 + wrow, rlast) * (args.cols / 4);
+    const uint xloc = tid % 16, xcb = (tid / 16) * 8;   // Xt column is tile-local
+    const uint xtok = tok0 + xloc;                       // device rows are global
+    device const char *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * args.cols;
+    const uint rowA = row0 + sg * 8 + lane / 8, rowB = rowA + 4;
+    const ulong wsrowA = (ulong)min(rowA, rlast) * (args.cols / 128);
+    const ulong wsrowB = (ulong)min(rowB, rlast) * (args.cols / 128);
+    simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    float4 racc = 0.0f;
+    threadgroup float *sc = Sc + sg * 256;
+    const uint tokA = tok0 + lane % 8, tokB = tok0 + 8 + lane % 8;
+    for (uint c0 = 0; c0 < args.cols; c0 += 64) {
+        {
+            const uint wp = *(device const uint *)(wsrc + (c0 + wcb) / 4);
+            // Roofline round (docs/plans/2026-07-16-mma-roofline.md): one
+            // byte-LUT gather per 4 trits + 4 vector stores replaces the
+            // 16 shift/mask/int-sub/convert chains and 16 scalar stores —
+            // staged halves are identical values, so output is
+            // bit-identical to the arithmetic unpack. (K=128 staging was
+            // also tried in the round and REGRESSED — 16 KB threadgroup
+            // footprint cost more occupancy than the halved barrier
+            // cadence saved; K=64 stands, as K=32 already showed from the
+            // other side. wcb is a multiple of 16 -> half4-aligned.)
+            threadgroup half4 *dst = (threadgroup half4 *)(Wt + wrow * 64 + wcb);
+            dst[0] = q27_t2_half4_lut[wp         & 0xffu];
+            dst[1] = q27_t2_half4_lut[(wp >>  8) & 0xffu];
+            dst[2] = q27_t2_half4_lut[(wp >> 16) & 0xffu];
+            dst[3] = q27_t2_half4_lut[wp >> 24         ];
+        }
+        {
+            const char4 xa = *(device const char4 *)(xsrc + c0 + xcb);
+            const char4 xb = *(device const char4 *)(xsrc + c0 + xcb + 4);
+            threadgroup half *dst = Xt + xcb * 16 + xloc;
+            // Raw int8 values: exact in half. The per-token 32-group scale
+            // folds at the flush below; invalid token slots stage clamped
+            // real values whose outputs are never stored. (Stores are
+            // 16-strided by tile layout — not vectorizable; a device-side
+            // int8->half pre-pass measured C/Cx = 1.006, not worth a
+            // kernel + ABI bump.)
+            dst[0 * 16] = half(xa.x); dst[1 * 16] = half(xa.y);
+            dst[2 * 16] = half(xa.z); dst[3 * 16] = half(xa.w);
+            dst[4 * 16] = half(xb.x); dst[5 * 16] = half(xb.y);
+            dst[6 * 16] = half(xb.z); dst[7 * 16] = half(xb.w);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const float wsA = float(weight_scales[wsrowA + c0 / 128]);
+        const float wsB = float(weight_scales[wsrowB + c0 / 128]);
+        // Float accumulators keep int8 x trit sums exact to 2^24. The two
+        // 32-K sub-slabs (activation-scale groups) accumulate into separate
+        // tile pairs so both fold in ONE barrier region per staged 64.
+        for (uint k8 = 0; k8 < 32; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc1, a, b, acc1);
+        }
+        for (uint k8 = 32; k8 < 64; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc2, a, b, acc2);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc3, a, b, acc3);
+        }
+        simdgroup_store(acc0, sc, 8);
+        simdgroup_store(acc1, sc + 64, 8);
+        simdgroup_store(acc2, sc + 128, 8);
+        simdgroup_store(acc3, sc + 192, 8);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        {
+            const ulong xrow_a = (ulong)min(tokA, args.x_rows - 1) * (args.cols / 32);
+            const ulong xrow_b = (ulong)min(tokB, args.x_rows - 1) * (args.cols / 32);
+            const float xsA0 = x_scales[xrow_a + c0 / 32],     xsB0 = x_scales[xrow_b + c0 / 32];
+            const float xsA1 = x_scales[xrow_a + c0 / 32 + 1], xsB1 = x_scales[xrow_b + c0 / 32 + 1];
+            racc += float4(sc[lane], sc[lane + 32], sc[lane + 64], sc[lane + 96]) *
+                    float4(wsA * xsA0, wsB * xsA0, wsA * xsB0, wsB * xsB0);
+            racc += float4(sc[lane + 128], sc[lane + 160], sc[lane + 192], sc[lane + 224]) *
+                    float4(wsA * xsA1, wsB * xsA1, wsA * xsB1, wsB * xsB1);
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
+    if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
+    if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
+    if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = racc.w;
+}
+
+
+
+
+// Constrained tool decoding: clear grammar-illegal logits to -inf under a
+// uint32 bitset mask (bit set = legal), so GPU argmax, top-k extraction,
+// and the CPU sampling fallback all see only legal tokens.
+kernel void q27_mask_logits(device float *logits [[buffer(0)]],
+                            device const uint *mask [[buffer(1)]],
+                            constant uint &n [[buffer(2)]],
+                            uint gid [[thread_position_in_grid]]) {
+    if (gid >= n) return;
+    if (!((mask[gid >> 5] >> (gid & 31)) & 1u)) logits[gid] = -INFINITY;
+}
+
+// ---- Chunked layer-major prefill (2..96 tokens per dispatch; per-path
+// caps: MTP rounds and NLL/KL teacher forcing at CHUNK_MAX=12, prompt
+// ingestion at PREFILL_CHUNK_MAX=96 and verify chunks at
+// VERIFY_CHUNK_MAX=48 ----
 //
 // These kernels advance a whole token chunk through one operation so the
 // engine can execute prompts layer-major and route projections through the
@@ -1111,7 +1621,7 @@ kernel void q27_matmul_t2_mm(
 // stay sequential across the chunk inside a single dispatch and commit
 // their state once per chunk.
 
-struct EmbedRowsArgs { uint cols; uint count; uint tokens[12]; };
+struct EmbedRowsArgs { uint cols; uint count; uint tokens[96]; };
 kernel void q27_embedding_q8_rows(
         device const char *weights [[buffer(0)]],
         device const half *scales  [[buffer(1)]],
@@ -1139,6 +1649,7 @@ kernel void q27_embedding_t2_rows(
     out[(ulong)gid.y * args.cols + gid.x] = float(int(code) - 1) * float(scales[si]);
 }
 
+
 struct RowsNormArgs { uint n; uint rows; uint groups; float eps; };
 kernel void q27_rmsnorm_rows_quantized(
         device const float *x [[buffer(0)]], device const float *w [[buffer(1)]],
@@ -1163,7 +1674,10 @@ kernel void q27_rmsnorm_rows_quantized(
     for (uint block = simdgroup; block < blocks; block += 8) {
         const uint i = block * 32 + lane; const float v = or_[i];
         const float amax = simd_max(abs(v)); const float scale = amax / 127.0f;
-        int q = scale > 0.0f ? int(rint(v / scale)) : 0; q = clamp(q, -127, 127);
+        // Reciprocal-multiply matches CUDA k_quantize_x, keeping one rounding
+        // rule across backends (rint == __float2int_rn under RNE).
+        const float qinv = scale > 0.0f ? 1.0f / scale : 0.0f;
+        int q = int(rint(v * qinv)); q = clamp(q, -127, 127);
         vr[i] = char(q); if (lane == 0) sr[block] = scale;
     }
 }
@@ -1229,7 +1743,8 @@ kernel void q27_gdn_gates_rows(device const float *alpha [[buffer(0)]],
     if (gid >= args.heads * args.tokens) return;
     const uint head = gid % args.heads;
     const float value = alpha[gid] + ssm_dt[head];
-    const float softplus = stable_softplus(value);
+    const float softplus = value > 20.0f ? value
+                         : (value < -16.0f ? exp(value) : log1p_f(exp(value)));
     g[gid] = ssm_a[head] * softplus;
     beta[gid] = 1.0f / (1.0f + exp(-beta_raw[gid]));
 }
@@ -1349,6 +1864,32 @@ kernel void q27_rope_neox_rows(device float *x [[buffer(0)]],
     xh[d + args.n_rot / 2] = x0 * sn + x1 * cs;
 }
 
+// OCP e4m3 round-trip (fp8-KV control arm, docs/plans/2026-07-17-fp8-kv-
+// control.md; hot-cells arm, 2026-07-17-kv-e4m3-hot-cells.md): RNE onto
+// the e4m3 grid — 3 mantissa bits, exponent [-6..8], subnormal step
+// 2^-9, saturate to +-448 (no inf; 480 is the NaN encoding). Because the
+// codec is transform-free, round-tripped values are bit-identical to
+// what a real e4m3 cache would feed attention, so store-time rounding is
+// production-exact for this codec (unlike turbo3, whose production
+// attention sums in the WHT domain). frexp is exact and division by a
+// power of two is exact, so rint gives true round-nearest-even on the
+// grid. Finite inputs only (KV rows).
+inline float q27_e4m3_roundtrip(float x) {
+    const float a = fabs(x);
+    if (a == 0.0f) return x;                      // signed zero unchanged
+    float q;
+    if (a > 448.0f) {
+        q = 448.0f;                               // saturate, no infinity
+    } else if (a < 0.015625f) {                   // below min normal 2^-6
+        q = rint(a * 512.0f) * 0.001953125f;      // subnormal grid 2^-9
+    } else {
+        int e; frexp(a, e);                       // a in [2^(e-1), 2^e)
+        const float step = exp2(float(e - 4));    // 2^(exp-3), exp = e-1
+        q = min(rint(a / step) * step, 448.0f);
+    }
+    return x < 0.0f ? -q : q;
+}
+
 struct KvStoreRowsArgs { uint position; uint row_length; uint tokens; };
 kernel void q27_kv_store_f16_rows(device const float *k [[buffer(0)]],
                                    device const float *v [[buffer(1)]],
@@ -1360,6 +1901,33 @@ kernel void q27_kv_store_f16_rows(device const float *k [[buffer(0)]],
     const ulong src = (ulong)gid.y * args.row_length + gid.x;
     const ulong dst = (ulong)(args.position + gid.y) * args.row_length + gid.x;
     kc[dst] = half(k[src]); vc[dst] = half(v[src]);
+}
+
+// KV fp16 exception cells (docs/plans/2026-07-17-kv-except-production.md):
+// copies ONE head's K/V rows out of the packed multi-head staging buffers
+// (src rows are src_stride apart; the head offset rides the buffer binding)
+// into a kv_heads=1 fp16 side cache (dst rows are row_length apart). tokens
+// = 1 covers the serial store. codec 1 (hot-cells arm, 2026-07-17-kv-
+// e4m3-hot-cells.md) rounds each value onto the e4m3 grid before the
+// half store — values-exact for a real 1-byte e4m3 side cache, every
+// downstream kernel unchanged.
+struct KvStoreHeadRowsArgs { uint position; uint src_stride; uint row_length; uint tokens;
+                             uint codec; };
+kernel void q27_kv_store_f16_head_rows(device const float *k [[buffer(0)]],
+                                        device const float *v [[buffer(1)]],
+                                        device half *kc       [[buffer(2)]],
+                                        device half *vc       [[buffer(3)]],
+                                        constant KvStoreHeadRowsArgs &args [[buffer(4)]],
+                                        uint2 gid [[thread_position_in_grid]]) {
+    if (gid.x >= args.row_length || gid.y >= args.tokens) return;
+    const ulong src = (ulong)gid.y * args.src_stride + gid.x;
+    const ulong dst = (ulong)(args.position + gid.y) * args.row_length + gid.x;
+    if (args.codec) {
+        kc[dst] = half(q27_e4m3_roundtrip(k[src]));
+        vc[dst] = half(q27_e4m3_roundtrip(v[src]));
+    } else {
+        kc[dst] = half(k[src]); vc[dst] = half(v[src]);
+    }
 }
 
 struct GateRowsArgs { uint heads; uint head_dim; uint tokens; };
@@ -1440,11 +2008,7 @@ kernel void q27_nll_rows(device const float *logits [[buffer(0)]],
     }
     if (tid == 0) {
         const uint target = tgt[row];
-        if (target >= args.n) {
-            nll[row] = INFINITY;
-            return;
-        }
-        nll[row] = log(values[0]) + mx - xr[target];
+        nll[row] = target < args.n ? log(values[0]) + mx - xr[target] : INFINITY;
     }
 }
 
@@ -1523,6 +2087,80 @@ kernel void q27_attention_f16_causal(device const float *q [[buffer(0)]],
     }
 }
 
+// KV fp16-exception window variant of q27_attention_f16_causal
+// (docs/plans/2026-07-17-kv-except-production.md): identical math over a
+// kv_heads=1 fp16 side cache for a WINDOW of query heads (the base head
+// offset rides the q/out buffer bindings), overwriting the production
+// dispatch's rows for those heads. The one structural difference is
+// out_row_stride: the full output rows are q_heads_total*head_dim apart,
+// while this dispatch only covers window heads — so the stride is explicit
+// instead of derived from args.q_heads. Additive kernel, own args struct:
+// the production causal kernel and the shader ABI are untouched.
+struct AttentionCausalWinArgs {
+    uint q_stride; uint q_row_stride; uint base_len;
+    uint q_heads; uint kv_heads; uint head_dim; uint tokens;
+    uint out_row_stride; float scale;
+};
+kernel void q27_attention_f16_causal_win(device const float *q [[buffer(0)]],
+                                         device const half *kc [[buffer(1)]],
+                                         device const half *vc [[buffer(2)]],
+                                         device float *out      [[buffer(3)]],
+                                         constant AttentionCausalWinArgs &args [[buffer(4)]],
+                                         uint2 group [[threadgroup_position_in_grid]],
+                                         ushort lane [[thread_index_in_simdgroup]],
+                                         ushort sg [[simdgroup_index_in_threadgroup]]) {
+    const uint qh = group.x, token = group.y;
+    if (qh >= args.q_heads || token >= args.tokens) return;
+    const uint seq_len = args.base_len + token;
+    const uint gqa = args.q_heads / args.kv_heads;
+    const uint kvh = qh / gqa;
+    device const float *qh_ptr = q + (ulong)token * args.q_row_stride + (ulong)qh * args.q_stride;
+
+    float acc[8];                       // head_dim <= 256 -> at most 8 dims per lane
+    for (uint i = 0; i < 8; i++) acc[i] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    for (uint p = sg; p < seq_len; p += 8) {
+        device const half *kh = kc + ((ulong)p * args.kv_heads + kvh) * args.head_dim;
+        float partial = 0.0f;
+        for (uint d = lane; d < args.head_dim; d += 32) partial += qh_ptr[d] * float(kh[d]);
+        const float score = simd_sum(partial) * args.scale;
+        const float m_new = max(m, score);
+        const float correction = exp(m - m_new);    // first iteration: exp(-inf) = 0
+        const float weight = exp(score - m_new);
+        l = l * correction + weight;
+        device const half *vh = vc + ((ulong)p * args.kv_heads + kvh) * args.head_dim;
+        for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+            acc[i] = acc[i] * correction + weight * float(vh[d]);
+        m = m_new;
+    }
+
+    threadgroup float tg_m[4], tg_l[4], tg_acc[4][256];
+    for (uint offset = 4; offset >= 1; offset /= 2) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (sg >= offset && sg < 2 * offset) {
+            if (lane == 0) { tg_m[sg - offset] = m; tg_l[sg - offset] = l; }
+            for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+                tg_acc[sg - offset][d] = acc[i];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (sg < offset) {
+            const float m_other = tg_m[sg], l_other = tg_l[sg];
+            const float m_new = max(m, m_other);
+            if (m_new == -INFINITY) continue;       // both stripes empty
+            const float c_mine = exp(m - m_new), c_other = exp(m_other - m_new);
+            l = l * c_mine + l_other * c_other;
+            for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+                acc[i] = acc[i] * c_mine + tg_acc[sg][d] * c_other;
+            m = m_new;
+        }
+    }
+    if (sg == 0) {
+        const float inv = l > 0.0f ? 1.0f / l : 0.0f;
+        for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+            out[(ulong)token * args.out_row_stride + (ulong)qh * args.head_dim + d] = acc[i] * inv;
+    }
+}
+
 kernel void q27_copy_bytes(device const uchar *src [[buffer(0)]],
                             device uchar *dst [[buffer(1)]],
                             constant ulong &bytes [[buffer(2)]],
@@ -1560,7 +2198,12 @@ kernel void q27_turbo_wht(device float *x [[buffer(0)]],
                            uint group [[threadgroup_position_in_grid]],
                            uint j [[thread_index_in_threadgroup]]) {
     const uint head = group >> 1, g = group & 1;
-    if (head >= args.heads || j >= 128) return;
+    // Guards here must be threadgroup-uniform (they derive from
+    // threadgroup_position only): a thread-index guard before the butterfly
+    // barriers is divergent and would under-populate them if a dispatch ever
+    // exceeded 128 threads. The host dispatches exactly 128; width guards
+    // remain host-side.
+    if (head >= args.heads) return;
     device float *xh = x + (ulong)head * args.stride + g * 128;
     threadgroup float xs[128];
     xs[j] = xh[j] * float(args.inverse ? turbo_s2[j] : turbo_s1[j]);
@@ -1577,7 +2220,7 @@ kernel void q27_kv_store_turbo3(device const float *k [[buffer(0)]],
                                  uint2 group [[threadgroup_position_in_grid]],
                                  uint j [[thread_index_in_threadgroup]]) {
     const uint h = group.x >> 1, g = group.x & 1;
-    if (h >= args.kv_heads || group.y >= 2 || j >= 128) return;
+    if (h >= args.kv_heads || group.y >= 2) return;
     device const float *src = (group.y ? v : k) + (ulong)h * 256 + g * 128;
     device uchar *cache = group.y ? vc : kc;
     device uchar *block = cache + ((ulong)args.position * args.kv_heads * 2 + h * 2 + g) * 50;
@@ -1691,7 +2334,7 @@ kernel void q27_kv_store_turbo3_rows(device const float *k [[buffer(0)]],
                                       uint3 group [[threadgroup_position_in_grid]],
                                       uint j [[thread_index_in_threadgroup]]) {
     const uint h = group.x >> 1, g = group.x & 1, token = group.z;
-    if (h >= args.kv_heads || group.y >= 2 || token >= args.tokens || j >= 128) return;
+    if (h >= args.kv_heads || group.y >= 2 || token >= args.tokens) return;
     device const float *src = (group.y ? v : k) +
         (ulong)token * args.kv_heads * 256 + (ulong)h * 256 + g * 128;
     device uchar *cache = group.y ? vc : kc;
@@ -1791,4 +2434,604 @@ kernel void q27_attention_turbo3_causal(device const float *q [[buffer(0)]],
         for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
             out[((ulong)token * args.q_heads + qh) * args.head_dim + d] = acc[i] * inv;
     }
+}
+
+// GQA KV-reuse decode attention. The per-query-head kernels above stream
+// each KV row q_heads/kv_heads (= 6) times; here one threadgroup serves ALL
+// query heads of one KV head over one sequence block: K/V rows are staged
+// (turbo3: dequantized once, not per query head) into threadgroup memory,
+// and one simdgroup per query head runs its own online softmax over the
+// staged tile. Blocks write {m, l, acc[head_dim]} partials (258 floats);
+// q27_attention_gqa_merge folds the blocks in index order — deterministic
+// run-to-run, but NOT bit-equal to the per-query-head kernels (different
+// summation order). The host routes only long sequences here; short
+// contexts keep the proven kernels, and the causal chunk kernels are
+// untouched.
+struct AttentionGqaArgs {
+    uint q_stride;
+    uint seq_len;
+    uint q_heads;
+    uint kv_heads;
+    uint head_dim;
+    uint block;
+    uint n_blocks;
+    float scale;
+};
+
+kernel void q27_attention_f16_gqa(device const float *q [[buffer(0)]],
+                                   device const half *kc [[buffer(1)]],
+                                   device const half *vc [[buffer(2)]],
+                                   device float *partials [[buffer(3)]],
+                                   constant AttentionGqaArgs &args [[buffer(4)]],
+                                   uint2 group [[threadgroup_position_in_grid]],
+                                   ushort lane [[thread_index_in_simdgroup]],
+                                   ushort sg [[simdgroup_index_in_threadgroup]]) {
+    const uint kvh = group.x, blk = group.y;
+    const uint gqa = args.q_heads / args.kv_heads;
+    if (kvh >= args.kv_heads || blk >= args.n_blocks || sg >= gqa) return;
+    const uint p0 = blk * args.block;
+    const uint p1 = min(p0 + args.block, args.seq_len);
+    const uint qh = kvh * gqa + sg;
+    device const float *qh_ptr = q + (ulong)qh * args.q_stride;
+    const uint tid = (uint)sg * 32 + lane, threads = gqa * 32;
+
+    threadgroup float Kt[8][256], Vt[8][256];
+    float acc[8];                       // head_dim <= 256 -> at most 8 dims per lane
+    for (uint i = 0; i < 8; i++) acc[i] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    for (uint t0 = p0; t0 < p1; t0 += 8) {
+        const uint rows = min(8u, p1 - t0);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint idx = tid; idx < rows * args.head_dim; idx += threads) {
+            const uint r = idx / args.head_dim, d = idx % args.head_dim;
+            const ulong row = ((ulong)(t0 + r) * args.kv_heads + kvh) * args.head_dim;
+            Kt[r][d] = float(kc[row + d]);
+            Vt[r][d] = float(vc[row + d]);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint r = 0; r < rows; r++) {
+            float partial = 0.0f;
+            for (uint d = lane; d < args.head_dim; d += 32) partial += qh_ptr[d] * Kt[r][d];
+            const float score = simd_sum(partial) * args.scale;
+            const float m_new = max(m, score);
+            const float correction = exp(m - m_new);    // first iteration: exp(-inf) = 0
+            const float weight = exp(score - m_new);
+            l = l * correction + weight;
+            for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+                acc[i] = acc[i] * correction + weight * Vt[r][d];
+            m = m_new;
+        }
+    }
+    device float *ph = partials + ((ulong)qh * args.n_blocks + blk) * 258;
+    if (lane == 0) { ph[0] = m; ph[1] = l; }
+    for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++) ph[2 + d] = acc[i];
+}
+
+kernel void q27_attention_turbo3_gqa(device const float *q [[buffer(0)]],
+                                      device const uchar *kc [[buffer(1)]],
+                                      device const uchar *vc [[buffer(2)]],
+                                      device float *partials [[buffer(3)]],
+                                      constant AttentionGqaArgs &args [[buffer(4)]],
+                                      uint2 group [[threadgroup_position_in_grid]],
+                                      ushort lane [[thread_index_in_simdgroup]],
+                                      ushort sg [[simdgroup_index_in_threadgroup]]) {
+    const uint kvh = group.x, blk = group.y;
+    const uint gqa = args.q_heads / args.kv_heads;
+    if (kvh >= args.kv_heads || blk >= args.n_blocks || sg >= gqa) return;
+    const uint p0 = blk * args.block;
+    const uint p1 = min(p0 + args.block, args.seq_len);
+    const uint qh = kvh * gqa + sg;
+    device const float *qh_ptr = q + (ulong)qh * args.q_stride;
+    const uint tid = (uint)sg * 32 + lane, threads = gqa * 32;
+
+    threadgroup float Kt[8][256], Vt[8][256];
+    float acc[8];                       // head_dim == 256 -> 8 dims per lane
+    for (uint i = 0; i < 8; i++) acc[i] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    for (uint t0 = p0; t0 < p1; t0 += 8) {
+        const uint rows = min(8u, p1 - t0);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint idx = tid; idx < rows * 256; idx += threads) {
+            const uint r = idx >> 8, d = idx & 255;
+            device const uchar *kb = kc + ((ulong)(t0 + r) * args.kv_heads + kvh) * 2 * 50;
+            device const uchar *vb = vc + ((ulong)(t0 + r) * args.kv_heads + kvh) * 2 * 50;
+            Kt[r][d] = turbo_dequant(kb + (d >> 7) * 50, d & 127);
+            Vt[r][d] = turbo_dequant(vb + (d >> 7) * 50, d & 127);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint r = 0; r < rows; r++) {
+            float partial = 0.0f;
+            for (uint d = lane; d < 256; d += 32) partial += qh_ptr[d] * Kt[r][d];
+            const float score = simd_sum(partial) * args.scale;
+            const float m_new = max(m, score);
+            const float correction = exp(m - m_new);    // first iteration: exp(-inf) = 0
+            const float weight = exp(score - m_new);
+            l = l * correction + weight;
+            for (uint d = lane, i = 0; d < 256; d += 32, i++)
+                acc[i] = acc[i] * correction + weight * Vt[r][d];
+            m = m_new;
+        }
+    }
+    device float *ph = partials + ((ulong)qh * args.n_blocks + blk) * 258;
+    if (lane == 0) { ph[0] = m; ph[1] = l; }
+    for (uint d = lane, i = 0; d < 256; d += 32, i++) ph[2 + d] = acc[i];
+}
+
+// Folds the {m, l, acc} block partials for one query head in block-index
+// order and writes the normalized output row. One simdgroup per query head;
+// a single-block dispatch reduces to normalize-and-store.
+kernel void q27_attention_gqa_merge(device const float *partials [[buffer(0)]],
+                                     device float *out [[buffer(1)]],
+                                     constant AttentionGqaArgs &args [[buffer(2)]],
+                                     uint qh [[threadgroup_position_in_grid]],
+                                     ushort lane [[thread_index_in_simdgroup]]) {
+    if (qh >= args.q_heads) return;
+    float acc[8];
+    for (uint i = 0; i < 8; i++) acc[i] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    for (uint b = 0; b < args.n_blocks; b++) {
+        device const float *ph = partials + ((ulong)qh * args.n_blocks + b) * 258;
+        const float m_other = ph[0], l_other = ph[1];
+        const float m_new = max(m, m_other);
+        if (m_new == -INFINITY) continue;       // both partials empty
+        const float c_mine = exp(m - m_new), c_other = exp(m_other - m_new);
+        l = l * c_mine + l_other * c_other;
+        for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+            acc[i] = acc[i] * c_mine + ph[2 + d] * c_other;
+        m = m_new;
+    }
+    const float inv = l > 0.0f ? 1.0f / l : 0.0f;
+    for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+        out[(ulong)qh * args.head_dim + d] = acc[i] * inv;
+}
+
+// GQA KV-reuse causal chunk attention. Same blocked structure as the decode
+// GQA kernels above — identical tile staging, per-simdgroup online softmax,
+// and block-order merge — so a chunk token's output is bit-identical to the
+// GQA decode kernel at the same sequence length. Grid adds the chunk-token
+// dimension; a token whose visible sequence ends before this block returns
+// before any barrier, and the merge derives each token's live block count
+// from base_len + token, so dead partials are never read.
+struct AttentionGqaCausalArgs {
+    uint q_stride;
+    uint q_row_stride;
+    uint base_len;
+    uint q_heads;
+    uint kv_heads;
+    uint head_dim;
+    uint block;
+    uint n_blocks_max;
+    uint tokens;
+    float scale;
+};
+
+kernel void q27_attention_f16_causal_gqa(device const float *q [[buffer(0)]],
+                                          device const half *kc [[buffer(1)]],
+                                          device const half *vc [[buffer(2)]],
+                                          device float *partials [[buffer(3)]],
+                                          constant AttentionGqaCausalArgs &args [[buffer(4)]],
+                                          uint3 group [[threadgroup_position_in_grid]],
+                                          ushort lane [[thread_index_in_simdgroup]],
+                                          ushort sg [[simdgroup_index_in_threadgroup]]) {
+    const uint kvh = group.x, blk = group.y, token = group.z;
+    const uint gqa = args.q_heads / args.kv_heads;
+    if (kvh >= args.kv_heads || token >= args.tokens || sg >= gqa) return;
+    const uint seq_len = args.base_len + token;
+    const uint p0 = blk * args.block;
+    if (p0 >= seq_len) return;
+    const uint p1 = min(p0 + args.block, seq_len);
+    const uint qh = kvh * gqa + sg;
+    device const float *qh_ptr = q + (ulong)token * args.q_row_stride + (ulong)qh * args.q_stride;
+    const uint tid = (uint)sg * 32 + lane, threads = gqa * 32;
+
+    threadgroup float Kt[8][256], Vt[8][256];
+    float acc[8];                       // head_dim <= 256 -> at most 8 dims per lane
+    for (uint i = 0; i < 8; i++) acc[i] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    for (uint t0 = p0; t0 < p1; t0 += 8) {
+        const uint rows = min(8u, p1 - t0);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint idx = tid; idx < rows * args.head_dim; idx += threads) {
+            const uint r = idx / args.head_dim, d = idx % args.head_dim;
+            const ulong row = ((ulong)(t0 + r) * args.kv_heads + kvh) * args.head_dim;
+            Kt[r][d] = float(kc[row + d]);
+            Vt[r][d] = float(vc[row + d]);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint r = 0; r < rows; r++) {
+            float partial = 0.0f;
+            for (uint d = lane; d < args.head_dim; d += 32) partial += qh_ptr[d] * Kt[r][d];
+            const float score = simd_sum(partial) * args.scale;
+            const float m_new = max(m, score);
+            const float correction = exp(m - m_new);    // first iteration: exp(-inf) = 0
+            const float weight = exp(score - m_new);
+            l = l * correction + weight;
+            for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+                acc[i] = acc[i] * correction + weight * Vt[r][d];
+            m = m_new;
+        }
+    }
+    device float *ph = partials +
+        (((ulong)token * args.q_heads + qh) * args.n_blocks_max + blk) * 258;
+    if (lane == 0) { ph[0] = m; ph[1] = l; }
+    for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++) ph[2 + d] = acc[i];
+}
+
+kernel void q27_attention_turbo3_causal_gqa(device const float *q [[buffer(0)]],
+                                             device const uchar *kc [[buffer(1)]],
+                                             device const uchar *vc [[buffer(2)]],
+                                             device float *partials [[buffer(3)]],
+                                             constant AttentionGqaCausalArgs &args [[buffer(4)]],
+                                             uint3 group [[threadgroup_position_in_grid]],
+                                             ushort lane [[thread_index_in_simdgroup]],
+                                             ushort sg [[simdgroup_index_in_threadgroup]]) {
+    const uint kvh = group.x, blk = group.y, token = group.z;
+    const uint gqa = args.q_heads / args.kv_heads;
+    if (kvh >= args.kv_heads || token >= args.tokens || sg >= gqa) return;
+    const uint seq_len = args.base_len + token;
+    const uint p0 = blk * args.block;
+    if (p0 >= seq_len) return;
+    const uint p1 = min(p0 + args.block, seq_len);
+    const uint qh = kvh * gqa + sg;
+    device const float *qh_ptr = q + (ulong)token * args.q_row_stride + (ulong)qh * args.q_stride;
+    const uint tid = (uint)sg * 32 + lane, threads = gqa * 32;
+
+    threadgroup float Kt[8][256], Vt[8][256];
+    float acc[8];                       // head_dim == 256 -> 8 dims per lane
+    for (uint i = 0; i < 8; i++) acc[i] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    for (uint t0 = p0; t0 < p1; t0 += 8) {
+        const uint rows = min(8u, p1 - t0);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint idx = tid; idx < rows * 256; idx += threads) {
+            const uint r = idx >> 8, d = idx & 255;
+            device const uchar *kb = kc + ((ulong)(t0 + r) * args.kv_heads + kvh) * 2 * 50;
+            device const uchar *vb = vc + ((ulong)(t0 + r) * args.kv_heads + kvh) * 2 * 50;
+            Kt[r][d] = turbo_dequant(kb + (d >> 7) * 50, d & 127);
+            Vt[r][d] = turbo_dequant(vb + (d >> 7) * 50, d & 127);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint r = 0; r < rows; r++) {
+            float partial = 0.0f;
+            for (uint d = lane; d < 256; d += 32) partial += qh_ptr[d] * Kt[r][d];
+            const float score = simd_sum(partial) * args.scale;
+            const float m_new = max(m, score);
+            const float correction = exp(m - m_new);    // first iteration: exp(-inf) = 0
+            const float weight = exp(score - m_new);
+            l = l * correction + weight;
+            for (uint d = lane, i = 0; d < 256; d += 32, i++)
+                acc[i] = acc[i] * correction + weight * Vt[r][d];
+            m = m_new;
+        }
+    }
+    device float *ph = partials +
+        (((ulong)token * args.q_heads + qh) * args.n_blocks_max + blk) * 258;
+    if (lane == 0) { ph[0] = m; ph[1] = l; }
+    for (uint d = lane, i = 0; d < 256; d += 32, i++) ph[2 + d] = acc[i];
+}
+
+// Causal-chunk merge: folds each (token, query head)'s live blocks in index
+// order. The live block count comes from base_len + token, so partials of
+// blocks past a token's visible sequence are never touched.
+kernel void q27_attention_gqa_merge_rows(device const float *partials [[buffer(0)]],
+                                          device float *out [[buffer(1)]],
+                                          constant AttentionGqaCausalArgs &args [[buffer(2)]],
+                                          uint2 group [[threadgroup_position_in_grid]],
+                                          ushort lane [[thread_index_in_simdgroup]]) {
+    const uint qh = group.x, token = group.y;
+    if (qh >= args.q_heads || token >= args.tokens) return;
+    const uint seq_len = args.base_len + token;
+    const uint live_blocks = 1 + (seq_len - 1) / args.block;    // base_len >= 1 host-checked
+    float acc[8];
+    for (uint i = 0; i < 8; i++) acc[i] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    for (uint b = 0; b < live_blocks; b++) {
+        device const float *ph = partials +
+            (((ulong)token * args.q_heads + qh) * args.n_blocks_max + b) * 258;
+        const float m_other = ph[0], l_other = ph[1];
+        const float m_new = max(m, m_other);
+        if (m_new == -INFINITY) continue;       // both partials empty
+        const float c_mine = exp(m - m_new), c_other = exp(m_other - m_new);
+        l = l * c_mine + l_other * c_other;
+        for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+            acc[i] = acc[i] * c_mine + ph[2 + d] * c_other;
+        m = m_new;
+    }
+    const float inv = l > 0.0f ? 1.0f / l : 0.0f;
+    for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++)
+        out[((ulong)token * args.q_heads + qh) * args.head_dim + d] = acc[i] * inv;
+}
+
+// Token-tiled causal GQA. The production factor-2 route shares each
+// dequantized KV tile across two teacher-forced tokens while preserving each
+// token's arithmetic order and the existing partials merge layout.
+// R1b: token-tiled causal GQA. TF chunk tokens share one (kvh, blk)
+// threadgroup: each staged 8-row tile is dequantized once and every resident
+// token's per-simdgroup online softmax walks it in token order — the KV
+// device stream and dequant ALU divide by TF while each token's arithmetic
+// sequence is unchanged, so per-token output is bit-identical to the
+// untiled causal GQA kernels (Phase-0 memcmp plus the chunk↔decode parity
+// suite). Factor 2 is production (2.0× at 32K+); factor 4 measured strictly
+// worse (register pressure) and exists only for the bench comparison.
+// Causality: position rows at or past a token's visible sequence are skipped
+// per token; only the tile containing a token's own boundary diverges across
+// the TF tokens. Partials land at the same per-token slots, so the existing
+// merge kernel is reused unchanged.
+template <uint TF>
+inline void turbo3_causal_gqa_tiled_body(device const float *q,
+                                          device const uchar *kc,
+                                          device const uchar *vc,
+                                          device float *partials,
+                                          constant AttentionGqaCausalArgs &args,
+                                          uint3 group, ushort lane, ushort sg,
+                                          threadgroup float (*Kt)[256],
+                                          threadgroup float (*Vt)[256]) {
+    const uint kvh = group.x, blk = group.y, tile0 = group.z * TF;
+    const uint gqa = args.q_heads / args.kv_heads;
+    if (kvh >= args.kv_heads || tile0 >= args.tokens || sg >= gqa) return;
+    const uint live = min(TF, args.tokens - tile0);
+    const uint p0 = blk * args.block;
+    // Exclusive sequence length for the deepest live token. `base_len` is
+    // already position + 1, so this includes that token's newest KV row.
+    const uint max_seq_len = args.base_len + tile0 + live - 1;
+    if (p0 >= max_seq_len) return;
+    const uint p1 = min(p0 + args.block, max_seq_len);
+    const uint qh = kvh * gqa + sg;
+    const uint tid = (uint)sg * 32 + lane, threads = gqa * 32;
+    device const float *qp[TF];
+    for (uint f = 0; f < TF; f++)
+        qp[f] = q + (ulong)(tile0 + min(f, live - 1)) * args.q_row_stride + (ulong)qh * args.q_stride;
+
+    float acc[TF][8];
+    float m[TF], l[TF];
+    for (uint f = 0; f < TF; f++) {
+        m[f] = -INFINITY; l[f] = 0.0f;
+        for (uint i = 0; i < 8; i++) acc[f][i] = 0.0f;
+    }
+    for (uint t0 = p0; t0 < p1; t0 += 8) {
+        const uint rows = min(8u, p1 - t0);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint idx = tid; idx < rows * 256; idx += threads) {
+            const uint r = idx >> 8, d = idx & 255;
+            device const uchar *kb = kc + ((ulong)(t0 + r) * args.kv_heads + kvh) * 2 * 50;
+            device const uchar *vb = vc + ((ulong)(t0 + r) * args.kv_heads + kvh) * 2 * 50;
+            Kt[r][d] = turbo_dequant(kb + (d >> 7) * 50, d & 127);
+            Vt[r][d] = turbo_dequant(vb + (d >> 7) * 50, d & 127);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint r = 0; r < rows; r++) {
+            const uint pos = t0 + r;
+            float partial[TF];
+            for (uint f = 0; f < TF; f++) partial[f] = 0.0f;
+            for (uint d = lane; d < 256; d += 32) {
+                const float k = Kt[r][d];
+                for (uint f = 0; f < TF; f++) partial[f] += qp[f][d] * k;
+            }
+            float corr[TF], w[TF];
+            bool vis[TF];
+            for (uint f = 0; f < TF; f++) {
+                vis[f] = f < live && pos < args.base_len + tile0 + f;
+                corr[f] = 1.0f; w[f] = 0.0f;
+                if (vis[f]) {
+                    const float score = simd_sum(partial[f]) * args.scale;
+                    const float m_new = max(m[f], score);
+                    corr[f] = exp(m[f] - m_new);            // first iteration: exp(-inf) = 0
+                    w[f] = exp(score - m_new);
+                    l[f] = l[f] * corr[f] + w[f];
+                    m[f] = m_new;
+                }
+            }
+            for (uint d = lane, i = 0; d < 256; d += 32, i++) {
+                const float v = Vt[r][d];
+                for (uint f = 0; f < TF; f++)
+                    if (vis[f]) acc[f][i] = acc[f][i] * corr[f] + w[f] * v;
+            }
+        }
+    }
+    for (uint f = 0; f < live; f++) {
+        if (p0 >= args.base_len + tile0 + f) continue;    // merge never reads this slot
+        device float *ph = partials +
+            (((ulong)(tile0 + f) * args.q_heads + qh) * args.n_blocks_max + blk) * 258;
+        if (lane == 0) { ph[0] = m[f]; ph[1] = l[f]; }
+        for (uint d = lane, i = 0; d < 256; d += 32, i++) ph[2 + d] = acc[f][i];
+    }
+}
+kernel void q27_attention_turbo3_causal_gqa_t2(device const float *q [[buffer(0)]],
+        device const uchar *kc [[buffer(1)]], device const uchar *vc [[buffer(2)]],
+        device float *partials [[buffer(3)]],
+        constant AttentionGqaCausalArgs &args [[buffer(4)]],
+        uint3 group [[threadgroup_position_in_grid]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup float Kt[8][256], Vt[8][256];
+    turbo3_causal_gqa_tiled_body<2>(q, kc, vc, partials, args, group, lane, sg, Kt, Vt);
+}
+// fp16 token-tiled causal GQA: the same tiling transform applied to
+// q27_attention_f16_causal_gqa — head_dim-parametric staging and d-loops
+// mirror the untiled kernel expression-for-expression so per-token output
+// stays bit-identical.
+template <uint TF>
+inline void f16_causal_gqa_tiled_body(device const float *q,
+                                       device const half *kc,
+                                       device const half *vc,
+                                       device float *partials,
+                                       constant AttentionGqaCausalArgs &args,
+                                       uint3 group, ushort lane, ushort sg,
+                                       threadgroup float (*Kt)[256],
+                                       threadgroup float (*Vt)[256]) {
+    const uint kvh = group.x, blk = group.y, tile0 = group.z * TF;
+    const uint gqa = args.q_heads / args.kv_heads;
+    if (kvh >= args.kv_heads || tile0 >= args.tokens || sg >= gqa) return;
+    const uint live = min(TF, args.tokens - tile0);
+    const uint p0 = blk * args.block;
+    // Exclusive sequence length for the deepest live token. `base_len` is
+    // already position + 1, so this includes that token's newest KV row.
+    const uint max_seq_len = args.base_len + tile0 + live - 1;
+    if (p0 >= max_seq_len) return;
+    const uint p1 = min(p0 + args.block, max_seq_len);
+    const uint qh = kvh * gqa + sg;
+    const uint tid = (uint)sg * 32 + lane, threads = gqa * 32;
+    device const float *qp[TF];
+    for (uint f = 0; f < TF; f++)
+        qp[f] = q + (ulong)(tile0 + min(f, live - 1)) * args.q_row_stride + (ulong)qh * args.q_stride;
+
+    float acc[TF][8];
+    float m[TF], l[TF];
+    for (uint f = 0; f < TF; f++) {
+        m[f] = -INFINITY; l[f] = 0.0f;
+        for (uint i = 0; i < 8; i++) acc[f][i] = 0.0f;
+    }
+    for (uint t0 = p0; t0 < p1; t0 += 8) {
+        const uint rows = min(8u, p1 - t0);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint idx = tid; idx < rows * args.head_dim; idx += threads) {
+            const uint r = idx / args.head_dim, d = idx % args.head_dim;
+            const ulong row = ((ulong)(t0 + r) * args.kv_heads + kvh) * args.head_dim;
+            Kt[r][d] = float(kc[row + d]);
+            Vt[r][d] = float(vc[row + d]);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint r = 0; r < rows; r++) {
+            const uint pos = t0 + r;
+            float partial[TF];
+            for (uint f = 0; f < TF; f++) partial[f] = 0.0f;
+            for (uint d = lane; d < args.head_dim; d += 32) {
+                const float k = Kt[r][d];
+                for (uint f = 0; f < TF; f++) partial[f] += qp[f][d] * k;
+            }
+            float corr[TF], w[TF];
+            bool vis[TF];
+            for (uint f = 0; f < TF; f++) {
+                vis[f] = f < live && pos < args.base_len + tile0 + f;
+                corr[f] = 1.0f; w[f] = 0.0f;
+                if (vis[f]) {
+                    const float score = simd_sum(partial[f]) * args.scale;
+                    const float m_new = max(m[f], score);
+                    corr[f] = exp(m[f] - m_new);            // first iteration: exp(-inf) = 0
+                    w[f] = exp(score - m_new);
+                    l[f] = l[f] * corr[f] + w[f];
+                    m[f] = m_new;
+                }
+            }
+            for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++) {
+                const float v = Vt[r][d];
+                for (uint f = 0; f < TF; f++)
+                    if (vis[f]) acc[f][i] = acc[f][i] * corr[f] + w[f] * v;
+            }
+        }
+    }
+    for (uint f = 0; f < live; f++) {
+        if (p0 >= args.base_len + tile0 + f) continue;
+        device float *ph = partials +
+            (((ulong)(tile0 + f) * args.q_heads + qh) * args.n_blocks_max + blk) * 258;
+        if (lane == 0) { ph[0] = m[f]; ph[1] = l[f]; }
+        for (uint d = lane, i = 0; d < args.head_dim; d += 32, i++) ph[2 + d] = acc[f][i];
+    }
+}
+
+kernel void q27_attention_f16_causal_gqa_t2(device const float *q [[buffer(0)]],
+        device const half *kc [[buffer(1)]], device const half *vc [[buffer(2)]],
+        device float *partials [[buffer(3)]],
+        constant AttentionGqaCausalArgs &args [[buffer(4)]],
+        uint3 group [[threadgroup_position_in_grid]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup float Kt[8][256], Vt[8][256];
+    f16_causal_gqa_tiled_body<2>(q, kc, vc, partials, args, group, lane, sg, Kt, Vt);
+}
+
+// Top-k candidate extraction for GPU-assisted sampling: a 16-bit radix
+// select finds a threshold whose over-set contains the true top-k, then
+// compacts (value, index) pairs so the host reads ~k candidates instead of
+// the whole vocabulary. The over-set can exceed k on 16-bit-key ties; the
+// host truncates after an exact sort, and falls back to a full logits
+// readback when out_count exceeds the capacity (degenerate tie storms).
+struct TopkArgs { uint n; uint k; uint capacity; };
+
+inline uint topk_sortable(float value) {
+    // Monotonic finite-float -> uint map: larger float == larger key.
+    // NaNs never enter the radix set; q27_topk_logits emits a fallback
+    // sentinel so the host reads and validates the complete row instead.
+    // CPU float comparison treats -0 and +0 as equal, so canonicalize both
+    // before radix keying and leave token-index order to the host exact sort.
+    uint u = as_type<uint>(value == 0.0f ? 0.0f : value);
+    return (u & 0x80000000u) ? ~u : (u | 0x80000000u);
+}
+
+kernel void q27_topk_logits(device const float *logits [[buffer(0)]],
+                             device float *out_values [[buffer(1)]],
+                             device uint *out_indices [[buffer(2)]],
+                             device atomic_uint *out_count [[buffer(3)]],
+                             constant TopkArgs &args [[buffer(4)]],
+                             uint tid [[thread_position_in_threadgroup]],
+                             uint threads [[threads_per_threadgroup]]) {
+    threadgroup atomic_uint hist[256];
+    threadgroup atomic_uint nan_seen;
+    threadgroup uint tg_b1, tg_above, tg_threshold;
+
+    // Pass 1: histogram of the top key byte; find the bin where the
+    // descending cumulative count crosses k, and the count strictly above it.
+    for (uint b = tid; b < 256; b += threads) atomic_store_explicit(&hist[b], 0u, memory_order_relaxed);
+    if (tid == 0) atomic_store_explicit(&nan_seen, 0u, memory_order_relaxed);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint i = tid; i < args.n; i += threads) {
+        const float value = logits[i];
+        if (isnan(value))
+            atomic_store_explicit(&nan_seen, 1u, memory_order_relaxed);
+        else
+            atomic_fetch_add_explicit(&hist[topk_sortable(value) >> 24], 1u, memory_order_relaxed);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid == 0) {
+        uint cumulative = 0, bin = 255;
+        for (;; bin--) {
+            const uint count = atomic_load_explicit(&hist[bin], memory_order_relaxed);
+            if (cumulative + count >= args.k || bin == 0) { tg_above = cumulative; break; }
+            cumulative += count;
+        }
+        tg_b1 = bin;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const uint b1 = tg_b1;
+    const uint above = tg_above;
+
+    // Pass 2: histogram of the second byte within the boundary bin; walk it
+    // for the k - above candidates the boundary bin must still supply.
+    for (uint b = tid; b < 256; b += threads) atomic_store_explicit(&hist[b], 0u, memory_order_relaxed);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint i = tid; i < args.n; i += threads) {
+        const float value = logits[i];
+        if (isnan(value)) continue;
+        const uint key = topk_sortable(value);
+        if ((key >> 24) == b1)
+            atomic_fetch_add_explicit(&hist[(key >> 16) & 255u], 1u, memory_order_relaxed);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid == 0) {
+        const uint remaining = args.k > above ? args.k - above : 1;
+        uint cumulative = 0, bin = 255;
+        for (;; bin--) {
+            cumulative += atomic_load_explicit(&hist[bin], memory_order_relaxed);
+            if (cumulative >= remaining || bin == 0) break;
+        }
+        tg_threshold = (b1 << 8) | bin;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const uint threshold = tg_threshold;
+
+    // Pass 3: compact every finite candidate at or above the 16-bit
+    // threshold. Any NaN replaces the final count with a fallback sentinel
+    // after all compaction writes have completed.
+    for (uint i = tid; i < args.n; i += threads) {
+        const float value = logits[i];
+        if (isnan(value)) continue;
+        const uint key16 = topk_sortable(value) >> 16;
+        if (key16 >= threshold) {
+            const uint slot = atomic_fetch_add_explicit(out_count, 1u, memory_order_relaxed);
+            if (slot < args.capacity) { out_values[slot] = value; out_indices[slot] = i; }
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_device | mem_flags::mem_threadgroup);
+    if (tid == 0 && atomic_load_explicit(&nan_seen, memory_order_relaxed))
+        atomic_store_explicit(out_count, args.capacity + 1u, memory_order_relaxed);
 }

--- a/src/metal/serving_policy.h
+++ b/src/metal/serving_policy.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+
+namespace q27 {
+enum class MetalEndpoint { Completions, Chat, Messages, Responses };
+
+inline uint32_t metal_default_max_tokens(MetalEndpoint endpoint) {
+    switch(endpoint) {
+        case MetalEndpoint::Completions:
+        case MetalEndpoint::Chat: return 256;
+        case MetalEndpoint::Messages: return 1024;
+        case MetalEndpoint::Responses: return 4096;
+    }
+    return 256;
+}
+
+// Request-local speculation width. Admission must reserve only for the decode
+// path this request can actually take, not every server-level capability.
+inline uint32_t metal_serving_speculation_width(
+    uint32_t mtp_width, bool has_mtp,
+    bool chunked_prefill, bool sampled, bool sample_plain,
+    bool bounded_reasoning) {
+    if (bounded_reasoning || !chunked_prefill) return 0;
+    if (mtp_width && has_mtp && !(sampled && sample_plain)) return mtp_width;
+    return 0;
+}
+
+inline uint32_t metal_max_prompt_tokens(uint32_t context,
+                                        uint32_t speculation_width) {
+    const uint32_t reserve = 1 + speculation_width;
+    return context > reserve ? context - reserve : 1;
+}
+
+// Once the output count is clamped to the remaining context, speculative
+// decode only needs the lanes this request can actually consume. One-token
+// (resident-logit) and zero-token requests need no extra prompt reserve.
+inline uint32_t metal_max_prompt_tokens_for_request(
+    uint32_t context, uint32_t speculation_width, uint32_t output_tokens) {
+    if (output_tokens <= 1) return context;
+    const uint32_t reserve = std::min(speculation_width, output_tokens - 1);
+    return context > reserve ? context - reserve : 1;
+}
+
+inline uint32_t metal_max_generation_tokens(uint64_t prompt_tokens,
+                                            uint32_t context) {
+    if(prompt_tokens>context) return 0;
+    return context-(uint32_t)prompt_tokens+(prompt_tokens?1u:0u);
+}
+
+inline bool metal_generation_fits(uint64_t prompt_tokens,uint32_t count,
+                                  uint32_t context) {
+    return count<=metal_max_generation_tokens(prompt_tokens,context);
+}
+
+inline std::string metal_snapshot_head_mask_tag(const uint8_t* masks,size_t count) {
+    static constexpr char hex[]="0123456789abcdef";
+    std::string tag;
+    tag.reserve(count*2);
+    for(size_t i=0;i<count;i++) {
+        tag.push_back(hex[masks[i]>>4]);
+        tag.push_back(hex[masks[i]&15]);
+    }
+    return tag;
+}
+
+inline bool metal_tool_constraint_enabled(bool constrain_tools,bool has_tools,
+                                          bool greedy,uint32_t speculation_width,
+                                          bool forced_tool_choice) {
+    return constrain_tools && has_tools && greedy && speculation_width==0 &&
+           !forced_tool_choice;
+}
+
+inline bool responses_closed_tool_tail_after_segment(
+    bool closed_tool_tail, bool just_closed_tool, bool reasoning,
+    const std::string& text) {
+    if(reasoning) return false;
+    if(just_closed_tool) closed_tool_tail=true;
+    if(text.find_first_not_of(" \t\r\n")!=std::string::npos) return false;
+    return closed_tool_tail;
+}
+
+inline int responses_output_index_after_stream_item(
+    int current_index, int reserved_index, bool emitted) {
+    return emitted && reserved_index>=0 ? reserved_index+1 : current_index;
+}
+
+inline bool responses_token_limit_remains(bool token_limit_reached,
+                                          bool accepted_tool_call,
+                                          bool tool_calls_clean,
+                                          bool final_tool_incomplete) {
+    return token_limit_reached &&
+           !(accepted_tool_call && tool_calls_clean && !final_tool_incomplete);
+}
+
+
+} // namespace q27

--- a/src/metal/snapshot_evict.h
+++ b/src/metal/snapshot_evict.h
@@ -1,0 +1,66 @@
+#pragma once
+// T1 spine-vs-leaf eviction ordering (docs/plans/2026-07-18-t1-snapshot-
+// eviction-classes.md). Header-only and free of GPU/engine dependencies so
+// the ordering is unit-testable offline (tools/test_snapshot_evict.cpp)
+// without a resident model — this box holds exactly one.
+//
+// Semantics: a snapshot is SPINE iff its stored token ids are a STRICT
+// prefix of another stored snapshot's (the conversation grew past it). With
+// the pin on, eviction removes every leaf (mtime-oldest first) before any
+// spine (mtime-oldest first). Recency is already persisted by the caller's
+// touch-on-hit mtime, so within a class the order stays mtime-oldest first
+// — the pin only reorders ACROSS the spine/leaf classes. Eviction only ever
+// deletes files: a wrong victim costs a re-prefill, never a wrong result.
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace q27 {
+
+struct EvictCandidate {
+    std::string path;
+    uint64_t size = 0;
+    uint64_t mtime = 0;      // opaque; only ordering matters
+    bool spine = false;
+};
+
+// Mark spine bits: candidate i is spine iff tokens[i] is a strict prefix of
+// tokens[j] for some j != i. Entries missing from `tokens` stay leaves.
+inline void mark_spine(std::vector<EvictCandidate>& files,
+                       const std::map<std::string, std::vector<uint32_t>>& tokens) {
+    for (size_t i = 0; i < files.size(); i++) {
+        auto ai = tokens.find(files[i].path);
+        if (ai == tokens.end()) { files[i].spine = false; continue; }
+        const std::vector<uint32_t>& a = ai->second;
+        bool spine = false;
+        for (size_t j = 0; j < files.size(); j++) {
+            if (i == j) continue;
+            auto bi = tokens.find(files[j].path);
+            if (bi == tokens.end()) continue;
+            const std::vector<uint32_t>& b = bi->second;
+            if (a.size() < b.size() && std::equal(a.begin(), a.end(), b.begin())) { spine = true; break; }
+        }
+        files[i].spine = spine;
+    }
+}
+
+// Eviction victim order: with pin, leaves before spine (each mtime-oldest
+// first); without pin, flat mtime-oldest first. stable_sort keeps mtime
+// order within a class.
+inline void eviction_order(std::vector<EvictCandidate>& files, bool spine_pin) {
+    if (spine_pin) {
+        std::stable_sort(files.begin(), files.end(), [](const EvictCandidate& x, const EvictCandidate& y) {
+            if (x.spine != y.spine) return !x.spine;   // leaves first
+            return x.mtime < y.mtime;
+        });
+    } else {
+        std::stable_sort(files.begin(), files.end(), [](const EvictCandidate& x, const EvictCandidate& y) {
+            return x.mtime < y.mtime;
+        });
+    }
+}
+
+} // namespace q27

--- a/src/metal/stream_format.h
+++ b/src/metal/stream_format.h
@@ -1,0 +1,290 @@
+// Model-free streaming helpers for the Metal server: UTF-8 boundary gating,
+// stop-sequence holdback, and SSE event framing. Kept separate from the
+// engine so the SSE shapes and stop logic have unit coverage that runs
+// without the model artifact (build/test_metal_stream). The event shapes and
+// the UTF-8 gate mirror the CUDA reference server (src/server.cu,
+// src/api_common.h) so Metal and CUDA are wire-compatible.
+#pragma once
+
+#include "../../third_party/json.hpp"
+// Utf8Gate now comes from the shared header directly (it was a verbatim
+// copy here until the 2026-07-17 agentic-parity round, which made the
+// Metal server consume api_common.h wholesale — one gate, both servers).
+#include "../api_common.h"
+
+#include <algorithm>
+#include <array>
+#include <queue>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace q27 {
+
+// Stop-sequence holdback for streaming text. Implements the OpenAI `stop` /
+// Anthropic `stop_sequences` contract for an incremental byte stream: text up
+// to (but not including) the first stop occurrence is emitted, the stop
+// sequence itself and everything after it is suppressed, and generation stops.
+// Because pieces arrive incrementally, a trailing substring of the emitted
+// text that could still grow into a stop sequence is held back until it is
+// resolved (completed -> stop, or diverged -> released). This is the standard
+// partial-prefix holdback; without it a stop sequence split across two tokens
+// would leak its first half to the client before the match fires.
+inline constexpr size_t kMaxOpenAIStopSequences=4;
+inline constexpr size_t kMaxStopSequenceTotalBytes=64u<<10;
+
+inline void validate_stop_sequences(const std::vector<std::string>& stops,
+                                    bool openai_count_limit=false) {
+    if(openai_count_limit && stops.size()>kMaxOpenAIStopSequences)
+        throw std::invalid_argument("too many stop sequences");
+    size_t total=0;
+    for(const std::string& stop:stops) {
+        if(stop.size()>kMaxStopSequenceTotalBytes-total)
+            throw std::invalid_argument("stop sequences too large");
+        total+=stop.size();
+    }
+}
+
+struct StopBuffer {
+    struct Node {
+        int edge=-1;
+        uint32_t fail=0;
+        uint32_t depth=0;
+        int terminal=-1;
+        int output=-1;
+    };
+    struct Edge {
+        uint32_t child=0;
+        int next=-1;
+        unsigned char byte=0;
+    };
+    static_assert(sizeof(Node)<=24,"stop trie nodes must remain compact");
+    static_assert(sizeof(Edge)<=12,"stop trie edges must remain compact");
+
+    std::vector<std::string> stops;
+    std::string pend;
+    size_t pend_head=0;
+    int matched = -1; // index into `stops` once a full match fires, else -1
+    std::vector<Node> nodes;
+    std::vector<Edge> edges;
+    std::array<int,256> root_next;
+    uint32_t state=0;
+    size_t candidate_pos=std::string::npos;
+    int candidate_idx=-1;
+
+    int child_index(uint32_t node,unsigned char c) const {
+        if(node==0) return root_next[c];
+        for(int edge=nodes[node].edge;edge>=0;edge=edges[(size_t)edge].next)
+            if(edges[(size_t)edge].byte==c) return (int)edges[(size_t)edge].child;
+        return -1;
+    }
+
+    uint32_t ensure_child(uint32_t node,unsigned char c) {
+        const int found=child_index(node,c);
+        if(found>=0) return (uint32_t)found;
+        const uint32_t child=(uint32_t)nodes.size();
+        nodes.emplace_back();
+        nodes[child].depth=nodes[node].depth+1;
+        edges.push_back({child,nodes[node].edge,c});
+        nodes[node].edge=(int)edges.size()-1;
+        if(node==0) root_next[c]=(int)child;
+        return child;
+    }
+
+    explicit StopBuffer(std::vector<std::string> seqs = {}) : stops(std::move(seqs)) {
+        // Drop empty stop strings: they would "match" at every position.
+        stops.erase(std::remove(stops.begin(), stops.end(), std::string()), stops.end());
+        validate_stop_sequences(stops);
+        root_next.fill(-1);
+        nodes.emplace_back();
+        for(size_t si=0;si<stops.size();si++) {
+            uint32_t node=0;
+            for(unsigned char c:stops[si]) node=ensure_child(node,c);
+            if(nodes[node].terminal<0 || (int)si<nodes[node].terminal)
+                nodes[node].terminal=(int)si;
+            nodes[node].output=nodes[node].terminal;
+        }
+        auto better_output=[&](int candidate,int current) {
+            if(candidate<0) return false;
+            if(current<0) return true;
+            const size_t candidate_len=stops[(size_t)candidate].size();
+            const size_t current_len=stops[(size_t)current].size();
+            return candidate_len>current_len ||
+                (candidate_len==current_len && candidate<current);
+        };
+        std::queue<uint32_t> pending;
+        for(int edge=nodes[0].edge;edge>=0;edge=edges[(size_t)edge].next)
+            pending.push(edges[(size_t)edge].child);
+        while(!pending.empty()) {
+            const uint32_t parent=pending.front();
+            pending.pop();
+            for(int edge=nodes[parent].edge;edge>=0;edge=edges[(size_t)edge].next) {
+                const unsigned char c=edges[(size_t)edge].byte;
+                const uint32_t child=edges[(size_t)edge].child;
+                uint32_t fallback=nodes[parent].fail;
+                int next=child_index(fallback,c);
+                while(fallback && next<0) {
+                    fallback=nodes[fallback].fail;
+                    next=child_index(fallback,c);
+                }
+                if(next>=0 && (uint32_t)next!=child) nodes[child].fail=(uint32_t)next;
+                const int inherited=nodes[nodes[child].fail].output;
+                if(better_output(inherited,nodes[child].output))
+                    nodes[child].output=inherited;
+                pending.push(child);
+            }
+        }
+    }
+
+    size_t pending_size() const { return pend.size()-pend_head; }
+
+    void compact_pending() {
+        if(pend_head>=4096 && pend_head>=pend.size()-pend_head) {
+            pend.erase(0,pend_head);
+            pend_head=0;
+        }
+    }
+
+    bool candidate_ready() const {
+        if(candidate_idx<0) return false;
+        // A still-active prefix can delay a completed stop only when it began
+        // earlier. A longer stop beginning at the same byte must not consume
+        // more generated output after a complete stop has already matched.
+        const size_t active_start=pending_size()-nodes[state].depth;
+        return active_start>=candidate_pos;
+    }
+
+    std::string finish_match(bool& stopped) {
+        stopped=true;
+        matched=candidate_idx;
+        std::string out=pend.substr(pend_head,candidate_pos);
+        pend.clear();
+        pend_head=0;
+        state=0;
+        candidate_pos=std::string::npos;
+        candidate_idx=-1;
+        return out;
+    }
+
+    bool active() const { return !stops.empty(); }
+
+    // Feed one decoded (already UTF-8-gated) piece. A compact Aho-Corasick
+    // automaton makes matching linear in generated bytes regardless of the
+    // number or length of accepted Anthropic stop sequences.
+    std::string feed(const std::string& piece, bool& stopped) {
+        stopped=false;
+        if(stops.empty()) return piece;
+        for(unsigned char c:piece) {
+            pend.push_back((char)c);
+            int next=child_index(state,c);
+            while(state && next<0) {
+                state=nodes[state].fail;
+                next=child_index(state,c);
+            }
+            state=next<0?0:(uint32_t)next;
+            const int candidate=nodes[state].output;
+            if(candidate>=0) {
+                const size_t pos=pending_size()-stops[(size_t)candidate].size();
+                if(pos<candidate_pos || (pos==candidate_pos && candidate<candidate_idx)) {
+                    candidate_pos=pos;
+                    candidate_idx=candidate;
+                }
+            }
+            if(candidate_ready()) return finish_match(stopped);
+        }
+        size_t emit_len=pending_size()-nodes[state].depth;
+        if(candidate_idx>=0) emit_len=std::min(emit_len,candidate_pos);
+        std::string out=pend.substr(pend_head,emit_len);
+        pend_head+=emit_len;
+        if(candidate_idx>=0) candidate_pos-=emit_len;
+        compact_pending();
+        return out;
+    }
+
+    // End of stream resolves any provisional match now that no earlier,
+    // longer prefix can complete.
+    std::string flush(bool* did_stop=nullptr) {
+        if(candidate_idx>=0) {
+            bool stopped=false;
+            std::string out=finish_match(stopped);
+            if(did_stop) *did_stop=true;
+            return out;
+        }
+        std::string out=pend.substr(pend_head);
+        pend.clear();
+        pend_head=0;
+        state=0;
+        if(did_stop) *did_stop=false;
+        return out;
+    }
+};
+
+// ---- SSE framing (mirrors src/server.cu) ----
+
+// Invalid-UTF-8-tolerant serialize: json::dump's strict default throws
+// type_error.316, and an uncaught throw inside a streaming provider is
+// std::terminate. The Utf8Gate keeps split characters intact; this is the
+// backstop for everything else. Same as server.cu's file-scope jdump.
+inline std::string sse_dump(const nlohmann::json& j) {
+    return j.dump(-1, ' ', false, nlohmann::json::error_handler_t::replace);
+}
+
+// OpenAI framing: "data: {json}\n\n".
+inline std::string sse_data(const nlohmann::json& j) {
+    return "data: " + sse_dump(j) + "\n\n";
+}
+
+// Anthropic / Responses framing: "event: NAME\ndata: {json}\n\n".
+inline std::string sse_event(const std::string& name, const nlohmann::json& j) {
+    return "event: " + name + "\ndata: " + sse_dump(j) + "\n\n";
+}
+
+// OpenAI stream terminator.
+inline std::string sse_done() { return "data: [DONE]\n\n"; }
+
+// One OpenAI streaming delta chunk. `chat` selects chat.completion.chunk
+// (delta.content) vs text_completion (text); finish_reason is null in piece
+// chunks, exactly as the CUDA server emits them.
+inline nlohmann::json openai_stream_chunk(bool chat, const std::string& id, const char* object,
+                                          long created, const std::string& model,
+                                          const std::string& piece) {
+    using nlohmann::json;
+    json choice = chat
+        ? json{{"index", 0}, {"delta", {{"content", piece}}}, {"finish_reason", nullptr}}
+        : json{{"index", 0}, {"text", piece}, {"finish_reason", nullptr}};
+    return json{{"id", id}, {"object", object}, {"created", created},
+                {"model", model}, {"choices", json::array({choice})}};
+}
+
+// Terminal OpenAI streaming chunk: a real finish_reason ("stop"/"length")
+// before [DONE], per the OpenAI streaming spec — clients otherwise never
+// learn whether generation hit EOS or the token cap. Mirrors the CUDA
+// server's shape (upstream security-review fix #7): empty delta object for
+// chat, empty text for completions.
+inline nlohmann::json openai_stream_final_chunk(bool chat, const std::string& id,
+                                                const char* object, long created,
+                                                const std::string& model,
+                                                const char* finish_reason) {
+    using nlohmann::json;
+    json choice = chat
+        ? json{{"index", 0}, {"delta", json::object()}, {"finish_reason", finish_reason}}
+        : json{{"index", 0}, {"text", ""}, {"finish_reason", finish_reason}};
+    return json{{"id", id}, {"object", object}, {"created", created},
+                {"model", model}, {"choices", json::array({choice})}};
+}
+
+inline nlohmann::json openai_stream_usage_chunk(const std::string& id,
+                                                const char* object,long created,
+                                                const std::string& model,
+                                                uint32_t prompt_tokens,
+                                                uint32_t completion_tokens) {
+    using nlohmann::json;
+    return json{{"id",id},{"object",object},{"created",created},{"model",model},
+                {"choices",json::array()},
+                {"usage",{{"prompt_tokens",prompt_tokens},
+                          {"completion_tokens",completion_tokens},
+                          {"total_tokens",prompt_tokens+completion_tokens}}}};
+}
+
+} // namespace q27

--- a/src/metal/test_metal_engine_contracts.cpp
+++ b/src/metal/test_metal_engine_contracts.cpp
@@ -1,12 +1,19 @@
 #include "metal_engine.h"
 
+#include <algorithm>
+#include <cstdint>
 #include <cstring>
+#include <cstdlib>
 #include <cstdio>
 #include <exception>
+#include <functional>
 #include <limits>
 #include <stdexcept>
+#include <string>
+#include <utility>
 #include <vector>
 
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -55,6 +62,42 @@ int main(int argc, char** argv) {
         return 2;
     }
     try {
+        {
+            const char* old_cells=getenv("Q27_METAL_KV_FP16_CELLS");
+            const char* old_codec=getenv("Q27_METAL_KV_CELLS_CODEC");
+            const bool had_cells=old_cells!=nullptr, had_codec=old_codec!=nullptr;
+            const std::string saved_cells=had_cells?old_cells:"";
+            const std::string saved_codec=had_codec?old_codec:"";
+            if(setenv("Q27_METAL_KV_FP16_CELLS","",1) ||
+               setenv("Q27_METAL_KV_CELLS_CODEC","e4m3",1))
+                throw std::runtime_error("could not set KV codec test environment");
+            bool rejected=false;
+            try {
+                auto shared=q27::MetalEngine::open_shared(argv[1]);
+                (void)q27::MetalEngine::serving_reservation_bytes(*shared,1,false,0);
+            } catch(const std::runtime_error& error) {
+                rejected=std::string(error.what()).find("needs a non-empty")!=std::string::npos;
+            }
+            if(had_cells) setenv("Q27_METAL_KV_FP16_CELLS",saved_cells.c_str(),1);
+            else unsetenv("Q27_METAL_KV_FP16_CELLS");
+            if(had_codec) setenv("Q27_METAL_KV_CELLS_CODEC",saved_codec.c_str(),1);
+            else unsetenv("Q27_METAL_KV_CELLS_CODEC");
+            if(!rejected)
+                throw std::runtime_error("empty e4m3 KV side-cache configuration was accepted");
+        }
+        {
+            auto limited=q27::MetalEngine::open_shared(argv[1]);
+            limited->cache_budget=1;
+            bool rejected=false;
+            try { q27::MetalEngine over_budget(limited,1,false); }
+            catch(const std::runtime_error& error) {
+                rejected=std::string(error.what()).find("configured cache budget")!=std::string::npos;
+            }
+            if(!rejected) {
+                std::fprintf(stderr,"explicit shared cache budget was not enforced before allocation\n");
+                return 1;
+            }
+        }
         q27::MetalEngine engine(argv[1], 8);
         const bool expected_per_tensor = artifact_requires_per_tensor_upload(
             argv[1], engine.backend().max_buffer_length());
@@ -65,6 +108,18 @@ int main(int argc, char** argv) {
                          expected_per_tensor ? "per-tensor" : "whole-mapping",
                          engine.used_per_tensor_upload() ? "per-tensor" : "whole-mapping");
             return 1;
+        }
+        {
+            auto initial=engine.capture_state();
+            const std::vector<uint32_t> baseline=engine.generate_mtp(
+                {760},2,2,UINT32_MAX);
+            engine.restore_state(*initial);
+            const uint32_t restored_pending=engine.ingest_prompt({760},true,false);
+            const std::vector<uint32_t> restored=engine.generate_from_pending(
+                restored_pending,2,2,UINT32_MAX);
+            if(restored!=baseline)
+                throw std::runtime_error("position-zero snapshot changed MTP continuation");
+            engine.restore_state(*initial);
         }
         if (!rejects_logits(engine)) {
             std::fprintf(stderr, "fresh engine exposed non-resident logits\n");
@@ -90,6 +145,120 @@ int main(int argc, char** argv) {
             engine.read_logits().size() != q27::MetalEngine::vocabulary_size()) {
             std::fprintf(stderr, "snapshot restore did not restore logits residency\n");
             return 1;
+        }
+        {
+            q27::MetalEngine engine(argv[1], 16, false);
+            // The serving scheduler splits MTP prompt warming into bounded
+            // serial quanta. It must match the former whole-prompt path.
+            const std::vector<uint32_t> serial_prompt(9,1);
+            auto run_mtp_round=[&](bool chunked) {
+                engine.reset();
+                uint32_t pending=0;
+                if(chunked) {
+                    for(size_t i=0;i<serial_prompt.size();) {
+                        const uint32_t take=(uint32_t)std::min<size_t>(
+                            q27::MetalEngine::serial_prefill_chunk_max(),
+                            serial_prompt.size()-i);
+                        const bool final=i+take==serial_prompt.size();
+                        const uint32_t next=engine.prefill_serial_chunk(
+                            serial_prompt.data()+i,take,true,final);
+                        if(final) pending=next;
+                        i+=take;
+                    }
+                } else pending=engine.ingest_prompt(serial_prompt,true,false);
+                uint32_t live=4;
+                std::vector<uint32_t> committed;
+                const uint32_t next=engine.mtp_round(
+                    pending,4,std::numeric_limits<uint32_t>::max(),4,live,committed);
+                return std::make_pair(committed,next);
+            };
+            const auto whole=run_mtp_round(false);
+            const auto split=run_mtp_round(true);
+            if(whole!=split)
+                throw std::runtime_error("chunked serial MTP prefill changed decode state");
+            engine.reset();
+            engine.set_chunked_prefill(true);
+            const auto batched_generation=engine.generate_mtp(serial_prompt,6,4);
+            const uint32_t batched_position=engine.position();
+            engine.reset();
+            engine.set_chunked_prefill(false);
+            const auto serial_generation=engine.generate_mtp(serial_prompt,6,4);
+            if(serial_generation!=batched_generation || engine.position()!=batched_position)
+                throw std::runtime_error("serial multi-round MTP changed decode state");
+            engine.set_chunked_prefill(true);
+            // A serial prefill that does not warm layer-64 KV must fail
+            // before MTP can read stale rows from a previous generation.
+            engine.reset();
+            const uint32_t stale_pending = engine.ingest_prompt({1, 1}, false, false);
+            const uint32_t stale_position = engine.position();
+            bool stale_mtp_rejected = false;
+            try {
+                uint32_t live = 4;
+                std::vector<uint32_t> committed;
+                (void)engine.mtp_round(stale_pending, 4, UINT32_MAX, 4, live, committed);
+            } catch (const std::runtime_error& error) {
+                stale_mtp_rejected = std::string(error.what()).find(
+                    "MTP cache is not valid") != std::string::npos;
+            }
+            if (!stale_mtp_rejected || engine.position() != stale_position)
+                throw std::runtime_error("MTP accepted an unwarmed serial prefix");
+            engine.reset();
+
+            const uint32_t pending = engine.ingest_prompt({1}, false, true);
+            int sink_calls = 0;
+            q27::MetalEngine::StopCause cause = q27::MetalEngine::StopCause::MaxTokens;
+            const uint32_t emitted = engine.stream_from_pending(
+                pending, 4, std::numeric_limits<uint32_t>::max(), 4,
+                [&](uint32_t) { return ++sink_calls < 2; }, cause);
+            if (cause != q27::MetalEngine::StopCause::Cancelled || emitted != 1)
+                throw std::runtime_error("batched MTP cancellation contract mismatch");
+            if (engine.position() != 0)
+                throw std::runtime_error("cancelled batched MTP left speculative state resident");
+            bool stale_rejected = false;
+            try {
+                (void)engine.pending_from_logits();
+            } catch (const std::runtime_error& error) {
+                stale_rejected = std::string(error.what()).find("no resident logits") !=
+                                 std::string::npos;
+            }
+            if (!stale_rejected)
+                throw std::runtime_error("cancelled batched MTP left logits reusable");
+
+            std::vector<uint32_t> mask((q27::MetalEngine::vocabulary_size()+31)/32,~0u);
+            const int mask_id=engine.mask_pool_add(mask.data());
+            if(mask_id<0) throw std::runtime_error("failed to allocate tool constraint mask");
+            engine.set_tool_constraint(mask_id);
+            const uint32_t constrained_pending=engine.ingest_prompt({1},true,true);
+            const uint32_t constrained_position=engine.position();
+            auto expect_constraint_reject=[&](const char* label,const std::function<void()>& call) {
+                bool rejected=false;
+                try { call(); }
+                catch(const std::runtime_error& error) {
+                    rejected=std::string(error.what()).find("tool constraints require serial decode")!=
+                             std::string::npos;
+                }
+                if(!rejected) throw std::runtime_error(std::string(label)+" accepted active tool constraint");
+                if(engine.position()!=constrained_position)
+                    throw std::runtime_error(std::string(label)+" mutated state before rejection");
+            };
+            expect_constraint_reject("stream_from_pending",[&] {
+                q27::MetalEngine::StopCause stop;
+                (void)engine.stream_from_pending(constrained_pending,2,UINT32_MAX,4,
+                    [](uint32_t) { return true; },stop);
+            });
+            expect_constraint_reject("generate_from_pending",[&] {
+                (void)engine.generate_from_pending(constrained_pending,2,4);
+            });
+            expect_constraint_reject("mtp_round",[&] {
+                uint32_t live=4; std::vector<uint32_t> committed;
+                (void)engine.mtp_round(constrained_pending,2,UINT32_MAX,4,live,committed);
+            });
+            expect_constraint_reject("mtp_sample_round",[&] {
+                uint32_t live=4; std::vector<uint32_t> committed;
+                q27::SamplingParams params; std::mt19937_64 rng(1);
+                (void)engine.mtp_sample_round(constrained_pending,2,UINT32_MAX,4,live,
+                                              params,rng,committed);
+            });
         }
 
         const std::vector<float> baseline_logits = engine.read_logits();
@@ -117,6 +286,177 @@ int main(int argc, char** argv) {
         if (engine.generate_from_pending(pending, 2, 2) != baseline_retry) {
             std::fprintf(stderr, "MTP EOS changed retry behavior\n");
             return 1;
+        }
+        {
+            auto requires_mtp_reject=[&](const char* label) {
+                bool rejected=false;
+                try {
+                    uint32_t live=2;
+                    std::vector<uint32_t> committed;
+                    (void)engine.mtp_round(pending,2,UINT32_MAX,2,live,committed);
+                } catch(const std::runtime_error& error) {
+                    rejected=std::string(error.what()).find(
+                        "MTP cache is not valid for this prefix")!=std::string::npos;
+                }
+                if(!rejected)
+                    throw std::runtime_error(std::string(label)+
+                        " left stale MTP state usable");
+            };
+            const uint32_t forced[2]={1,1};
+            std::vector<float> logits;
+            engine.restore_state(*snapshot);
+            engine.teacher_force_logits(forced,2,logits);
+            requires_mtp_reject("teacher_force_logits");
+            engine.restore_state(*snapshot);
+            engine.teacher_force_logits_wide(forced,2,logits);
+            requires_mtp_reject("teacher_force_logits_wide");
+            engine.restore_state(*snapshot);
+            (void)engine.teacher_force_nll({1,1,1});
+            requires_mtp_reject("teacher_force_nll");
+        }
+        {
+            q27::MetalEngine engine(argv[1], 16, false);
+            const std::vector<uint32_t> prompt{1, 2};
+            (void)engine.ingest_prompt(prompt, false, true);
+            const std::string path = "/tmp/q27-snapshot-fd-" +
+                                     std::to_string((long long)getpid()) + ".q27snap";
+            int fd = -1;
+            try {
+                uint32_t device_leases = 0;
+                engine.save_state(path, prompt.data(), (uint32_t)prompt.size(), true,
+                    [&](const std::function<void()>& operation) {
+                        device_leases++;
+                        operation();
+                    });
+                if (device_leases < 2)
+                    throw std::runtime_error("snapshot device work was not split into bounded leases");
+                fd = open(path.c_str(), O_RDONLY | O_CLOEXEC);
+                if (fd < 0 || lseek(fd, 7, SEEK_SET) != 7)
+                    throw std::runtime_error("cannot prepare snapshot descriptor offset gate");
+                const auto info = q27::MetalEngine::peek_snapshot_fd(fd, path);
+                if (info.tokens != prompt || lseek(fd, 0, SEEK_CUR) != 7)
+                    throw std::runtime_error("peek_snapshot_fd changed its caller descriptor offset");
+                engine.reset();
+                uint32_t restore_leases = 0;
+                const auto restored = engine.load_state_fd(fd, path,
+                    nullptr,
+                    [&](const std::function<void()>& operation) {
+                        restore_leases++;
+                        operation();
+                    });
+                if (restored != prompt.size() || restore_leases < 2 ||
+                    lseek(fd, 0, SEEK_CUR) != 7)
+                    throw std::runtime_error("load_state_fd lease or descriptor offset mismatch");
+                int checkpoints = 0;
+                bool cancelled = false;
+                engine.reset();
+                try {
+                    (void)engine.load_state_fd(fd, path, nullptr,
+                        q27::MetalEngine::DeviceLease{},
+                        [&] {
+                            if (++checkpoints == 3)
+                                throw std::runtime_error("snapshot cancellation gate");
+                        });
+                } catch (const std::runtime_error& error) {
+                    cancelled = std::string(error.what()) == "snapshot cancellation gate";
+                }
+                if (!cancelled || checkpoints != 3 || lseek(fd, 0, SEEK_CUR) != 7)
+                    throw std::runtime_error("snapshot validation ignored cancellation checkpoint");
+                const uint32_t original_threshold = engine.backend().gqa_threshold();
+                engine.backend().set_gqa_threshold(original_threshold == 1 ? 2 : 1);
+                bool runtime_rejected = false;
+                try {
+                    (void)engine.load_state_fd(fd, path);
+                } catch (const std::runtime_error& error) {
+                    runtime_rejected = std::string(error.what()).find(
+                        "snapshot runtime configuration does not match") != std::string::npos;
+                }
+                engine.backend().set_gqa_threshold(original_threshold);
+                if (!runtime_rejected)
+                    throw std::runtime_error("snapshot runtime configuration mismatch was accepted");
+                const int mutable_fd = open(path.c_str(), O_RDWR | O_CLOEXEC);
+                if (mutable_fd < 0)
+                    throw std::runtime_error("cannot open snapshot mutation gate");
+                try {
+                    struct stat snapshot_stat{};
+                    if (fstat(mutable_fd, &snapshot_stat) != 0 || snapshot_stat.st_size < 1)
+                        throw std::runtime_error("cannot size snapshot mutation gate");
+                    const off_t mutation_offset = snapshot_stat.st_size - 1;
+                    unsigned char original = 0;
+                    if (pread(mutable_fd, &original, 1, mutation_offset) != 1)
+                        throw std::runtime_error("cannot read snapshot mutation byte");
+                    const unsigned char changed = original ^ 0xff;
+                    if (pwrite(mutable_fd, &changed, 1, mutation_offset) != 1)
+                        throw std::runtime_error("cannot corrupt snapshot payload");
+                    bool checksum_rejected = false;
+                    engine.reset();
+                    try {
+                        (void)engine.load_state_fd(fd, path);
+                    } catch (const std::runtime_error& error) {
+                        checksum_rejected = std::string(error.what()).find(
+                            "snapshot payload checksum mismatch") != std::string::npos;
+                    }
+                    if (pwrite(mutable_fd, &original, 1, mutation_offset) != 1)
+                        throw std::runtime_error("cannot restore corrupted snapshot byte");
+                    if (!checksum_rejected)
+                        throw std::runtime_error("stable snapshot payload corruption was accepted");
+                    // Q27SNAP3 reserved follows magic, artifact size, two SHA-1
+                    // identities, and kv/position/token_count.
+                    constexpr off_t reserved_offset=8+8+20+20+3*4;
+                    unsigned char reserved=0;
+                    if(pread(mutable_fd,&reserved,1,reserved_offset)!=1)
+                        throw std::runtime_error("cannot read snapshot control metadata");
+                    const unsigned char flipped_reserved=reserved^1u;
+                    if(pwrite(mutable_fd,&flipped_reserved,1,reserved_offset)!=1)
+                        throw std::runtime_error("cannot corrupt snapshot control metadata");
+                    bool metadata_rejected=false;
+                    try {
+                        (void)engine.load_state_fd(fd,path);
+                    } catch(const std::runtime_error& error) {
+                        metadata_rejected=std::string(error.what()).find(
+                            "snapshot payload checksum mismatch")!=std::string::npos;
+                    }
+                    if(pwrite(mutable_fd,&reserved,1,reserved_offset)!=1)
+                        throw std::runtime_error("cannot restore snapshot control metadata");
+                    if(!metadata_rejected)
+                        throw std::runtime_error("snapshot control metadata corruption was accepted");
+                    bool mutated = false;
+                    restore_leases = 0;
+                    bool rejected = false;
+                    engine.reset();
+                    try {
+                        (void)engine.load_state_fd(fd, path,
+                            nullptr,
+                            [&](const std::function<void()>& operation) {
+                                if (!mutated && ++restore_leases == 2) {
+                                    const unsigned char changed = original ^ 0xff;
+                                    if (pwrite(mutable_fd, &changed, 1, mutation_offset) != 1)
+                                        throw std::runtime_error("cannot mutate snapshot payload");
+                                    mutated = true;
+                                }
+                                operation();
+                            });
+                    } catch (const std::runtime_error& error) {
+                        rejected = std::string(error.what()).find(
+                            "snapshot payload changed during load") != std::string::npos;
+                    }
+                    if (pwrite(mutable_fd, &original, 1, mutation_offset) != 1)
+                        throw std::runtime_error("cannot restore snapshot mutation byte");
+                    if (!mutated || !rejected)
+                        throw std::runtime_error("snapshot payload mutation was not rejected");
+                } catch (...) {
+                    close(mutable_fd);
+                    throw;
+                }
+                close(mutable_fd);
+                close(fd);
+                fd = -1;
+                std::remove(path.c_str());
+            } catch (...) {
+                if (fd >= 0) close(fd);
+                std::remove(path.c_str());
+                throw;
+            }
         }
         engine.restore_state(*snapshot);
 

--- a/src/metal/test_metal_model_contracts.cpp
+++ b/src/metal/test_metal_model_contracts.cpp
@@ -1,0 +1,123 @@
+#include "metal_engine.h"
+
+#include <cstdint>
+#include <fcntl.h>
+#include <cstdio>
+#include <stdexcept>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::fprintf(stderr, "usage: %s MODEL\n", argv[0]);
+        return 2;
+    }
+    try {
+        q27::MetalEngine engine(argv[1], 32, false);
+        constexpr uint32_t vocab = q27::MetalEngine::vocabulary_size();
+        std::vector<uint32_t> allow_all((vocab + 31) / 32, UINT32_MAX);
+        for (int i = 0; i < q27::MetalEngine::MASK_POOL_CAP; i++)
+            if (engine.mask_pool_add(allow_all.data()) != i)
+                throw std::runtime_error("constraint mask pool allocation mismatch");
+        if (engine.mask_pool_add(allow_all.data()) >= 0)
+            throw std::runtime_error("constraint mask pool exceeded its cap");
+        engine.reset_mask_pool();
+        const int mask = engine.mask_pool_add(allow_all.data());
+        if (mask != 0) throw std::runtime_error("constraint mask pool did not reset");
+        engine.set_tool_constraint(mask);
+
+        const uint32_t initial_position = engine.position();
+        auto rejects_without_mutation = [&](auto&& call, const char* label) {
+            bool rejected = false;
+            try {
+                call();
+            } catch (const std::runtime_error& error) {
+                rejected = std::string(error.what()).find("tool constraints require serial decode")
+                    != std::string::npos;
+            }
+            if (!rejected || engine.position() != initial_position)
+                throw std::runtime_error(std::string(label) +
+                    " did not reject before mutating engine position");
+        };
+
+        rejects_without_mutation([&]{
+            (void)engine.generate_mtp({1}, 1, 2);
+        }, "greedy MTP");
+
+        q27::SamplingParams sampling;
+        sampling.temperature = 0.8f;
+        sampling.top_p = 0.95f;
+        sampling.top_k = 40;
+        rejects_without_mutation([&]{
+            (void)engine.generate_mtp_sampled({1}, 1, 2, sampling);
+        }, "sampled MTP");
+
+        // The supported constrained path remains usable.
+        (void)engine.ingest_prompt({1}, false, true);
+        if (engine.position() != 1)
+            throw std::runtime_error("serial constrained prefill did not advance");
+
+        // A mid-prefill snapshot deliberately marks its logits row stale.
+        // Loading it may resume ingestion, but must not derive a token until
+        // a successful forward pass replaces that row.
+        struct SnapshotFile {
+            std::string path;
+            ~SnapshotFile() { unlink(path.c_str()); }
+        } snapshot{"/private/tmp/q27-metal-stale-logits-" +
+                   std::to_string((long long)getpid()) + ".snap"};
+        unlink(snapshot.path.c_str());
+        const uint32_t snapshot_token = 1;
+        engine.save_state(snapshot.path, &snapshot_token, 1, false);
+        engine.reset();
+        (void)engine.load_state(snapshot.path);
+        auto require_stale_rejection = [&](const char* label) {
+            bool rejected = false;
+            try {
+                (void)engine.pending_from_logits();
+            } catch (const std::runtime_error& error) {
+                rejected = std::string(error.what()).find("no resident logits") !=
+                           std::string::npos;
+            }
+            if (!rejected)
+                throw std::runtime_error(std::string(label) + " stale logits were accepted");
+        };
+        require_stale_rejection("snapshot");
+        // A pinned descriptor must still reject metadata that no longer
+        // matches the prefix selected by the snapshot store. This is the
+        // final guard against same-inode mutation between shallow peek and
+        // deep restore.
+        const int snapshot_fd=::open(snapshot.path.c_str(),O_RDONLY|O_CLOEXEC|O_NOFOLLOW);
+        if(snapshot_fd<0) throw std::runtime_error("cannot open snapshot fixture");
+        std::vector<uint32_t> wrong_tokens{2};
+        bool token_mismatch_rejected=false;
+        try {
+            (void)engine.load_state_fd(snapshot_fd,snapshot.path,&wrong_tokens);
+        } catch(const std::runtime_error& error) {
+            token_mismatch_rejected=std::string(error.what()).find(
+                "tokens do not match the requested prefix")!=std::string::npos;
+        }
+        ::close(snapshot_fd);
+        if(!token_mismatch_rejected)
+            throw std::runtime_error("snapshot token mismatch was accepted");
+        (void)engine.step(1);
+        if (engine.pending_from_logits() >= vocab) {
+            throw std::runtime_error("refreshed snapshot logits produced an invalid token");
+        }
+
+        // Scheduler chunk quanta advance recurrent/KV state without an
+        // output-head pass, so they must invalidate a previously resident row.
+        const uint32_t chunk_tokens[2] = {1, 1};
+        engine.prefill_chunk(chunk_tokens, 2);
+        require_stale_rejection("chunk prefill");
+        (void)engine.step(1);
+        if (engine.pending_from_logits() >= vocab)
+            throw std::runtime_error("post-chunk forward produced an invalid token");
+
+        std::puts("Metal constrained MTP, stale-snapshot, and chunk-logit contracts: PASS");
+        return 0;
+    } catch (const std::exception& error) {
+        std::fprintf(stderr, "%s\n", error.what());
+        return 1;
+    }
+}

--- a/src/metal/test_metal_ops.cpp
+++ b/src/metal/test_metal_ops.cpp
@@ -128,6 +128,25 @@ int test_primitives(q27::MetalBackend& backend) {
     // Stable lower-index tie break.
     std::vector<float> logits={-1,7,3,7,2}; auto lb=upload_buffer(backend,logits); auto ib=backend.allocate(4); backend.argmax(*lb,5,*ib); uint32_t index=99; backend.read(*ib,0,&index,4); if(index!=1){fprintf(stderr,"argmax: got %u want 1\n",index);failures++;}
 
+    // GPU radix selection must preserve CPU float equality for signed zero:
+    // top_k=1 needs both candidates so the host can apply lower-index tie order.
+    if(backend.gpu_topk_supported()) {
+        std::vector<float> zero_logits={-0.0f,0.0f,-1.0f};
+        auto zero_in=upload_buffer(backend,zero_logits);
+        auto top_values=backend.allocate(8*4), top_indices=backend.allocate(8*4);
+        auto top_count=backend.allocate(4);
+        backend.topk(*zero_in,3,1,*top_values,*top_indices,*top_count);
+        uint32_t count=0; backend.read(*top_count,0,&count,4);
+        std::vector<uint32_t> ids(count);
+        if(count) backend.read(*top_indices,0,ids.data(),count*4);
+        const bool saw_negative=std::find(ids.begin(),ids.end(),0)!=ids.end();
+        const bool saw_positive=std::find(ids.begin(),ids.end(),1)!=ids.end();
+        if(!saw_negative || !saw_positive) {
+            fprintf(stderr,"top-k signed-zero tie lost a candidate (count=%u)\n",count);
+            failures++;
+        }
+    }
+
     return failures;
 }
 

--- a/src/metal/test_metal_stream.cpp
+++ b/src/metal/test_metal_stream.cpp
@@ -1,0 +1,453 @@
+// Model-free unit tests for the Metal server's streaming helpers:
+// UTF-8 boundary gating, stop-sequence holdback, SSE event framing, and the
+// StreamSplitter channel router (incl. the adjacent-call boundary segment).
+// These run without the model artifact (part of `make test-metal`) and are
+// the regression net for the wire shapes the CUDA reference server defines.
+#include "stream_format.h"
+#include "serving_policy.h"
+
+#include "../stream_split.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using json = nlohmann::json;
+
+namespace {
+
+int failures = 0;
+void check(bool ok, const char* what) {
+    if (!ok) { fprintf(stderr, "FAIL: %s\n", what); failures++; }
+}
+
+// ---- Utf8Gate ----
+int test_utf8_gate() {
+    // A three-byte em dash (E2 80 94) split across two token pieces: the first
+    // feed must hold the incomplete lead+continuation back, the second complete
+    // it. Emitting the partial would make json::dump throw.
+    q27::Utf8Gate g;
+    check(g.feed("ab") == "ab", "utf8: ascii passes through");
+    check(g.feed("\xE2\x80") == "", "utf8: incomplete multibyte held back");
+    check(g.feed("\x94") == "\xE2\x80\x94", "utf8: multibyte completes on continuation");
+    check(g.flush() == "", "utf8: clean flush is empty");
+
+    // A dangling partial at end of stream becomes U+FFFD.
+    q27::Utf8Gate g2;
+    check(g2.feed("x\xE2\x80") == "x", "utf8: emits valid prefix, holds tail");
+    check(g2.flush() == "\xEF\xBF\xBD", "utf8: dangling tail flushes to U+FFFD");
+    return 0;
+}
+
+// ---- StopBuffer ----
+int test_stop_buffer() {
+    // No stop sequences: identity passthrough, nothing held.
+    {
+        q27::StopBuffer sb;
+        bool stopped = false;
+        check(!sb.active(), "stop: empty is inactive");
+        check(sb.feed("hello world", stopped) == "hello world", "stop: passthrough");
+        check(!stopped, "stop: passthrough not stopped");
+        check(sb.flush() == "", "stop: passthrough flush empty");
+    }
+    // Empty stop strings are dropped (would otherwise match everywhere).
+    {
+        q27::StopBuffer sb({"", ""});
+        check(!sb.active(), "stop: empty strings dropped");
+    }
+    // Full match within one feed truncates at the stop and reports the index.
+    {
+        q27::StopBuffer sb({"STOP"});
+        bool stopped = false;
+        check(sb.feed("abcSTOPdef", stopped) == "abc", "stop: truncates before match");
+        check(stopped && sb.matched == 0, "stop: reports stopped + index");
+    }
+    // Stop sequence split across two feeds: the first half is held back, not
+    // leaked, and the match fires when the second half arrives.
+    {
+        q27::StopBuffer sb({"</s>"});
+        bool stopped = false;
+        check(sb.feed("hello</", stopped) == "hello", "stop: holds back partial prefix");
+        check(!stopped, "stop: partial not yet stopped");
+        check(sb.feed("s>world", stopped) == "", "stop: completes across feeds");
+        check(stopped && sb.matched == 0, "stop: split match stops");
+    }
+    // A partial prefix that diverges is released, not swallowed.
+    {
+        q27::StopBuffer sb({"</s>"});
+        bool stopped = false;
+        check(sb.feed("a</b", stopped) == "a</b", "stop: diverging partial released");
+        check(!stopped, "stop: diverging not stopped");
+    }
+    // Earliest match across multiple sequences wins.
+    {
+        q27::StopBuffer sb({"XX", "Y"});
+        bool stopped = false;
+        check(sb.feed("aYbXX", stopped) == "a", "stop: earliest position wins");
+        check(stopped && sb.matched == 1, "stop: matched index is the Y sequence");
+    }
+    // Held-back partial with no completion is real output at flush.
+    {
+        q27::StopBuffer sb({"</s>"});
+        bool stopped = false;
+        check(sb.feed("text</s", stopped) == "text", "stop: holds trailing partial");
+        check(!stopped, "stop: trailing partial not stopped");
+        check(sb.flush() == "</s", "stop: flush releases held partial");
+    }
+    // OpenAI documents at most four stops; Anthropic accepts a general list.
+    {
+        const std::vector<std::string> five={"S0","S1","S2","S3","S4"};
+        bool openai_rejected=false,anthropic_accepted=true,total_rejected=false;
+        try { q27::validate_stop_sequences(five,true); }
+        catch(const std::invalid_argument&) { openai_rejected=true; }
+        try { q27::validate_stop_sequences(five,false); }
+        catch(const std::invalid_argument&) { anthropic_accepted=false; }
+        try {
+            q27::StopBuffer sb({std::string(q27::kMaxStopSequenceTotalBytes+1,'x')});
+        } catch(const std::invalid_argument&) { total_rejected=true; }
+        check(openai_rejected, "stop: OpenAI count bounded");
+        check(anthropic_accepted, "stop: Anthropic list count unrestricted");
+        check(total_rejected, "stop: aggregate matcher storage bounded");
+    }
+    // The automaton preserves earliest-position semantics and handles a long
+    // repeated prefix across pieces without quadratic suffix rescans.
+    {
+        q27::StopBuffer overlap({"abcd","b"});
+        bool stopped=false;
+        check(overlap.feed("abcd",stopped)=="", "stop: earliest start beats earlier completion");
+        check(stopped && overlap.matched==0, "stop: earliest-start sequence index");
+
+        q27::StopBuffer split_overlap({"abcd","b"});
+        stopped=false;
+        check(split_overlap.feed("ab",stopped)=="", "stop: overlapping candidate deferred");
+        check(!stopped, "stop: earlier prefix remains eligible");
+        check(split_overlap.feed("cd",stopped)=="", "stop: split earlier match suppressed");
+        check(stopped && split_overlap.matched==0,
+              "stop: split pieces preserve earliest-start sequence");
+
+        q27::StopBuffer same_start({"ab","a"});
+        stopped=false;
+        check(same_start.feed("a",stopped)=="", "stop: complete same-start prefix suppressed");
+        check(stopped && same_start.matched==1,
+              "stop: complete same-start prefix fires without waiting for a longer stop");
+
+        q27::StopBuffer failed_prefix({"abcd","b"});
+        stopped=false;
+        check(failed_prefix.feed("ab",stopped)=="" && !stopped,
+              "stop: later match waits for earlier prefix");
+        check(failed_prefix.feed("x",stopped)=="a",
+              "stop: deferred later match emits only preceding text");
+        check(stopped && failed_prefix.matched==1,
+              "stop: deferred later match resolves after prefix failure");
+
+        q27::StopBuffer eos_overlap({"abcd","b"});
+        stopped=false;
+        check(eos_overlap.feed("ab",stopped)=="" && !stopped,
+              "stop: provisional match survives to stream end");
+        bool flush_stopped=false;
+        check(eos_overlap.flush(&flush_stopped)=="a",
+              "stop: stream end resolves provisional match");
+        check(flush_stopped && eos_overlap.matched==1,
+              "stop: flush reports provisional match");
+
+        std::string long_stop(100,'x');
+        long_stop+='!';
+        q27::StopBuffer long_prefix({long_stop});
+        stopped=false;
+        check(long_prefix.feed(std::string(80,'x'),stopped)=="", "stop: long prefix held");
+        check(!stopped, "stop: long prefix remains pending");
+        check(long_prefix.feed(std::string(20,'x')+"!tail",stopped)=="",
+              "stop: long split sequence suppressed");
+        check(stopped, "stop: long split sequence matched");
+
+        std::string repeated_stop(32768,'a');
+        repeated_stop+='b';
+        q27::StopBuffer repeated({repeated_stop});
+        stopped=false;
+        check(repeated.feed(std::string(32768,'a'),stopped)=="" && !stopped,
+              "stop: maximal repeated prefix held");
+        const std::string one_a="a";
+        size_t released=0;
+        for(size_t i=0;i<131072;i++) released+=repeated.feed(one_a,stopped).size();
+        check(released==131072 && !stopped,
+              "stop: repeated-prefix sliding releases one byte per feed");
+        check(repeated.pend.size()<=repeated_stop.size()*2+4096,
+              "stop: pending storage compacts amortized");
+        check(repeated.feed("b",stopped)=="" && stopped,
+              "stop: repeated-prefix match still fires after compaction");
+    }
+    return 0;
+}
+
+// ---- SSE framing ----
+int test_sse_framing() {
+    check(q27::sse_data(json{{"a", 1}}) == "data: {\"a\":1}\n\n", "sse: data frame");
+    check(q27::sse_done() == "data: [DONE]\n\n", "sse: done terminator");
+
+    std::string ev = q27::sse_event("message_stop", json{{"type", "message_stop"}});
+    check(ev == "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n", "sse: event frame");
+
+    // OpenAI chat delta chunk shape: choices[0].delta.content, null finish.
+    json chat = q27::openai_stream_chunk(true, "chatcmpl-metal", "chat.completion.chunk",
+                                         1700000000, "q27-metal", "hi");
+    check(chat["object"] == "chat.completion.chunk", "sse: chat chunk object");
+    check(chat["choices"][0]["delta"]["content"] == "hi", "sse: chat delta content");
+    check(chat["choices"][0]["finish_reason"].is_null(), "sse: chat chunk null finish");
+
+    // Completions chunk shape: choices[0].text.
+    json txt = q27::openai_stream_chunk(false, "cmpl-metal", "text_completion",
+                                        1700000000, "q27-metal", "yo");
+    check(txt["object"] == "text_completion", "sse: text chunk object");
+    check(txt["choices"][0]["text"] == "yo", "sse: text chunk text");
+    check(txt["choices"][0]["finish_reason"].is_null(), "sse: text chunk null finish");
+
+    // Terminal chunk: real finish_reason, empty delta object (chat) / empty
+    // text (completions) — server.cu's shape after security-review fix #7.
+    json fchat = q27::openai_stream_final_chunk(true, "chatcmpl-metal", "chat.completion.chunk",
+                                                1700000000, "q27-metal", "stop");
+    check(fchat["choices"][0]["finish_reason"] == "stop", "sse: final chat finish_reason");
+    check(fchat["choices"][0]["delta"].is_object() && fchat["choices"][0]["delta"].empty(),
+          "sse: final chat empty delta object");
+    json ftxt = q27::openai_stream_final_chunk(false, "cmpl-metal", "text_completion",
+                                               1700000000, "q27-metal", "length");
+    check(ftxt["choices"][0]["finish_reason"] == "length", "sse: final text finish_reason");
+    check(ftxt["choices"][0]["text"] == "", "sse: final text empty");
+
+    json usage = q27::openai_stream_usage_chunk("chatcmpl-metal","chat.completion.chunk",
+                                                1700000000,"q27-metal",7,3);
+    check(usage["choices"].is_array() && usage["choices"].empty(),
+          "sse: usage chunk has empty choices");
+    check(usage["usage"]["prompt_tokens"] == 7 &&
+          usage["usage"]["completion_tokens"] == 3 &&
+          usage["usage"]["total_tokens"] == 10,
+          "sse: usage chunk totals");
+
+    // Invalid UTF-8 must not throw through the serializer (replace backstop).
+    std::string bad = q27::sse_data(q27::openai_stream_chunk(true, "id", "chat.completion.chunk",
+                                                             0, "m", std::string("\xE2\x80")));
+    check(!bad.empty(), "sse: invalid utf-8 serializes via replace handler");
+    return 0;
+}
+
+} // namespace
+
+// ---- StreamSplitter ----
+namespace {
+using Seg = std::pair<q27::StreamSplitter::Chan, std::string>;
+bool segs_eq(const std::vector<Seg>& got, std::initializer_list<Seg> want) {
+    return got == std::vector<Seg>(want);
+}
+int test_splitter() {
+    using C = q27::StreamSplitter::Chan;
+    const C TEXT = q27::StreamSplitter::TEXT, THINK = q27::StreamSplitter::THINK,
+            TOOL = q27::StreamSplitter::TOOL;
+    {   // plain text/think routing
+        q27::StreamSplitter sp;
+        check(segs_eq(sp.feed("hello<think>t</think>world"),
+                      {{TEXT,"hello"},{THINK,"t"},{TEXT,"world"}}),
+              "splitter: text/think/text routing");
+        check(sp.flush().empty(), "splitter: clean flush");
+    }
+    {   // adjacent wrapped calls in one feed: an empty TEXT boundary segment
+        // must separate them because consumers buffer one TOOL segment and
+        // flush on any non-TOOL segment; without it, calls fold together.
+        q27::StreamSplitter sp;
+        check(segs_eq(sp.feed("<tool_call>A</tool_call><tool_call>B</tool_call>"),
+                      {{TOOL,"A"},{TEXT,""},{TOOL,"B"}}),
+              "splitter: adjacent calls emit a boundary segment");
+    }
+    {   // same adjacency across feed boundaries
+        q27::StreamSplitter sp;
+        check(segs_eq(sp.feed("<tool_call>A</tool_call>"), {{TOOL,"A"}}),
+              "splitter: first call routed");
+        check(sp.chan==TEXT && sp.tool_boundary,
+              "splitter: exact final closer remains observable");
+        check(segs_eq(sp.feed("<tool_call>B</tool_call>"), {{TEXT,""},{TOOL,"B"}}),
+              "splitter: cross-feed adjacency emits the boundary");
+    }
+    {   // closer split across feeds, then an adjacent call
+        q27::StreamSplitter sp;
+        check(segs_eq(sp.feed("<tool_call>A</tool_"), {{TOOL,"A"}}),
+              "splitter: partial closer held back, head emitted");
+        check(segs_eq(sp.feed("call><tool_call>B</tool_call>"), {{TEXT,""},{TOOL,"B"}}),
+              "splitter: split-closer adjacency emits the boundary");
+    }
+    {   // A held prefix of another wrapper means the response did not end at
+        // the previous closed call, even though tool_boundary is still set.
+        q27::StreamSplitter sp;
+        check(segs_eq(sp.feed("<tool_call>A</tool_call><tool_"), {{TOOL,"A"}}),
+              "splitter: partial next wrapper stays held");
+        check(sp.chan==TEXT && sp.tool_boundary && !sp.hold.empty(),
+              "splitter: partial next wrapper is not a clean closed-tool tail");
+    }
+    {   // controls: real text between calls, think after a call, and text
+        // before a call must NOT grow boundary segments
+        q27::StreamSplitter sp;
+        check(segs_eq(sp.feed("<tool_call>A</tool_call>x<tool_call>B</tool_call>"),
+                      {{TOOL,"A"},{TEXT,"x"},{TOOL,"B"}}),
+              "splitter: text between calls, no boundary segment");
+        q27::StreamSplitter sp2;
+        check(segs_eq(sp2.feed("<tool_call>A</tool_call><think>t</think>"),
+                      {{TOOL,"A"},{THINK,"t"}}),
+              "splitter: think after call, no boundary segment");
+        q27::StreamSplitter sp3;
+        check(segs_eq(sp3.feed("x<tool_call>A</tool_call>"), {{TEXT,"x"},{TOOL,"A"}}),
+              "splitter: text before call, no boundary segment");
+    }
+    return 0;
+}
+int test_think_budget() {
+    using C = q27::StreamSplitter::Chan;
+    struct Task {
+        bool sampling=false;
+        bool accept_one=false;
+        const std::vector<int>* forced=nullptr;
+        void force(const std::vector<int>& ids) { forced=&ids; accept_one=true; }
+        bool force_from_public_budget(const std::vector<int>& ids) { force(ids); return true; }
+        void release_accept_one() { if(!forced) accept_one=false; }
+    } task;
+    const std::vector<int> close_ids{7,8};
+    auto apply=[&](q27::ThinkBudgetAction action) {
+        if(action==q27::ThinkBudgetAction::FORCE_RESERVED) task.force(close_ids);
+        else if(action==q27::ThinkBudgetAction::FORCE_PUBLIC)
+            task.force_from_public_budget(close_ids);
+    };
+
+    q27::StreamSplitter sp;
+    sp.chan = C::THINK;
+    q27::ThinkBudgetState budget{2};
+    apply(budget.start(sp.chan));
+    C before=sp.chan;
+    (void)sp.feed("first");
+    budget.observe(before,sp.chan);
+    apply(budget.finish_round(sp.chan));
+    check(!task.forced && budget.used == 1 && !budget.tripped,
+          "think budget: counts inside THINK without early trip");
+    before=sp.chan;
+    (void)sp.feed("second");
+    budget.observe(before,sp.chan);
+    apply(budget.finish_round(sp.chan));
+    check(task.forced == &close_ids && budget.used == 2 && budget.tripped,
+          "think budget: queues decoder-visible close exactly at limit");
+    task.forced=nullptr;
+    before=sp.chan;
+    (void)sp.feed(q27::StreamSplitter::T_CLOSE);
+    budget.observe(before,sp.chan,true);
+    check(sp.chan == C::TEXT, "think budget: forced close resumes TEXT");
+    before=sp.chan;
+    (void)sp.feed("answer");
+    budget.observe(before,sp.chan);
+    apply(budget.finish_round(sp.chan));
+    check(!task.forced && budget.used == 2,
+          "think budget: stops counting after close");
+
+    q27::StreamSplitter unbounded;
+    unbounded.chan = C::THINK;
+    q27::ThinkBudgetState no_limit{-1};
+    before=unbounded.chan;
+    (void)unbounded.feed("token");
+    no_limit.observe(before,unbounded.chan);
+    apply(no_limit.finish_round(unbounded.chan));
+    check(!task.forced && no_limit.used == 1 && !no_limit.tripped,
+          "think budget: unbounded mode still reports usage");
+
+    q27::ThinkBudgetState zero{0};
+    apply(zero.start(C::THINK));
+    check(task.forced == &close_ids && zero.tripped && zero.used == 0,
+          "think budget: zero cap closes before generation");
+    return 0;
+}
+
+int test_serving_policy() {
+    check(q27::metal_default_max_tokens(q27::MetalEndpoint::Completions)==256 &&
+          q27::metal_default_max_tokens(q27::MetalEndpoint::Chat)==256 &&
+          q27::metal_default_max_tokens(q27::MetalEndpoint::Messages)==1024 &&
+          q27::metal_default_max_tokens(q27::MetalEndpoint::Responses)==4096,
+          "policy: endpoint-specific default output limits");
+    check(q27::metal_serving_speculation_width(4,true,true,false,false,false)==4,
+          "policy: greedy MTP reserves configured width");
+    check(q27::metal_serving_speculation_width(4,true,true,true,true,false)==0,
+          "policy: forced plain sampling reserves no MTP lanes");
+    check(q27::metal_serving_speculation_width(4,true,true,false,false,true)==0,
+          "policy: bounded reasoning reserves no speculation lanes");
+    check(q27::metal_serving_speculation_width(4,false,true,false,false,false)==0,
+          "policy: artifact without MTP reserves no MTP lanes");
+    check(q27::metal_serving_speculation_width(4,true,false,false,false,false)==0,
+          "policy: serial-only backend reserves no lanes");
+    check(q27::metal_tool_constraint_enabled(true,true,true,0,false) &&
+          !q27::metal_tool_constraint_enabled(true,true,true,4,false) &&
+          !q27::metal_tool_constraint_enabled(true,true,true,0,true),
+          "policy: constraints require active serial decode without forced preseed");
+    check(q27::metal_tool_constraint_enabled(
+              true,true,true,
+              q27::metal_serving_speculation_width(4,false,true,false,false,false),false) &&
+          q27::metal_tool_constraint_enabled(
+              true,true,true,
+              q27::metal_serving_speculation_width(4,true,true,false,false,true),false),
+          "policy: configured speculation keeps constraints on serial fallback");
+    check(!q27::responses_token_limit_remains(true,true,true,false),
+          "policy: exact-limit closed eligible tool call remains actionable");
+    check(q27::responses_token_limit_remains(true,false,true,false) &&
+          q27::responses_token_limit_remains(true,true,false,false) &&
+          q27::responses_token_limit_remains(true,true,true,true),
+          "policy: token limit remains for missing, rejected, or incomplete calls");
+    bool closed_tail=false;
+    closed_tail=q27::responses_closed_tool_tail_after_segment(
+        closed_tail,true,false," \n");
+    check(closed_tail,
+          "policy: trailing whitespace preserves a structurally closed tool");
+    closed_tail=q27::responses_closed_tool_tail_after_segment(
+        closed_tail,false,false,"answer");
+    check(!closed_tail,
+          "policy: substantive trailing text clears closed tool state");
+    check(!q27::responses_closed_tool_tail_after_segment(
+              true,false,true,""),
+          "policy: a reasoning transition clears closed tool state");
+    check(q27::responses_output_index_after_stream_item(0,0,false)==0 &&
+          q27::responses_output_index_after_stream_item(0,0,true)==1 &&
+          q27::responses_output_index_after_stream_item(2,-1,true)==2,
+          "policy: suppressed streamed calls do not consume output indices");
+    const uint8_t low_masks[2]={0x01,0x0f};
+    const uint8_t high_masks[2]={0x11,0x8f};
+    check(q27::metal_snapshot_head_mask_tag(low_masks,2)=="010f" &&
+          q27::metal_snapshot_head_mask_tag(high_masks,2)=="118f",
+          "policy: snapshot tag includes all eight head-mask bits");
+    check(q27::metal_max_prompt_tokens(16,4)==11 &&
+          q27::metal_max_prompt_tokens(16,0)==15,
+          "policy: prompt ceiling follows effective speculation");
+    check(q27::metal_max_prompt_tokens_for_request(16,12,0)==16 &&
+          q27::metal_max_prompt_tokens_for_request(16,12,1)==16 &&
+          q27::metal_max_prompt_tokens_for_request(16,12,2)==15 &&
+          q27::metal_max_prompt_tokens_for_request(16,12,5)==12,
+          "policy: request output bounds live speculation reserve");
+    check(q27::metal_max_generation_tokens(15,16)==2 &&
+          q27::metal_max_generation_tokens(16,16)==1 &&
+          q27::metal_max_generation_tokens(0,16)==16,
+          "policy: resident prompt logits extend output capacity by one");
+    check(q27::metal_generation_fits(15,2,16) &&
+          !q27::metal_generation_fits(16,2,16) &&
+          q27::metal_generation_fits(16,0,16),
+          "policy: full request fit is known before prefill");
+    const auto speculative_boundary=q27::resolve_think_decode_limits(
+        4,16,12,5,2,true,q27::ThinkCfg{},-1);
+    const auto serial_boundary=q27::resolve_think_decode_limits(
+        4,16,12,1,2,true,q27::ThinkCfg{},-1);
+    check(!speculative_boundary.context_ok && serial_boundary.context_ok &&
+              serial_boundary.budget==1,
+          "policy: bounded near-boundary request selects serial reserve");
+    return 0;
+}
+
+} // namespace
+
+int main() {
+    test_utf8_gate();
+    test_stop_buffer();
+    test_sse_framing();
+    test_splitter();
+    test_think_budget();
+    test_serving_policy();
+    if (failures) { fprintf(stderr, "%d stream-format check(s) failed\n", failures); return 1; }
+    puts("Metal stream format: OK");
+    return 0;
+}

--- a/src/metal/test_server_recovery.py
+++ b/src/metal/test_server_recovery.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Exercise Metal server recovery and shared snapshot reuse against a real model.
+
+Usage: test_server_recovery.py SERVER MODEL TOKENIZER
+"""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+
+
+def fail(message, process=None, stderr_lines=None):
+    if process is not None and process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+    if stderr_lines:
+        sys.stderr.write("".join(stderr_lines))
+    raise SystemExit(message)
+
+
+def available_port():
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def start_server(server, model, tokenizer, snapshot_dir, extra_env):
+    port = available_port()
+    env = os.environ.copy()
+    env.pop("Q27_API_KEY", None)
+    env.update(extra_env)
+    process = subprocess.Popen(
+        [server, model, tokenizer, "--host", "127.0.0.1", "--port", str(port),
+         "--ctx", "256", "--slots", "1", "--max-tokens-default", "1",
+         "--think-budget", "0", "--snapshot-dir", snapshot_dir,
+         "--snapshot-max-mb", "256"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True, env=env,
+    )
+    stderr_lines = []
+    ready = threading.Event()
+
+    def drain_stderr():
+        for line in process.stderr:
+            stderr_lines.append(line)
+            if "listening on http://" in line:
+                ready.set()
+
+    thread = threading.Thread(target=drain_stderr, daemon=True)
+    thread.start()
+    if not ready.wait(300):
+        fail("server did not become ready", process, stderr_lines)
+    return process, thread, stderr_lines, port
+
+
+def stop_server(process, thread):
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+    thread.join(timeout=5)
+
+
+def request_json(port, path, payload=None):
+    data = None if payload is None else json.dumps(payload).encode()
+    headers = {} if payload is None else {"Content-Type": "application/json"}
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}", data=data, headers=headers,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=300) as response:
+            raw = response.read()
+            return response.status, json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as error:
+        raw = error.read()
+        body = json.loads(raw) if raw else {}
+        return error.code, body
+
+
+def request_sse(port, path, payload):
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=300) as response:
+            events = []
+            for line in response.read().decode().splitlines():
+                if line.startswith("data: ") and line != "data: [DONE]":
+                    events.append(json.loads(line[6:]))
+            return response.status, response.headers.get_all("Content-Type") or [], events
+    except urllib.error.HTTPError as error:
+        raw = error.read()
+        body = json.loads(raw) if raw else {}
+        return error.code, error.headers.get_all("Content-Type") or [], [body]
+
+
+def require_json_success(label, status, body):
+    if status != 200:
+        raise AssertionError(f"{label} returned {status}: {body}")
+    return body
+
+
+def exercise_recovery(server, model, tokenizer):
+    snapshot_dir = tempfile.TemporaryDirectory(prefix="q27-shared-snapshots-")
+    os.chmod(snapshot_dir.name, 0o777)
+    process = thread = None
+    stderr_lines = []
+    try:
+        process, thread, stderr_lines, port = start_server(
+            server, model, tokenizer, snapshot_dir.name,
+            {"Q27_METAL_FAIL_FINISH": "1"},
+        )
+        snapshot_mode = os.stat(snapshot_dir.name).st_mode & 0o777
+        if snapshot_mode != 0o700:
+            fail(f"snapshot directory mode is {snapshot_mode:o}, expected 700",
+                 process, stderr_lines)
+
+        models_status, models = request_json(port, "/v1/models")
+        catalog = (models.get("data") or [{}])[0]
+        if (models_status != 200 or models.get("object") != "list" or
+                catalog.get("id") != "q27-metal"):
+            fail(f"model catalog mismatch: {models_status} {models}", process, stderr_lines)
+
+        first_status, content_types, first_events = request_sse(
+            port, "/v1/completions",
+            {"model": "q27-metal", "prompt": "Hello", "max_tokens": 1,
+             "stream": True, "temperature": 0},
+        )
+        errors = [event.get("error", {}) for event in first_events if "error" in event]
+        if (first_status != 200 or content_types != ["text/event-stream"] or
+                not any(error.get("type") == "api_error" for error in errors)):
+            fail(f"injected stream did not surface an API error: "
+                 f"{first_status} {content_types} {first_events}", process, stderr_lines)
+
+        second_status, second = request_json(
+            port, "/v1/completions",
+            {"model": "q27-metal", "prompt": "Hello", "max_tokens": 1,
+             "stream": False, "temperature": 0},
+        )
+        if (second_status != 200 or
+                second.get("usage", {}).get("completion_tokens") != 1):
+            fail(f"post-recovery completion failed: {second_status} {second}",
+                 process, stderr_lines)
+        if not any("Metal backend recovery: rebuilt 1 slot" in line
+                   for line in stderr_lines):
+            fail("server did not reconstruct the failed Metal slot", process, stderr_lines)
+
+        chat_status, chat = request_json(
+            port, "/v1/chat/completions",
+            {"model": "q27-metal", "messages": [{"role": "user", "content": "Hello"}],
+             "max_tokens": 1, "temperature": 0},
+        )
+        require_json_success("chat completion", chat_status, chat)
+        if chat.get("object") != "chat.completion":
+            fail(f"chat response shape mismatch: {chat}", process, stderr_lines)
+
+        responses_status, responses = request_json(
+            port, "/v1/responses",
+            {"model": "q27-metal", "input": "Hello", "max_output_tokens": 1,
+             "stream": False},
+        )
+        require_json_success("Responses request", responses_status, responses)
+        if responses.get("object") != "response":
+            fail(f"Responses shape mismatch: {responses}", process, stderr_lines)
+
+        messages_payload = {
+            "model": "q27-metal",
+            "system": "Stable shared prefix for two independent clients.",
+            "messages": [{"role": "user", "content": "Return one short token."}],
+            "max_tokens": 1,
+            "temperature": 0,
+            "snapshot": True,
+        }
+        first_message_status, first_message = request_json(
+            port, "/v1/messages", messages_payload,
+        )
+        require_json_success("first Messages request", first_message_status, first_message)
+        second_payload = dict(messages_payload)
+        second_payload.pop("snapshot")
+        second_message_status, second_message = request_json(
+            port, "/v1/messages", second_payload,
+        )
+        require_json_success("second Messages request", second_message_status, second_message)
+        if second_message.get("q27_prefix_hit", 0) <= 0:
+            fail(f"shared snapshot was not reused by the second client: {second_message}",
+                 process, stderr_lines)
+    except AssertionError as error:
+        fail(str(error), process, stderr_lines)
+    finally:
+        if process is not None:
+            stop_server(process, thread)
+        snapshot_dir.cleanup()
+
+
+def exercise_post_publish_failure(server, model, tokenizer):
+    snapshot_dir = tempfile.TemporaryDirectory(prefix="q27-publish-failure-")
+    process = thread = None
+    stderr_lines = []
+    try:
+        process, thread, stderr_lines, port = start_server(
+            server, model, tokenizer, snapshot_dir.name,
+            {"Q27_METAL_FAIL_AFTER_SNAPSHOT_PUBLISH": "1"},
+        )
+        status, body = request_json(
+            port, "/v1/completions",
+            {"model": "q27-metal", "prompt": "z " * 180, "max_tokens": 1,
+             "stream": False, "temperature": 0, "snapshot": True},
+        )
+        if status != 200 or body.get("usage", {}).get("completion_tokens") != 1:
+            fail(f"post-publication failure escaped inference: {status} {body}",
+                 process, stderr_lines)
+        deadline = time.monotonic() + 5
+        while (time.monotonic() < deadline and not any(
+                "injected failure after snapshot publication" in line
+                for line in stderr_lines)):
+            time.sleep(0.01)
+        if not any("injected failure after snapshot publication" in line
+                   for line in stderr_lines):
+            fail("post-publication failpoint was not consumed", process, stderr_lines)
+        snapshots = [name for name in os.listdir(snapshot_dir.name)
+                     if name.endswith(".q27snap")]
+        if not snapshots:
+            fail("snapshot publication failpoint ran before publishing the shared artifact",
+                 process, stderr_lines)
+    finally:
+        if process is not None:
+            stop_server(process, thread)
+        snapshot_dir.cleanup()
+
+
+def main():
+    if len(sys.argv) != 4:
+        raise SystemExit(f"usage: {sys.argv[0]} SERVER MODEL TOKENIZER")
+    server, model, tokenizer = map(os.path.abspath, sys.argv[1:])
+    for path in (server, model, tokenizer):
+        if not os.path.isfile(path):
+            raise SystemExit(f"not a file: {path}")
+
+    exercise_recovery(server, model, tokenizer)
+    exercise_post_publish_failure(server, model, tokenizer)
+    print("Metal server recovery and shared snapshots: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/third_party/httplib.h
+++ b/third_party/httplib.h
@@ -4,6 +4,11 @@
 //  Copyright (c) 2024 Yuji Hirose. All rights reserved.
 //  MIT License
 //
+// q27 local patch: expose nonblocking peer-liveness callbacks to long-running
+// server handlers and content providers. Keep this patch when updating the
+// vendored cpp-httplib release; metal_server.cpp depends on both callbacks.
+//
+//
 
 #ifndef CPPHTTPLIB_HTTPLIB_H
 #define CPPHTTPLIB_HTTPLIB_H
@@ -535,6 +540,8 @@ public:
 
   std::function<bool(const char *data, size_t data_len)> write;
   std::function<bool()> is_writable;
+  // Nonblocking peer-disconnect probe for long-running content providers.
+  std::function<bool()> is_alive;
   std::function<void()> done;
   std::function<void(const Headers &trailer)> done_with_trailer;
   std::ostream os;
@@ -629,6 +636,8 @@ struct Request {
   Match matches;
   std::unordered_map<std::string, std::string> path_params;
 
+  // Nonblocking peer-disconnect probe for long-running server handlers.
+  std::function<bool()> is_connection_alive;
   // for client
   ResponseHandler response_handler;
   ContentReceiverWithProgress content_receiver;
@@ -661,6 +670,7 @@ struct Request {
   ContentProvider content_provider_;
   bool is_chunked_content_provider_ = false;
   size_t authorization_count_ = 0;
+
 };
 
 struct Response {
@@ -4471,6 +4481,7 @@ inline bool write_content(Stream &strm, const ContentProvider &content_provider,
   };
 
   data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
+  data_sink.is_alive = [&]() -> bool { return is_socket_alive(strm.socket()); };
 
   while (offset < end_offset && !is_shutting_down()) {
     if (!strm.is_writable()) {
@@ -4517,6 +4528,7 @@ write_content_without_length(Stream &strm,
   };
 
   data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
+  data_sink.is_alive = [&]() -> bool { return is_socket_alive(strm.socket()); };
 
   data_sink.done = [&](void) { data_available = false; };
 
@@ -4569,6 +4581,7 @@ write_content_chunked(Stream &strm, const ContentProvider &content_provider,
   };
 
   data_sink.is_writable = [&]() -> bool { return strm.is_writable(); };
+  data_sink.is_alive = [&]() -> bool { return is_socket_alive(strm.socket()); };
 
   auto done_with_trailer = [&](const Headers *trailer) {
     if (!ok) { return; }
@@ -7050,6 +7063,9 @@ Server::process_request(Stream &strm, const std::string &remote_addr,
   if (!line_reader.getline()) { return false; }
 
   Request req;
+  req.is_connection_alive = [&strm]() -> bool {
+    return detail::is_socket_alive(strm.socket());
+  };
 
   Response res;
   res.version = "HTTP/1.1";

--- a/tools/canonical_md5.sh
+++ b/tools/canonical_md5.sh
@@ -23,9 +23,11 @@ canonical_md5_for() {
   # within sm_86. A non-Blackwell `6894254e...` result therefore reproduces its
   # own architecture's canonical rather than failing to reproduce Blackwell.
   # Unlisted pairs require a same-device upstream/candidate differential.
-  # metal-m4:q4s was derived on a base Apple M4 and independently matched on a
-  # 24 GB Apple M4 Pro byte-for-byte using the same q4s artifact (artifact MD5
-  # 7e5454e0c0ded717136ad3e42634ba25), establishing the shared family canonical.
+  # metal-m4:q4s was re-derived after the serving stack promoted the measured
+  # reciprocal-multiply activation quantization and revised shader arithmetic.
+  # The new trajectory was reproduced byte-for-byte on a base Apple M4 and an
+  # independent 24 GB Apple M4 Pro using the same q4s artifact (artifact MD5
+  # 7e5454e0c0ded717136ad3e42634ba25), preserving the shared family canonical.
 
   case "$arch:$tier" in
     sm120:default) printf '%s\n' a2982c5197c627551b27d76a0a94b220 ;;
@@ -33,7 +35,7 @@ canonical_md5_for() {
     sm120:q5f)    printf '%s\n' 683f7f4450ca4c60837abdb603ee3237 ;;
     sm120:q6f)    printf '%s\n' 2a4d22eafcde63e962bf2408605fe502 ;;
     sm86:default) printf '%s\n' 6894254e3b1a184ee3802771ddd59c2b ;;
-    metal-m4:q4s) printf '%s\n' 3a82b01053311807cc8bbaacdd8dcec7 ;;
+    metal-m4:q4s) printf '%s\n' f301095522174bdb99f75ec840ad1389 ;;
     *) return 1 ;;
   esac
 }

--- a/tools/test_inspect.py
+++ b/tools/test_inspect.py
@@ -96,9 +96,12 @@ def output(result):
 
 
 def main():
-    if len(sys.argv) != 2:
-        raise SystemExit(f'usage: {sys.argv[0]} build/inspect')
+    if len(sys.argv) not in (2, 4):
+        raise SystemExit(
+            f'usage: {sys.argv[0]} build/inspect [build/q27-metal TOKENIZER]')
     inspect = sys.argv[1]
+    metal = sys.argv[2] if len(sys.argv) == 4 else None
+    tokenizer = sys.argv[3] if len(sys.argv) == 4 else None
     with tempfile.TemporaryDirectory(prefix='q27-inspect-') as tmp:
         root = pathlib.Path(tmp)
         valid = root / 'valid.q27'
@@ -158,6 +161,16 @@ def main():
                 'T2 payload contains reserved code 3' not in output(invalid_t2)):
             sys.stderr.write(output(invalid_t2))
             raise SystemExit('reserved T2 code was not detected')
+
+        if metal:
+            invalid_metal = subprocess.run(
+                [metal, str(bad_t2), tokenizer, '--validate-only'],
+                text=True, capture_output=True)
+            if (invalid_metal.returncode == 0 or
+                    'T2 payload contains reserved code 3' not in
+                    output(invalid_metal)):
+                sys.stderr.write(output(invalid_metal))
+                raise SystemExit('Metal --validate-only accepted reserved T2 code')
 
         invalid_t3_range = run(inspect, bad_t3_range)
         if (invalid_t3_range.returncode == 0 or

--- a/tools/test_responses_integration.py
+++ b/tools/test_responses_integration.py
@@ -125,6 +125,106 @@ def run_response_case(port, header_label, codex_headers, stream, reasoning_limit
     print(f"{label}: PASS")
 
 
+def tool_body(max_output_tokens):
+    return {
+        "input": "Call the echo tool with text hello world. Do not answer directly.",
+        "stream": True,
+        "max_output_tokens": max_output_tokens,
+        "enable_thinking": False,
+        "tools": [{
+            "type": "function",
+            "name": "echo",
+            "description": "Echo text",
+            "parameters": {
+                "type": "object",
+                "properties": {"text": {"type": "string"}},
+                "required": ["text"],
+                "additionalProperties": False,
+            },
+        }],
+        "tool_choice": "required",
+    }
+
+
+def require_balanced_output_items(label, events):
+    added = {
+        event.get("item", {}).get("id")
+        for event in events
+        if event.get("type") == "response.output_item.added"
+    }
+    done = {
+        event.get("item", {}).get("id")
+        for event in events
+        if event.get("type") == "response.output_item.done"
+    }
+    dangling = added - done
+    if dangling:
+        fail(f"{label}: output items left in progress: {sorted(dangling)!r}")
+
+
+def run_tool_stream_cases(port):
+    headers = {
+        "Authorization": f"Bearer {API_KEY}",
+        "x-codex-turn-metadata": "{}",
+    }
+
+    label = "tool/stream/truncated"
+    status, response_headers, payload = request(
+        port, "POST", "/v1/responses", tool_body(12), headers
+    )
+    require_status(label, status, 200)
+    if not response_headers.get("Content-Type", "").startswith("text/event-stream"):
+        fail(f"{label}: wrong content type {response_headers!r}")
+    events = parse_sse(label, payload)
+    terminal = events[-1]
+    error = terminal.get("response", {}).get("error", {})
+    if (terminal.get("type") != "response.failed" or
+            error.get("code") != "invalid_model_output"):
+        fail(f"{label}: unexpected terminal event: {terminal!r}")
+    call_item_events = [
+        event for event in events
+        if (event.get("type") in ("response.output_item.added",
+                                  "response.output_item.done") and
+            event.get("item", {}).get("type") in ("function_call",
+                                                    "custom_tool_call"))
+    ]
+    if call_item_events:
+        fail(f"{label}: incomplete call was advertised: {call_item_events!r}")
+    print(f"{label}: PASS")
+
+    label = "tool/stream/completed"
+    status, response_headers, payload = request(
+        port, "POST", "/v1/responses", tool_body(64), headers
+    )
+    require_status(label, status, 200)
+    events = parse_sse(label, payload)
+    types = [event.get("type") for event in events]
+    required = (
+        "response.output_item.added",
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.done",
+        "response.output_item.done",
+        "response.completed",
+    )
+    if any(event_type not in types for event_type in required):
+        fail(f"{label}: incomplete function-call lifecycle: {types!r}")
+    positions = [types.index(event_type) for event_type in required]
+    if positions != sorted(positions):
+        fail(f"{label}: out-of-order function-call lifecycle: {types!r}")
+    done_items = [
+        event.get("item", {}) for event in events
+        if event.get("type") == "response.output_item.done"
+    ]
+    if (not done_items or done_items[-1].get("status") != "completed" or
+            done_items[-1].get("name") != "echo"):
+        fail(f"{label}: wrong completed function call: {done_items!r}")
+    arguments = parse_json(label, done_items[-1].get("arguments", ""))
+    if arguments != {"text": "hello world"}:
+        fail(f"{label}: wrong function arguments: {arguments!r}")
+    require_balanced_output_items(label, events)
+    print(f"{label}: PASS")
+
+
 def wait_ready(process, port, log_path):
     deadline = time.monotonic() + 300
     last_error = "not started"
@@ -203,6 +303,7 @@ def main():
                     run_response_case(
                         port, header_label, codex_headers, stream, reasoning_limited
                     )
+        run_tool_stream_cases(port)
         print("all production Responses integration tests passed")
     finally:
         if process.poll() is None:

--- a/tools/test_snapshot_store_shared.cpp
+++ b/tools/test_snapshot_store_shared.cpp
@@ -1,0 +1,283 @@
+#include "disk_snapshot_store.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <poll.h>
+#include <sys/wait.h>
+#include <thread>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+static SnapPeekInfo fixture_peek(int fd,const std::string&) {
+    uint8_t resident=0;
+    uint32_t count=0;
+    if(::pread(fd,&resident,sizeof resident,0)!=(ssize_t)sizeof resident ||
+       ::pread(fd,&count,sizeof count,sizeof resident)!=(ssize_t)sizeof count)
+        throw std::runtime_error("invalid snapshot fixture");
+    SnapPeekInfo info;
+    info.logits_resident=resident!=0;
+    info.position=count;
+    info.tokens.resize(count);
+    if(count && ::pread(fd,info.tokens.data(),(size_t)count*sizeof(uint32_t),
+                        sizeof resident+sizeof count)!=(ssize_t)((size_t)count*sizeof(uint32_t)))
+        throw std::runtime_error("invalid snapshot fixture");
+    return info;
+}
+
+static void fixture_hash(const uint32_t* tokens,uint32_t count,char out[41]) {
+    uint64_t hash=1469598103934665603ull;
+    for(uint32_t i=0;i<count;i++) {
+        hash^=tokens[i];
+        hash*=1099511628211ull;
+    }
+    std::snprintf(out,41,"%040llx",(unsigned long long)hash);
+}
+
+static uint64_t publication_stripe(const std::string& path) {
+    uint64_t hash=1469598103934665603ull;
+    for(const unsigned char c:path) {
+        hash^=c;
+        hash*=1099511628211ull;
+    }
+    return hash%64;
+}
+
+static void write_file(const std::string& path,size_t bytes,int age_seconds) {
+    std::ofstream out(path,std::ios::binary);
+    std::string payload(bytes,'x');
+    out.write(payload.data(),(std::streamsize)payload.size());
+    out.close();
+    std::error_code ec;
+    fs::last_write_time(path,fs::file_time_type::clock::now()-
+        std::chrono::seconds(age_seconds),ec);
+}
+
+static void publish_fixture(const std::string& path,
+                            const std::vector<uint32_t>& tokens,bool resident) {
+    const std::string tmp=path+".next";
+    std::ofstream out(tmp,std::ios::binary);
+    const uint8_t flag=resident?1:0;
+    const uint32_t count=(uint32_t)tokens.size();
+    out.write(reinterpret_cast<const char*>(&flag),sizeof flag);
+    out.write(reinterpret_cast<const char*>(&count),sizeof count);
+    if(count) out.write(reinterpret_cast<const char*>(tokens.data()),
+                        (std::streamsize)count*sizeof(uint32_t));
+    out.close();
+    fs::rename(tmp,path);
+}
+
+static bool publication_lock_same_process(DiskSnapshotStore& store,
+                                          const std::string& path) {
+    std::atomic<bool> entered{false};
+    bool blocked=false;
+    std::thread contender;
+    const bool outer=store.with_publication_lock(path,[&] {
+        contender=std::thread([&] {
+            store.with_publication_lock(path,[&] {
+                entered.store(true,std::memory_order_release);
+                return true;
+            });
+        });
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        blocked=!entered.load(std::memory_order_acquire);
+        return true;
+    });
+    contender.join();
+    return outer && blocked && entered.load(std::memory_order_acquire);
+}
+
+static bool publication_lock_cross_process(DiskSnapshotStore& store,
+                                           const std::string& path) {
+    int start_pipe[2],entered_pipe[2];
+    if(::pipe(start_pipe)!=0 || ::pipe(entered_pipe)!=0) return false;
+    const pid_t child=::fork();
+    if(child<0) return false;
+    if(child==0) {
+        ::close(start_pipe[1]);
+        ::close(entered_pipe[0]);
+        char byte=0;
+        if(::read(start_pipe[0],&byte,1)!=1) _exit(2);
+        const bool ok=store.with_publication_lock(path,[&] {
+            byte=1;
+            return ::write(entered_pipe[1],&byte,1)==1;
+        });
+        _exit(ok?0:3);
+    }
+    ::close(start_pipe[0]);
+    ::close(entered_pipe[1]);
+    bool blocked=false;
+    const bool outer=store.with_publication_lock(path,[&] {
+        char byte=1;
+        if(::write(start_pipe[1],&byte,1)!=1) return false;
+        pollfd wait_for_child{entered_pipe[0],POLLIN,0};
+        blocked=::poll(&wait_for_child,1,150)==0;
+        return true;
+    });
+    pollfd wait_for_child{entered_pipe[0],POLLIN,0};
+    const bool entered=::poll(&wait_for_child,1,2000)==1;
+    char byte=0;
+    if(entered) (void)::read(entered_pipe[0],&byte,1);
+    int status=0;
+    const bool reaped=::waitpid(child,&status,0)==child;
+    ::close(start_pipe[1]);
+    ::close(entered_pipe[0]);
+    return outer && blocked && entered && byte==1 && reaped &&
+           WIFEXITED(status) && WEXITSTATUS(status)==0;
+}
+
+int main() {
+    const std::string dir=(::getenv("TMPDIR")?::getenv("TMPDIR"):"/tmp")+
+        std::string("/q27-snapshot-shared-")+std::to_string((long long)getpid());
+    std::error_code ec;
+    fs::remove_all(dir,ec);
+    fs::create_directories(dir,ec);
+    if(ec) {
+        std::fprintf(stderr,"cannot create fixture directory: %s\n",ec.message().c_str());
+        return 1;
+    }
+
+    const std::string owned_temp=dir+"/own-"+std::string(40,'a')+
+        ".q27snap.tmp.A1b2C3";
+    const std::string unrelated_temp=dir+"/notes.q27snap.tmp.backup";
+    const std::string malformed_owned=dir+"/own-"+std::string(40,'a')+
+        ".q27snap.tmp.backups";
+    const std::string foreign_temp=dir+"/other-"+std::string(40,'a')+
+        ".q27snap.tmp.A1b2C3";
+    write_file(owned_temp,1,100);
+    write_file(unrelated_temp,1,100);
+    write_file(malformed_owned,1,100);
+    write_file(foreign_temp,1,100);
+
+    const std::string own=dir+"/own-current.q27snap";
+    const std::string foreign=dir+"/other-older.q27snap";
+    write_file(own,100,10);
+    write_file(foreign,200,100);
+
+    DiskSnapshotStore store(&fixture_peek,&fixture_hash);
+    store.init(dir,100,"own-",false);
+    const auto evicted=store.evict_past_budget();
+    const bool owned_removed=!fs::exists(owned_temp,ec);
+    const bool unrelated_kept=fs::exists(unrelated_temp,ec);
+    const bool malformed_kept=fs::exists(malformed_owned,ec);
+    const bool foreign_kept=fs::exists(foreign_temp,ec);
+    const bool stale_cleanup_ok=owned_removed && unrelated_kept && malformed_kept &&
+        foreign_kept;
+    if(!stale_cleanup_ok) {
+        std::fprintf(stderr,"snapshot temporary cleanup crossed ownership boundary "
+            "(owned=%d unrelated=%d malformed=%d foreign=%d)\n",
+            owned_removed,unrelated_kept,malformed_kept,foreign_kept);
+        fs::remove_all(dir,ec);
+        return 1;
+    }
+    const bool eviction_ok=evicted.first==0 && fs::exists(own,ec) && fs::exists(foreign,ec);
+    if(!eviction_ok) {
+        std::fprintf(stderr,"snapshot eviction crossed artifact tag boundary\n");
+        fs::remove_all(dir,ec);
+        return 1;
+    }
+
+    fs::remove(own,ec);
+    fs::remove(foreign,ec);
+    const uint64_t eviction_stripe=publication_stripe(dir+"/.race-eviction");
+    std::string colliding_path;
+    for(int i=0;colliding_path.empty();i++) {
+        const std::string candidate=dir+"/race-collision-"+
+            std::to_string(i)+".q27snap";
+        if(publication_stripe(candidate)==eviction_stripe) colliding_path=candidate;
+    }
+    write_file(colliding_path,100,30);
+    write_file(dir+"/race-newer-a.q27snap",100,20);
+    write_file(dir+"/race-newer-b.q27snap",100,10);
+    DiskSnapshotStore evictor_a(&fixture_peek,&fixture_hash);
+    DiskSnapshotStore evictor_b(&fixture_peek,&fixture_hash);
+    evictor_a.init(dir,150,"race-",false);
+    evictor_b.init(dir,150,"race-",false);
+    std::thread eviction_a([&] { (void)evictor_a.evict_past_budget(); });
+    std::thread eviction_b([&] { (void)evictor_b.evict_past_budget(); });
+    eviction_a.join();
+    eviction_b.join();
+    size_t remaining_files=0;
+    uint64_t remaining_bytes=0;
+    for(const auto& entry:fs::directory_iterator(dir,ec)) {
+        if(entry.path().extension()==".q27snap" &&
+           entry.path().filename().string().rfind("race-",0)==0) {
+            remaining_files++;
+            remaining_bytes+=(uint64_t)entry.file_size();
+        }
+    }
+    if(remaining_files!=1 || remaining_bytes!=100) {
+        std::fprintf(stderr,"concurrent snapshot eviction over-deleted files\n");
+        fs::remove_all(dir,ec);
+        return 1;
+    }
+
+    fs::remove_all(dir,ec);
+    fs::create_directories(dir,ec);
+    DiskSnapshotStore shared(&fixture_peek,&fixture_hash);
+    shared.init(dir,0,"own-",false);
+    const std::vector<uint32_t> tokens={1,2,3};
+    const std::string path=shared.path_for(tokens.data(),(uint32_t)tokens.size());
+    publish_fixture(path,tokens,false);
+    const bool saw_stale=!shared.exact_resident(tokens.data(),(uint32_t)tokens.size());
+    publish_fixture(path,tokens,true);
+    const bool saw_external_resident=shared.exact_resident(tokens.data(),(uint32_t)tokens.size());
+    publish_fixture(path,tokens,false);
+    auto stale_match=shared.best_match(tokens);
+    const bool rejected_external_stale=!stale_match;
+    const bool peer_removed_meta=fs::remove(path,ec);
+    (void)shared.best_match(tokens);
+    const auto cached_after_meta_remove=shared.cache_entry_counts();
+    publish_fixture(path,tokens,false);
+    shared.published(path,tokens.data(),(uint32_t)tokens.size());
+    const bool peer_removed_tokens=fs::remove(path,ec);
+    (void)shared.best_match(tokens);
+    const auto cached_after_token_remove=shared.cache_entry_counts();
+    const bool pruned_peer_metadata=peer_removed_meta && peer_removed_tokens &&
+        cached_after_meta_remove.first==0 && cached_after_meta_remove.second==0 &&
+        cached_after_token_remove.first==0 && cached_after_token_remove.second==0;
+    const bool same_process_lock=publication_lock_same_process(shared,path);
+    const bool cross_process_lock=publication_lock_cross_process(shared,path);
+    publish_fixture(path,tokens,false);
+    const int old_fd=::open(path.c_str(),O_RDONLY|O_CLOEXEC);
+    publish_fixture(path,tokens,true);
+    shared.reject(path,old_fd);
+    if(old_fd>=0) ::close(old_fd);
+    const bool replacement_survived=fs::exists(path,ec) &&
+        shared.exact_resident(tokens.data(),(uint32_t)tokens.size());
+    const int current_fd=::open(path.c_str(),O_RDONLY|O_CLOEXEC);
+    shared.reject(path,current_fd);
+    if(current_fd>=0) ::close(current_fd);
+    const bool failed_current_removed=!fs::exists(path,ec);
+    publish_fixture(path,tokens,true);
+    const std::string real_path=path+".real";
+    fs::rename(path,real_path,ec);
+    const bool rename_ok=!ec;
+    const bool symlink_created=rename_ok && ::symlink(real_path.c_str(),path.c_str())==0;
+    auto symlink_match=shared.best_match(tokens);
+    const bool symlink_rejected=symlink_created && !symlink_match;
+    (void)::unlink(path.c_str());
+    if(rename_ok) fs::rename(real_path,path,ec);
+    DiskSnapshotStore peer(&fixture_peek,&fixture_hash);
+    peer.init(dir,0,"own-",false);
+    auto peer_match=peer.best_match(tokens);
+    const bool shared_across_instances=peer_match &&
+        peer_match.path==path && peer_match.info.tokens.size()==tokens.size() &&
+        peer.exact_resident(tokens.data(),(uint32_t)tokens.size());
+    peer_match=DiskSnapshotStore::Match{};
+    fs::remove_all(dir,ec);
+    if(!saw_stale || !saw_external_resident || !rejected_external_stale ||
+       !pruned_peer_metadata || !same_process_lock || !cross_process_lock ||
+       !replacement_survived || !failed_current_removed || !symlink_rejected ||
+       !shared_across_instances) {
+        std::fprintf(stderr,"snapshot metadata, shared reuse, or publication lock failed\n");
+        return 1;
+    }
+    std::puts("snapshot store metadata, shared reuse, and publication locking: PASS");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- add the Metal HTTP server for OpenAI, Anthropic, and Responses APIs on top of the merged shared-serving contract
- add memory- and disk-backed prefix snapshots, atomic recovery, backend health handling, stream formatting, and focused serving-policy helpers
- preserve truthful incomplete Responses lifecycles, incremental tool-call streaming, optional one-principal API-key authentication, and the repository's single-operator security boundary
- publish the measured M4-family q4s canonical produced by the promoted serving shaders

## Scope

This is the Metal-serving stage separated from the Metal engine and shared API/CUDA serving work negotiated in issue #8. It is replayed directly onto the actual PR #20 merge.

Serving commit: `5013a57663e88285101beeec63f19d5b6faf1ec0`  
Diagnostic commit: `062ae1a133e3b81a5aff3c9091ce82a867182ff2`  
Exact tree: `b8364066d923db16617e6abbf672b2fe81a9f06f`  
Base: `c2b04865bde08f46db24774d3c454181440e2df2`

22 files, +11,234/-515 versus the parent. The second commit only adds the runtime Metal shader SHA-1 to the model-ready diagnostic so canonical reports identify the source actually compiled.

The branch removes Bonsai-specific artifact/execution support, dormant Metal probe APIs and kernels, private review provenance, and the no-op shared sampling refactor. Bonsai remains a separate follow-up proposal.

It excludes `docs/metal/`, activity logs, experiments, packaging, CUDA compiler-policy changes, request-body/aggregate-stop caps, bounded queue policy, browser filters, separate admin authorization, credential-scoped caches, extended existing-file privacy policy, and pre-response socket cancellation.

## Canonical publication

This serving stack intentionally changes Metal forward-pass numerics through promoted reciprocal-multiply activation quantization and revised shader arithmetic. The published `metal-m4:q4s` digest is:

```
f301095522174bdb99f75ec840ad1389
```

The exact corrected tip rebuilt locally with runtime shader SHA-1:

```
0292df9ee92de94a9af8d65dd916aabbf76342be
```

and produced `f301095522174bdb99f75ec840ad1389`, 56 speculation rounds, 127 drafts, and 72 accepted drafts (56.7%). The 16-token MTP/plain prefix remained byte-identical. The earlier contradictory `3a82b010...` report did not identify the shader loaded; this diagnostic removes that ambiguity, and the owner's report was correct.

## Review findings addressed

- every CUDA server target names `third_party/httplib.h` as a dependency; touching the header schedules all three rebuilds
- the vendored header records the q27 nonblocking peer-liveness patch so a vendor update cannot silently drop it
- the unrelated `src/sampling.h` refactor is absent
- Metal tool-constraint mask pools are request-scoped; slot assignment resets the allocator and invalidates the host-id map
- every teacher-forced NLL/logit path invalidates MTP cache state after advancing the main model

## Verification

On Apple M4, exact corrected source:

- clean `-Wall -Wextra -Werror` Metal CLI build: PASS
- `tools/metal_canonical_gate.sh MODEL TOKENIZER`: `f301095522174bdb99f75ec840ad1389`; runtime shader SHA-1 `0292df9ee92de94a9af8d65dd916aabbf76342be`; 16-token MTP/plain prefix byte-identical; `METAL CANONICAL GATES: ALL PASS`
- `build/test-metal-backend`: PASS
- `build/test-metal-ops`: PASS
- `touch third_party/httplib.h && make -n build/q27-server build/q27-server-w8 build/q27-server-w16`: all three compile commands emitted
- `git diff --check`: PASS
- remote branch OID matches `062ae1a133e3b81a5aff3c9091ce82a867182ff2`

The previous full exact-tree verification remains applicable to serving commit `5013a576...`; the only follow-up change is the startup diagnostic above. A concurrent rerun of the long engine-contract binary exceeded the one-hour harness timeout after reaching repeated real-model loads, so it is not claimed as a fresh pass here.

## Serving boundary

- loopback remains the default bind
- API keys remain optional and use one rotation set for every non-health route
- prefix caches remain content-keyed across that set
- production request failpoints are disabled; recovery failpoints exist only in the dedicated test build
- explicit memory budgets are honored by auto-context admission
- no header-triggered client exception changes Responses terminal semantics

Follows the completed decomposition in #8 and the shared-serving merge in #20.
