### PR TITLE
metal: restore Bonsai model support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,8 @@ build/test_metal_engine_contracts: src/metal/test_metal_engine_contracts.cpp \
 
 test-metal-contracts: build/test_metal_engine_contracts build/test_metal_model_contracts build/test_metal_stream
 	@test -n "$(MODEL)" || { echo "set MODEL=...q4s.q27" >&2; exit 2; }
-	./build/test_metal_engine_contracts "$(MODEL)"
+	@test -n "$(BONSAI_MODEL)" || { echo "set BONSAI_MODEL=...bonsai-t2.q27" >&2; exit 2; }
+	./build/test_metal_engine_contracts "$(MODEL)" "$(BONSAI_MODEL)"
 	./build/test_metal_model_contracts "$(MODEL)"
 	./build/test_metal_stream
 

--- a/Makefile
+++ b/Makefile
@@ -201,8 +201,11 @@ build/test_metal_engine_contracts: src/metal/test_metal_engine_contracts.cpp \
 
 test-metal-contracts: build/test_metal_engine_contracts build/test_metal_model_contracts build/test_metal_stream
 	@test -n "$(MODEL)" || { echo "set MODEL=...q4s.q27" >&2; exit 2; }
-	@test -n "$(BONSAI_MODEL)" || { echo "set BONSAI_MODEL=...bonsai-t2.q27" >&2; exit 2; }
-	./build/test_metal_engine_contracts "$(MODEL)" "$(BONSAI_MODEL)"
+	@if test -n "$(BONSAI_MODEL)"; then \
+		./build/test_metal_engine_contracts "$(MODEL)" "$(BONSAI_MODEL)"; \
+	else \
+		./build/test_metal_engine_contracts "$(MODEL)"; \
+	fi
 	./build/test_metal_model_contracts "$(MODEL)"
 	./build/test_metal_stream
 

--- a/src/metal/metal_backend.h
+++ b/src/metal/metal_backend.h
@@ -18,6 +18,7 @@ class MetalBackend final : public ComputeBackend {
     static const char* shader_abi_tag();
     std::string shader_source_sha1() const;
     bool gemm_half_enabled() const;
+    bool gemm_half_q4_enabled() const;
     uint32_t gqa_tile() const;
     uint32_t gqa_block() const;
     uint32_t gqa_threshold() const;
@@ -54,7 +55,57 @@ class MetalBackend final : public ComputeBackend {
     void matvec_quantized_pair(const BackendTensor& a, BackendBuffer& a_out,
                                const BackendTensor& b, BackendBuffer& b_out,
                                const BackendQuantized& x) override;
-void matmul_quantized(const BackendTensor& weight,const BackendQuantized& x,
+    // N=2 slot-batched T2 GEMV (Phase 2 probe): x = 2 activation rows
+    // ([2,cols] values / [2,cols/32] scales), y = [2,rows] token-major.
+    // PARKED by measurement (2026-07-16): aggregate s_k 1.093 vs the 1.31
+    // decision line — bench-only reference surface, never engine-routed.
+    void matvec_quantized_x2(const BackendTensor& weight,
+                             const BackendQuantized& x, BackendBuffer& y);
+    // Select-form float-activation variant (the production serial-decode
+    // path), two independent x/y buffer pairs. Same PARKED status.
+    void matvec_x2(const BackendTensor& weight,
+                   const BackendBuffer& x_a, const BackendBuffer& x_b,
+                   BackendBuffer& y_a, BackendBuffer& y_b);
+    // A/B/C MMA roofline probe (bench-only): arm 'a' = MMA-core ceiling
+    // (w_or_seed = opaque tile seed, other pointers null), arm 'b' =
+    // half-plumbing (half weights/scales/activations, float x scales).
+    // Same dispatch grid and tile geometry as the production T2 GEMM.
+    void mma_roofline(char arm, uint32_t rows, uint32_t cols, uint32_t x_rows,
+                      const BackendBuffer& w_or_seed, const BackendBuffer* w_scales,
+                      const BackendBuffer* x, const BackendBuffer* x_scales,
+                      BackendBuffer& y);
+    // B1 Phase 0B probe (bench-only, docs/metal/plans/2026-07-15-binary-tier.md):
+    // candidate 1 select / 2 sign-XOR / 3 int8 bitplane+popcount, raw
+    // buffers, no DType. Candidate 3 dispatches its activation preprocess
+    // (int8 quantize + bitplane transpose + group sums) before the dot, so
+    // both land inside any timed region; scratch holds its planes + aux
+    // ((cols/128)*136 bytes) and is ignored by candidates 1-2. Never
+    // engine-routed.
+    void matvec_b1_probe(int candidate, uint32_t rows, uint32_t cols,
+                         const BackendBuffer& bits, const BackendBuffer& scales,
+                         const BackendBuffer& x, BackendBuffer* scratch,
+                         BackendBuffer& y);
+    // Q4 rewrite-round candidate arms (bench-only, docs/plans/2026-07-17-
+    // q4-rewrite-round.md): candidate 1 = the production kernel through the
+    // probe path (A/B parity in one code path; Q4 or Q8 weight), 2 = Q4
+    // 2-rows-per-simdgroup (retained comparison arm), 3 = alias of the
+    // production kernel (r4 was promoted, 2026-07-17), 4 = THROWS (the A'
+    // Q8 twin was killed by measurement — round doc RESULTS). Validation as
+    // matvec_quantized; candidate PSOs build lazily on first call, so
+    // production startup never creates them. Never engine-routed.
+    void matvec_q4_probe(int candidate, const BackendTensor& weight,
+                         const BackendQuantized& x, BackendBuffer& y);
+    // B1 select round-2 candidate arms (bench-only, docs/plans/2026-07-17-
+    // b1-select-round2.md): candidate 1 = the production B1 select GEMV
+    // through the probe path (A/B parity in one code path), 2 = alias of
+    // the production kernel (the 4-row r2 arm was PROMOTED, 2026-07-17
+    // round), 3 = the retained 8-row issue-depth arm (never run in the
+    // round). Validation as matvec_quantized; the r3 PSO builds lazily on
+    // first call, so production startup never creates it. Never
+    // engine-routed.
+    void matvec_b1r2_probe(int candidate, const BackendTensor& weight,
+                           const BackendQuantized& x, BackendBuffer& y);
+    void matmul_quantized(const BackendTensor& weight,const BackendQuantized& x,
                           uint32_t x_rows,BackendBuffer& y) override;
     void embedding_q8(const BackendTensor& weight, uint32_t token,
                       BackendBuffer& out) override;
@@ -200,6 +251,11 @@ void matmul_quantized(const BackendTensor& weight,const BackendQuantized& x,
     void kv_store_turbo3_rows(const BackendBuffer& k, const BackendBuffer& v,
                               BackendBuffer& k_cache, BackendBuffer& v_cache,
                               uint32_t position, uint32_t kv_heads, uint32_t tokens);
+    void kv_store_f16_attrib_rows(const BackendBuffer& k, const BackendBuffer& v,
+                                  BackendBuffer& k_cache, BackendBuffer& v_cache,
+                                  uint32_t position, uint32_t kv_heads, uint32_t tokens,
+                                  uint32_t mode, uint32_t head, uint32_t flags,
+                                  uint32_t scale_off, BackendBuffer* aux);
     void attention_f16_causal(const BackendBuffer& q, uint32_t q_stride,
                               uint32_t q_row_stride, const BackendBuffer& k_cache,
                               const BackendBuffer& v_cache,
@@ -212,6 +268,34 @@ void matmul_quantized(const BackendTensor& weight,const BackendQuantized& x,
                                  BackendBuffer& out, uint32_t base_len, uint32_t q_heads,
                                  uint32_t kv_heads, uint32_t head_dim, uint32_t tokens,
                                  float scale, BackendBuffer* partials);
+    // Phase-0 probes for cache-block scheduling R1/R1b — bench-only entry
+    // points (build/metal_attn_bench), never engine-routed; see
+    // docs/metal/plans/2026-07-15-cache-block-scheduling.md. k/v caches hold rows
+    // head-major: (kvh * seq_cap + pos) * 100 bytes.
+    // Probe entries always run blocked, so partials is required (callers are
+    // benches; they allocate their own scratch sized for their sweep).
+    void attention_turbo3_gqa_headmajor(const BackendBuffer& q, uint32_t q_stride,
+                                        const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                                        BackendBuffer& out, uint32_t seq_len, uint32_t seq_cap,
+                                        uint32_t q_heads, uint32_t kv_heads,
+                                        uint32_t head_dim, float scale, BackendBuffer& partials);
+    // tile must be 2 or 4; interleaved (production-layout) caches.
+    // R3 probe (bench-only): barrier-free direct-read block-partial causal
+    // GQA at token factor 2 with an explicit block-size override.
+    void attention_turbo3_causal_gqa_bf(const BackendBuffer& q, uint32_t q_stride,
+                                        uint32_t q_row_stride,
+                                        const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                                        BackendBuffer& out, uint32_t base_len,
+                                        uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
+                                        uint32_t tokens, uint32_t block, float scale,
+                                        BackendBuffer& partials);
+    void attention_turbo3_causal_gqa_tiled(const BackendBuffer& q, uint32_t q_stride,
+                                           uint32_t q_row_stride,
+                                           const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                                           BackendBuffer& out, uint32_t base_len,
+                                           uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
+                                           uint32_t tokens, uint32_t tile, float scale,
+                                           BackendBuffer& partials);
     void sigmoid_gate_mul_rows(BackendBuffer& out, const BackendBuffer& qg,
                                uint32_t heads, uint32_t head_dim, uint32_t tokens) override;
     void argmax_rows(const BackendBuffer& x, uint32_t n, uint32_t rows,

--- a/src/metal/metal_backend.mm
+++ b/src/metal/metal_backend.mm
@@ -210,6 +210,7 @@ struct L2RowsArgs { uint32_t heads, head_dim, row_stride, tokens; float eps; };
 struct RopeRowsArgs { uint32_t heads, head_dim, n_rot, stride, row_stride, position, tokens; float freq_base; };
 struct KvStoreRowsArgs { uint32_t position, row_length, tokens; };
 struct TurboStoreRowsArgs { uint32_t position, kv_heads, tokens; };
+struct TurboAttribArgs { uint32_t position, kv_heads, tokens, mode, head, flags, scale_off; };
 struct GateRowsArgs { uint32_t heads, head_dim, tokens; };
 struct ArgmaxRowsArgs { uint32_t n, rows; };
 struct AttentionCausalArgs { uint32_t q_stride, q_row_stride, base_len, q_heads, kv_heads, head_dim, tokens; float scale; };
@@ -228,7 +229,10 @@ struct MetalBackend::Impl {
     id<MTLComputePipelineState> q8;
     id<MTLComputePipelineState> q4;
     id<MTLComputePipelineState> t2;
+    id<MTLComputePipelineState> t3;
+    id<MTLComputePipelineState> b1;
     id<MTLComputePipelineState> t2_quantized_matmul_h;
+    id<MTLComputePipelineState> q4_quantized_matmul_h;
     id<MTLComputePipelineState> mask_logits_p;
     // Half-staging chunk GEMMs: default ON (T2 landed at 1.22x chunk rate at
     // quality parity — the GEMM envelope class, docs/plans/2026-07-15-
@@ -236,19 +240,32 @@ struct MetalBackend::Impl {
     // reproduces the float-staged routes (used to attribute the kl-kv
     // calibration shift to the digit, 2026-07-16-kv-codec-step1.md).
     bool gemm_half = true;
+    // Q4 half port remains probe-only pending a valid quiet gate
+    // (2026-07-17-t2-prefill-throughput.md asks >=1.7x). The 0.855 run was
+    // forced with idle>=0 and is explicitly rejected in
+    // logs/q4port-20260717/QUIET_BENCH_EVIDENCE.md. Correctness-gated;
+    // never the default until a valid quiet run clears the ship line.
+    bool gemm_half_q4 = false;
     id<MTLComputePipelineState> quantize;
     id<MTLComputePipelineState> q8_quantized;
     id<MTLComputePipelineState> q4_quantized;
     id<MTLComputePipelineState> t2_quantized;
+    id<MTLComputePipelineState> b1_quantized;
+    id<MTLComputePipelineState> t2_quantized_x2;
+    id<MTLComputePipelineState> t2_x2;
     id<MTLComputePipelineState> f16_pair;
     id<MTLComputePipelineState> q4_quantized_matmul;
     id<MTLComputePipelineState> q8_quantized_matmul;
     id<MTLComputePipelineState> t2_quantized_matmul;
+    id<MTLComputePipelineState> b1_quantized_matmul;
     id<MTLComputePipelineState> embedding;
     id<MTLComputePipelineState> embedding_t2;
+    id<MTLComputePipelineState> embedding_b1;
     id<MTLComputePipelineState> embedding_dev;
     id<MTLComputePipelineState> embedding_t2_dev;
+    id<MTLComputePipelineState> embedding_b1_dev;
     id<MTLComputePipelineState> embedding_t2_rows;
+    id<MTLComputePipelineState> embedding_b1_rows;
     id<MTLComputePipelineState> rms;
     id<MTLComputePipelineState> rms_quantized;
     id<MTLComputePipelineState> rms_heads;
@@ -279,6 +296,8 @@ struct MetalBackend::Impl {
     id<MTLComputePipelineState> rope_rows;
     id<MTLComputePipelineState> kv_store_rows;
     id<MTLComputePipelineState> kv_store_turbo3_rows;
+    id<MTLComputePipelineState> kv_store_attrib_rows;
+    id<MTLBuffer> attrib_dummy;
     id<MTLComputePipelineState> attention_causal;
     id<MTLComputePipelineState> attention_causal_win;
     id<MTLComputePipelineState> kv_store_head_rows;
@@ -293,7 +312,34 @@ struct MetalBackend::Impl {
     id<MTLComputePipelineState> attention_turbo3_causal_gqa_p;
     id<MTLComputePipelineState> attention_gqa_merge_rows_p;
     // R1b token-tiled causal GQA (t2 = production route, t4 + hm = bench).
+    id<MTLComputePipelineState> attention_turbo3_gqa_hm_p;
     id<MTLComputePipelineState> attention_turbo3_causal_gqa_t2_p;
+    id<MTLComputePipelineState> attention_turbo3_causal_gqa_t4_p;
+    id<MTLComputePipelineState> attention_turbo3_causal_gqa_bf2_p;
+    id<MTLComputePipelineState> mma_roofline_a_p;
+    id<MTLComputePipelineState> mma_roofline_b_p;
+    id<MTLComputePipelineState> mma_roofline_b_eq_p;
+    id<MTLComputePipelineState> mma_roofline_cx_p;
+    id<MTLComputePipelineState> mma_roofline_f_p;
+    id<MTLComputePipelineState> b1_select_p;
+    id<MTLComputePipelineState> b1_signxor_p;
+    id<MTLComputePipelineState> b1_popcount_p;
+    id<MTLComputePipelineState> b1_x_prep_p;
+    // Q4-round retained comparison arm (bench-only): built on first
+    // matvec_q4_probe use (the roofline-k pattern), so production startup
+    // never creates it. r4 was promoted into q4_quantized; the q8 twin was
+    // killed by measurement (2026-07-17 round doc).
+    id<MTLComputePipelineState> q4_r2_p;
+    // B1 round-2 retained 8-row arm (bench-only): built on first
+    // matvec_b1r2_probe use, same lazy pattern as q4_r2_p above. The 4-row
+    // r2 arm was promoted into b1_quantized (2026-07-17 round).
+    id<MTLComputePipelineState> b1_r3_p;
+    // Arm K (function-constant probe): one specialized PSO per baked cols.
+    std::map<uint32_t, id<MTLComputePipelineState>> mma_roofline_k_p;
+    id<MTLComputePipelineState> mm_dr_p;
+    id<MTLComputePipelineState> mm_dr2_p;
+    id<MTLComputePipelineState> x_to_half_t_p;
+    id<MTLBuffer> dr_xt_scratch;
     id<MTLComputePipelineState> attention_f16_causal_gqa_t2_p;
     // Q27_METAL_GQA_TILE: causal token-tile factor, 1 (untiled A/B lever)
     // or 2 (default; docs/plans/2026-07-15-cache-block-scheduling.md R1b).
@@ -627,11 +673,20 @@ MetalBackend::MetalBackend() : impl_(new Impl) {
         impl_->q8 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_q8_g128");
         impl_->q4 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_q4_g64");
         impl_->t2 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_t2_g128");
+        impl_->t3 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_t3_g128");
+        impl_->b1 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_b1_g128");
         impl_->mask_logits_p = make_pipeline(impl_->device, impl_->library, @"q27_mask_logits");
+        impl_->b1_select_p = make_pipeline(impl_->device, impl_->library, @"q27_matvec_b1_select");
+        impl_->b1_signxor_p = make_pipeline(impl_->device, impl_->library, @"q27_matvec_b1_signxor");
+        impl_->b1_popcount_p = make_pipeline(impl_->device, impl_->library, @"q27_matvec_b1_popcount");
+        impl_->b1_x_prep_p = make_pipeline(impl_->device, impl_->library, @"q27_b1_x_prep");
         impl_->quantize = make_pipeline(impl_->device, impl_->library, @"q27_quantize_x");
         impl_->q8_quantized = make_pipeline(impl_->device, impl_->library, @"q27_matvec_q8_quantized");
         impl_->q4_quantized = make_pipeline(impl_->device, impl_->library, @"q27_matvec_q4_quantized");
         impl_->t2_quantized = make_pipeline(impl_->device, impl_->library, @"q27_matvec_t2_quantized");
+        impl_->b1_quantized = make_pipeline(impl_->device, impl_->library, @"q27_matvec_b1_quantized");
+        impl_->t2_quantized_x2 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_t2_quantized_x2");
+        impl_->t2_x2 = make_pipeline(impl_->device, impl_->library, @"q27_matvec_t2_g128_x2");
         impl_->f16_pair = make_pipeline(impl_->device, impl_->library, @"q27_matvec_f16_pair");
         // SIMD-scoped matrix multiply is optional on older Intel-family Metal
         // devices. Decode GEMV remains available there; only small-N GEMM is gated.
@@ -640,14 +695,32 @@ MetalBackend::MetalBackend() : impl_(new Impl) {
             impl_->q8_quantized_matmul = make_pipeline(impl_->device, impl_->library, @"q27_matmul_q8_mm");
             impl_->t2_quantized_matmul = make_pipeline(impl_->device, impl_->library, @"q27_matmul_t2_mm");
             impl_->t2_quantized_matmul_h = make_pipeline(impl_->device, impl_->library, @"q27_matmul_t2_mm_h");
+            // q27_matmul_q4_mm_h is probe-only pending its valid quiet gate
+            // and routes only under Q27_METAL_GEMM_HALF_Q4=1 — built lazily on
+            // first use so production startup never compiles it (same pattern
+            // as the probe-only q4_r2_p/b1_r3_p PSOs).
+            impl_->b1_quantized_matmul = make_pipeline(impl_->device, impl_->library, @"q27_matmul_b1_mm");
+            impl_->mma_roofline_a_p = make_pipeline(impl_->device, impl_->library, @"q27_mma_roofline_a");
+            impl_->mma_roofline_b_p = make_pipeline(impl_->device, impl_->library, @"q27_mma_roofline_b");
+            impl_->mma_roofline_b_eq_p = make_pipeline(impl_->device, impl_->library, @"q27_mma_roofline_b_eq");
+            impl_->mma_roofline_cx_p = make_pipeline(impl_->device, impl_->library, @"q27_mma_roofline_cx");
+            impl_->mma_roofline_f_p = make_pipeline(impl_->device, impl_->library, @"q27_mma_roofline_f");
+            impl_->mm_dr_p = make_pipeline(impl_->device, impl_->library, @"q27_matmul_t2_mm_dr");
+            impl_->mm_dr2_p = make_pipeline(impl_->device, impl_->library, @"q27_matmul_t2_mm_dr2");
+            impl_->x_to_half_t_p = make_pipeline(impl_->device, impl_->library, @"q27_x_int8_to_half_t");
             if (const char* env = getenv("Q27_METAL_GEMM_HALF"); env && *env)
                 impl_->gemm_half = strtoul(env, nullptr, 10) != 0;
+            if (const char* env = getenv("Q27_METAL_GEMM_HALF_Q4"); env && *env)
+                impl_->gemm_half_q4 = strtoul(env, nullptr, 10) != 0;
         }
         impl_->embedding = make_pipeline(impl_->device, impl_->library, @"q27_embedding_q8");
         impl_->embedding_t2 = make_pipeline(impl_->device, impl_->library, @"q27_embedding_t2");
+        impl_->embedding_b1 = make_pipeline(impl_->device, impl_->library, @"q27_embedding_b1");
         impl_->embedding_dev = make_pipeline(impl_->device, impl_->library, @"q27_embedding_q8_dev");
         impl_->embedding_t2_dev = make_pipeline(impl_->device, impl_->library, @"q27_embedding_t2_dev");
+        impl_->embedding_b1_dev = make_pipeline(impl_->device, impl_->library, @"q27_embedding_b1_dev");
         impl_->embedding_t2_rows = make_pipeline(impl_->device, impl_->library, @"q27_embedding_t2_rows");
+        impl_->embedding_b1_rows = make_pipeline(impl_->device, impl_->library, @"q27_embedding_b1_rows");
         impl_->rms = make_pipeline(impl_->device, impl_->library, @"q27_rmsnorm");
         impl_->rms_quantized = make_pipeline(impl_->device, impl_->library, @"q27_rmsnorm_quantized");
         impl_->rms_heads = make_pipeline(impl_->device, impl_->library, @"q27_rmsnorm_heads");
@@ -678,6 +751,7 @@ MetalBackend::MetalBackend() : impl_(new Impl) {
         impl_->rope_rows = make_pipeline(impl_->device, impl_->library, @"q27_rope_neox_rows");
         impl_->kv_store_rows = make_pipeline(impl_->device, impl_->library, @"q27_kv_store_f16_rows");
         impl_->kv_store_turbo3_rows = make_pipeline(impl_->device, impl_->library, @"q27_kv_store_turbo3_rows");
+        impl_->kv_store_attrib_rows = make_pipeline(impl_->device, impl_->library, @"q27_kv_store_f16_attrib_rows");
         impl_->attention_causal = make_pipeline(impl_->device, impl_->library, @"q27_attention_f16_causal");
         impl_->attention_causal_win = make_pipeline(impl_->device, impl_->library, @"q27_attention_f16_causal_win");
         impl_->kv_store_head_rows = make_pipeline(impl_->device, impl_->library, @"q27_kv_store_f16_head_rows");
@@ -691,7 +765,10 @@ MetalBackend::MetalBackend() : impl_(new Impl) {
         impl_->attention_f16_causal_gqa_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_f16_causal_gqa");
         impl_->attention_turbo3_causal_gqa_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_turbo3_causal_gqa");
         impl_->attention_gqa_merge_rows_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_gqa_merge_rows");
+        impl_->attention_turbo3_gqa_hm_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_turbo3_gqa_hm");
         impl_->attention_turbo3_causal_gqa_t2_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_turbo3_causal_gqa_t2");
+        impl_->attention_turbo3_causal_gqa_t4_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_turbo3_causal_gqa_t4");
+        impl_->attention_turbo3_causal_gqa_bf2_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_turbo3_causal_gqa_bf2");
         impl_->attention_f16_causal_gqa_t2_p = make_pipeline(impl_->device, impl_->library, @"q27_attention_f16_causal_gqa_t2");
         if (const char* env = getenv("Q27_METAL_GQA_TILE"); env && *env) {
             const unsigned long tile = strtoul(env, nullptr, 10);
@@ -764,6 +841,7 @@ const char* MetalBackend::shader_abi_tag() { return kShaderAbiTag; }
 
 std::string MetalBackend::shader_source_sha1() const { return impl_->shader_hash; }
 bool MetalBackend::gemm_half_enabled() const { return impl_->gemm_half; }
+bool MetalBackend::gemm_half_q4_enabled() const { return impl_->gemm_half_q4; }
 uint32_t MetalBackend::gqa_tile() const { return impl_->gqa_tile; }
 uint32_t MetalBackend::gqa_block() const { return impl_->gqa_block; }
 uint32_t MetalBackend::gqa_threshold() const { return impl_->gqa_threshold; }
@@ -1019,6 +1097,8 @@ void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
     MetalBuffer& output = metal_buffer(y);
     const uint64_t quant_group = weight.dtype == DType::Q8_G128 ? 128 :
                                  weight.dtype == DType::T2_G128 ? 128 :
+                                 weight.dtype == DType::T3_G128 ? 128 :
+                                 weight.dtype == DType::B1_G128 ? 128 :
                                  weight.dtype == DType::Q4_G64 ? 64 : 0;
     if (quant_group && weight.cols % quant_group)
         throw std::runtime_error("q27 Metal: matvec columns do not match quantization group");
@@ -1028,6 +1108,9 @@ void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
     if (weight.dtype == DType::F16) data_bytes = checked_mul(elements, 2, "matvec weight");
     if (weight.dtype == DType::Q4_G64) data_bytes /= 2;
     if (weight.dtype == DType::T2_G128) data_bytes /= 4;
+    if (weight.dtype == DType::T3_G128)
+        data_bytes = checked_mul(weight.rows, checked_mul(weight.cols / 128, 26, "matvec weight"), "matvec weight");
+    if (weight.dtype == DType::B1_G128) data_bytes /= 8;
     check_range(x.size(), 0, weight.cols * sizeof(float), "matvec input");
     check_range(y.size(), 0, weight.rows * sizeof(float), "matvec output");
     check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset, data_bytes, "matvec weight");
@@ -1039,9 +1122,8 @@ void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
         case DType::Q8_G128: pipeline = impl_->q8; label = "q27_matvec_q8_g128"; break;
         case DType::Q4_G64: pipeline = impl_->q4; label = "q27_matvec_q4_g64"; break;
         case DType::T2_G128: pipeline = impl_->t2; label = "q27_matvec_t2_g128"; break;
-        case DType::T3_G128:
-        case DType::B1_G128:
-            throw std::runtime_error("q27 Metal: packed dtype is not supported by this backend");
+        case DType::T3_G128: pipeline = impl_->t3; label = "q27_matvec_t3_g128"; break;
+        case DType::B1_G128: pipeline = impl_->b1; label = "q27_matvec_b1_g128"; break;
     }
     const MetalBuffer* quant_scales = nullptr;
     if (quant_group) {
@@ -1069,8 +1151,10 @@ void MetalBackend::matvec(const BackendTensor& weight, const BackendBuffer& x,
             [encoder setBuffer:output.handle() offset:0 atIndex:3];
             [encoder setBytes:&args length:sizeof(args) atIndex:4];
         }
-        // T2 runs 4 rows per simdgroup (32 per threadgroup); others run 1 (8).
-        const NSUInteger row_groups = weight.dtype == DType::T2_G128
+        // T2/T3/B1 run 4 rows per simdgroup (32 per threadgroup); others 1 (8).
+        const bool ternary = weight.dtype == DType::T2_G128 || weight.dtype == DType::T3_G128 ||
+                             weight.dtype == DType::B1_G128;
+        const NSUInteger row_groups = ternary
             ? (NSUInteger)(weight.rows + 31) / 32 : (NSUInteger)(weight.rows + 7) / 8;
         [encoder dispatchThreadgroups:MTLSizeMake(row_groups, 1, 1)
                 threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
@@ -1134,8 +1218,8 @@ void MetalBackend::quantize(const BackendBuffer& x, BackendQuantized& out) {
 void MetalBackend::matvec_quantized(const BackendTensor& weight,
                                      const BackendQuantized& x, BackendBuffer& y) {
     if ((weight.dtype!=DType::Q4_G64 && weight.dtype!=DType::Q8_G128 &&
-         weight.dtype!=DType::T2_G128) || !weight.data || !weight.scales)
-        throw std::runtime_error("q27 Metal: quantized matvec requires Q4/Q8/T2 weight");
+         weight.dtype!=DType::T2_G128 && weight.dtype!=DType::B1_G128) || !weight.data || !weight.scales)
+        throw std::runtime_error("q27 Metal: quantized matvec requires Q4/Q8/T2/B1 weight");
     const uint64_t group=weight.dtype==DType::Q4_G64?64:128;
     if (!weight.rows || !weight.cols || weight.rows>UINT32_MAX || weight.cols>UINT32_MAX ||
         weight.cols%group)
@@ -1145,7 +1229,8 @@ void MetalBackend::matvec_quantized(const BackendTensor& weight,
     check_range(y.size(),0,weight.rows*4,"quantized matvec output");
     const MetalBuffer& data=metal_buffer_view(weight.data); const MetalBuffer& ws=metal_buffer_view(weight.scales);
     const MetalBuffer& xv=metal_buffer_view(x.values); const MetalBuffer& xs=metal_buffer_view(x.scales); MetalBuffer& out=metal_buffer(y);
-    const uint64_t divisor=weight.dtype==DType::Q4_G64?2:weight.dtype==DType::T2_G128?4:1;
+    const uint64_t divisor=weight.dtype==DType::Q4_G64?2:weight.dtype==DType::T2_G128?4:
+                           weight.dtype==DType::B1_G128?8:1;
     const uint64_t data_bytes=weight.rows*weight.cols/divisor;
     check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,data_bytes,"quantized matvec weight");
     check_range(tensor_limit(ws.size(), weight.scales_offset, weight.scales_size), weight.scales_offset,weight.rows*(weight.cols/group)*2,"quantized matvec weight scales");
@@ -1154,19 +1239,96 @@ void MetalBackend::matvec_quantized(const BackendTensor& weight,
     @autoreleasepool {
         bool own; auto enc=impl_->encoder_for_operation(own,
             weight.dtype==DType::Q8_G128?"q27_matvec_q8_quantized":
-            weight.dtype==DType::T2_G128?"q27_matvec_t2_quantized":"q27_matvec_q4_quantized");
+            weight.dtype==DType::T2_G128?"q27_matvec_t2_quantized":
+            weight.dtype==DType::B1_G128?"q27_matvec_b1_quantized":"q27_matvec_q4_quantized");
         [enc setComputePipelineState:weight.dtype==DType::Q8_G128?impl_->q8_quantized:
-                                     weight.dtype==DType::T2_G128?impl_->t2_quantized:impl_->q4_quantized];
+                                     weight.dtype==DType::T2_G128?impl_->t2_quantized:
+                                     weight.dtype==DType::B1_G128?impl_->b1_quantized:impl_->q4_quantized];
         [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
         [enc setBuffer:ws.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
         [enc setBuffer:xv.handle() offset:0 atIndex:2]; [enc setBuffer:xs.handle() offset:0 atIndex:3];
         [enc setBuffer:out.handle() offset:0 atIndex:4]; [enc setBytes:&args length:sizeof(args) atIndex:5];
-        // Q4 runs its promoted 4-rows-per-simdgroup kernel; Q8/T2 keep one row.
-        const NSUInteger rpg = weight.dtype==DType::Q4_G64 ? 32 : 8;
+        // Q4 and B1 run their promoted 4-rows-per-simdgroup kernels (32
+        // rows/group; q4 round + b1 select round 2, both 2026-07-17); the
+        // other dtypes keep 1 row/simdgroup.
+        const NSUInteger rpg = (weight.dtype==DType::Q4_G64 ||
+                                weight.dtype==DType::B1_G128) ? 32 : 8;
         [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(weight.rows+rpg-1)/rpg,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
         if(own) impl_->finish_command("quantized matvec");
     }
 }
+
+// N=2 slot-batched select-form T2 GEMV (multislot Phase 2 probe): the
+// float-activation production serial-decode path with two independent
+// activation/output buffer pairs. PARKED by measurement (2026-07-16):
+// aggregate s_k 1.093 vs the 1.31 decision line — bench-only reference
+// surface, never engine-routed.
+void MetalBackend::matvec_x2(const BackendTensor& weight,
+                             const BackendBuffer& x_a, const BackendBuffer& x_b,
+                             BackendBuffer& y_a, BackendBuffer& y_b) {
+    if (weight.dtype!=DType::T2_G128 || !weight.data || !weight.scales)
+        throw std::runtime_error("q27 Metal: x2 matvec requires T2 weight");
+    if (!weight.rows || !weight.cols || weight.rows>UINT32_MAX || weight.cols>UINT32_MAX ||
+        weight.cols%128)
+        throw std::runtime_error("q27 Metal: invalid x2 matvec dimensions");
+    check_range(x_a.size(),0,weight.cols*sizeof(float),"x2 matvec input a");
+    check_range(x_b.size(),0,weight.cols*sizeof(float),"x2 matvec input b");
+    check_range(y_a.size(),0,weight.rows*sizeof(float),"x2 matvec output a");
+    check_range(y_b.size(),0,weight.rows*sizeof(float),"x2 matvec output b");
+    const MetalBuffer& data=metal_buffer_view(weight.data); const MetalBuffer& ws=metal_buffer_view(weight.scales);
+    const MetalBuffer& xa=metal_buffer(x_a); const MetalBuffer& xb=metal_buffer(x_b);
+    MetalBuffer& ya=metal_buffer(y_a); MetalBuffer& yb=metal_buffer(y_b);
+    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,weight.rows*weight.cols/4,"x2 matvec weight");
+    check_range(tensor_limit(ws.size(), weight.scales_offset, weight.scales_size), weight.scales_offset,weight.rows*(weight.cols/128)*2,"x2 matvec weight scales");
+    MatvecArgs args{(uint32_t)weight.rows,(uint32_t)weight.cols};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own,"q27_matvec_t2_g128_x2");
+        [enc setComputePipelineState:impl_->t2_x2];
+        [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
+        [enc setBuffer:ws.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
+        [enc setBuffer:xa.handle() offset:0 atIndex:2]; [enc setBuffer:xb.handle() offset:0 atIndex:3];
+        [enc setBuffer:ya.handle() offset:0 atIndex:4]; [enc setBuffer:yb.handle() offset:0 atIndex:5];
+        [enc setBytes:&args length:sizeof(args) atIndex:6];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(weight.rows+31)/32,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("x2 matvec");
+    }
+}
+
+// N=2 slot-batched T2 GEMV (multislot Phase 2 probe): x carries two
+// activation rows ([2, cols] values, [2, cols/32] scales), out is token-
+// major [2, rows] — the matmul_quantized layouts at x_rows=2. Metal-only
+// surface (not on the Backend interface). PARKED by measurement
+// (2026-07-16, docs/plans/2026-07-16-multislot-phase2-probe.md): aggregate
+// s_k 1.093 vs the 1.31 decision line — bench-only reference surface,
+// never engine-routed.
+void MetalBackend::matvec_quantized_x2(const BackendTensor& weight,
+                                       const BackendQuantized& x, BackendBuffer& y) {
+    if (weight.dtype!=DType::T2_G128 || !weight.data || !weight.scales)
+        throw std::runtime_error("q27 Metal: x2 matvec requires T2 weight");
+    if (!weight.rows || !weight.cols || weight.rows>UINT32_MAX || weight.cols>UINT32_MAX ||
+        weight.cols%128)
+        throw std::runtime_error("q27 Metal: invalid x2 matvec dimensions");
+    if ((uint64_t)x.count!=(uint64_t)weight.cols*2 || !x.values || !x.scales)
+        throw std::runtime_error("q27 Metal: x2 matvec activation mismatch (needs 2 rows)");
+    check_range(y.size(),0,weight.rows*2*4,"x2 matvec output");
+    const MetalBuffer& data=metal_buffer_view(weight.data); const MetalBuffer& ws=metal_buffer_view(weight.scales);
+    const MetalBuffer& xv=metal_buffer_view(x.values); const MetalBuffer& xs=metal_buffer_view(x.scales); MetalBuffer& out=metal_buffer(y);
+    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,weight.rows*weight.cols/4,"x2 matvec weight");
+    check_range(tensor_limit(ws.size(), weight.scales_offset, weight.scales_size), weight.scales_offset,weight.rows*(weight.cols/128)*2,"x2 matvec weight scales");
+    check_range(xv.size(),0,x.count,"x2 matvec values"); check_range(xs.size(),0,(uint64_t)(x.count/32)*4,"x2 matvec activation scales");
+    MatvecArgs args{(uint32_t)weight.rows,(uint32_t)weight.cols};
+    @autoreleasepool {
+        bool own; auto enc=impl_->encoder_for_operation(own,"q27_matvec_t2_quantized_x2");
+        [enc setComputePipelineState:impl_->t2_quantized_x2];
+        [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
+        [enc setBuffer:ws.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
+        [enc setBuffer:xv.handle() offset:0 atIndex:2]; [enc setBuffer:xs.handle() offset:0 atIndex:3];
+        [enc setBuffer:out.handle() offset:0 atIndex:4]; [enc setBytes:&args length:sizeof(args) atIndex:5];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(weight.rows+7)/8,1,1) threadsPerThreadgroup:MTLSizeMake(256,1,1)];
+        if(own) impl_->finish_command("x2 quantized matvec");
+    }
+}
+
 // Two independent packed-dot dispatches now beat a fused pair kernel: the
 // rewritten GEMV is weight-stream-bound, so sharing the (cached) activation
 // bytes buys nothing, while the fused kernel's doubled register pressure
@@ -1186,8 +1348,8 @@ void MetalBackend::matmul_quantized(const BackendTensor& weight,const BackendQua
         throw std::runtime_error("q27 Metal: quantized matmul requires Apple GPU family 7 or newer");
     }
     if((weight.dtype!=DType::Q4_G64 && weight.dtype!=DType::Q8_G128 &&
-        weight.dtype!=DType::T2_G128) || !weight.data || !weight.scales)
-        throw std::runtime_error("q27 Metal: quantized matmul requires Q4/Q8/T2 weight");
+        weight.dtype!=DType::T2_G128 && weight.dtype!=DType::B1_G128) || !weight.data || !weight.scales)
+        throw std::runtime_error("q27 Metal: quantized matmul requires Q4/Q8/T2/B1 weight");
     uint64_t group=weight.dtype==DType::Q4_G64?64:128;
     // Wide prefill chunks: the kernels tile tokens 16 per threadgroup on
     // grid.y (docs/plans/2026-07-15-wide-chunks.md phase A). 96 = 8x12.
@@ -1197,20 +1359,37 @@ void MetalBackend::matmul_quantized(const BackendTensor& weight,const BackendQua
     check_range(y.size(),0,weight.rows*x_rows*4,"quantized matmul output");
     const MetalBuffer& data=metal_buffer_view(weight.data); const MetalBuffer& ws=metal_buffer_view(weight.scales);
     const MetalBuffer& xv=metal_buffer_view(x.values); const MetalBuffer& xs=metal_buffer_view(x.scales); MetalBuffer& out=metal_buffer(y);
-    uint64_t divisor=weight.dtype==DType::Q4_G64?2:weight.dtype==DType::T2_G128?4:1;
+    uint64_t divisor=weight.dtype==DType::Q4_G64?2:weight.dtype==DType::T2_G128?4:
+                     weight.dtype==DType::B1_G128?8:1;
     check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,weight.rows*weight.cols/divisor,"quantized matmul weight");
     check_range(tensor_limit(ws.size(), weight.scales_offset, weight.scales_size), weight.scales_offset,weight.rows*(weight.cols/group)*2,"quantized matmul weight scales");
     check_range(xv.size(),0,x.count,"quantized matmul values"); check_range(xs.size(),0,(uint64_t)(x.count/32)*4,"quantized matmul scales");
     MatmulArgs args{(uint32_t)weight.rows,(uint32_t)weight.cols,x_rows,1};
     @autoreleasepool {
-        // Q27_METAL_GEMM_HALF controls the production T2 half-staging GEMM.
-        // Q4 and Q8 stay on their validated float-staged kernels.
+        // Q27_METAL_GEMM_HALF=1: half-staging T2 GEMM (A/B lever, see
+        // docs/plans/2026-07-15-gemm-half-staging.md). Q4's half twin is
+        // correctness-gated but default-off pending its valid >=1.7x quiet
+        // ship-line run (QUIET_BENCH_EVIDENCE.md rejects the idle>=0 run);
+        // Q27_METAL_GEMM_HALF_Q4=1 routes it for re-measurement only. Q8
+        // stays on the float-staged kernel: its half variant failed the
+        // shape suite (5.5e-4 at the high-cancellation 33x5120 repro vs the
+        // 3e-4 bound) because half-operand MMA products up to 127*127 round
+        // past half's 2048 exact-integer range — the parked
+        // q27_matmul_q8_mm_h records the attempt.
         const bool h = impl_->gemm_half;
+        const bool h4 = impl_->gemm_half_q4;
+        if (h4 && !impl_->q4_quantized_matmul_h)
+            impl_->q4_quantized_matmul_h = make_pipeline(impl_->device, impl_->library,
+                                                         @"q27_matmul_q4_mm_h");
         bool own; auto enc=impl_->encoder_for_operation(own,
             weight.dtype==DType::Q8_G128?"q27_matmul_q8_mm":
-            weight.dtype==DType::T2_G128?(h?"q27_matmul_t2_mm_h":"q27_matmul_t2_mm"):"q27_matmul_q4_mm");
+            weight.dtype==DType::T2_G128?(h?"q27_matmul_t2_mm_h":"q27_matmul_t2_mm"):
+            weight.dtype==DType::B1_G128?"q27_matmul_b1_mm":
+            (h4?"q27_matmul_q4_mm_h":"q27_matmul_q4_mm"));
         [enc setComputePipelineState:weight.dtype==DType::Q8_G128?impl_->q8_quantized_matmul:
-                                     weight.dtype==DType::T2_G128?(h?impl_->t2_quantized_matmul_h:impl_->t2_quantized_matmul):impl_->q4_quantized_matmul];
+                                     weight.dtype==DType::T2_G128?(h?impl_->t2_quantized_matmul_h:impl_->t2_quantized_matmul):
+                                     weight.dtype==DType::B1_G128?impl_->b1_quantized_matmul:
+                                     (h4?impl_->q4_quantized_matmul_h:impl_->q4_quantized_matmul)];
         [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0]; [enc setBuffer:ws.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
         [enc setBuffer:xv.handle() offset:0 atIndex:2]; [enc setBuffer:xs.handle() offset:0 atIndex:3]; [enc setBuffer:out.handle() offset:0 atIndex:4];
         [enc setBytes:&args length:sizeof(args) atIndex:5];
@@ -1218,10 +1397,399 @@ void MetalBackend::matmul_quantized(const BackendTensor& weight,const BackendQua
         if(own) impl_->finish_command("quantized simdgroup matmul");
     }
 }
+
+// A/B/C MMA roofline probe entries (bench-only, docs/plans/2026-07-16-mma-
+// roofline.md): same dispatch grid and MatmulArgs as the production T2
+// GEMM. Arm 'b' takes half operands + half weight scales + float
+// activation scales; arm 'a' takes only the opaque tile seed. Never
+// engine-routed.
+void MetalBackend::mma_roofline(char arm, uint32_t rows, uint32_t cols, uint32_t x_rows,
+                                const BackendBuffer& w_or_seed, const BackendBuffer* w_scales,
+                                const BackendBuffer* x, const BackendBuffer* x_scales,
+                                BackendBuffer& y) {
+    if (!impl_->mma_roofline_a_p || !impl_->mma_roofline_b_p)
+        throw std::runtime_error("q27 Metal: MMA roofline requires Apple GPU family 7 or newer");
+    if ((arm != 'a' && arm != 'b' && arm != 'e' && arm != 'x' && arm != 'd' && arm != '2' &&
+         arm != 'f' && arm != 'k') || !rows || !cols ||
+        !x_rows || x_rows > 96 || cols % 128)
+        throw std::runtime_error("q27 Metal: invalid MMA roofline arguments");
+    // Arms 'f' (f16-accumulate, docs/plans/2026-07-16-f16acc-probe.md) and
+    // 'k' (function-constant cols baking, BaseRT survey probe 2): the
+    // production mm_h operands and grid; 'k' resolves a per-cols
+    // specialized PSO on first use.
+    if (arm == 'f' || arm == 'k') {
+        if (arm == 'k' && !impl_->mma_roofline_k_p.count(cols)) {
+            MTLFunctionConstantValues* fc = [MTLFunctionConstantValues new];
+            [fc setConstantValue:&cols type:MTLDataTypeUInt atIndex:0];
+            NSError* err = nil;
+            id<MTLFunction> fn = [impl_->library newFunctionWithName:@"q27_mma_roofline_k"
+                                                      constantValues:fc
+                                                               error:&err];
+            id<MTLComputePipelineState> pso =
+                fn ? [impl_->device newComputePipelineStateWithFunction:fn error:&err] : nil;
+            if (!pso)
+                throw std::runtime_error(std::string("q27 Metal: roofline k specialization failed: ") +
+                                         (err ? err.localizedDescription.UTF8String : "unknown"));
+            impl_->mma_roofline_k_p[cols] = pso;
+        }
+        if (!w_scales || !x || !x_scales)
+            throw std::runtime_error("q27 Metal: roofline arm f needs scales and activations");
+        const MetalBuffer& wb = metal_buffer(w_or_seed);
+        const MetalBuffer& ws = metal_buffer(*w_scales);
+        const MetalBuffer& xb = metal_buffer(*x);
+        const MetalBuffer& xs = metal_buffer(*x_scales);
+        MetalBuffer& out = metal_buffer(y);
+        check_range(wb.size(), 0, (uint64_t)rows * cols / 4, "roofline f weights");
+        check_range(ws.size(), 0, (uint64_t)rows * (cols / 128) * 2, "roofline f weight scales");
+        check_range(xb.size(), 0, (uint64_t)x_rows * cols, "roofline f activations");
+        check_range(xs.size(), 0, (uint64_t)x_rows * (cols / 32) * 4, "roofline f activation scales");
+        check_range(out.size(), 0, (uint64_t)rows * x_rows * 4, "roofline f output");
+        MatmulArgs args{rows, cols, x_rows, 1};
+        @autoreleasepool {
+            bool own;
+            auto enc = impl_->encoder_for_operation(
+                own, arm == 'k' ? "q27_mma_roofline_k" : "q27_mma_roofline_f");
+            [enc setComputePipelineState:arm == 'k' ? impl_->mma_roofline_k_p[cols]
+                                                    : impl_->mma_roofline_f_p];
+            [enc setBuffer:wb.handle() offset:0 atIndex:0];
+            [enc setBuffer:ws.handle() offset:0 atIndex:1];
+            [enc setBuffer:xb.handle() offset:0 atIndex:2];
+            [enc setBuffer:xs.handle() offset:0 atIndex:3];
+            [enc setBuffer:out.handle() offset:0 atIndex:4];
+            [enc setBytes:&args length:sizeof(args) atIndex:5];
+            [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(rows + 31) / 32,
+                                                  (NSUInteger)(x_rows + 15) / 16, 1)
+                threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+            if (own) impl_->finish_command(arm == 'k' ? "mma roofline k" : "mma roofline f");
+        }
+        return;
+    }
+    // Arm 'd' — lever 1 direct-RHS probe (docs/plans/2026-07-16-lever1-
+    // direct-rhs.md): w_or_seed = packed T2 weight bytes, x = int8
+    // activation values, x_scales = float per-32 scales. Encodes the RHS
+    // pre-pass (int8 -> K-major half, charged to this arm) and the 64x32
+    // direct-RHS GEMM.
+    if (arm == 'd' || arm == '2') {
+        if (!w_scales || !x || !x_scales)
+            throw std::runtime_error("q27 Metal: roofline arm d needs scales and activations");
+        const MetalBuffer& wb = metal_buffer(w_or_seed);
+        const MetalBuffer& ws = metal_buffer(*w_scales);
+        const MetalBuffer& xb = metal_buffer(*x);
+        const MetalBuffer& xs = metal_buffer(*x_scales);
+        MetalBuffer& out = metal_buffer(y);
+        check_range(wb.size(), 0, (uint64_t)rows * cols / 4, "roofline d weights");
+        check_range(ws.size(), 0, (uint64_t)rows * (cols / 128) * 2, "roofline d weight scales");
+        check_range(xb.size(), 0, (uint64_t)x_rows * cols, "roofline d activations");
+        check_range(xs.size(), 0, (uint64_t)x_rows * (cols / 32) * 4, "roofline d activation scales");
+        check_range(out.size(), 0, (uint64_t)rows * x_rows * 4, "roofline d output");
+        const uint32_t tokens_pad = (x_rows + 7) / 8 * 8;
+        const uint64_t xt_bytes = (uint64_t)cols * tokens_pad * 2;
+        if (!impl_->dr_xt_scratch || impl_->dr_xt_scratch.length < xt_bytes)
+            impl_->dr_xt_scratch = [impl_->device newBufferWithLength:(NSUInteger)xt_bytes
+                                                              options:MTLResourceStorageModePrivate];
+        if (!impl_->dr_xt_scratch) throw std::runtime_error("q27 Metal: dr xT allocation failed");
+        MatmulArgs args{rows, cols, x_rows, tokens_pad};
+        @autoreleasepool {
+            bool own; auto enc = impl_->encoder_for_operation(own, "q27_matmul_t2_mm_dr");
+            [enc setComputePipelineState:impl_->x_to_half_t_p];
+            [enc setBuffer:xb.handle() offset:0 atIndex:0];
+            [enc setBuffer:impl_->dr_xt_scratch offset:0 atIndex:1];
+            [enc setBytes:&args length:sizeof(args) atIndex:2];
+            const uint64_t pre_threads = (uint64_t)cols * tokens_pad;
+            [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)((pre_threads + 255) / 256), 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+            // The GEMM reads the xT the pre-pass wrote, ordered by default
+            // per-resource hazard tracking rather than the encoder.
+            [enc setComputePipelineState:arm == '2' ? impl_->mm_dr2_p : impl_->mm_dr_p];
+            [enc setBuffer:wb.handle() offset:0 atIndex:0];
+            [enc setBuffer:ws.handle() offset:0 atIndex:1];
+            [enc setBuffer:impl_->dr_xt_scratch offset:0 atIndex:2];
+            [enc setBuffer:xs.handle() offset:0 atIndex:3];
+            [enc setBuffer:out.handle() offset:0 atIndex:4];
+            [enc setBytes:&args length:sizeof(args) atIndex:5];
+            [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(rows + 63) / 64,
+                                                  (NSUInteger)(x_rows + (arm == '2' ? 15 : 31)) /
+                                                      (arm == '2' ? 16 : 32), 1)
+                threadsPerThreadgroup:MTLSizeMake(arm == '2' ? 128 : 256, 1, 1)];
+            if (own) impl_->finish_command("mm direct-rhs probe");
+        }
+        return;
+    }
+    const MetalBuffer& wb = metal_buffer(w_or_seed);
+    MetalBuffer& out = metal_buffer(y);
+    check_range(out.size(), 0, (uint64_t)rows * x_rows * 4, "roofline output");
+    MatmulArgs args{rows, cols, x_rows, 1};
+    @autoreleasepool {
+        if (arm == 'a') {
+            check_range(wb.size(), 0, (32 * 64 + 64 * 16) * 2, "roofline seed");
+            bool own; auto enc = impl_->encoder_for_operation(own, "q27_mma_roofline_a");
+            [enc setComputePipelineState:impl_->mma_roofline_a_p];
+            [enc setBuffer:wb.handle() offset:0 atIndex:0];
+            [enc setBuffer:out.handle() offset:0 atIndex:1];
+            [enc setBytes:&args length:sizeof(args) atIndex:2];
+            [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(rows + 31) / 32, (NSUInteger)(x_rows + 15) / 16, 1)
+                threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+            if (own) impl_->finish_command("mma roofline a");
+            return;
+        }
+        if (!w_scales || !x || !x_scales)
+            throw std::runtime_error("q27 Metal: roofline arm b needs scales and activations");
+        const MetalBuffer& ws = metal_buffer(*w_scales);
+        const MetalBuffer& xb = metal_buffer(*x);
+        const MetalBuffer& xs = metal_buffer(*x_scales);
+        // 'e' (equal-traffic) reads C's device byte volume: cols/8 halves per
+        // weight row, cols/2 halves per activation row. 'x' (pre-converted
+        // activations) reads C's packed T2 weight bytes and full half
+        // activations.
+        const uint64_t wbytes = arm == 'e' ? (uint64_t)rows * (cols / 8) * 2
+                              : arm == 'x' ? (uint64_t)rows * cols / 4
+                                           : (uint64_t)rows * cols * 2;
+        const uint64_t xdiv = arm == 'e' ? 2 : 1;
+        check_range(wb.size(), 0, wbytes, "roofline b weights");
+        check_range(ws.size(), 0, (uint64_t)rows * (cols / 128) * 2, "roofline b weight scales");
+        check_range(xb.size(), 0, (uint64_t)x_rows * (cols / xdiv) * 2, "roofline b activations");
+        check_range(xs.size(), 0, (uint64_t)x_rows * (cols / 32) * 4, "roofline b activation scales");
+        bool own; auto enc = impl_->encoder_for_operation(own,
+            arm == 'e' ? "q27_mma_roofline_b_eq" :
+            arm == 'x' ? "q27_mma_roofline_cx" : "q27_mma_roofline_b");
+        [enc setComputePipelineState:arm == 'e' ? impl_->mma_roofline_b_eq_p :
+                                     arm == 'x' ? impl_->mma_roofline_cx_p
+                                                : impl_->mma_roofline_b_p];
+        [enc setBuffer:wb.handle() offset:0 atIndex:0];
+        [enc setBuffer:ws.handle() offset:0 atIndex:1];
+        [enc setBuffer:xb.handle() offset:0 atIndex:2];
+        [enc setBuffer:xs.handle() offset:0 atIndex:3];
+        [enc setBuffer:out.handle() offset:0 atIndex:4];
+        [enc setBytes:&args length:sizeof(args) atIndex:5];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(rows + 31) / 32, (NSUInteger)(x_rows + 15) / 16, 1)
+            threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+        if (own) impl_->finish_command("mma roofline b");
+    }
+}
+
+// B1 Phase 0B probe (bench-only): raw bits/scales buffers, no DType.
+// Candidate 3 encodes its activation preprocess and the dot on the same
+// serial encoder, so a timed dispatch always pays the preprocessing (the
+// plan's kill rule: a candidate that wins only with preprocessing excluded
+// is a kill).
+void MetalBackend::matvec_b1_probe(int candidate, uint32_t rows, uint32_t cols,
+                                   const BackendBuffer& bits, const BackendBuffer& scales,
+                                   const BackendBuffer& x, BackendBuffer* scratch,
+                                   BackendBuffer& y) {
+    if (candidate < 1 || candidate > 3 || !rows || !cols || cols % 128)
+        throw std::runtime_error("q27 Metal: invalid b1 probe arguments");
+    const uint32_t nb = cols / 128;
+    const MetalBuffer& wb = metal_buffer(bits);
+    const MetalBuffer& ws = metal_buffer(scales);
+    const MetalBuffer& xb = metal_buffer(x);
+    MetalBuffer& out = metal_buffer(y);
+    check_range(wb.size(), 0, (uint64_t)rows * cols / 8, "b1 probe bits");
+    check_range(ws.size(), 0, (uint64_t)rows * nb * 2, "b1 probe scales");
+    check_range(xb.size(), 0, (uint64_t)cols * 4, "b1 probe activations");
+    check_range(out.size(), 0, (uint64_t)rows * 4, "b1 probe output");
+    MatvecArgs args{rows, cols};
+    @autoreleasepool {
+        if (candidate == 3) {
+            if (!scratch) throw std::runtime_error("q27 Metal: b1 popcount needs scratch");
+            MetalBuffer& sb = metal_buffer(*scratch);
+            // planes: nb*32 uints; aux: nb float2, aux base kept 8-aligned.
+            const uint64_t planes_bytes = (uint64_t)nb * 32 * 4;
+            check_range(sb.size(), 0, planes_bytes + (uint64_t)nb * 8, "b1 probe scratch");
+            bool own; auto enc = impl_->encoder_for_operation(own, "q27_matvec_b1_popcount");
+            [enc setComputePipelineState:impl_->b1_x_prep_p];
+            [enc setBuffer:xb.handle() offset:0 atIndex:0];
+            [enc setBuffer:sb.handle() offset:0 atIndex:1];
+            [enc setBuffer:sb.handle() offset:(NSUInteger)planes_bytes atIndex:2];
+            [enc setBytes:&args length:sizeof(args) atIndex:3];
+            [enc dispatchThreadgroups:MTLSizeMake(nb, 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(128, 1, 1)];
+            // The dot reads what the preprocess wrote, ordered by default
+            // per-resource hazard tracking rather than the encoder.
+            [enc setComputePipelineState:impl_->b1_popcount_p];
+            [enc setBuffer:wb.handle() offset:0 atIndex:0];
+            [enc setBuffer:ws.handle() offset:0 atIndex:1];
+            [enc setBuffer:sb.handle() offset:0 atIndex:2];
+            [enc setBuffer:sb.handle() offset:(NSUInteger)planes_bytes atIndex:3];
+            [enc setBuffer:out.handle() offset:0 atIndex:4];
+            [enc setBytes:&args length:sizeof(args) atIndex:5];
+            [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(rows + 7) / 8, 1, 1)
+                threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+            if (own) impl_->finish_command("b1 popcount probe");
+            return;
+        }
+        const bool sel = candidate == 1;
+        bool own; auto enc = impl_->encoder_for_operation(
+            own, sel ? "q27_matvec_b1_select" : "q27_matvec_b1_signxor");
+        [enc setComputePipelineState:sel ? impl_->b1_select_p : impl_->b1_signxor_p];
+        [enc setBuffer:wb.handle() offset:0 atIndex:0];
+        [enc setBuffer:ws.handle() offset:0 atIndex:1];
+        [enc setBuffer:xb.handle() offset:0 atIndex:2];
+        [enc setBuffer:out.handle() offset:0 atIndex:3];
+        [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)(rows + 31) / 32, 1, 1)
+            threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        if (own) impl_->finish_command(sel ? "b1 select probe" : "b1 signxor probe");
+    }
+}
+
+// Q4 rewrite-round candidate arms (bench-only, docs/plans/2026-07-17-q4-
+// rewrite-round.md): the production quantized-matvec validation, then
+// candidate routing. Candidate 1 re-dispatches the production PSO so the
+// bench's A/B runs one code path; 2/3 are the Q4 multi-row arms, 4 the Q8
+// twin. Candidate PSOs build lazily on first use (the roofline-k pattern) —
+// production startup never creates them. Never engine-routed.
+void MetalBackend::matvec_q4_probe(int candidate, const BackendTensor& weight,
+                                   const BackendQuantized& x, BackendBuffer& y) {
+    if (candidate < 1 || candidate > 4)
+        throw std::runtime_error("q27 Metal: invalid q4 probe candidate");
+    if ((weight.dtype != DType::Q4_G64 && weight.dtype != DType::Q8_G128) ||
+        !weight.data || !weight.scales)
+        throw std::runtime_error("q27 Metal: q4 probe requires Q4/Q8 weight");
+    if ((candidate == 2 || candidate == 3) && weight.dtype != DType::Q4_G64)
+        throw std::runtime_error("q27 Metal: q4 probe candidates 2-3 require Q4_G64");
+    if (candidate == 4 && weight.dtype != DType::Q8_G128)
+        throw std::runtime_error("q27 Metal: q4 probe candidate 4 requires Q8_G128");
+    const uint64_t group = weight.dtype == DType::Q4_G64 ? 64 : 128;
+    if (!weight.rows || !weight.cols || weight.rows > UINT32_MAX || weight.cols > UINT32_MAX ||
+        weight.cols % group)
+        throw std::runtime_error("q27 Metal: invalid q4 probe dimensions");
+    if (x.count != weight.cols || !x.values || !x.scales)
+        throw std::runtime_error("q27 Metal: q4 probe activation mismatch");
+    check_range(y.size(), 0, weight.rows * 4, "q4 probe output");
+    const MetalBuffer& data = metal_buffer_view(weight.data);
+    const MetalBuffer& ws = metal_buffer_view(weight.scales);
+    const MetalBuffer& xv = metal_buffer_view(x.values);
+    const MetalBuffer& xs = metal_buffer_view(x.scales);
+    MetalBuffer& out = metal_buffer(y);
+    const uint64_t data_bytes = weight.rows * weight.cols /
+                                (weight.dtype == DType::Q4_G64 ? 2 : 1);
+    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size),
+                weight.data_offset, data_bytes, "q4 probe weight");
+    check_range(tensor_limit(ws.size(), weight.scales_offset, weight.scales_size),
+                weight.scales_offset, weight.rows * (weight.cols / group) * 2,
+                "q4 probe weight scales");
+    check_range(xv.size(), 0, x.count, "q4 probe values");
+    check_range(xs.size(), 0, (uint64_t)(x.count / 32) * 4, "q4 probe activation scales");
+    const bool q8 = weight.dtype == DType::Q8_G128;
+    id<MTLComputePipelineState> pso = nil;
+    const char* label = nullptr;
+    switch (candidate) {
+        case 1:
+            pso = q8 ? impl_->q8_quantized : impl_->q4_quantized;
+            label = q8 ? "q27_matvec_q8_quantized" : "q27_matvec_q4_quantized";
+            break;
+        case 2:
+            if (!impl_->q4_r2_p)
+                impl_->q4_r2_p = make_pipeline(impl_->device, impl_->library,
+                                               @"q27_matvec_q4_quantized_r2");
+            pso = impl_->q4_r2_p;
+            label = "q27_matvec_q4_quantized_r2";
+            break;
+        case 3:
+            // r4 was PROMOTED into the production kernel (q4 round
+            // 2026-07-17) — alias so recorded A/B invocations keep working.
+            pso = impl_->q4_quantized;
+            label = "q27_matvec_q4_quantized";
+            break;
+        default:
+            throw std::runtime_error("q27 Metal: q4 probe candidate 4 (q8 r4 twin) was "
+                "KILLED by measurement — regressed the head shape "
+                "(docs/plans/2026-07-17-q4-rewrite-round.md RESULTS)");
+    }
+    // Rows per 256-thread group: post-promotion Q4 production runs 4 rows
+    // per simdgroup (32/group); Q8 production and legacy stay 1 (8/group).
+    const uint32_t rows_per_group = candidate == 2 ? 16 : q8 ? 8 : 32;
+    MatvecArgs args{(uint32_t)weight.rows, (uint32_t)weight.cols};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, label);
+        [enc setComputePipelineState:pso];
+        [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
+        [enc setBuffer:ws.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
+        [enc setBuffer:xv.handle() offset:0 atIndex:2];
+        [enc setBuffer:xs.handle() offset:0 atIndex:3];
+        [enc setBuffer:out.handle() offset:0 atIndex:4];
+        [enc setBytes:&args length:sizeof(args) atIndex:5];
+        [enc dispatchThreadgroups:MTLSizeMake(
+                (NSUInteger)(weight.rows + rows_per_group - 1) / rows_per_group, 1, 1)
+            threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        if (own) impl_->finish_command("q4 probe");
+    }
+}
+
+// B1 select round-2 candidate arms (bench-only, docs/plans/2026-07-17-b1-
+// select-round2.md): validation as matvec_quantized, then candidate
+// routing. Candidate 1 re-dispatches the production PSO so the bench's A/B
+// runs one code path; 2/3 are the multi-row arms. Candidate PSOs build
+// lazily on first use (the roofline-k pattern) — production startup never
+// creates them. Never engine-routed.
+void MetalBackend::matvec_b1r2_probe(int candidate, const BackendTensor& weight,
+                                     const BackendQuantized& x, BackendBuffer& y) {
+    if (candidate < 1 || candidate > 3)
+        throw std::runtime_error("q27 Metal: invalid b1 round-2 probe candidate");
+    if (weight.dtype != DType::B1_G128 || !weight.data || !weight.scales)
+        throw std::runtime_error("q27 Metal: b1 round-2 probe requires B1_G128 weight");
+    if (!weight.rows || !weight.cols || weight.rows > UINT32_MAX ||
+        weight.cols > UINT32_MAX || weight.cols % 128)
+        throw std::runtime_error("q27 Metal: invalid b1 round-2 probe dimensions");
+    if (x.count != weight.cols || !x.values || !x.scales)
+        throw std::runtime_error("q27 Metal: b1 round-2 probe activation mismatch");
+    check_range(y.size(), 0, weight.rows * 4, "b1 r2 probe output");
+    const MetalBuffer& data = metal_buffer_view(weight.data);
+    const MetalBuffer& ws = metal_buffer_view(weight.scales);
+    const MetalBuffer& xv = metal_buffer_view(x.values);
+    const MetalBuffer& xs = metal_buffer_view(x.scales);
+    MetalBuffer& out = metal_buffer(y);
+    check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size),
+                weight.data_offset, weight.rows * weight.cols / 8, "b1 r2 probe weight");
+    check_range(tensor_limit(ws.size(), weight.scales_offset, weight.scales_size),
+                weight.scales_offset, weight.rows * (weight.cols / 128) * 2,
+                "b1 r2 probe weight scales");
+    check_range(xv.size(), 0, x.count, "b1 r2 probe values");
+    check_range(xs.size(), 0, (uint64_t)(x.count / 32) * 4, "b1 r2 probe activation scales");
+    id<MTLComputePipelineState> pso = nil;
+    const char* label = nullptr;
+    switch (candidate) {
+        case 1:
+        case 2:
+            // r2 was PROMOTED into the production kernel (b1 round 2,
+            // 2026-07-17) — candidate 2 aliases it so recorded A/B
+            // invocations keep working.
+            pso = impl_->b1_quantized;
+            label = "q27_matvec_b1_quantized";
+            break;
+        default:
+            if (!impl_->b1_r3_p)
+                impl_->b1_r3_p = make_pipeline(impl_->device, impl_->library,
+                                               @"q27_matvec_b1_quantized_r3");
+            pso = impl_->b1_r3_p;
+            label = "q27_matvec_b1_quantized_r3";
+            break;
+    }
+    // Rows per 256-thread group: post-promotion production runs 4 rows per
+    // simdgroup (32/group); r3 runs 8 (64/group).
+    const uint32_t rows_per_group = candidate == 3 ? 64 : 32;
+    MatvecArgs args{(uint32_t)weight.rows, (uint32_t)weight.cols};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, label);
+        [enc setComputePipelineState:pso];
+        [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
+        [enc setBuffer:ws.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
+        [enc setBuffer:xv.handle() offset:0 atIndex:2];
+        [enc setBuffer:xs.handle() offset:0 atIndex:3];
+        [enc setBuffer:out.handle() offset:0 atIndex:4];
+        [enc setBytes:&args length:sizeof(args) atIndex:5];
+        [enc dispatchThreadgroups:MTLSizeMake(
+                (NSUInteger)(weight.rows + rows_per_group - 1) / rows_per_group, 1, 1)
+            threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        if (own) impl_->finish_command("b1 r2 probe");
+    }
+}
+
 void MetalBackend::embedding_q8(const BackendTensor& weight, uint32_t token,
                                  BackendBuffer& out) {
     const bool t2 = weight.dtype == DType::T2_G128;
-    if ((weight.dtype != DType::Q8_G128 && !t2) || !weight.data || !weight.scales ||
+    const bool b1 = weight.dtype == DType::B1_G128;
+    if ((weight.dtype != DType::Q8_G128 && !t2 && !b1) || !weight.data || !weight.scales ||
         token >= weight.rows ||
         !weight.rows || !weight.cols || weight.rows > UINT32_MAX || weight.cols > UINT32_MAX ||
         weight.cols % 128)
@@ -1230,14 +1798,15 @@ void MetalBackend::embedding_q8(const BackendTensor& weight, uint32_t token,
     const MetalBuffer& data = metal_buffer_view(weight.data);
     const MetalBuffer& scales = metal_buffer_view(weight.scales);
     check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,
-                weight.rows * weight.cols / (t2 ? 4 : 1), "embedding weight");
+                weight.rows * weight.cols / (t2 ? 4 : b1 ? 8 : 1), "embedding weight");
     check_range(tensor_limit(scales.size(), weight.scales_offset, weight.scales_size), weight.scales_offset,
                 weight.rows * (weight.cols / 128) * 2, "embedding scales");
     MetalBuffer& output = metal_buffer(out);
     @autoreleasepool {
         bool own; id<MTLComputeCommandEncoder> enc = impl_->encoder_for_operation(own,
-            t2 ? "q27_embedding_t2" : "q27_embedding_q8");
-        [enc setComputePipelineState:t2 ? impl_->embedding_t2 : impl_->embedding];
+            t2 ? "q27_embedding_t2" : b1 ? "q27_embedding_b1" : "q27_embedding_q8");
+        [enc setComputePipelineState:t2 ? impl_->embedding_t2 :
+                                     b1 ? impl_->embedding_b1 : impl_->embedding];
         [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
         [enc setBuffer:scales.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
         [enc setBuffer:output.handle() offset:0 atIndex:2];
@@ -1256,7 +1825,8 @@ void MetalBackend::embedding_q8(const BackendTensor& weight, uint32_t token,
 void MetalBackend::embedding_from_device(const BackendTensor& weight, const BackendBuffer& token,
                                          BackendBuffer& out) {
     const bool t2 = weight.dtype == DType::T2_G128;
-    if ((weight.dtype != DType::Q8_G128 && !t2) || !weight.data || !weight.scales ||
+    const bool b1 = weight.dtype == DType::B1_G128;
+    if ((weight.dtype != DType::Q8_G128 && !t2 && !b1) || !weight.data || !weight.scales ||
         !weight.rows || !weight.cols || weight.rows > UINT32_MAX || weight.cols > UINT32_MAX ||
         weight.cols % 128)
         throw std::runtime_error("q27 Metal: invalid embedding tensor");
@@ -1266,14 +1836,15 @@ void MetalBackend::embedding_from_device(const BackendTensor& weight, const Back
     const MetalBuffer& data = metal_buffer_view(weight.data);
     const MetalBuffer& scales = metal_buffer_view(weight.scales);
     check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,
-                weight.rows * weight.cols / (t2 ? 4 : 1), "embedding weight");
+                weight.rows * weight.cols / (t2 ? 4 : b1 ? 8 : 1), "embedding weight");
     check_range(tensor_limit(scales.size(), weight.scales_offset, weight.scales_size), weight.scales_offset,
                 weight.rows * (weight.cols / 128) * 2, "embedding scales");
     MetalBuffer& output = metal_buffer(out);
     @autoreleasepool {
         bool own; id<MTLComputeCommandEncoder> enc = impl_->encoder_for_operation(own,
-            t2 ? "q27_embedding_t2_dev" : "q27_embedding_q8_dev");
-        [enc setComputePipelineState:t2 ? impl_->embedding_t2_dev : impl_->embedding_dev];
+            t2 ? "q27_embedding_t2_dev" : b1 ? "q27_embedding_b1_dev" : "q27_embedding_q8_dev");
+        [enc setComputePipelineState:t2 ? impl_->embedding_t2_dev :
+                                     b1 ? impl_->embedding_b1_dev : impl_->embedding_dev];
         [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
         [enc setBuffer:scales.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
         [enc setBuffer:output.handle() offset:0 atIndex:2];
@@ -1616,6 +2187,171 @@ void MetalBackend::attention_turbo3(const BackendBuffer& q, uint32_t q_stride,
     }
 }
 
+// Phase-0 R1 probe: same dispatch shape as the GQA decode path, head-major
+// cache addressing. The merge kernel is reused unchanged (partials layout is
+// identical); its AttentionGqaArgs is built alongside the probe args.
+void MetalBackend::attention_turbo3_gqa_headmajor(const BackendBuffer& q, uint32_t q_stride,
+                                                  const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                                                  BackendBuffer& out, uint32_t seq_len, uint32_t seq_cap,
+                                                  uint32_t q_heads, uint32_t kv_heads,
+                                                  uint32_t head_dim, float scale,
+                                                  BackendBuffer& partials) {
+    const uint32_t gqa = kv_heads ? q_heads / kv_heads : 0;
+    if (!seq_len || seq_len > seq_cap || !kv_heads || q_heads % kv_heads ||
+        head_dim != 256 || gqa < 2 || gqa > 8)
+        throw std::runtime_error("q27 Metal: invalid head-major probe dimensions");
+    const MetalBuffer& qb = metal_buffer(q);
+    const MetalBuffer& kc = metal_buffer(k_cache);
+    const MetalBuffer& vc = metal_buffer(v_cache);
+    MetalBuffer& output = metal_buffer(out);
+    check_range(qb.size(), 0, ((uint64_t)(q_heads - 1) * q_stride + head_dim) * 4, "hm probe Q");
+    const uint64_t cache_bytes = (uint64_t)seq_cap * kv_heads * 100;
+    check_range(kc.size(), 0, cache_bytes, "hm probe K cache");
+    check_range(vc.size(), 0, cache_bytes, "hm probe V cache");
+    check_range(output.size(), 0, (uint64_t)q_heads * head_dim * 4, "hm probe output");
+    const uint32_t block = impl_->gqa_block;
+    const uint32_t n_blocks = 1 + (seq_len - 1) / block;
+    const uint64_t partial_bytes = (uint64_t)q_heads * n_blocks * 258 * 4;
+    MetalBuffer& gqa_partials = metal_buffer(partials);
+    check_range(gqa_partials.size(), 0, partial_bytes, "hm probe partials");
+    struct HmArgs { uint32_t q_stride, seq_len, seq_cap, q_heads, kv_heads, head_dim, block, n_blocks; float scale; };
+    HmArgs args{q_stride, seq_len, seq_cap, q_heads, kv_heads, head_dim, block, n_blocks, scale};
+    AttentionGqaArgs margs{q_stride, seq_len, q_heads, kv_heads, head_dim, block, n_blocks, scale};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_attention_turbo3_gqa_hm");
+        [enc setComputePipelineState:impl_->attention_turbo3_gqa_hm_p];
+        [enc setBuffer:qb.handle() offset:0 atIndex:0];
+        [enc setBuffer:kc.handle() offset:0 atIndex:1];
+        [enc setBuffer:vc.handle() offset:0 atIndex:2];
+        [enc setBuffer:gqa_partials.handle() offset:0 atIndex:3];
+        [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake(kv_heads, n_blocks, 1)
+            threadsPerThreadgroup:MTLSizeMake((NSUInteger)gqa * 32, 1, 1)];
+        id<MTLResource> partial_resources[] = { gqa_partials.handle() };
+        [enc memoryBarrierWithResources:partial_resources count:1];
+        [enc setComputePipelineState:impl_->attention_gqa_merge_p];
+        [enc setBuffer:gqa_partials.handle() offset:0 atIndex:0];
+        [enc setBuffer:output.handle() offset:0 atIndex:1];
+        [enc setBytes:&margs length:sizeof(margs) atIndex:2];
+        [enc dispatchThreadgroups:MTLSizeMake(q_heads, 1, 1)
+            threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
+        if (own) impl_->finish_command("hm probe attention");
+    }
+}
+
+// Phase-0 R1b probe: token-tiled causal GQA at tile 2 or 4. Interleaved
+// production cache layout; merge kernel reused unchanged.
+// R3 probe entry (bench-only): barrier-free direct-read block-partial causal
+// GQA, token factor 2, with an explicit block-size override — the sweep is
+// the experiment (docs/plans/2026-07-16-r3-barrier-free-attention.md). At
+// block == gqa_block the output is bit-identical to the t2 route.
+void MetalBackend::attention_turbo3_causal_gqa_bf(const BackendBuffer& q, uint32_t q_stride,
+                                                  uint32_t q_row_stride,
+                                                  const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                                                  BackendBuffer& out, uint32_t base_len,
+                                                  uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
+                                                  uint32_t tokens, uint32_t block, float scale,
+                                                  BackendBuffer& partials) {
+    const uint32_t gqa = kv_heads ? q_heads / kv_heads : 0;
+    if (!base_len || !tokens || !kv_heads || q_heads % kv_heads || head_dim != 256 ||
+        gqa < 2 || gqa > 8 || !block || block % 8 ||
+        base_len > UINT32_MAX - tokens)
+        throw std::runtime_error("q27 Metal: invalid bf probe dimensions");
+    const MetalBuffer& qb = metal_buffer(q);
+    const MetalBuffer& kc = metal_buffer(k_cache);
+    const MetalBuffer& vc = metal_buffer(v_cache);
+    MetalBuffer& output = metal_buffer(out);
+    const uint32_t max_seq = base_len + tokens - 1;
+    check_range(qb.size(), 0,
+                ((uint64_t)(tokens - 1) * q_row_stride + (uint64_t)(q_heads - 1) * q_stride + head_dim) * 4,
+                "bf probe Q");
+    const uint64_t cache_bytes = (uint64_t)max_seq * kv_heads * 2 * 50;
+    check_range(kc.size(), 0, cache_bytes, "bf probe K cache");
+    check_range(vc.size(), 0, cache_bytes, "bf probe V cache");
+    check_range(output.size(), 0, (uint64_t)tokens * q_heads * head_dim * 4, "bf probe output");
+    const uint32_t n_blocks_max = 1 + (max_seq - 1) / block;
+    const uint64_t partial_bytes = (uint64_t)tokens * q_heads * n_blocks_max * 258 * 4;
+    MetalBuffer& gqa_partials = metal_buffer(partials);
+    check_range(gqa_partials.size(), 0, partial_bytes, "bf probe partials");
+    AttentionGqaCausalArgs args{q_stride, q_row_stride, base_len, q_heads, kv_heads,
+                                head_dim, block, n_blocks_max, tokens, scale};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_attention_turbo3_causal_gqa_bf2");
+        [enc setComputePipelineState:impl_->attention_turbo3_causal_gqa_bf2_p];
+        [enc setBuffer:qb.handle() offset:0 atIndex:0];
+        [enc setBuffer:kc.handle() offset:0 atIndex:1];
+        [enc setBuffer:vc.handle() offset:0 atIndex:2];
+        [enc setBuffer:gqa_partials.handle() offset:0 atIndex:3];
+        [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake(kv_heads, n_blocks_max, (tokens + 1) / 2)
+            threadsPerThreadgroup:MTLSizeMake((NSUInteger)gqa * 32, 1, 1)];
+        id<MTLResource> partial_resources[] = { gqa_partials.handle() };
+        [enc memoryBarrierWithResources:partial_resources count:1];
+        [enc setComputePipelineState:impl_->attention_gqa_merge_rows_p];
+        [enc setBuffer:gqa_partials.handle() offset:0 atIndex:0];
+        [enc setBuffer:output.handle() offset:0 atIndex:1];
+        [enc setBytes:&args length:sizeof(args) atIndex:2];
+        [enc dispatchThreadgroups:MTLSizeMake(q_heads, tokens, 1)
+            threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
+        if (own) impl_->finish_command("bf probe attention");
+    }
+}
+
+void MetalBackend::attention_turbo3_causal_gqa_tiled(const BackendBuffer& q, uint32_t q_stride,
+                                                     uint32_t q_row_stride,
+                                                     const BackendBuffer& k_cache, const BackendBuffer& v_cache,
+                                                     BackendBuffer& out, uint32_t base_len,
+                                                     uint32_t q_heads, uint32_t kv_heads, uint32_t head_dim,
+                                                     uint32_t tokens, uint32_t tile, float scale,
+                                                     BackendBuffer& partials) {
+    const uint32_t gqa = kv_heads ? q_heads / kv_heads : 0;
+    if (!base_len || !tokens || !kv_heads || q_heads % kv_heads || head_dim != 256 ||
+        gqa < 2 || gqa > 8 || (tile != 2 && tile != 4) ||
+        base_len > UINT32_MAX - tokens)
+        throw std::runtime_error("q27 Metal: invalid tiled probe dimensions");
+    const MetalBuffer& qb = metal_buffer(q);
+    const MetalBuffer& kc = metal_buffer(k_cache);
+    const MetalBuffer& vc = metal_buffer(v_cache);
+    MetalBuffer& output = metal_buffer(out);
+    const uint32_t max_seq = base_len + tokens - 1;
+    check_range(qb.size(), 0,
+                ((uint64_t)(tokens - 1) * q_row_stride + (uint64_t)(q_heads - 1) * q_stride + head_dim) * 4,
+                "tiled probe Q");
+    const uint64_t cache_bytes = (uint64_t)max_seq * kv_heads * 2 * 50;
+    check_range(kc.size(), 0, cache_bytes, "tiled probe K cache");
+    check_range(vc.size(), 0, cache_bytes, "tiled probe V cache");
+    check_range(output.size(), 0, (uint64_t)tokens * q_heads * head_dim * 4, "tiled probe output");
+    const uint32_t block = impl_->gqa_block;
+    const uint32_t n_blocks_max = 1 + (max_seq - 1) / block;
+    const uint64_t partial_bytes = (uint64_t)tokens * q_heads * n_blocks_max * 258 * 4;
+    MetalBuffer& gqa_partials = metal_buffer(partials);
+    check_range(gqa_partials.size(), 0, partial_bytes, "tiled probe partials");
+    AttentionGqaCausalArgs args{q_stride, q_row_stride, base_len, q_heads, kv_heads,
+                                head_dim, block, n_blocks_max, tokens, scale};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own,
+            tile == 2 ? "q27_attention_turbo3_causal_gqa_t2" : "q27_attention_turbo3_causal_gqa_t4");
+        [enc setComputePipelineState:tile == 2 ? impl_->attention_turbo3_causal_gqa_t2_p
+                                               : impl_->attention_turbo3_causal_gqa_t4_p];
+        [enc setBuffer:qb.handle() offset:0 atIndex:0];
+        [enc setBuffer:kc.handle() offset:0 atIndex:1];
+        [enc setBuffer:vc.handle() offset:0 atIndex:2];
+        [enc setBuffer:gqa_partials.handle() offset:0 atIndex:3];
+        [enc setBytes:&args length:sizeof(args) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake(kv_heads, n_blocks_max, (tokens + tile - 1) / tile)
+            threadsPerThreadgroup:MTLSizeMake((NSUInteger)gqa * 32, 1, 1)];
+        id<MTLResource> partial_resources[] = { gqa_partials.handle() };
+        [enc memoryBarrierWithResources:partial_resources count:1];
+        [enc setComputePipelineState:impl_->attention_gqa_merge_rows_p];
+        [enc setBuffer:gqa_partials.handle() offset:0 atIndex:0];
+        [enc setBuffer:output.handle() offset:0 atIndex:1];
+        [enc setBytes:&args length:sizeof(args) atIndex:2];
+        [enc dispatchThreadgroups:MTLSizeMake(q_heads, tokens, 1)
+            threadsPerThreadgroup:MTLSizeMake(32, 1, 1)];
+        if (own) impl_->finish_command("tiled probe attention");
+    }
+}
+
 void MetalBackend::attention_f16(const BackendBuffer& q, uint32_t q_stride,
                                   const BackendBuffer& k_cache, const BackendBuffer& v_cache,
                                   BackendBuffer& out, uint32_t seq_len,
@@ -1719,7 +2455,8 @@ void MetalBackend::embedding_q8_rows(const BackendTensor& weight, const uint32_t
     if (!tokens || !count || count > 96)
         throw std::runtime_error("q27 Metal: chunked embedding requires 1..96 tokens");
     const bool t2 = weight.dtype == DType::T2_G128;
-    if ((weight.dtype != DType::Q8_G128 && !t2) || !weight.data || !weight.scales ||
+    const bool b1 = weight.dtype == DType::B1_G128;
+    if ((weight.dtype != DType::Q8_G128 && !t2 && !b1) || !weight.data || !weight.scales ||
         !weight.rows || !weight.cols || weight.rows > UINT32_MAX || weight.cols > UINT32_MAX ||
         weight.cols % 128)
         throw std::runtime_error("q27 Metal: invalid chunked embedding tensor");
@@ -1732,13 +2469,14 @@ void MetalBackend::embedding_q8_rows(const BackendTensor& weight, const uint32_t
     const MetalBuffer& data = metal_buffer_view(weight.data);
     const MetalBuffer& scales = metal_buffer_view(weight.scales);
     check_range(tensor_limit(data.size(), weight.data_offset, weight.data_size), weight.data_offset,
-                weight.rows * weight.cols / (t2 ? 4 : 1), "chunked embedding weight");
+                weight.rows * weight.cols / (t2 ? 4 : b1 ? 8 : 1), "chunked embedding weight");
     check_range(tensor_limit(scales.size(), weight.scales_offset, weight.scales_size), weight.scales_offset, weight.rows * (weight.cols / 128) * 2, "chunked embedding scales");
     MetalBuffer& output = metal_buffer(out);
     @autoreleasepool {
         bool own; auto enc = impl_->encoder_for_operation(own,
-            t2 ? "q27_embedding_t2_rows" : "q27_embedding_q8_rows");
-        [enc setComputePipelineState:t2 ? impl_->embedding_t2_rows : impl_->embedding_rows];
+            t2 ? "q27_embedding_t2_rows" : b1 ? "q27_embedding_b1_rows" : "q27_embedding_q8_rows");
+        [enc setComputePipelineState:t2 ? impl_->embedding_t2_rows :
+                                     b1 ? impl_->embedding_b1_rows : impl_->embedding_rows];
         [enc setBuffer:data.handle() offset:(NSUInteger)weight.data_offset atIndex:0];
         [enc setBuffer:scales.handle() offset:(NSUInteger)weight.scales_offset atIndex:1];
         [enc setBuffer:output.handle() offset:0 atIndex:2];
@@ -2113,6 +2851,69 @@ void MetalBackend::kv_store_turbo3_rows(const BackendBuffer& k, const BackendBuf
         [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)kv_heads*2,2,tokens)
                 threadsPerThreadgroup:MTLSizeMake(kTurboThreads,1,1)];
         if (own) impl_->finish_command("chunked turbo3 KV store");
+    }
+}
+
+void MetalBackend::kv_store_f16_attrib_rows(const BackendBuffer& k, const BackendBuffer& v,
+                                            BackendBuffer& k_cache, BackendBuffer& v_cache,
+                                            uint32_t position, uint32_t kv_heads, uint32_t tokens,
+                                            uint32_t mode, uint32_t head, uint32_t flags,
+                                            uint32_t scale_off, BackendBuffer* aux) {
+    if (!kv_heads || !tokens || tokens > 96)
+        throw std::runtime_error("q27 Metal: invalid KV attribution store");
+    if (mode != 1 && mode != 2 && mode != 3 && mode != 4)
+        throw std::runtime_error("q27 Metal: KV attribution mode must be 1 (K), 2 (V), 3 (except-mask), or 4 (e4m3 both sides)");
+    if (mode == 3) {
+        // Exception mode: head carries the per-layer (head, side) bitmask
+        // (bit = head*2 + side); flags modifiers are side-arm-only.
+        if (head > 0xffu)
+            throw std::runtime_error("q27 Metal: KV exception mask out of range");
+        if (flags)
+            throw std::runtime_error("q27 Metal: KV exception mode takes no round-trip flags");
+    } else if (mode == 4) {
+        // fp8 control arm: head is ignored, no turbo3 scale to modify.
+        if (flags)
+            throw std::runtime_error("q27 Metal: KV e4m3 mode takes no round-trip flags");
+    } else if (head != UINT32_MAX && head >= kv_heads)
+        throw std::runtime_error("q27 Metal: KV attribution head out of range");
+    if (flags & ~7u)
+        throw std::runtime_error("q27 Metal: unknown KV attribution flags");
+    const bool needs_aux = (flags & 6u) != 0;   // FEATURE or STATS
+    if (needs_aux && !aux)
+        throw std::runtime_error("q27 Metal: KV attribution flags need an aux buffer");
+    const MetalBuffer& kb = metal_buffer(k); const MetalBuffer& vb = metal_buffer(v);
+    MetalBuffer& kc = metal_buffer(k_cache); MetalBuffer& vc = metal_buffer(v_cache);
+    const uint64_t row_floats = (uint64_t)kv_heads * 256;
+    check_range(kb.size(), 0, row_floats * tokens * 4, "attrib K rows");
+    check_range(vb.size(), 0, row_floats * tokens * 4, "attrib V rows");
+    check_range(kc.size(), (uint64_t)position * row_floats * 2, row_floats * tokens * 2, "attrib K cache");
+    check_range(vc.size(), (uint64_t)position * row_floats * 2, row_floats * tokens * 2, "attrib V cache");
+    if (needs_aux) {
+        // Highest index the kernel touches for this layer: the V side's
+        // slice at this scale_off, not the layer offset added to both full
+        // side regions.
+        const uint64_t need = ((uint64_t)scale_off + 16384 + (uint64_t)kv_heads * 256) * 4;
+        check_range(metal_buffer(*aux).size(), 0, need, "attrib aux");
+    }
+    // buffer(5) must always be bound; a 4-byte dummy covers flag-free calls.
+    if (!aux && !impl_->attrib_dummy) {
+        impl_->attrib_dummy = [impl_->device newBufferWithLength:4
+                                                         options:MTLResourceStorageModePrivate];
+        if (!impl_->attrib_dummy)
+            throw std::runtime_error("q27 Metal: cannot allocate attribution dummy buffer");
+    }
+    TurboAttribArgs args{position, kv_heads, tokens, mode, head, flags, scale_off};
+    @autoreleasepool {
+        bool own; auto enc = impl_->encoder_for_operation(own, "q27_kv_store_f16_attrib_rows");
+        [enc setComputePipelineState:impl_->kv_store_attrib_rows];
+        [enc setBuffer:kb.handle() offset:0 atIndex:0]; [enc setBuffer:vb.handle() offset:0 atIndex:1];
+        [enc setBuffer:kc.handle() offset:0 atIndex:2]; [enc setBuffer:vc.handle() offset:0 atIndex:3];
+        [enc setBytes:&args length:sizeof(args) atIndex:4];
+        if (aux) [enc setBuffer:metal_buffer(*aux).handle() offset:0 atIndex:5];
+        else [enc setBuffer:impl_->attrib_dummy offset:0 atIndex:5];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)kv_heads*2,2,tokens)
+                threadsPerThreadgroup:MTLSizeMake(kTurboThreads,1,1)];
+        if (own) impl_->finish_command("KV attribution store");
     }
 }
 

--- a/src/metal/metal_engine.cpp
+++ b/src/metal/metal_engine.cpp
@@ -1,6 +1,7 @@
 #include "metal_engine.h"
 
 #include "../../third_party/json.hpp"
+#include "../suffixdraft.h"
 
 #include <algorithm>
 #include <cassert>
@@ -23,6 +24,13 @@
 
 namespace q27 {
 namespace {
+
+// Bonsai matrix tiers (T2 ternary / B1 binary): exact select-form math on
+// float activations, no activation quantization — one dispatch policy for
+// both (binary-tier plan, Phase 3). Q4/Q8 keep the packed-dot quantized path.
+bool is_bonsai_dtype(DType dtype) {
+    return dtype == DType::T2_G128 || dtype == DType::B1_G128;
+}
 
 class CommandBatch {
   public:
@@ -88,10 +96,46 @@ void MetalEngine::validate_architecture() const {
     };
     if (meta.value("general.architecture", std::string()) != "qwen35")
         throw std::runtime_error("q27 Metal: expected qwen35 architecture");
-    if (meta.value("quant_policy", std::string()) != "q4s-v1" ||
-        !meta.value("q4_head", false))
-        throw std::runtime_error("q27 Metal: expected q4s-v1 artifact");
-    exact("qwen35.block_count", 65); exact("qwen35.embedding_length", N_EMBD);
+    // Bonsai artifacts (T2 ternary / B1 binary repacks): 64 blocks, no MTP
+    // layer, bonsai-dtype embeddings/head/alpha/beta. The sibling packs
+    // share this architecture even though their trained tensor bytes differ.
+    const std::string policy = meta.value("quant_policy", std::string());
+    const bool ternary = policy == "bonsai-t2-v1";
+    const bool binary = policy == "bonsai-b1-v1";
+    // Mixed-tier census packs (docs/metal/plans/2026-07-17-mixed-tier-census.md,
+    // tools/q27_mix.py): per-tensor T2/B1 routing over the same bonsai
+    // shape. Both tiers' layout declarations are demanded below.
+    const bool mixed = policy == "bonsai-mixed-v1";
+    const bool bonsai = ternary || binary || mixed;
+    // Published Q-tier packs are exact recipes, not arbitrary mixtures of
+    // otherwise executable Q4/Q8 tensors. Pin both the policy name and the
+    // repack metadata so a malformed or unknown tier fails before upload.
+    bool q4_head=false;
+    const char* q8_extra=nullptr;
+    if (!bonsai) {
+        if (policy=="q4s-v1") q4_head=true;
+        else if (policy=="q5f-v1") { q4_head=true; q8_extra="(ffn_down)\\."; }
+        else if (policy=="q6-v1") q8_extra="(ssm_out|attn_output|ffn_down)\\.";
+        else if (policy=="q6f-v1") { q4_head=true; q8_extra="(ffn_down|ffn_gate)\\."; }
+        else if (policy=="q6k-v1") q8_extra="(ssm_out|attn_output|ffn_down|ffn_gate)\\.";
+        else if (policy=="q8-v1") q8_extra=".*";
+        else if (policy=="v1.4") q8_extra="(ssm_out|attn_output)\\.";
+        else throw std::runtime_error("q27 Metal: unsupported quantization policy: "+policy);
+        if (q4_head) {
+            if (!meta.contains("q4_head") || !meta["q4_head"].is_boolean() ||
+                !meta["q4_head"].get<bool>())
+                throw std::runtime_error("q27 Metal: quantization policy requires q4_head");
+        } else if (meta.contains("q4_head")) {
+            throw std::runtime_error("q27 Metal: unexpected q4_head metadata");
+        }
+        if (q8_extra) {
+            if (meta.value("q8_extra",std::string())!=q8_extra)
+                throw std::runtime_error("q27 Metal: q8_extra does not match quantization policy");
+        } else if (meta.contains("q8_extra")) {
+            throw std::runtime_error("q27 Metal: unexpected q8_extra metadata");
+        }
+    }
+    exact("qwen35.block_count", bonsai ? 64 : 65); exact("qwen35.embedding_length", N_EMBD);
     exact("qwen35.feed_forward_length", N_FFN); exact("qwen35.attention.head_count", N_HEAD);
     exact("qwen35.attention.head_count_kv", N_KV); exact("qwen35.attention.key_length", HEAD_DIM);
     exact("qwen35.attention.value_length", HEAD_DIM); exact("qwen35.ssm.state_size", GDN_DIM);
@@ -99,8 +143,24 @@ void MetalEngine::validate_architecture() const {
     exact("qwen35.context_length", 262144); exact("qwen35.rope.dimension_count", N_ROT);
     exact("qwen35.ssm.conv_kernel", 4); exact("qwen35.ssm.time_step_rank", GDN_HEADS);
     exact("qwen35.full_attention_interval", 4);
-    exact("qwen35.nextn_predict_layers", 1);
+    if (!bonsai) exact("qwen35.nextn_predict_layers", 1);
     exact("group_q4", 64); exact("group_q8", 128);
+    auto exact_str = [&](const char* key, const char* expected) {
+        if (meta.value(key, std::string()) != expected)
+            throw std::runtime_error(std::string("q27 Metal: architecture mismatch: ") + key);
+    };
+    // The kernels hardcode the pack encodings; the metadata strings declare
+    // exactly what the repack wrote for both ternary and binary weights.
+    if (ternary || mixed) {
+        exact("group_t2", 128);
+        exact_str("t2_codes", "0=-1,1=0,2=+1;3 forbidden");
+        exact_str("t2_slot_order", "seq-lsb-first");
+    }
+    if (binary || mixed) {
+        exact("group_b1", 128);
+        exact_str("b1_codes", "1=+d,0=-d");
+        exact_str("b1_bit_order", "seq-lsb-first");
+    }
     if (meta.value("nibble_order", std::string()) != "even=low")
         throw std::runtime_error("q27 Metal: incompatible Q4 nibble order");
     auto exact_float = [&](const char* key, double expected, double tolerance) {
@@ -117,13 +177,13 @@ void MetalEngine::validate_architecture() const {
 
     std::vector<uint32_t> expected_attention;
     for (uint32_t i = 3; i < N_LAYER; i += 4) expected_attention.push_back(i);
-    const size_t expected_map = expected_attention.size() + 1;
+    const size_t expected_map = expected_attention.size() + (bonsai ? 0 : 1);
     if (!meta.contains("attn_layers") || meta["attn_layers"].size() != expected_map)
         throw std::runtime_error("q27 Metal: invalid attention layer map");
     for (size_t i = 0; i < expected_attention.size(); i++)
         if (meta["attn_layers"][i].get<uint32_t>() != expected_attention[i])
             throw std::runtime_error("q27 Metal: unexpected attention layer map");
-    if (meta["attn_layers"].back().get<uint32_t>() != 64)
+    if (!bonsai && meta["attn_layers"].back().get<uint32_t>() != 64)
         throw std::runtime_error("q27 Metal: missing MTP attention layer");
 
     auto require = [&](const std::string& name, DType dtype, std::initializer_list<uint64_t> shape) {
@@ -131,59 +191,129 @@ void MetalEngine::validate_architecture() const {
         if (!tensor || tensor->dtype != dtype || tensor->shape != std::vector<uint64_t>(shape))
             throw std::runtime_error("q27 Metal: required tensor mismatch: " + name);
     };
-    auto matrix = [&](const std::string& name, DType dtype, uint64_t rows, uint64_t cols) {
+    // Pure/mixed Bonsai policies pin their packed dtype. Published Q tiers
+    // use the exact repack recipe named by quant_policy above.
+    auto bonsai_matrix_dtype_ok = [&](DType dtype) {
+        if (ternary) return dtype == DType::T2_G128;
+        if (binary) return dtype == DType::B1_G128;
+        return mixed && (dtype == DType::T2_G128 || dtype == DType::B1_G128);
+    };
+    auto has_suffix = [](const std::string& name,const char* suffix) {
+        const size_t n=std::strlen(suffix);
+        return name.size()>=n && name.compare(name.size()-n,n,suffix)==0;
+    };
+    auto q_matrix_dtype = [&](const std::string& name) {
+        if (name.compare(0,7,"blk.64.")==0 ||
+            has_suffix(name,".attn_k.weight") || has_suffix(name,".attn_v.weight"))
+            return DType::Q8_G128;
+        if (policy=="q8-v1") return DType::Q8_G128;
+        if ((policy=="v1.4" || policy=="q6-v1" || policy=="q6k-v1") &&
+            (has_suffix(name,".ssm_out.weight") || has_suffix(name,".attn_output.weight")))
+            return DType::Q8_G128;
+        if ((policy=="q5f-v1" || policy=="q6-v1" ||
+             policy=="q6f-v1" || policy=="q6k-v1") &&
+            has_suffix(name,".ffn_down.weight"))
+            return DType::Q8_G128;
+        if ((policy=="q6f-v1" || policy=="q6k-v1") &&
+            has_suffix(name,".ffn_gate.weight"))
+            return DType::Q8_G128;
+        return DType::Q4_G64;
+    };
+    auto matrix = [&](const std::string& name, uint64_t rows, uint64_t cols) {
         const Tensor* tensor = model_.find(name);
-        if (!tensor || tensor->dtype != dtype || tensor->shape != std::vector<uint64_t>{rows, cols})
+        const bool dtype_ok=tensor && (bonsai ? bonsai_matrix_dtype_ok(tensor->dtype)
+                                             : tensor->dtype==q_matrix_dtype(name));
+        if (!dtype_ok || tensor->shape != std::vector<uint64_t>{rows, cols})
             throw std::runtime_error("q27 Metal: required matrix mismatch: " + name);
     };
 
-    require("token_embd.weight", DType::Q8_G128, {VOCAB, N_EMBD});
-    require("output.weight", DType::Q4_G64, {VOCAB, N_EMBD});
-    if (model_.find("output_q4.weight"))
-        throw std::runtime_error("q27 Metal: q4s artifact must not duplicate the output head");
+    // Tensors whose tier follows the pack policy: mixed admits either
+    // bonsai dtype (per-tensor routing decides at dispatch), the pure
+    // packs stay pinned exactly.
+    auto require_tier = [&](const std::string& name, DType pure,
+                            std::initializer_list<uint64_t> shape) {
+        if (!mixed) { require(name, pure, shape); return; }
+        const Tensor* tensor = model_.find(name);
+        if (!tensor || (tensor->dtype != DType::T2_G128 && tensor->dtype != DType::B1_G128) ||
+            tensor->shape != std::vector<uint64_t>(shape))
+            throw std::runtime_error("q27 Metal: required tensor mismatch: " + name);
+    };
+    const DType vocab_dtype = ternary ? DType::T2_G128
+                            : binary ? DType::B1_G128 : DType::Q8_G128;   // unused under mixed
+    // Vocabulary tensors are policy-pinned too. Q-tier packs keep the token
+    // embedding at Q8; q4-head tiers replace the Q8 lm_head and omit the
+    // draft-only duplicate, while every other tier carries both heads.
+    if (bonsai) {
+        require_tier("token_embd.weight", vocab_dtype, {VOCAB, N_EMBD});
+        require_tier("output.weight", vocab_dtype, {VOCAB, N_EMBD});
+    } else {
+        require("token_embd.weight", DType::Q8_G128, {VOCAB, N_EMBD});
+        require("output.weight", q4_head ? DType::Q4_G64 : DType::Q8_G128,
+                {VOCAB, N_EMBD});
+        if (q4_head) {
+            if (model_.find("output_q4.weight"))
+                throw std::runtime_error("q27 Metal: q4-head tier must not duplicate the output head");
+        } else {
+            require("output_q4.weight", DType::Q4_G64, {VOCAB, N_EMBD});
+        }
+    }
     require("output_norm.weight", DType::F32, {N_EMBD});
     for (uint32_t layer = 0; layer < N_LAYER; layer++) {
         const std::string p = "blk." + std::to_string(layer) + ".";
         require(p + "attn_norm.weight", DType::F32, {N_EMBD});
         require(p + "post_attention_norm.weight", DType::F32, {N_EMBD});
-        matrix(p + "ffn_gate.weight", DType::Q4_G64, N_FFN, N_EMBD);
-        matrix(p + "ffn_up.weight", DType::Q4_G64, N_FFN, N_EMBD);
-        matrix(p + "ffn_down.weight", DType::Q4_G64, N_EMBD, N_FFN);
+        matrix(p + "ffn_gate.weight", N_FFN, N_EMBD);
+        matrix(p + "ffn_up.weight", N_FFN, N_EMBD);
+        matrix(p + "ffn_down.weight", N_EMBD, N_FFN);
         if (attention_layer(layer)) {
-            matrix(p + "attn_q.weight", DType::Q4_G64, 2 * N_HEAD * HEAD_DIM, N_EMBD);
-            matrix(p + "attn_k.weight", DType::Q8_G128, N_KV * HEAD_DIM, N_EMBD);
-            matrix(p + "attn_v.weight", DType::Q8_G128, N_KV * HEAD_DIM, N_EMBD);
-            matrix(p + "attn_output.weight", DType::Q4_G64, N_EMBD, N_HEAD * HEAD_DIM);
+            matrix(p + "attn_q.weight", 2 * N_HEAD * HEAD_DIM, N_EMBD);
+            matrix(p + "attn_k.weight", N_KV * HEAD_DIM, N_EMBD);
+            matrix(p + "attn_v.weight", N_KV * HEAD_DIM, N_EMBD);
+            matrix(p + "attn_output.weight", N_EMBD, N_HEAD * HEAD_DIM);
             require(p + "attn_q_norm.weight", DType::F32, {HEAD_DIM});
             require(p + "attn_k_norm.weight", DType::F32, {HEAD_DIM});
         } else {
-            matrix(p + "attn_qkv.weight", DType::Q4_G64, GDN_CH, N_EMBD);
-            matrix(p + "attn_gate.weight", DType::Q4_G64, GDN_V, N_EMBD);
-            require(p + "ssm_alpha.weight", DType::F16, {GDN_HEADS, N_EMBD});
-            require(p + "ssm_beta.weight", DType::F16, {GDN_HEADS, N_EMBD});
+            matrix(p + "attn_qkv.weight", GDN_CH, N_EMBD);
+            matrix(p + "attn_gate.weight", GDN_V, N_EMBD);
+            if (bonsai) {
+                require_tier(p + "ssm_alpha.weight", ternary ? DType::T2_G128 : DType::B1_G128,
+                             {GDN_HEADS, N_EMBD});
+                require_tier(p + "ssm_beta.weight", ternary ? DType::T2_G128 : DType::B1_G128,
+                             {GDN_HEADS, N_EMBD});
+            } else {
+                require(p + "ssm_alpha.weight", DType::F16, {GDN_HEADS, N_EMBD});
+                require(p + "ssm_beta.weight", DType::F16, {GDN_HEADS, N_EMBD});
+            }
             require(p + "ssm_a", DType::F32, {GDN_HEADS});
             require(p + "ssm_dt.bias", DType::F32, {GDN_HEADS});
             require(p + "ssm_conv1d.weight", DType::F32, {GDN_CH, 4});
             require(p + "ssm_norm.weight", DType::F32, {GDN_DIM});
-            matrix(p + "ssm_out.weight", DType::Q4_G64, N_EMBD, GDN_V);
+            matrix(p + "ssm_out.weight", N_EMBD, GDN_V);
         }
+    }
+    if (bonsai) {
+        // No MTP layer in bonsai packs; a partial blk.64 would mean a broken
+        // repack, so its absence is asserted rather than tolerated silently.
+        if (model_.find("blk.64.attn_norm.weight") || model_.find("output_q4.weight"))
+            throw std::runtime_error("q27 Metal: unexpected MTP tensors in a bonsai artifact");
+        return;
     }
     const std::string p = "blk.64.";
     require(p + "nextn.enorm.weight", DType::F32, {N_EMBD});
     require(p + "nextn.hnorm.weight", DType::F32, {N_EMBD});
     require(p + "nextn.shared_head_norm.weight", DType::F32, {N_EMBD});
-    matrix(p + "nextn.eh_proj.weight", DType::Q8_G128, N_EMBD, 2 * N_EMBD);
+    matrix(p + "nextn.eh_proj.weight", N_EMBD, 2 * N_EMBD);
     require(p + "attn_norm.weight", DType::F32, {N_EMBD});
     require(p + "post_attention_norm.weight", DType::F32, {N_EMBD});
     require(p + "attn_q_norm.weight", DType::F32, {HEAD_DIM});
     require(p + "attn_k_norm.weight", DType::F32, {HEAD_DIM});
-    matrix(p + "attn_q.weight", DType::Q8_G128, 2 * N_HEAD * HEAD_DIM, N_EMBD);
-    matrix(p + "attn_k.weight", DType::Q8_G128, N_KV * HEAD_DIM, N_EMBD);
-    matrix(p + "attn_v.weight", DType::Q8_G128, N_KV * HEAD_DIM, N_EMBD);
-    matrix(p + "attn_output.weight", DType::Q8_G128, N_EMBD, N_HEAD * HEAD_DIM);
-    matrix(p + "ffn_gate.weight", DType::Q8_G128, N_FFN, N_EMBD);
-    matrix(p + "ffn_up.weight", DType::Q8_G128, N_FFN, N_EMBD);
-    matrix(p + "ffn_down.weight", DType::Q8_G128, N_EMBD, N_FFN);
+    matrix(p + "attn_q.weight", 2 * N_HEAD * HEAD_DIM, N_EMBD);
+    matrix(p + "attn_k.weight", N_KV * HEAD_DIM, N_EMBD);
+    matrix(p + "attn_v.weight", N_KV * HEAD_DIM, N_EMBD);
+    matrix(p + "attn_output.weight", N_EMBD, N_HEAD * HEAD_DIM);
+    matrix(p + "ffn_gate.weight", N_FFN, N_EMBD);
+    matrix(p + "ffn_up.weight", N_FFN, N_EMBD);
+    matrix(p + "ffn_down.weight", N_EMBD, N_FFN);
 }
 
 std::shared_ptr<MetalEngine::Shared> MetalEngine::open_shared(const std::string& model_path) {
@@ -431,8 +561,10 @@ MetalEngine::MetalEngine(std::shared_ptr<Shared> shared, uint32_t context, bool 
                         backend_.allocate_private((uint64_t)max_context_ * HEAD_DIM * 2)});
 
     // Layer-major chunked prefill routes every projection through
-    // activation-quantized simdgroup GEMM. The q4s artifact carries the
-    // required MTP layer, so the device-family capability is the remaining gate.
+    // activation-quantized simdgroup GEMM. Official Q4/Q8 models use that
+    // contract; Bonsai T2/B1/mixed serial projection deliberately keeps
+    // float activations, so it must remain serial until an equivalent
+    // batched float-activation path exists.
     chunked_prefill_ = chunk_capable;
     if (chunked_prefill_) {
         ch_ = alloc_f32((uint64_t)PREFILL_CHUNK_MAX * N_EMBD);
@@ -485,10 +617,104 @@ MetalEngine::MetalEngine(std::shared_ptr<Shared> shared, uint32_t context, bool 
 
 void MetalEngine::set_chunked_prefill(bool enabled) {
     if (enabled && !has_mtp_)
-        throw std::runtime_error("q27 Metal: artifact has no MTP layer; chunked prefill is unavailable");
+        throw std::runtime_error("q27 Metal: Bonsai models require serial float-activation prefill");
     if (enabled && !ch_)
         throw std::runtime_error("q27 Metal: chunked prefill requires quantized matmul support");
     chunked_prefill_ = enabled;
+}
+
+void MetalEngine::set_kv_attrib(uint32_t mode) {
+    // Mode 4 (fp8-KV control arm): e4m3 round-trip of BOTH sides, every
+    // head — production-exact for a transform-free codec. Mode 3 is set
+    // via set_kv_attrib_except only (it needs the cell masks).
+    if (mode > 2 && mode != 4)
+        throw std::runtime_error("q27 Metal: KV attribution mode must be 0 (off), 1 (K), 2 (V), or 4 (e4m3 both sides)");
+    if (mode && turbo3_kv_)
+        throw std::runtime_error("q27 Metal: KV attribution requires an fp16-KV engine (drop --kv turbo3)");
+    // Any change after rows are cached — including turning attribution off
+    // or widening a cell back to all layers/heads — would leave a mixed
+    // cache behind position_.
+    if (position_ && (mode != kv_attrib_ ||
+                      kv_attrib_layer_ != UINT32_MAX || kv_attrib_head_ != UINT32_MAX))
+        throw std::runtime_error("q27 Metal: set KV attribution before encoding any tokens");
+    kv_attrib_ = mode;
+    kv_attrib_layer_ = UINT32_MAX;
+    kv_attrib_head_ = UINT32_MAX;
+    kv_attrib_flags_ = 0;
+    kv_attrib_aux_.reset();
+}
+
+void MetalEngine::set_kv_attrib_rt(bool scale32, const float* feature_scales) {
+    // Side arms (1/2) only: modes 3/4 have no turbo3 scale to modify.
+    if (!kv_attrib_ || (kv_attrib_flags_ & 4u) || kv_attrib_ >= 3)
+        throw std::runtime_error("q27 Metal: KV round-trip modifiers need a side arm (set_kv_attrib first)");
+    if (position_)
+        throw std::runtime_error("q27 Metal: set KV attribution before encoding any tokens");
+    kv_attrib_flags_ = (scale32 ? 1u : 0u) | (feature_scales ? 2u : 0u);
+    if (feature_scales) {
+        kv_attrib_aux_ = backend_.allocate(2ull * 16 * 4 * 256 * 4);
+        backend_.write(*kv_attrib_aux_, 0, feature_scales, 2ull * 16 * 4 * 256 * 4);
+    }
+}
+
+void MetalEngine::set_kv_attrib_stats() {
+    if (turbo3_kv_)
+        throw std::runtime_error("q27 Metal: KV attribution requires an fp16-KV engine (drop --kv turbo3)");
+    if (position_)
+        throw std::runtime_error("q27 Metal: set KV attribution before encoding any tokens");
+    kv_attrib_ = 1;              // ignored by the STATS branch; enables routing
+    kv_attrib_layer_ = UINT32_MAX;
+    kv_attrib_head_ = UINT32_MAX;
+    kv_attrib_flags_ = 4u;
+    kv_attrib_aux_ = backend_.allocate(2ull * 16 * 4 * 256 * 4);
+    backend_.zero(*kv_attrib_aux_);
+}
+
+void MetalEngine::read_kv_attrib_stats(std::vector<float>& out) {
+    if (!(kv_attrib_flags_ & 4u) || !kv_attrib_aux_)
+        throw std::runtime_error("q27 Metal: no KV attribution stats pass is active");
+    backend_.synchronize();
+    out.resize(2ull * 16 * 4 * 256);
+    backend_.read(*kv_attrib_aux_, 0, out.data(), out.size() * 4);
+}
+
+void MetalEngine::set_kv_attrib_cell(uint32_t mode, uint32_t layer, uint32_t head) {
+    if (mode != 1 && mode != 2)
+        throw std::runtime_error("q27 Metal: KV attribution cell mode must be 1 (K) or 2 (V)");
+    if (turbo3_kv_)
+        throw std::runtime_error("q27 Metal: KV attribution requires an fp16-KV engine (drop --kv turbo3)");
+    if (layer != UINT32_MAX && (layer >= 64 || layer % 4 != 3))
+        throw std::runtime_error("q27 Metal: KV attribution layer must be an attention layer (layer%4==3)");
+    if (head != UINT32_MAX && head >= N_KV)
+        throw std::runtime_error("q27 Metal: KV attribution head out of range");
+    if (position_ && (mode != kv_attrib_ || layer != kv_attrib_layer_ || head != kv_attrib_head_))
+        throw std::runtime_error("q27 Metal: set KV attribution before encoding any tokens");
+    kv_attrib_ = mode;
+    kv_attrib_layer_ = layer;
+    kv_attrib_head_ = head;
+    kv_attrib_flags_ = 0;
+    kv_attrib_aux_.reset();
+}
+
+void MetalEngine::set_kv_attrib_except(const uint32_t* cells, size_t n) {
+    if (turbo3_kv_)
+        throw std::runtime_error("q27 Metal: KV attribution requires an fp16-KV engine (drop --kv turbo3)");
+    if (position_)
+        throw std::runtime_error("q27 Metal: set KV attribution before encoding any tokens");
+    if (n && !cells)
+        throw std::runtime_error("q27 Metal: KV exception cells pointer is null");
+    uint8_t masks[sizeof kv_attrib_masks_] = {};
+    for (size_t i = 0; i < n; i++) {
+        if (cells[i] >= 128)
+            throw std::runtime_error("q27 Metal: KV exception cell must be 0..127");
+        masks[cells[i] >> 3] |= uint8_t(1u << (cells[i] & 7u));
+    }
+    kv_attrib_ = 3;
+    kv_attrib_layer_ = UINT32_MAX;
+    kv_attrib_head_ = UINT32_MAX;
+    kv_attrib_flags_ = 0;
+    kv_attrib_aux_.reset();
+    std::memcpy(kv_attrib_masks_, masks, sizeof masks);
 }
 
 void MetalEngine::initialize_mtp_sentinel() {
@@ -826,6 +1052,7 @@ std::array<unsigned char,20> MetalEngine::snapshot_runtime_identity() const {
     add_string(backend_.shader_source_sha1());
     add_string(backend_.name());
     add_u32(backend_.gemm_half_enabled());
+    add_u32(backend_.gemm_half_q4_enabled());
     add_u32(backend_.gqa_tile());
     add_u32(backend_.gqa_block());
     add_u32(backend_.gqa_threshold());
@@ -839,6 +1066,8 @@ std::array<unsigned char,20> MetalEngine::snapshot_runtime_identity() const {
 void MetalEngine::save_state(const std::string& path, const uint32_t* tokens,
                              uint32_t token_count, bool logits_resident,
                              const DeviceLease& with_device) {
+    if (kv_attrib_)
+        throw std::runtime_error("q27 Metal: snapshots are unavailable during KV attribution");
     if (token_count && !tokens)
         throw std::runtime_error("q27 Metal: snapshot token metadata is null");
     if (logits_resident && !logits_resident_)
@@ -1040,6 +1269,8 @@ uint32_t MetalEngine::load_state_fd(int source_fd,const std::string& path,
                                     const std::vector<uint32_t>* expected_tokens,
                                     const DeviceLease& with_device,
                                     const LoadCheckpoint& checkpoint) {
+    if (kv_attrib_)
+        throw std::runtime_error("q27 Metal: snapshots are unavailable during KV attribution");
     auto check_cancel = [&] { if (checkpoint) checkpoint(); };
     auto run_device = [&](const std::function<void()>& operation) {
         check_cancel();
@@ -1299,18 +1530,26 @@ uint32_t MetalEngine::pending_from_logits() {
     return pending;
 }
 
-// Both operand sets are live at these call sites because rmsnorm_quantized
-// produces the float output and packed activation together. The official q4s
-// contract routes projections through the quantized kernels.
-void MetalEngine::project(const BackendTensor& w, const BackendBuffer&,
+// Serial-decode projection dispatch: bonsai (T2/B1) weights route to the
+// float-activation select-form GEMV (exact math, no activation quantization
+// — ternary/binary-tier plans, Phase 2); Q4/Q8 keep the packed-dot quantized path. Both
+// operand sets are always live at the call sites: the fused rmsnorm/quantize
+// kernels produce the float output and the int8 copy together.
+void MetalEngine::project(const BackendTensor& w, const BackendBuffer& x_float,
                           const BackendQuantized& xq, BackendBuffer& out) {
-    backend_.matvec_quantized(w, xq, out);
+    if (is_bonsai_dtype(w.dtype)) backend_.matvec(w, x_float, out);
+    else backend_.matvec_quantized(w, xq, out);
 }
 
 void MetalEngine::project_pair(const BackendTensor& a, BackendBuffer& a_out,
                                const BackendTensor& b, BackendBuffer& b_out,
-                               const BackendBuffer&, const BackendQuantized& xq) {
-    backend_.matvec_quantized_pair(a, a_out, b, b_out, xq);
+                               const BackendBuffer& x_float, const BackendQuantized& xq) {
+    if (is_bonsai_dtype(a.dtype) || is_bonsai_dtype(b.dtype)) {
+        project(a, x_float, xq, a_out);
+        project(b, x_float, xq, b_out);
+    } else {
+        backend_.matvec_quantized_pair(a, a_out, b, b_out, xq);
+    }
 }
 
 void MetalEngine::gdn_block(uint32_t layer) {
@@ -1329,7 +1568,7 @@ void MetalEngine::gdn_block(uint32_t layer) {
     backend_.gated_norm_gdn(*delta_out_, layer_weight(layer, "ssm_norm.weight"), *z_,
                             *gated_out_, GDN_HEADS, GDN_DIM, EPS);
     const BackendTensor& ssm_out_w = layer_weight(layer, "ssm_out.weight");
-    backend_.quantize(*gated_out_, q6144_);
+    if (!is_bonsai_dtype(ssm_out_w.dtype)) backend_.quantize(*gated_out_, q6144_);
     project(ssm_out_w, *gated_out_, q6144_, *y_);
 }
 
@@ -1372,7 +1611,15 @@ void MetalEngine::attention_block(uint32_t layer, uint32_t pos) {
                                           1.0f / std::sqrt((float)HEAD_DIM));
         backend_.turbo_wht(*attn_out_, N_HEAD, HEAD_DIM, true);
     } else {
-        backend_.kv_store_f16(*kbuf_, *vbuf_, *state.k_cache, *state.v_cache, pos, N_KV * HEAD_DIM);
+        if (kv_attrib_ && (kv_attrib_layer_ == UINT32_MAX || kv_attrib_layer_ == layer))
+            backend_.kv_store_f16_attrib_rows(*kbuf_, *vbuf_, *state.k_cache, *state.v_cache,
+                                              pos, N_KV, 1, kv_attrib_,
+                                              kv_attrib_ == 3 ? kv_attrib_masks_[layer / 4]
+                                                              : kv_attrib_head_,
+                                              kv_attrib_flags_, (layer / 4) * 1024,
+                                              kv_attrib_aux_.get());
+        else
+            backend_.kv_store_f16(*kbuf_, *vbuf_, *state.k_cache, *state.v_cache, pos, N_KV * HEAD_DIM);
         backend_.attention_f16(*qg_, 2 * HEAD_DIM, *state.k_cache, *state.v_cache,
                                *attn_out_, pos + 1, N_HEAD, N_KV,
                                HEAD_DIM, 1.0f / std::sqrt((float)HEAD_DIM),
@@ -1380,7 +1627,7 @@ void MetalEngine::attention_block(uint32_t layer, uint32_t pos) {
     }
     backend_.sigmoid_gate_mul(*attn_out_, *qg_, N_HEAD, HEAD_DIM);
     const BackendTensor& attn_out_w = layer_weight(layer, "attn_output.weight");
-    backend_.quantize(*attn_out_, q6144_);
+    if (!is_bonsai_dtype(attn_out_w.dtype)) backend_.quantize(*attn_out_, q6144_);
     project(attn_out_w, *attn_out_, q6144_, *y_);
 }
 
@@ -1389,13 +1636,13 @@ void MetalEngine::ffn(uint32_t layer) {
                  layer_weight(layer,"ffn_up.weight"),*ffn_up_,*x1_,q5120_);
     backend_.silu_mul(*ffn_gate_, *ffn_up_, *ffn_gate_, N_FFN);
     const BackendTensor& ffn_down_w = layer_weight(layer, "ffn_down.weight");
-    backend_.quantize(*ffn_gate_, q17408_);
+    if (!is_bonsai_dtype(ffn_down_w.dtype)) backend_.quantize(*ffn_gate_, q17408_);
     project(ffn_down_w, *ffn_gate_, q17408_, *y_);
 }
 
 // position_ advances at the call site after successful finish, so a backend
-// throw leaves host state describing only completed work. mtp_round follows
-// the same rule.
+// throw leaves host state describing only completed work. mtp_round and
+// suffix_round follow the same rule.
 // pos_offset places the row for multi-token command batches (prefill,
 // resident decode): the token encodes at position_ + pos_offset.
 void MetalEngine::encode_token(uint32_t token, bool produce_logits, bool token_from_device,
@@ -1432,9 +1679,16 @@ void MetalEngine::gdn_chunk(uint32_t layer, uint32_t count, bool verify) {
     BackendQuantized x5 = quantized_view(cq5120_, count * N_EMBD);
     backend_.matmul_quantized(layer_weight(layer, "attn_qkv.weight"), x5, count, *cqkv_);
     backend_.matmul_quantized(layer_weight(layer, "attn_gate.weight"), x5, count, *cz_);
+    // Official tier: fused F16 pair-rows kernel. Bonsai tiers: alpha/beta
+    // are T2/B1 matrices; their chunk GEMMs write the same [token][row] layout.
     const BackendTensor& alpha_w = layer_weight(layer, "ssm_alpha.weight");
     const BackendTensor& beta_w = layer_weight(layer, "ssm_beta.weight");
-    backend_.matvec_f16_pair_rows(alpha_w, *calpha_, beta_w, *cbeta_raw_, *cx1_, count);
+    if (is_bonsai_dtype(alpha_w.dtype)) {
+        backend_.matmul_quantized(alpha_w, x5, count, *calpha_);
+        backend_.matmul_quantized(beta_w, x5, count, *cbeta_raw_);
+    } else {
+        backend_.matvec_f16_pair_rows(alpha_w, *calpha_, beta_w, *cbeta_raw_, *cx1_, count);
+    }
     backend_.gdn_gates_rows(*calpha_, *cbeta_raw_, layer_weight(layer, "ssm_a"),
                             layer_weight(layer, "ssm_dt.bias"), *cg_, *cbeta_, GDN_HEADS, count);
     LayerState& state = layers_[layer];
@@ -1506,8 +1760,16 @@ void MetalEngine::attention_chunk(uint32_t layer, uint32_t count) {
                                                  HEAD_DIM, count, scale);
         backend_.turbo_wht(*cattn_out_, count * N_HEAD, HEAD_DIM, true);
     } else {
-        backend_.kv_store_f16_rows(*ckbuf_, *cvbuf_, *state.k_cache, *state.v_cache,
-                                   position_, N_KV * HEAD_DIM, count);
+        if (kv_attrib_ && (kv_attrib_layer_ == UINT32_MAX || kv_attrib_layer_ == layer))
+            backend_.kv_store_f16_attrib_rows(*ckbuf_, *cvbuf_, *state.k_cache, *state.v_cache,
+                                              position_, N_KV, count, kv_attrib_,
+                                              kv_attrib_ == 3 ? kv_attrib_masks_[layer / 4]
+                                                              : kv_attrib_head_,
+                                              kv_attrib_flags_, (layer / 4) * 1024,
+                                              kv_attrib_aux_.get());
+        else
+            backend_.kv_store_f16_rows(*ckbuf_, *cvbuf_, *state.k_cache, *state.v_cache,
+                                       position_, N_KV * HEAD_DIM, count);
         backend_.attention_f16_causal(*cqg_, 2 * HEAD_DIM, 2 * N_HEAD * HEAD_DIM,
                                       *state.k_cache, *state.v_cache,
                                       *cattn_out_, position_ + 1, N_HEAD, N_KV,
@@ -1640,7 +1902,7 @@ uint32_t MetalEngine::prefill_serial_chunk(const uint32_t* tokens, uint32_t coun
 
 void MetalEngine::mtp_warm(const BackendBuffer& hidden, uint32_t token, uint32_t position) {
     if (!has_mtp_)
-        throw std::runtime_error("q27 Metal: artifact has no MTP layer; MTP is unavailable for this artifact");
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
     constexpr uint32_t layer = 64;
     backend_.embedding_q8(weight("token_embd.weight"), token, *h_);
     backend_.rmsnorm(*h_, layer_weight(layer, "nextn.enorm.weight"), *mtp_embed_norm_, N_EMBD, EPS);
@@ -1656,6 +1918,16 @@ void MetalEngine::mtp_warm(const BackendBuffer& hidden, uint32_t token, uint32_t
     backend_.rope_neox(*kbuf_, N_KV, HEAD_DIM, N_ROT, HEAD_DIM, position, FREQ_BASE);
     if (turbo3_kv_)
         backend_.kv_store_turbo3(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_, position, N_KV);
+    else if (kv_attrib_ && kv_attrib_layer_ == UINT32_MAX)
+        // Plain round-trip only: step-2 flags index per-attn-layer slots
+        // that do not exist for the MTP layer (instrument never runs MTP).
+        // Mode 3: MTP KV is not a census cell, so it is never excepted
+        // (mask 0 = both sides quantized), keeping the empty-mask control
+        // arm comparable to the modes-1/2 full-side treatment.
+        backend_.kv_store_f16_attrib_rows(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_,
+                                          position, N_KV, 1, kv_attrib_,
+                                          kv_attrib_ == 3 ? 0u : kv_attrib_head_,
+                                          0, 0, nullptr);
     else
         backend_.kv_store_f16(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_, position, N_KV * HEAD_DIM);
 }
@@ -1728,7 +2000,7 @@ uint32_t MetalEngine::mtp_forward(const BackendBuffer& hidden, uint32_t token,
     if (active_mask_ >= 0)
         throw std::runtime_error("q27 Metal: MTP is unmasked; tool constraints require serial decode");
     if (!has_mtp_)
-        throw std::runtime_error("q27 Metal: artifact has no MTP layer; MTP is unavailable for this artifact");
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
     if (!mtp_cache_valid_)
         throw std::runtime_error("q27 Metal: MTP cache is not valid for this prefix");
     if (position >= max_context_) throw std::runtime_error("q27 Metal: MTP context exhausted");
@@ -1762,7 +2034,13 @@ uint32_t MetalEngine::mtp_forward(const BackendBuffer& hidden, uint32_t token,
                                   gqa_partials_.get());
         backend_.turbo_wht(*attn_out_, N_HEAD, HEAD_DIM, true);
     } else {
-        backend_.kv_store_f16(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_, position, N_KV * HEAD_DIM);
+        if (kv_attrib_ && kv_attrib_layer_ == UINT32_MAX)
+            backend_.kv_store_f16_attrib_rows(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_,
+                                              position, N_KV, 1, kv_attrib_,
+                                              kv_attrib_ == 3 ? 0u : kv_attrib_head_,
+                                              0, 0, nullptr);
+        else
+            backend_.kv_store_f16(*kbuf_, *vbuf_, *mtp_k_cache_, *mtp_v_cache_, position, N_KV * HEAD_DIM);
         backend_.attention_f16(*qg_, 2 * HEAD_DIM, *mtp_k_cache_, *mtp_v_cache_,
                                *attn_out_, position + 1, N_HEAD, N_KV,
                                HEAD_DIM, 1.0f / std::sqrt((float)HEAD_DIM),
@@ -1826,7 +2104,7 @@ uint32_t MetalEngine::mtp_round(uint32_t pending, uint32_t remaining, uint32_t e
     if (active_mask_ >= 0)
         throw std::runtime_error("q27 Metal: MTP is unmasked; tool constraints require serial decode");
     if (!has_mtp_)
-        throw std::runtime_error("q27 Metal: artifact has no MTP layer; MTP is unavailable for this artifact");
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
     if (!mtp_cache_valid_)
         throw std::runtime_error("q27 Metal: MTP cache is not valid for this prefix");
     if (width < 2 || width > CHUNK_MAX)
@@ -2068,6 +2346,74 @@ uint32_t MetalEngine::mtp_sample_round(uint32_t pending, uint32_t remaining, uin
     return sample_served(lane_dists[commit_n - 1], rng, /*exclude=*/-1);
 }
 
+// Gate 0 oracle round: mtp_round with the layer-64 draft stage replaced by
+// caller-supplied reference lanes and the acceptance walk replaced by a
+// teacher-forced full commit. The verify chunk, batched output head,
+// per-lane argmax, and gdn_replay commit are shared verbatim, so the round
+// cost is exactly V(w)+O(w) — what a perfect drafter would pay. Because the
+// committed tokens ARE the lanes, KV rows written during the verify chunk
+// are all real and the replayed GDN state matches a serial walk over the
+// same tokens bit-exactly (both chunk kernels are sequential in-kernel).
+void MetalEngine::oracle_round(const uint32_t* lanes, uint32_t live, bool last,
+                               uint32_t* predictions) {
+    if (live < 2 || live > VERIFY_CHUNK_MAX)
+        throw std::runtime_error("q27 Metal: oracle width must be 2..VERIFY_CHUNK_MAX");
+    if (!chunked_prefill_)
+        throw std::runtime_error("q27 Metal: oracle round requires chunked prefill");
+    // The verify chunk stores a KV row for every lane, so all `live` rows
+    // must fit the reserved context even on a `last` round whose final
+    // token never advances position_ — unlike the serial walk, which can
+    // end at max_context_+1 because it never encodes the final token.
+    // --oracle therefore needs --ctx >= prompt+count, one more than serial.
+    if ((uint64_t)position_ + live > max_context_)
+        throw std::runtime_error("q27 Metal: oracle verify rows exceed context; --oracle needs --ctx >= prompt+count");
+    for (uint32_t lane = 0; lane < live; lane++)
+        if (lanes[lane] >= VOCAB)
+            throw std::runtime_error("q27 Metal: oracle lane token out of range");
+    last_spec_stats_.rounds++;
+    last_spec_stats_.drafted += live - 1;
+    // Round-anatomy trace (verify-round-cost plan P0): verify batch vs
+    // prediction readback vs commit batch, per round.
+    static const bool trace = getenv("Q27_ORACLE_TRACE") != nullptr;
+    auto clock = [] { return std::chrono::steady_clock::now(); };
+    auto ms_since = [](std::chrono::steady_clock::time_point start) {
+        return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
+    };
+    auto verify_start = clock();
+    {
+        CommandBatch batch(backend_);
+        chunk_forward(lanes, live, /*verify=*/true);
+        BackendQuantized x5 = quantized_view(cq5120_, live * N_EMBD);
+        backend_.rmsnorm_rows_quantized(*ch_, weight("output_norm.weight"), *cfinal_,
+                                        N_EMBD, live, EPS, x5);
+        backend_.matmul_quantized(weight("output.weight"), x5, live, *clogits_);
+        backend_.argmax_rows(*clogits_, VOCAB, live, *cpred_);
+        batch.finish();
+    }
+    const double verify_ms = trace ? ms_since(verify_start) : 0.0;
+    auto read_start = clock();
+    backend_.read(*cpred_, 0, predictions, live * sizeof(uint32_t));
+    const double read_ms = trace ? ms_since(read_start) : 0.0;
+    auto commit_start = clock();
+    // Teacher-forced commit of every lane; the final output token of a
+    // generation is never encoded, exactly like the serial walk.
+    const uint32_t encoded = last ? live - 1 : live;
+    last_spec_stats_.accepted += live - 1;
+    if (encoded) {
+        CommandBatch batch(backend_);
+        gdn_replay(encoded);
+        backend_.copy(*cfinal_, (uint64_t)(encoded - 1) * N_EMBD * sizeof(float),
+                      *x1_, 0, (uint64_t)N_EMBD * sizeof(float));
+        backend_.copy(*clogits_, (uint64_t)(encoded - 1) * VOCAB * sizeof(float),
+                      *logits_, 0, (uint64_t)VOCAB * sizeof(float));
+        batch.finish();
+    }
+    position_ += encoded;
+    if (trace)
+        fprintf(stderr, "oracle round: live %u | verify %.2f ms read %.2f ms commit %.2f ms\n",
+                live, verify_ms, read_ms, ms_since(commit_start));
+}
+
 uint32_t MetalEngine::stream_mtp_batched(uint32_t pending, uint32_t count, uint32_t width,
                                          uint32_t eos, const TokenSink& sink, StopCause& cause) {
     if (active_mask_ >= 0)
@@ -2287,8 +2633,7 @@ std::vector<float> MetalEngine::teacher_force_nll(const std::vector<uint32_t>& t
         }
         done++;
     }
-    // reset() creates a row-0 MTP sentinel, but teacher forcing never warms
-    // layer-64 rows for the advanced main-model prefix.
+    // Teacher forcing advances only the main model, never the MTP layer.
     mtp_cache_valid_ = false;
     if (n_encode >= CHUNK_MAX) fprintf(stderr, "\n");
     return result;
@@ -2507,7 +2852,7 @@ uint32_t MetalEngine::stream_from_pending(uint32_t pending, uint32_t count, uint
     if (mtp_width && active_mask_ >= 0)
         throw std::runtime_error("q27 Metal: MTP is unmasked; tool constraints require serial decode");
     if (mtp_width && !has_mtp_)
-        throw std::runtime_error("q27 Metal: artifact has no MTP layer; MTP is unavailable for this artifact");
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
     if (mtp_width && (mtp_width < 2 || mtp_width > 12))
         throw std::runtime_error("q27 Metal: MTP width must be 2..12");
     if ((uint64_t)position_ + (count ? count - 1 : 0) > max_context_)
@@ -2538,7 +2883,7 @@ std::vector<uint32_t> MetalEngine::generate_from_pending(uint32_t pending, uint3
     if (mtp_width && active_mask_ >= 0)
         throw std::runtime_error("q27 Metal: MTP is unmasked; tool constraints require serial decode");
     if (mtp_width && !has_mtp_)
-        throw std::runtime_error("q27 Metal: artifact has no MTP layer; MTP is unavailable for this artifact");
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
     if (mtp_width && (mtp_width < 2 || mtp_width > 12))
         throw std::runtime_error("q27 Metal: MTP width must be 2..12");
     if ((uint64_t)position_ + (count ? count - 1 : 0) > max_context_)
@@ -2628,7 +2973,7 @@ std::vector<uint32_t> MetalEngine::generate_mtp(const std::vector<uint32_t>& pro
     if (active_mask_ >= 0)
         throw std::runtime_error("q27 Metal: MTP is unmasked; tool constraints require serial decode");
     if (!has_mtp_)
-        throw std::runtime_error("q27 Metal: artifact has no MTP layer; MTP is unavailable for this artifact");
+        throw std::runtime_error("q27 Metal: artifact has no MTP layer; use --suffix drafting");
     if ((uint64_t)prompt.size() + count > max_context_ + 1)
         throw std::runtime_error("q27 Metal: prompt/generation exceeds context");
     uint32_t pending = ingest_prompt(prompt, true, true);
@@ -2680,5 +3025,193 @@ std::vector<uint32_t> MetalEngine::generate_mtp_sampled(const std::vector<uint32
     return generated;
 }
 
+// Suffix-burst round (2026-07-16-suffix-burst-verify.md): oracle_round's
+// caller-lane verify chunk + batched head + argmax, then mtp_round's REAL
+// acceptance walk, commit_n/encoded rules, and early-EOS clamp (e765dde) —
+// verbatim semantics, lanes from the CPU-side SuffixDraft instead of the
+// layer-64 draft head. Committed tokens are greedy-identical to the serial
+// walk by the same argument as mtp_round (modulo the documented
+// tolerance-gated chunk-GEMM class).
+uint32_t MetalEngine::suffix_round(uint32_t remaining, uint32_t eos, const uint32_t* lanes,
+                                   uint32_t live, std::vector<uint32_t>& committed) {
+    if (remaining < 2)
+        throw std::runtime_error("q27 Metal: suffix round needs remaining >= 2 (emit the last token directly)");
+    if (active_mask_ >= 0)
+        throw std::runtime_error("q27 Metal: suffix rounds are unmasked; tool constraints require serial decode");
+    if (live < 2 || live > VERIFY_CHUNK_MAX)
+        throw std::runtime_error("q27 Metal: suffix round live width must be 2..VERIFY_CHUNK_MAX");
+    if (!chunked_prefill_)
+        throw std::runtime_error("q27 Metal: suffix round requires chunked prefill");
+    if ((uint64_t)position_ + live > max_context_)
+        throw std::runtime_error("q27 Metal: suffix verify rows exceed context");
+    for (uint32_t lane = 0; lane < live; lane++)
+        if (lanes[lane] >= VOCAB)
+            throw std::runtime_error("q27 Metal: suffix lane token out of range");
+    last_spec_stats_.rounds++;
+    last_spec_stats_.drafted += live - 1;
+    {
+        CommandBatch batch(backend_);
+        chunk_forward(lanes, live, /*verify=*/true);
+        BackendQuantized x5 = quantized_view(cq5120_, live * N_EMBD);
+        backend_.rmsnorm_rows_quantized(*ch_, weight("output_norm.weight"), *cfinal_,
+                                        N_EMBD, live, EPS, x5);
+        backend_.matmul_quantized(weight("output.weight"), x5, live, *clogits_);
+        backend_.argmax_rows(*clogits_, VOCAB, live, *cpred_);
+        batch.finish();
+    }
+    std::vector<uint32_t> predictions(live);
+    backend_.read(*cpred_, 0, predictions.data(), live * sizeof(uint32_t));
+    uint32_t accepted = 0;
+    while (accepted + 1 < live && predictions[accepted] == lanes[accepted + 1]) accepted++;
+    uint32_t commit_n = std::min(accepted + 1, remaining);
+    uint32_t encoded = commit_n == remaining ? commit_n - 1 : commit_n;
+    for (uint32_t i = 0; i < commit_n; i++)
+        if (lanes[i] == eos) {
+            commit_n = i + 1;
+            encoded = i;
+            break;
+        }
+    last_spec_stats_.accepted += commit_n - 1;
+    if (encoded) {
+        CommandBatch batch(backend_);
+        gdn_replay(encoded);
+        backend_.copy(*cfinal_, (uint64_t)(encoded - 1) * N_EMBD * sizeof(float),
+                      *x1_, 0, (uint64_t)N_EMBD * sizeof(float));
+        backend_.copy(*clogits_, (uint64_t)(encoded - 1) * VOCAB * sizeof(float),
+                      *logits_, 0, (uint64_t)VOCAB * sizeof(float));
+        batch.finish();
+    }
+    position_ += encoded;
+    committed.insert(committed.end(), lanes, lanes + commit_n);
+    // Dispatch evidence for the width gates (vacuous-gate lesson): printed
+    // at the dispatch site, not the driver's bookkeeping.
+    static const bool trace = getenv("Q27_SUFFIX_TRACE") != nullptr;
+    if (trace)
+        fprintf(stderr, "suffix round: live %u accepted %u committed %u\n", live, accepted, commit_n);
+    return predictions[commit_n - 1];
+}
+
+uint32_t MetalEngine::suffix_step(SuffixDraft& drafter, uint32_t pending, uint32_t remaining,
+                                  uint32_t eos, uint32_t width, uint32_t minimum_match,
+                                  std::vector<uint32_t>& committed, bool* burst) {
+    if (remaining < 2)
+        throw std::runtime_error("q27 Metal: suffix step needs remaining >= 2 (emit the last token directly)");
+    if (width < 2 || width > VERIFY_CHUNK_MAX)
+        throw std::runtime_error("q27 Metal: suffix width must be 2..VERIFY_CHUNK_MAX");
+    committed.clear();
+    if (burst) *burst = false;
+    // A pending eos commits without encoding, mirroring suffix_round's lane
+    // clamp — the serial fallback below must never step() the eos token.
+    // Unreachable from generate_suffix (its sentinel never matches).
+    if (pending == eos) { committed.push_back(eos); return eos; }
+    // Propose up to width-1 continuation tokens; the verify chunk also
+    // needs one KV row per lane inside the reserved context.
+    uint32_t max_lanes = std::min<uint32_t>(width, remaining);
+    if ((uint64_t)position_ + max_lanes > max_context_)
+        max_lanes = (uint32_t)(max_context_ - position_);
+    int proposals[VERIFY_CHUNK_MAX];
+    int match = 0;
+    if (max_lanes >= 2)
+        match = drafter.propose_with((int)pending, (int)(max_lanes - 1), proposals);
+    // Match-capped width: forward lanes are bounded by the matched suffix
+    // length. Proposals past that evidence are lag-copy extrapolation, and
+    // dispatching them would measure speculation beyond the justified match.
+    uint32_t live = match >= (int)minimum_match
+                        ? std::min<uint32_t>(max_lanes, (uint32_t)match + 1) : 0;
+    // Full-tile snap-down (lever 2: round cost steps one full weight
+    // stream per 16-token tile): a partial second/third tile pays a
+    // whole stream for < 16 possible tokens — never worth it. 17..31
+    // lanes snap to 16, 33..47 snap to 32.
+    if (live > 16 && live < 32) live = 16;
+    else if (live > 32 && live < 48) live = 32;
+    if (live >= 2) {
+        last_suffix_stats_.burst_rounds++;
+        if (live <= 16) last_suffix_stats_.lanes_le16++;
+        else if (live == 32) last_suffix_stats_.lanes_32++;
+        else last_suffix_stats_.lanes_48++;
+        if (burst) *burst = true;
+        uint32_t lanes[VERIFY_CHUNK_MAX];
+        lanes[0] = pending;
+        for (uint32_t i = 1; i < live; i++) lanes[i] = (uint32_t)proposals[i - 1];
+        pending = suffix_round(remaining, eos, lanes, live, committed);
+        for (uint32_t tok : committed) drafter.append((int)tok);
+        return pending;
+    }
+    last_suffix_stats_.fallback_rounds++;
+    last_spec_stats_.rounds++;
+    committed.push_back(pending);
+    drafter.append((int)pending);
+    return step(pending);
+}
+
+std::vector<uint32_t> MetalEngine::generate_suffix(const std::vector<uint32_t>& prompt,
+                                                   uint32_t count, uint32_t width,
+                                                   uint32_t minimum_match, uint32_t eos) {
+    if (prompt.empty()) throw std::runtime_error("q27 Metal: prompt is empty");
+    if (width < 2 || width > VERIFY_CHUNK_MAX)
+        throw std::runtime_error("q27 Metal: suffix width must be 2..VERIFY_CHUNK_MAX");
+    if (!chunked_prefill_)
+        throw std::runtime_error("q27 Metal: batched suffix requires chunked prefill; use --suffix-serial");
+    // Reject constraints at entry: burst rounds argmax unmasked logits while
+    // a serial-fallback round would mask them. A mixed stream is worse than a
+    // loud error. This matches the GPU-resident greedy contract.
+    if (active_mask_ >= 0)
+        throw std::runtime_error("q27 Metal: batched suffix refuses active tool constraints; use serial decode");
+    if ((uint64_t)prompt.size() + count > max_context_ + 1)
+        throw std::runtime_error("q27 Metal: prompt/generation exceeds context");
+    uint32_t pending = ingest_prompt(prompt, false, true);
+    last_spec_stats_ = {};
+    last_suffix_stats_ = {};
+    std::vector<int> history(prompt.begin(), prompt.end());
+    SuffixDraft drafter;
+    drafter.reset(history);
+    std::vector<uint32_t> output;
+    output.reserve(count);
+    std::vector<uint32_t> committed;
+    while (output.size() < count) {
+        if (pending == eos) break;
+        if (output.size() + 1 == count) { output.push_back(pending); break; }
+        pending = suffix_step(drafter, pending, (uint32_t)(count - output.size()),
+                              eos, width, minimum_match, committed);
+        for (uint32_t token : committed) {
+            if (token == eos) return output;
+            output.push_back(token);
+        }
+    }
+    return output;
+}
+
+std::vector<uint32_t> MetalEngine::generate_suffix_serial(const std::vector<uint32_t>& prompt,
+                                                          uint32_t count, uint32_t width,
+                                                          uint32_t minimum_match, uint32_t eos) {
+    if(prompt.empty()) throw std::runtime_error("q27 Metal: prompt is empty");
+    if(width<2 || width>12) throw std::runtime_error("q27 Metal: suffix width must be 2..12");
+    if((uint64_t)prompt.size()+count>max_context_+1)
+        throw std::runtime_error("q27 Metal: prompt/generation exceeds context");
+    uint32_t pending=ingest_prompt(prompt,false,true); last_spec_stats_={};
+    std::vector<int> history(prompt.begin(),prompt.end()); SuffixDraft drafter; drafter.reset(history);
+    std::vector<uint32_t> output; output.reserve(count);
+    while(output.size()<count) {
+        if(pending==eos) break;
+        if(output.size()+1==count) { output.push_back(pending); break; }
+        const uint32_t lanes=std::min<uint32_t>(width-1,(uint32_t)(count-output.size()-1));
+        std::vector<int> proposals(lanes);
+        int match=drafter.propose_with((int)pending,(int)lanes,proposals.data());
+        last_spec_stats_.rounds++;
+        if(match>=(int)minimum_match) last_spec_stats_.drafted+=proposals.size();
+        output.push_back(pending); drafter.append((int)pending);
+        uint32_t prediction=step(pending);
+        if(match>=(int)minimum_match) for(int proposal:proposals) {
+            if(prediction==eos) { pending=prediction; break; }
+            if(prediction!=(uint32_t)proposal) break;
+            last_spec_stats_.accepted++;
+            output.push_back((uint32_t)proposal); drafter.append(proposal);
+            if(output.size()==count) return output;
+            prediction=step((uint32_t)proposal);
+        }
+        pending=prediction;
+    }
+    return output;
+}
 
 } // namespace q27

--- a/src/metal/metal_engine.h
+++ b/src/metal/metal_engine.h
@@ -14,6 +14,8 @@
 
 namespace q27 {
 
+class SuffixDraft;
+
 class MetalEngine {
   public:
     struct Snapshot;
@@ -110,12 +112,50 @@ class MetalEngine {
     // clogits_/cpred_ and the gdn_replay parks; mtp_round stays capped at
     // CHUNK_MAX until the MTP lane machinery is testable (24 GB rig).
     static constexpr uint32_t VERIFY_CHUNK_MAX = 48;
+    // Default drafter engage threshold: rounds whose longest suffix match is
+    // shorter fall back to one serial step (Phase-0 sim: shorter thresholds
+    // trade acceptance for round overhead on burst-hostile text).
+    static constexpr uint32_t SUFFIX_MIN_MATCH = 12;
+    // Batched suffix-burst verification (2026-07-16-suffix-burst-verify.md):
+    // SuffixDraft proposals through the VERIFY_CHUNK_MAX-wide verify chunk
+    // with mtp_round's acceptance/commit semantics. width 2..VERIFY_CHUNK_MAX;
+    // rounds with match < minimum_match fall back to one serial step.
+    std::vector<uint32_t> generate_suffix(const std::vector<uint32_t>& prompt,
+                                          uint32_t count, uint32_t width,
+                                          uint32_t minimum_match = SUFFIX_MIN_MATCH,
+                                          uint32_t eos = UINT32_MAX);
+    // The pre-lever-2 serial walk (one step() per proposal): the batched
+    // path's A/B control and byte-level reference. width 2..12.
+    std::vector<uint32_t> generate_suffix_serial(const std::vector<uint32_t>& prompt,
+                                                 uint32_t count, uint32_t width,
+                                                 uint32_t minimum_match = SUFFIX_MIN_MATCH,
+                                                 uint32_t eos = UINT32_MAX);
+    // One suffix-burst driver round (the generate_suffix loop body, extracted
+    // for the server's quantum loop): propose from the drafter, match-cap and
+    // snap-down the width, then either a suffix_round burst or one serial
+    // fallback step. Fills committed with the round's tokens (>= 1, clamped at
+    // eos exactly like mtp_round — pass the REAL eos id here; generate_suffix
+    // passes a never-matching sentinel to run to a fixed count) and returns
+    // the next pending token. remaining must be >= 2 (the caller emits the
+    // final token directly). burst, when non-null, reports whether this
+    // round dispatched a batched verify (server /stats attribution).
+    uint32_t suffix_step(SuffixDraft& drafter, uint32_t pending, uint32_t remaining,
+                         uint32_t eos, uint32_t width, uint32_t minimum_match,
+                         std::vector<uint32_t>& committed, bool* burst = nullptr);
+    // Suffix-burst diagnostics for the last generate_suffix run: rounds that
+    // fell back to serial, and fired-burst lane counts by full-tile bucket.
+    struct SuffixStats {
+        uint64_t fallback_rounds = 0;
+        uint64_t burst_rounds = 0;
+        uint64_t lanes_le16 = 0, lanes_32 = 0, lanes_48 = 0; // dispatched live widths
+    };
+    SuffixStats last_suffix_stats() const { return last_suffix_stats_; }
     uint32_t ingest_prompt(const std::vector<uint32_t>& tokens, bool warm_mtp,
                            bool reset_first = true);
     // One bounded token-serial prefill quantum. Unlike step(), this optionally
     // warms the MTP lane state between tokens and avoids an output-head
     // projection until final_chunk. The server uses it to release the shared
-    // command-queue lease every eight tokens during serial MTP prefill.
+    // command-queue lease every eight tokens during MTP/Bonsai prefill.
     static constexpr uint32_t serial_prefill_chunk_max() { return 8; }
     uint32_t prefill_serial_chunk(const uint32_t* tokens, uint32_t count,
                                   bool warm_mtp, bool final_chunk);
@@ -214,6 +254,22 @@ class MetalEngine {
     // is sample_from_logits + step under one GPU lease. The RNG belongs to
     // the request, not the engine, so interleaved slots stay reproducible.
     uint32_t sample_from_logits(const SamplingParams& params, std::mt19937_64& rng);
+    // Gate 0 oracle round (sibling-drafter-probe doc): one batched verify
+    // round with the draft stage removed — `lanes` are caller-supplied
+    // reference tokens (lanes[0] = pending), commit is teacher-forced to all
+    // `live` lanes so verifier economics are measured at perfect acceptance
+    // (D=0) with no drafter in the loop. Works on artifacts without an MTP
+    // layer. Writes the per-lane argmax verdicts to `predictions[live]`
+    // (observational agreement only — never acted on). `last` marks the
+    // final round of a generation: the final token is committed but never
+    // encoded, exactly like mtp_round/serial semantics.
+    void oracle_round(const uint32_t* lanes, uint32_t live, bool last, uint32_t* predictions);
+    // Suffix-burst round: oracle_round's caller-lane verify machinery with
+    // mtp_round's real acceptance walk and early-EOS clamp. lanes[0] must be
+    // the pending token; live = 2..VERIFY_CHUNK_MAX. Returns the next pending.
+    uint32_t suffix_round(uint32_t remaining, uint32_t eos, const uint32_t* lanes,
+                          uint32_t live, std::vector<uint32_t>& committed);
+
     std::shared_ptr<Snapshot> capture_state();
     void restore_state(const Snapshot& snapshot);
     // Prefix snapshots to disk (docs/metal/plans/2026-07-16-prefix-snapshots.md,
@@ -258,15 +314,14 @@ class MetalEngine {
     // must match this digest in both their deep header and server namespace.
     std::array<unsigned char,20> snapshot_runtime_identity() const;
 
-    // Constrained tool decoding (BasicToolConstrainer engine surface): a
-    // request-scoped device pool of uint32 legal-token bitsets. The server
-    // resets the pool and invalidates its host-id map when a slot is assigned;
-    // ids therefore remain stable only within that request. mask_pool_add
-    // uploads one mask and returns its slot (-1 when the request exceeds the
-    // cap); set_tool_constraint selects the active slot (-1 disengages).
-    // The active mask is applied to logits inside encode_token, before argmax,
-    // so greedy decode, top-k extraction, and CPU sampling see only legal
-    // tokens. Serial decode only; Metal does not wire MTP verify-lane masks.
+    // Constrained tool decoding (BasicToolConstrainer engine surface): an
+    // append-only device pool of uint32 legal-token bitsets. mask_pool_add
+    // uploads one mask and returns its slot (-1 when the pool is full);
+    // set_tool_constraint selects the active slot (-1 disengages). The
+    // active mask is applied to the logits inside encode_token, before the
+    // argmax, so greedy decode, top-k extraction, and CPU sampling all see
+    // only legal tokens. Serial decode only; the MTP verify lanes
+    // (set_tool_masks5) are not wired on Metal.
     static constexpr int MASK_POOL_CAP = 64;
     int mask_pool_used = 0;
     int mask_pool_add(const void* bits);
@@ -279,6 +334,35 @@ class MetalEngine {
     bool used_per_tensor_upload() const { return per_tensor_upload_; }
     bool chunked_prefill() const { return chunked_prefill_; }
     void set_chunked_prefill(bool enabled);
+    // KV-codec attribution knob (kl-kv instrument): 0 = off, 1 = round-trip
+    // K through the turbo3 quantizer at store time, 2 = V. The engine keeps
+    // its fp16 cache and attention kernels, so the resulting KL against an
+    // fp16 baseline isolates one side's quantization error. fp16-KV engines
+    // only; set before any tokens are encoded.
+    void set_kv_attrib(uint32_t mode);
+    // Cell-granular variant (sensitivity census): restrict the round-trip
+    // to one attention layer (absolute index, layer%4==3) and one KV head.
+    // UINT32_MAX for layer/head widens that axis back to "all".
+    void set_kv_attrib_cell(uint32_t mode, uint32_t layer, uint32_t head);
+    // Step-2 scaling arms (docs/metal/plans/2026-07-16-kv-codec-step2.md), on top
+    // of an already-selected side arm: scale32 keeps the group scale in f32
+    // through the round-trip; feature_scales (2*16*4*256 floats,
+    // [side][attn_idx][head][dim]) descale each dimension before the
+    // quantizer and rescale after the inverse transform. Instrument-only,
+    // main-stream attention layers (never the MTP layer).
+    void set_kv_attrib_rt(bool scale32, const float* feature_scales);
+    // Stats pass: subject stores clean fp16 (KL vs baseline is exactly 0 —
+    // a rode-along canary) while per-feature sum-of-squares accumulates for
+    // both sides. read_kv_attrib_stats returns the 2*16*4*256 accumulator.
+    void set_kv_attrib_stats();
+    void read_kv_attrib_stats(std::vector<float>& out);
+    // Step-4 exception probe (docs/metal/plans/2026-07-17-kv-codec-step4-probe.md):
+    // round-trip BOTH sides of every attention layer through the turbo3
+    // quantizer EXCEPT the listed census cells (attn_idx*8 + head*2 + side),
+    // which stay clean fp16. n == 0 is the control arm (everything
+    // quantized). fp16-KV engines only; set before any tokens are encoded;
+    // not combinable with the step-2 rt flags.
+    void set_kv_attrib_except(const uint32_t* cells, size_t n);
     // True when Q27_METAL_KV_FP16_CELLS armed production fp16 exception
     // side caches on this engine. Snapshots carry the side rows (v2,
     // docs/metal/plans/2026-07-17-kv-except-snapshot-v2.md); the head masks are
@@ -328,6 +412,14 @@ class MetalEngine {
     uint32_t max_context_;
     bool turbo3_kv_;
     bool per_tensor_upload_ = false;
+    uint32_t kv_attrib_ = 0;
+    uint32_t kv_attrib_layer_ = UINT32_MAX;
+    uint32_t kv_attrib_head_ = UINT32_MAX;
+    uint32_t kv_attrib_flags_ = 0;
+    // Mode-3 per-attn-layer exception masks (bit = head*2 + side); rides
+    // the kernel's head argument at the attrib store call sites.
+    uint8_t kv_attrib_masks_[16] = {};
+    std::shared_ptr<BackendBuffer> kv_attrib_aux_;
     // Production KV fp16 exception cells
     // (docs/metal/plans/2026-07-17-kv-except-production.md): per masked head, a
     // kv_heads=1 fp16 side cache in the turbo3 WHT domain; the head's
@@ -352,6 +444,7 @@ class MetalEngine {
     // True only when MTP KV rows [0, position_) match the main-model state.
     bool mtp_cache_valid_ = false;
     SpecStats last_spec_stats_;
+    SuffixStats last_suffix_stats_;
     std::unordered_map<std::string, BackendTensor>& weights_;
     std::vector<LayerState> layers_;
 
@@ -393,7 +486,7 @@ class MetalEngine {
     std::vector<std::shared_ptr<BackendBuffer>> park_qkv_, park_g_, park_beta_;
     std::shared_ptr<BackendBuffer> discard_recurrent_, discard_ring_;
 
-    // The q4s contract requires the MTP layer; call sites still fail closed.
+    // Ternary artifacts (quant_policy bonsai-t2-v1) carry no MTP layer.
     bool has_mtp_ = true;
 
     std::shared_ptr<BackendBuffer> alloc_f32(uint64_t count);

--- a/src/metal/q27_kernels.metal
+++ b/src/metal/q27_kernels.metal
@@ -210,6 +210,438 @@ kernel void q27_matvec_t2_g128(
         if (lane == 0 && row0 + r < args.rows) out[row0 + r] = tot;
     }
 }
+
+// N=2 slot-batched select-form ternary GEMV (multislot Phase 2 probe): the
+// production serial-decode kernel (q27_matvec_t2_g128) computing two
+// activation vectors in one weight pass. The bit-extraction booleans — the
+// issue-heavy part of the select-form dot — are shared across the rows;
+// activations and outputs stay in separate buffers (no layout coupling).
+// Per-row op order matches the single kernel exactly, so each output is
+// bit-identical to two single dispatches.
+// PARKED by measurement (2026-07-16, multislot Phase-2 probe): aggregate
+// s_k 1.093 vs the 1.31 decision line — kept as the probe's reference
+// surface, never engine-routed.
+kernel void q27_matvec_t2_g128_x2(
+        device const uchar *weights [[buffer(0)]],
+        device const half  *scales  [[buffer(1)]],
+        device const float *xa      [[buffer(2)]],
+        device const float *xb      [[buffer(3)]],
+        device       float *out_a   [[buffer(4)]],
+        device       float *out_b   [[buffer(5)]],
+        constant MatvecArgs &args   [[buffer(6)]],
+        uint group                   [[threadgroup_position_in_grid]],
+        ushort lane                  [[thread_index_in_simdgroup]],
+        ushort simdgroup             [[simdgroup_index_in_threadgroup]]) {
+    const uint row0 = group * 32 + (uint)simdgroup * 4;   // 32 rows per threadgroup
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint nb = args.cols / 128;
+    const uint ix = lane / 8;              // block in flight (4 per simdgroup)
+    const uint il = (lane % 8) * 16;       // element offset within the block
+    float sumfa[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    float sumfb[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    device const float *ya = xa + ix * 128 + il;
+    device const float *yb = xb + ix * 128 + il;
+    for (uint ib = ix; ib < nb; ib += 4) {
+        float yla[16], ylb[16];
+        float sumya = 0.0f, sumyb = 0.0f;
+        for (uint i = 0; i < 16; i++) { yla[i] = ya[i]; sumya += ya[i]; }
+        for (uint i = 0; i < 16; i++) { ylb[i] = yb[i]; sumyb += yb[i]; }
+        for (uint r = 0; r < 4; r++) {
+            const uint row = min(row0 + r, rlast);   // clamped rows compute, don't store
+            device const uchar *qs = weights + (ulong)row * (args.cols / 4) + ib * 32 + il / 4;
+            const float d = float(scales[(ulong)row * nb + ib]);
+            const uchar4 b = *(device const uchar4 *)qs;
+            float alo = 0.0f, ahi = 0.0f, blo = 0.0f, bhi = 0.0f;
+            for (uint i = 0; i < 16; i++) {
+                const bool lo = bool(b[i / 4] & (1u << (2 * (i % 4))));
+                const bool hi = bool(b[i / 4] & (2u << (2 * (i % 4))));
+                alo += select(0.0f, yla[i], lo);
+                ahi += select(0.0f, yla[i], hi);
+                blo += select(0.0f, ylb[i], lo);
+                bhi += select(0.0f, ylb[i], hi);
+            }
+            sumfa[r] += d * (alo + 2.0f * ahi - sumya);
+            sumfb[r] += d * (blo + 2.0f * bhi - sumyb);
+        }
+        ya += 512;
+        yb += 512;
+    }
+    for (uint r = 0; r < 4; r++) {
+        const float tota = simd_sum(sumfa[r]);
+        const float totb = simd_sum(sumfb[r]);
+        if (lane == 0 && row0 + r < args.rows) {
+            out_a[row0 + r] = tota;
+            out_b[row0 + r] = totb;
+        }
+    }
+}
+
+// T3_G128: five ternary codes per byte, base-3 (243 values), 26 bytes per
+// 128-column group, scales as T2. The LUT expands a byte into five 2-bit
+// codes (bits 2t..2t+1 = code for slot t); the select-form dot then runs
+// the same math as the T2 kernel: scale * (sum(code_i * y_i) - sum(y_i)).
+// Entries 243..255 decode to all-code-1 (trit 0), so a corrupt byte is
+// inert rather than out-of-bounds.
+constant ushort t3_codes[256] = {
+    0x000, 0x001, 0x002, 0x004, 0x005, 0x006, 0x008, 0x009, 0x00a, 0x010, 0x011, 0x012, 0x014, 0x015, 0x016, 0x018,
+    0x019, 0x01a, 0x020, 0x021, 0x022, 0x024, 0x025, 0x026, 0x028, 0x029, 0x02a, 0x040, 0x041, 0x042, 0x044, 0x045,
+    0x046, 0x048, 0x049, 0x04a, 0x050, 0x051, 0x052, 0x054, 0x055, 0x056, 0x058, 0x059, 0x05a, 0x060, 0x061, 0x062,
+    0x064, 0x065, 0x066, 0x068, 0x069, 0x06a, 0x080, 0x081, 0x082, 0x084, 0x085, 0x086, 0x088, 0x089, 0x08a, 0x090,
+    0x091, 0x092, 0x094, 0x095, 0x096, 0x098, 0x099, 0x09a, 0x0a0, 0x0a1, 0x0a2, 0x0a4, 0x0a5, 0x0a6, 0x0a8, 0x0a9,
+    0x0aa, 0x100, 0x101, 0x102, 0x104, 0x105, 0x106, 0x108, 0x109, 0x10a, 0x110, 0x111, 0x112, 0x114, 0x115, 0x116,
+    0x118, 0x119, 0x11a, 0x120, 0x121, 0x122, 0x124, 0x125, 0x126, 0x128, 0x129, 0x12a, 0x140, 0x141, 0x142, 0x144,
+    0x145, 0x146, 0x148, 0x149, 0x14a, 0x150, 0x151, 0x152, 0x154, 0x155, 0x156, 0x158, 0x159, 0x15a, 0x160, 0x161,
+    0x162, 0x164, 0x165, 0x166, 0x168, 0x169, 0x16a, 0x180, 0x181, 0x182, 0x184, 0x185, 0x186, 0x188, 0x189, 0x18a,
+    0x190, 0x191, 0x192, 0x194, 0x195, 0x196, 0x198, 0x199, 0x19a, 0x1a0, 0x1a1, 0x1a2, 0x1a4, 0x1a5, 0x1a6, 0x1a8,
+    0x1a9, 0x1aa, 0x200, 0x201, 0x202, 0x204, 0x205, 0x206, 0x208, 0x209, 0x20a, 0x210, 0x211, 0x212, 0x214, 0x215,
+    0x216, 0x218, 0x219, 0x21a, 0x220, 0x221, 0x222, 0x224, 0x225, 0x226, 0x228, 0x229, 0x22a, 0x240, 0x241, 0x242,
+    0x244, 0x245, 0x246, 0x248, 0x249, 0x24a, 0x250, 0x251, 0x252, 0x254, 0x255, 0x256, 0x258, 0x259, 0x25a, 0x260,
+    0x261, 0x262, 0x264, 0x265, 0x266, 0x268, 0x269, 0x26a, 0x280, 0x281, 0x282, 0x284, 0x285, 0x286, 0x288, 0x289,
+    0x28a, 0x290, 0x291, 0x292, 0x294, 0x295, 0x296, 0x298, 0x299, 0x29a, 0x2a0, 0x2a1, 0x2a2, 0x2a4, 0x2a5, 0x2a6,
+    0x2a8, 0x2a9, 0x2aa, 0x155, 0x155, 0x155, 0x155, 0x155, 0x155, 0x155, 0x155, 0x155, 0x155, 0x155, 0x155, 0x155,
+};
+
+// Pure-ALU base-3 decode: five 2-bit codes from one byte, no memory access.
+inline ushort t3_decode(uint v) {
+    const uint c0 = v % 3u, v1 = v / 3u;
+    const uint c1 = v1 % 3u, v2 = v1 / 3u;
+    const uint c2 = v2 % 3u, v3 = v2 / 3u;
+    const uint c3 = v3 % 3u, c4 = v3 / 3u;
+    return (ushort)(c0 | (c1 << 2) | (c2 << 4) | (c3 << 6) | (c4 << 8));
+}
+
+kernel void q27_matvec_t3_g128(
+        device const uchar *weights [[buffer(0)]],
+        device const half  *scales  [[buffer(1)]],
+        device const float *x       [[buffer(2)]],
+        device       float *out     [[buffer(3)]],
+        constant MatvecArgs &args   [[buffer(4)]],
+        uint group                   [[threadgroup_position_in_grid]],
+        ushort tid                   [[thread_index_in_threadgroup]],
+        ushort lane                  [[thread_index_in_simdgroup]],
+        ushort simdgroup             [[simdgroup_index_in_threadgroup]]) {
+    // Divergent per-lane byte values make a constant-memory LUT serialize;
+    // stage it in banked threadgroup memory once per threadgroup.
+    threadgroup ushort lut[256];
+    for (uint i = tid; i < 256; i += 256) lut[i] = t3_codes[i];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const uint row0 = group * 32 + (uint)simdgroup * 4;   // 32 rows per threadgroup
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint nb = args.cols / 128;
+    const uint row_bytes = nb * 26;
+    float sumf[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    // uint-aligned weight walk: one 4-byte load per row covers 20 columns.
+    // Odd group counts leave a 1..3-byte row tail (row_bytes = nb*26); the
+    // first lanes pick those up as scalar bytes after the word loop. Each
+    // byte keeps its own group scale (a word can span a group boundary);
+    // byte b with b%26 == 25 is the 3-column group tail (slots 3-4 are
+    // canonical code-1 padding).
+    // Odd nb (cols % 256 != 0) disables the word walk entirely; every byte
+    // then takes the scalar tail below. That path is slower, not wrong —
+    // test_t3_wide gates cols=1152 (nb=9) against the CPU reference.
+    const uint words_per_row = (row_bytes & 3) ? 0 : row_bytes / 4;
+    for (uint wi = lane; wi < words_per_row; wi += 32) {
+        uint wv[4];
+        for (uint r = 0; r < 4; r++) {
+            const uint row = min(row0 + r, rlast);   // clamped rows compute, don't store
+            wv[r] = *(device const uint *)(weights + (ulong)row * row_bytes + wi * 4);
+        }
+        for (uint i = 0; i < 4; i++) {
+            const uint b = wi * 4 + i;
+            const uint g = b / 26;
+            const uint p = b - g * 26;
+            const uint col = g * 128 + p * 5;
+            float yl[5];
+            float sumy;
+            if (p != 25) {
+                const packed_float4 y4 = *(device const packed_float4 *)(x + col);
+                yl[0] = y4.x; yl[1] = y4.y; yl[2] = y4.z; yl[3] = y4.w; yl[4] = x[col + 4];
+                sumy = yl[0] + yl[1] + yl[2] + yl[3] + yl[4];
+            } else {   // group tail: three columns
+                yl[0] = x[col]; yl[1] = x[col + 1]; yl[2] = x[col + 2];
+                yl[3] = 0.0f; yl[4] = 0.0f;
+                sumy = yl[0] + yl[1] + yl[2];
+            }
+            for (uint r = 0; r < 4; r++) {
+                const uint row = min(row0 + r, rlast);
+                const ushort codes = lut[(wv[r] >> (8 * i)) & 0xff];
+                const float d = float(scales[(ulong)row * nb + g]);
+                float acc_lo = 0.0f, acc_hi = 0.0f;
+                for (uint t = 0; t < 5; t++) {
+                    acc_lo += select(0.0f, yl[t], bool(codes & (1u << (2 * t))));
+                    acc_hi += select(0.0f, yl[t], bool(codes & (2u << (2 * t))));
+                }
+                sumf[r] += d * (acc_lo + 2.0f * acc_hi - sumy);
+            }
+        }
+    }
+    // Odd group counts make row_bytes odd, so odd rows are not word-aligned
+    // and the word walk is skipped entirely; every byte then takes this
+    // scalar lane-strided path (model shapes all have even nb and never do).
+    for (uint b = words_per_row * 4 + lane; b < row_bytes; b += 32) {
+        const uint g = b / 26;
+        const uint p = b - g * 26;
+        const uint col = g * 128 + p * 5;
+        const uint valid = min(5u, 128u - p * 5);
+        float yl[5];
+        float sumy = 0.0f;
+        for (uint t = 0; t < 5; t++) {
+            yl[t] = t < valid ? x[col + t] : 0.0f;
+            sumy += yl[t];
+        }
+        for (uint r = 0; r < 4; r++) {
+            const uint row = min(row0 + r, rlast);
+            const ushort codes = lut[weights[(ulong)row * row_bytes + b]];
+            const float d = float(scales[(ulong)row * nb + g]);
+            float acc_lo = 0.0f, acc_hi = 0.0f;
+            for (uint t = 0; t < 5; t++) {
+                acc_lo += select(0.0f, yl[t], bool(codes & (1u << (2 * t))));
+                acc_hi += select(0.0f, yl[t], bool(codes & (2u << (2 * t))));
+            }
+            sumf[r] += d * (acc_lo + 2.0f * acc_hi - sumy);
+        }
+    }
+    for (uint r = 0; r < 4; r++) {
+        const float tot = simd_sum(sumf[r]);
+        if (lane == 0 && row0 + r < args.rows) out[row0 + r] = tot;
+    }
+}
+
+// B1_G128 binary weights (FORMAT.md): element i of a row -> byte i/8, 1 bit
+// at offset i%8 (sequential LSB-first, same convention as T2); bit b decodes
+// to (2b-1)*scale, one fp16 scale per 128 columns. This is the production
+// decode path for binary weights: FLOAT activations, select-form dot —
+//   sum((2b-1)*y) = 2*sum_{b=1}(y) - sum(y)
+// one conditional add per element plus one shared sum(y) per block slice
+// (T2 needs two conditional adds). Structure chosen by the Phase 0B bench
+// (docs/plans/2026-07-15-binary-tier.md: c1 select 0.504 wall ratio vs T2,
+// STRONG GO; sign-XOR measured 2.6x worse and was killed). Same shape as
+// the T2 kernel: 4 rows per simdgroup (32 per threadgroup), 4 blocks in
+// flight, the 16-float activation slice held in registers across rows; a
+// lane's 16 elements are 2 weight bytes, ushort-aligned by construction
+// (row stride cols/8 is a multiple of 16, il/8 is even).
+kernel void q27_matvec_b1_g128(
+        device const uchar *weights [[buffer(0)]],
+        device const half  *scales  [[buffer(1)]],
+        device const float *x       [[buffer(2)]],
+        device       float *out     [[buffer(3)]],
+        constant MatvecArgs &args   [[buffer(4)]],
+        uint group                   [[threadgroup_position_in_grid]],
+        ushort lane                  [[thread_index_in_simdgroup]],
+        ushort simdgroup             [[simdgroup_index_in_threadgroup]]) {
+    const uint row0 = group * 32 + (uint)simdgroup * 4;   // 32 rows per threadgroup
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint nb = args.cols / 128;
+    const uint ix = lane / 8;              // block in flight (4 per simdgroup)
+    const uint il = (lane % 8) * 16;       // element offset within the block
+    float sumf[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    device const float *yb = x + ix * 128 + il;
+    for (uint ib = ix; ib < nb; ib += 4) {
+        float yl[16];
+        float sumy = 0.0f;
+        for (uint i = 0; i < 16; i++) { yl[i] = yb[i]; sumy += yb[i]; }
+        for (uint r = 0; r < 4; r++) {
+            const uint row = min(row0 + r, rlast);   // clamped rows compute, don't store
+            const ushort b = *(device const ushort *)(weights + (ulong)row * (args.cols / 8) +
+                                                      ib * 16 + il / 8);
+            const float d = float(scales[(ulong)row * nb + ib]);
+            float acc_pos = 0.0f;
+            for (uint i = 0; i < 16; i++)
+                acc_pos += select(0.0f, yl[i], bool(b & (1u << i)));
+            sumf[r] += d * (2.0f * acc_pos - sumy);
+        }
+        yb += 512;
+    }
+    for (uint r = 0; r < 4; r++) {
+        const float tot = simd_sum(sumf[r]);
+        if (lane == 0 && row0 + r < args.rows) out[row0 + r] = tot;
+    }
+}
+
+// ---- B1 Phase 0B probe kernels (bench-only, never engine-routed) ----
+// B1_G128 (FORMAT.md): 1 bit per element, LSB-first sequential within the
+// row (element i -> byte i/8, bit i%8); bit ? +d : -d, one fp16 scale d per
+// 128 columns. Three dot structures under test, pre-registered bands in
+// docs/plans/2026-07-15-binary-tier.md §Phase 0B. Candidates 1-2 reuse the
+// T2 kernel's shape: 4 rows per simdgroup, 4 blocks in flight, the 16-float
+// activation slice held in registers across rows; a lane's 16 elements are
+// 2 weight bytes, ushort-aligned by construction (row stride cols/8 is a
+// multiple of 16, il/8 is even).
+
+// Candidate 1 — select-form: sum(±y) = 2*sum_bit1(y) - sum(y). One
+// conditional accumulate per element, same select idiom as production T2.
+kernel void q27_matvec_b1_select(
+        device const uchar *weights [[buffer(0)]],
+        device const half  *scales  [[buffer(1)]],
+        device const float *x       [[buffer(2)]],
+        device       float *out     [[buffer(3)]],
+        constant MatvecArgs &args   [[buffer(4)]],
+        uint group                   [[threadgroup_position_in_grid]],
+        ushort lane                  [[thread_index_in_simdgroup]],
+        ushort simdgroup             [[simdgroup_index_in_threadgroup]]) {
+    const uint row0 = group * 32 + (uint)simdgroup * 4;   // 32 rows per threadgroup
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint nb = args.cols / 128;
+    const uint ix = lane / 8;              // block in flight (4 per simdgroup)
+    const uint il = (lane % 8) * 16;       // element offset within the block
+    float sumf[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    device const float *yb = x + ix * 128 + il;
+    for (uint ib = ix; ib < nb; ib += 4) {
+        float yl[16];
+        float sumy = 0.0f;
+        for (uint i = 0; i < 16; i++) { yl[i] = yb[i]; sumy += yb[i]; }
+        for (uint r = 0; r < 4; r++) {
+            const uint row = min(row0 + r, rlast);   // clamped rows compute, don't store
+            const ushort b = *(device const ushort *)(weights + (ulong)row * (args.cols / 8) +
+                                                      ib * 16 + il / 8);
+            const float d = float(scales[(ulong)row * nb + ib]);
+            float acc_pos = 0.0f;
+            for (uint i = 0; i < 16; i++)
+                acc_pos += select(0.0f, yl[i], bool(b & (1u << i)));
+            sumf[r] += d * (2.0f * acc_pos - sumy);
+        }
+        yb += 512;
+    }
+    for (uint r = 0; r < 4; r++) {
+        const float tot = simd_sum(sumf[r]);
+        if (lane == 0 && row0 + r < args.rows) out[row0 + r] = tot;
+    }
+}
+
+// Candidate 2 — IEEE sign-bit XOR: ±y materialized by flipping y's sign bit
+// from the weight bit (bit==1 -> +y, bit==0 -> -y). Unconditional
+// accumulate, no sum(y) correction term. Exact for all finite y (a flipped
+// -0.0 contributes +0.0; float addition of signed zeros never perturbs a
+// finite accumulator).
+kernel void q27_matvec_b1_signxor(
+        device const uchar *weights [[buffer(0)]],
+        device const half  *scales  [[buffer(1)]],
+        device const float *x       [[buffer(2)]],
+        device       float *out     [[buffer(3)]],
+        constant MatvecArgs &args   [[buffer(4)]],
+        uint group                   [[threadgroup_position_in_grid]],
+        ushort lane                  [[thread_index_in_simdgroup]],
+        ushort simdgroup             [[simdgroup_index_in_threadgroup]]) {
+    const uint row0 = group * 32 + (uint)simdgroup * 4;   // 32 rows per threadgroup
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint nb = args.cols / 128;
+    const uint ix = lane / 8;              // block in flight (4 per simdgroup)
+    const uint il = (lane % 8) * 16;       // element offset within the block
+    float sumf[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    device const float *yb = x + ix * 128 + il;
+    for (uint ib = ix; ib < nb; ib += 4) {
+        uint yl[16];   // activation bits, sign flip applied bitwise below
+        for (uint i = 0; i < 16; i++) yl[i] = as_type<uint>(yb[i]);
+        for (uint r = 0; r < 4; r++) {
+            const uint row = min(row0 + r, rlast);   // clamped rows compute, don't store
+            const uint b = *(device const ushort *)(weights + (ulong)row * (args.cols / 8) +
+                                                    ib * 16 + il / 8);
+            const float d = float(scales[(ulong)row * nb + ib]);
+            float acc = 0.0f;
+            for (uint i = 0; i < 16; i++)
+                acc += as_type<float>(yl[i] ^ ((~(b >> i) & 1u) << 31));
+            sumf[r] += d * acc;
+        }
+        yb += 512;
+    }
+    for (uint r = 0; r < 4; r++) {
+        const float tot = simd_sum(sumf[r]);
+        if (lane == 0 && row0 + r < args.rows) out[row0 + r] = tot;
+    }
+}
+
+// Candidate 3 activation preprocessing — int8-domain offset quantization,
+// bitplane transpose, per-group sums. One 128-thread threadgroup per
+// 128-column group g:
+//   s_g   = max|x|/127 (0 if the group is all zero)
+//   u_i   = clamp(round(x_i/s_g) + 128, 0, 255)   (128 when s_g == 0)
+//   planes[g*32 + p*4 + w] = bit p of u over word w (columns w*32..w*32+31,
+//                            bit position = column%32, via simd_ballot)
+//   aux[g] = { s_g, sum(u) }
+// The dot kernel then reconstructs x_i ~= s_g*(u_i - 128) exactly in the
+// int8 model; the quantization error vs float activations is the candidate's
+// accuracy cost and is gated separately in the bench.
+kernel void q27_b1_x_prep(
+        device const float  *x      [[buffer(0)]],
+        device       uint   *planes [[buffer(1)]],
+        device       float2 *aux    [[buffer(2)]],
+        constant MatvecArgs &args   [[buffer(3)]],
+        uint group                   [[threadgroup_position_in_grid]],
+        ushort tid                   [[thread_index_in_threadgroup]],
+        ushort lane                  [[thread_index_in_simdgroup]],
+        ushort simdgroup             [[simdgroup_index_in_threadgroup]]) {
+    const float xv = x[group * 128 + tid];
+    // The max/sum phases overlap safely ONLY because pmax and psum are
+    // distinct arrays (a thread may write psum while another still reads
+    // pmax). The barrier below the pmax reads is insurance: it keeps this
+    // correct if the two arrays are ever consolidated into one.
+    threadgroup float pmax[4], psum[4];
+    float amax = simd_max(fabs(xv));
+    if (lane == 0) pmax[simdgroup] = amax;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    amax = max(max(pmax[0], pmax[1]), max(pmax[2], pmax[3]));
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    const float s = amax / 127.0f;
+    // B1 keeps round(xv/s), a Metal-native path with no CUDA twin; this
+    // matches its metal_gemv_bench CPU model and certified battery.
+    const uint u = s > 0.0f ? uint(clamp(round(xv / s) + 128.0f, 0.0f, 255.0f)) : 128u;
+    for (uint p = 0; p < 8; p++) {
+        const uint m = uint(uint64_t(simd_ballot(bool((u >> p) & 1u))));
+        if (lane == 0) planes[group * 32 + p * 4 + simdgroup] = m;
+    }
+    float sumu = simd_sum(float(u));
+    if (lane == 0) psum[simdgroup] = sumu;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid == 0)
+        aux[group] = float2(s, psum[0] + psum[1] + psum[2] + psum[3]);
+}
+
+// Candidate 3 — int8 bitplane + popcount dot. Per 32-column word: 8
+// AND+popcounts of the weight-bit word against the 8 activation bitplanes,
+// plane p weighted 2^p. With w_i in {-1,+1} = 2b_i - 1 and
+// x_i ~= s*(u_i - 128):
+//   sum_i w_i*x_i = 2*sum_{b_i=1} x_i - sum_i x_i
+//                 = s*( 2*(sum_p 2^p*popc(b & u_p) - 128*popc(b))
+//                       - (sum(u) - 128*128) )
+// One simdgroup per row (8 rows per threadgroup), lanes stride the groups;
+// all popcount math stays in uint until the one float scale per group.
+kernel void q27_matvec_b1_popcount(
+        device const uint   *weights [[buffer(0)]],
+        device const half   *scales  [[buffer(1)]],
+        device const uint   *planes  [[buffer(2)]],
+        device const float2 *aux     [[buffer(3)]],
+        device       float  *out     [[buffer(4)]],
+        constant MatvecArgs &args    [[buffer(5)]],
+        uint group                    [[threadgroup_position_in_grid]],
+        ushort lane                   [[thread_index_in_simdgroup]],
+        ushort simdgroup              [[simdgroup_index_in_threadgroup]]) {
+    const uint row = group * 8 + simdgroup;
+    if (row >= args.rows) return;
+    const uint nb = args.cols / 128;
+    const ulong wbase = (ulong)row * (args.cols / 32);
+    float sum = 0.0f;
+    for (uint g = lane; g < nb; g += 32) {
+        uint planesum = 0, wpop = 0;
+        for (uint w = 0; w < 4; w++) {
+            const uint wb = weights[wbase + g * 4 + w];
+            wpop += popcount(wb);
+            for (uint p = 0; p < 8; p++)
+                planesum += popcount(wb & planes[g * 32 + p * 4 + w]) << p;
+        }
+        const float2 sa = aux[g];
+        const float d = float(scales[(ulong)row * nb + g]);
+        sum += d * sa.x * (2.0f * (float(int(planesum) - int(128 * wpop))) -
+                           (sa.y - 16384.0f));
+    }
+    sum = simd_sum(sum);
+    if (lane == 0) out[row] = sum;
+}
+
 struct VectorArgs {
     uint n;
     uint groups;
@@ -265,6 +697,19 @@ kernel void q27_embedding_t2(
     out[gid] = float(int(code) - 1) * float(scales[si]);
 }
 
+kernel void q27_embedding_b1(
+        device const uchar *weights [[buffer(0)]],
+        device const half *scales   [[buffer(1)]],
+        device float *out           [[buffer(2)]],
+        constant uint &token        [[buffer(3)]],
+        constant uint &cols         [[buffer(4)]],
+        uint gid [[thread_position_in_grid]]) {
+    if (gid >= cols) return;
+    const ulong wi = (ulong)token * cols + gid;   // cols % 128 == 0, so wi/8 is exact bytes
+    const uint bit = (weights[wi >> 3] >> (wi & 7)) & 1;
+    const ulong si = (ulong)token * (cols / 128) + gid / 128;
+    out[gid] = float(2 * int(bit) - 1) * float(scales[si]);
+}
 
 // GPU-resident greedy decode: identical embedding lookups, but the token id
 // comes from the device buffer the previous step's argmax wrote, so chained
@@ -298,6 +743,19 @@ kernel void q27_embedding_t2_dev(
     out[gid] = float(int(code) - 1) * float(scales[si]);
 }
 
+kernel void q27_embedding_b1_dev(
+        device const uchar *weights [[buffer(0)]],
+        device const half *scales   [[buffer(1)]],
+        device float *out           [[buffer(2)]],
+        device const uint *token    [[buffer(3)]],
+        constant uint &cols         [[buffer(4)]],
+        uint gid [[thread_position_in_grid]]) {
+    if (gid >= cols) return;
+    const ulong wi = (ulong)token[0] * cols + gid;
+    const uint bit = (weights[wi >> 3] >> (wi & 7)) & 1;
+    const ulong si = (ulong)token[0] * (cols / 128) + gid / 128;
+    out[gid] = float(2 * int(bit) - 1) * float(scales[si]);
+}
 
 kernel void q27_rmsnorm(
         device const float *x [[buffer(0)]],
@@ -818,6 +1276,71 @@ kernel void q27_matvec_q4_quantized(device const uchar *weights [[buffer(0)]],
         if (lane == 0 && row0 + r < args.rows) out[row0 + r] = tot;
     }
 }
+
+// Round residue (docs/plans/2026-07-17-q4-rewrite-round.md): the r4 arm above
+// was PROMOTED into q27_matvec_q4_quantized (bench R = 0.957); r2 below stays
+// as the retained comparison arm (bench R = 0.826). Bench-only, dispatched by
+// matvec_q4_probe, never engine-routed.
+// The 2-row variant of the promoted structure (half the register pressure —
+// the bench decides between them). Same contracts: byte-identical per-row
+// math vs q27_matvec_q4_quantized, clamped edge rows compute and drop.
+kernel void q27_matvec_q4_quantized_r2(device const uchar *weights [[buffer(0)]],
+                                        device const half *weight_scales [[buffer(1)]],
+                                        device const char *x [[buffer(2)]],
+                                        device const float *x_scales [[buffer(3)]],
+                                        device float *out [[buffer(4)]],
+                                        constant MatvecArgs &args [[buffer(5)]],
+                                        uint group [[threadgroup_position_in_grid]],
+                                        ushort lane [[thread_index_in_simdgroup]],
+                                        ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    const uint row0 = (group * 8 + (uint)simdgroup) * 2;   // 16 rows per threadgroup
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    device const int4 *x16 = (device const int4 *)x;
+    const uint sgroups = args.cols / 64;
+    device const uint4 *w[2];
+    ulong sbase[2];
+    for (uint r = 0; r < 2; r++) {
+        const uint row = min(row0 + r, rlast);   // clamped rows compute, don't store
+        w[r] = (device const uint4 *)(weights + (ulong)row * (args.cols / 2));
+        sbase[r] = (ulong)row * sgroups;
+    }
+    float2 acc = 0.0f;
+    const uint chunks = args.cols / 1024;
+    for (uint chunk = 0; chunk < chunks; chunk++) {
+        const uint idx = chunk * 32 + lane;
+        const int4 xp0 = x16[idx * 2];
+        const int4 xp1 = x16[idx * 2 + 1];
+        const uint c = chunk * 1024 + lane * 32;
+        const float xs = x_scales[c / 32];
+        for (uint r = 0; r < 2; r++) {
+            const uint4 wp = w[r][idx];
+            const int dot0 = q27_dot8_q4(wp.x, as_type<char4>(xp0.x), as_type<char4>(xp0.y)) +
+                             q27_dot8_q4(wp.y, as_type<char4>(xp0.z), as_type<char4>(xp0.w));
+            const int dot1 = q27_dot8_q4(wp.z, as_type<char4>(xp1.x), as_type<char4>(xp1.y)) +
+                             q27_dot8_q4(wp.w, as_type<char4>(xp1.z), as_type<char4>(xp1.w));
+            // |dot0 + dot1| <= 32*8*127 = 32512 — exact in float (see r4).
+            acc[r] += float(dot0 + dot1) *
+                      float(weight_scales[sbase[r] + c / 64]) * xs;
+        }
+    }
+    for (uint c = chunks * 1024 + lane * 4; c < args.cols; c += 128) {
+        const char4 xp = *(device const char4 *)(x + c);
+        const float xs = x_scales[c / 32];
+        for (uint r = 0; r < 2; r++) {
+            const uchar2 wp = *(device const uchar2 *)((device const uchar *)w[r] + c / 2);
+            const int dot = (int(wp.x & 15u) - 8) * xp.x + (int(wp.x >> 4) - 8) * xp.y +
+                            (int(wp.y & 15u) - 8) * xp.z + (int(wp.y >> 4) - 8) * xp.w;
+            acc[r] += float(dot) * float(weight_scales[sbase[r] + c / 64]) * xs;
+        }
+    }
+    for (uint r = 0; r < 2; r++) {
+        const float tot = simd_sum(acc[r]);
+        if (lane == 0 && row0 + r < args.rows) out[row0 + r] = tot;
+    }
+}
+
+
 // 16 sequential LSB-first 2-bit codes per uint; code c contributes (c-1)*x.
 // The integer dot is exact: |dot| <= 16*1*127 = 2032 per uint, 4064 per
 // lane-chunk, well inside float's exact-integer range.
@@ -882,6 +1405,166 @@ kernel void q27_matvec_t2_quantized(device const uchar *weights [[buffer(0)]],
     if (lane == 0) out[row] = acc;
 }
 
+// 16 sequential LSB-first 1-bit codes from the low 16 bits; bit b
+// contributes (2b-1)*x. Select form in the int domain: 2*sum_{bit=1} x -
+// sum(x) — one conditional add per element plus one shared total (the T2
+// unpack pays a shift/mask/sub per code). Exact: |dot| <= 16*127 per call,
+// well inside float's exact-integer range.
+inline int q27_dot16_b1(uint bits, int4 xp) {
+    const char4 x0 = as_type<char4>(xp.x), x1 = as_type<char4>(xp.y);
+    const char4 x2 = as_type<char4>(xp.z), x3 = as_type<char4>(xp.w);
+    int pos = 0, tot = 0, v;
+    v = int(x0.x); tot += v; pos += select(0, v, bool(bits & 0x0001u));
+    v = int(x0.y); tot += v; pos += select(0, v, bool(bits & 0x0002u));
+    v = int(x0.z); tot += v; pos += select(0, v, bool(bits & 0x0004u));
+    v = int(x0.w); tot += v; pos += select(0, v, bool(bits & 0x0008u));
+    v = int(x1.x); tot += v; pos += select(0, v, bool(bits & 0x0010u));
+    v = int(x1.y); tot += v; pos += select(0, v, bool(bits & 0x0020u));
+    v = int(x1.z); tot += v; pos += select(0, v, bool(bits & 0x0040u));
+    v = int(x1.w); tot += v; pos += select(0, v, bool(bits & 0x0080u));
+    v = int(x2.x); tot += v; pos += select(0, v, bool(bits & 0x0100u));
+    v = int(x2.y); tot += v; pos += select(0, v, bool(bits & 0x0200u));
+    v = int(x2.z); tot += v; pos += select(0, v, bool(bits & 0x0400u));
+    v = int(x2.w); tot += v; pos += select(0, v, bool(bits & 0x0800u));
+    v = int(x3.x); tot += v; pos += select(0, v, bool(bits & 0x1000u));
+    v = int(x3.y); tot += v; pos += select(0, v, bool(bits & 0x2000u));
+    v = int(x3.z); tot += v; pos += select(0, v, bool(bits & 0x4000u));
+    v = int(x3.w); tot += v; pos += select(0, v, bool(bits & 0x8000u));
+    return 2 * pos - tot;
+}
+
+// Packed-dot binary GEMV, promoted round-2 form (docs/plans/2026-07-17-b1-
+// select-round2.md, bench mix speedup 2.36x): 4 rows per simdgroup with the
+// lane's 32-column int8 x-slice and activation scale loaded once per chunk
+// serving all 4 rows — the 1-row original re-issued the full x load per row
+// and its lone 4 B weight chain couldn't fill the issue window. A lane's 32
+// columns (one uint of code bits) are 32-aligned, so they share one
+// activation-scale block and sit inside one 128-column weight-scale group;
+// per-row chunk order, dot form, and scale-multiply order match the 1-row
+// original bit for bit (byte gate). Clamped edge rows compute, don't store.
+kernel void q27_matvec_b1_quantized(device const uchar *weights [[buffer(0)]],
+                                     device const half *weight_scales [[buffer(1)]],
+                                     device const char *x [[buffer(2)]],
+                                     device const float *x_scales [[buffer(3)]],
+                                     device float *out [[buffer(4)]],
+                                     constant MatvecArgs &args [[buffer(5)]],
+                                     uint group [[threadgroup_position_in_grid]],
+                                     ushort lane [[thread_index_in_simdgroup]],
+                                     ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    const uint row0 = (group * 8 + (uint)simdgroup) * 4;
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    device const int4 *x16 = (device const int4 *)x;
+    const uint sgroups = args.cols / 128;
+    device const uint *w[4];
+    ulong sbase[4];
+    for (uint r = 0; r < 4; r++) {
+        const uint row = min(row0 + r, rlast);
+        w[r] = (device const uint *)(weights + (ulong)row * (args.cols / 8));
+        sbase[r] = (ulong)row * sgroups;
+    }
+    float4 acc = 0.0f;
+    const uint chunks = args.cols / 1024;
+    for (uint chunk = 0; chunk < chunks; chunk++) {
+        const uint idx = chunk * 32 + lane;      // one uint = 32 columns
+        const int4 xp0 = x16[idx * 2];
+        const int4 xp1 = x16[idx * 2 + 1];
+        const uint c = chunk * 1024 + lane * 32;
+        const float xs = x_scales[c / 32];
+        for (uint r = 0; r < 4; r++) {
+            const uint wp = w[r][idx];
+            const int dot0 = q27_dot16_b1(wp, xp0);
+            const int dot1 = q27_dot16_b1(wp >> 16, xp1);
+            acc[r] += float(dot0 + dot1) *
+                      float(weight_scales[sbase[r] + c / 128]) * xs;
+        }
+    }
+    for (uint c = chunks * 1024 + lane * 4; c < args.cols; c += 128) {
+        const char4 xp = *(device const char4 *)(x + c);
+        const int tot = int(xp.x) + int(xp.y) + int(xp.z) + int(xp.w);
+        const float xs = x_scales[c / 32];
+        for (uint r = 0; r < 4; r++) {
+            const uint wp = uint(((device const uchar *)w[r])[c / 8]) >> (c % 8);
+            const int pos = select(0, int(xp.x), bool(wp & 1u)) +
+                            select(0, int(xp.y), bool(wp & 2u)) +
+                            select(0, int(xp.z), bool(wp & 4u)) +
+                            select(0, int(xp.w), bool(wp & 8u));
+            acc[r] += float(2 * pos - tot) *
+                      float(weight_scales[sbase[r] + c / 128]) * xs;
+        }
+    }
+    for (uint r = 0; r < 4; r++) {
+        const float tot = simd_sum(acc[r]);
+        if (lane == 0 && row0 + r < args.rows) out[row0 + r] = tot;
+    }
+}
+
+// B1 select round-2 residue (docs/plans/2026-07-17-b1-select-round2.md):
+// the r2 4-row arm was PROMOTED into q27_matvec_b1_quantized above (bench
+// mix speedup 2.36x); matvec_b1r2_probe candidate 2 aliases the production
+// PSO so recorded A/B invocations keep working. r3 below is the retained
+// 8-row issue-depth arm — never run in the round (r2 cleared the sub-line
+// first), bench-only, never engine-routed.
+// r3 — the 8-row issue-depth probe (run only if r2 misses the sub-line):
+// same lane-held x-slice, 8 independent 4 B weight chains per lane, at the
+// cost of x8 simd_sum/scale chains. Same byte-identity contract as r2.
+kernel void q27_matvec_b1_quantized_r3(device const uchar *weights [[buffer(0)]],
+                                        device const half *weight_scales [[buffer(1)]],
+                                        device const char *x [[buffer(2)]],
+                                        device const float *x_scales [[buffer(3)]],
+                                        device float *out [[buffer(4)]],
+                                        constant MatvecArgs &args [[buffer(5)]],
+                                        uint group [[threadgroup_position_in_grid]],
+                                        ushort lane [[thread_index_in_simdgroup]],
+                                        ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    const uint row0 = (group * 8 + (uint)simdgroup) * 8;
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    device const int4 *x16 = (device const int4 *)x;
+    const uint sgroups = args.cols / 128;
+    device const uint *w[8];
+    ulong sbase[8];
+    for (uint r = 0; r < 8; r++) {
+        const uint row = min(row0 + r, rlast);   // clamped rows compute, don't store
+        w[r] = (device const uint *)(weights + (ulong)row * (args.cols / 8));
+        sbase[r] = (ulong)row * sgroups;
+    }
+    float acc[8] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    const uint chunks = args.cols / 1024;
+    for (uint chunk = 0; chunk < chunks; chunk++) {
+        const uint idx = chunk * 32 + lane;      // one uint = 32 columns
+        const int4 xp0 = x16[idx * 2];
+        const int4 xp1 = x16[idx * 2 + 1];
+        const uint c = chunk * 1024 + lane * 32;
+        const float xs = x_scales[c / 32];
+        for (uint r = 0; r < 8; r++) {
+            const uint wp = w[r][idx];
+            const int dot0 = q27_dot16_b1(wp, xp0);
+            const int dot1 = q27_dot16_b1(wp >> 16, xp1);
+            acc[r] += float(dot0 + dot1) *
+                      float(weight_scales[sbase[r] + c / 128]) * xs;
+        }
+    }
+    for (uint c = chunks * 1024 + lane * 4; c < args.cols; c += 128) {
+        const char4 xp = *(device const char4 *)(x + c);
+        const int tot = int(xp.x) + int(xp.y) + int(xp.z) + int(xp.w);
+        const float xs = x_scales[c / 32];
+        for (uint r = 0; r < 8; r++) {
+            const uint wp = uint(((device const uchar *)w[r])[c / 8]) >> (c % 8);
+            const int pos = select(0, int(xp.x), bool(wp & 1u)) +
+                            select(0, int(xp.y), bool(wp & 2u)) +
+                            select(0, int(xp.z), bool(wp & 4u)) +
+                            select(0, int(xp.w), bool(wp & 8u));
+            acc[r] += float(2 * pos - tot) *
+                      float(weight_scales[sbase[r] + c / 128]) * xs;
+        }
+    }
+    for (uint r = 0; r < 8; r++) {
+        const float tot = simd_sum(acc[r]);
+        if (lane == 0 && row0 + r < args.rows) out[row0 + r] = tot;
+    }
+}
+
 // Dual-row ternary dot: unpack each 2-bit code ONCE, MAC into both rows.
 // The packed-dot GEMV is issue-bound on the unpack (shift/mask/sub per
 // code), not on the weight stream, so sharing the unpack — not the bytes —
@@ -911,6 +1594,66 @@ inline void q27_dot16_t2_dual(uint packed, int4 xpa, int4 xpb,
     w = int((packed >> 28) & 3u) - 1; sa += w * a3.z; sb += w * b3.z;
     w = int((packed >> 30)      ) - 1; sa += w * a3.w; sb += w * b3.w;
 }
+
+// N=2 slot-batched ternary GEMV (multislot Phase 2 probe): one pass over
+// the weight stream computes two activation rows, sharing the per-code
+// unpack via q27_dot16_t2_dual. Layouts match the MM kernels: x row-major
+// [2, cols], x_scales [2, cols/32], out token-major [2, rows]. Per-row
+// K-striping, scale-multiply order, and simd_sum are IDENTICAL to
+// q27_matvec_t2_quantized, and the integer dots are exact, so each row's
+// output is bit-identical to the single-row kernel. (The fused-pair
+// precedent — two weights, one x — lost on register pressure; here the
+// shared work is the unpack, the actual issue-bound resource.)
+// PARKED by measurement (2026-07-16, multislot Phase-2 probe): aggregate
+// s_k 1.093 vs the 1.31 decision line — kept as the probe's reference
+// surface, never engine-routed.
+kernel void q27_matvec_t2_quantized_x2(device const uchar *weights [[buffer(0)]],
+                                        device const half *weight_scales [[buffer(1)]],
+                                        device const char *x [[buffer(2)]],
+                                        device const float *x_scales [[buffer(3)]],
+                                        device float *out [[buffer(4)]],
+                                        constant MatvecArgs &args [[buffer(5)]],
+                                        uint group [[threadgroup_position_in_grid]],
+                                        ushort lane [[thread_index_in_simdgroup]],
+                                        ushort simdgroup [[simdgroup_index_in_threadgroup]]) {
+    const uint row = group * 8 + simdgroup;
+    if (row >= args.rows) return;
+    device const uint2 *w2 = (device const uint2 *)(weights + (ulong)row * (args.cols / 4));
+    device const int4 *xa16 = (device const int4 *)x;
+    device const int4 *xb16 = (device const int4 *)(x + args.cols);
+    device const float *xas = x_scales;
+    device const float *xbs = x_scales + args.cols / 32;
+    const ulong scale_base = (ulong)row * (args.cols / 128);
+    float acc_a = 0.0f, acc_b = 0.0f;
+    const uint chunks = args.cols / 1024;
+    for (uint chunk = 0; chunk < chunks; chunk++) {
+        const uint idx = chunk * 32 + lane;      // one uint2 = 32 columns
+        const uint2 wp = w2[idx];
+        const uint c = chunk * 1024 + lane * 32;
+        const float ws = float(weight_scales[scale_base + c / 128]);
+        int da = 0, db = 0;
+        q27_dot16_t2_dual(wp.x, xa16[idx * 2],     xb16[idx * 2],     da, db);
+        q27_dot16_t2_dual(wp.y, xa16[idx * 2 + 1], xb16[idx * 2 + 1], da, db);
+        acc_a += float(da) * ws * xas[c / 32];
+        acc_b += float(db) * ws * xbs[c / 32];
+    }
+    for (uint c = chunks * 1024 + lane * 4; c < args.cols; c += 128) {
+        const uchar wp = weights[(ulong)row * (args.cols / 4) + c / 4];
+        const float ws = float(weight_scales[scale_base + c / 128]);
+        const char4 xa = *(device const char4 *)(x + c);
+        const char4 xb = *(device const char4 *)(x + args.cols + c);
+        const int da = (int(wp         & 3u) - 1) * xa.x + (int((wp >> 2) & 3u) - 1) * xa.y +
+                       (int((wp >> 4) & 3u) - 1) * xa.z + (int((wp >> 6)      ) - 1) * xa.w;
+        const int db = (int(wp         & 3u) - 1) * xb.x + (int((wp >> 2) & 3u) - 1) * xb.y +
+                       (int((wp >> 4) & 3u) - 1) * xb.z + (int((wp >> 6)      ) - 1) * xb.w;
+        acc_a += float(da) * ws * xas[c / 32];
+        acc_b += float(db) * ws * xbs[c / 32];
+    }
+    acc_a = simd_sum(acc_a);
+    acc_b = simd_sum(acc_b);
+    if (lane == 0) { out[row] = acc_a; out[args.rows + row] = acc_b; }
+}
+
 // Tiled simdgroup-matrix GEMM (x_rows 1..12) for chunked prefill and
 // batched MTP verification. A 128-thread threadgroup (4 simdgroups) owns a
 // 32-row x 16-token output tile and walks K in 64-column tiles: weights are
@@ -1597,7 +2340,1405 @@ kernel void q27_matmul_t2_mm_h(
 }
 
 
+// Byte -> 2 Q4 halves (low nibble first, code n -> n-8): one constant-
+// memory gather replaces two shift/mask/int-sub/convert chains. 1 KB,
+// values -8..+7 are all exact in half.
+constant half2 q27_q4_half2_lut[256] = {
+    half2(-8.0h, -8.0h),
+    half2(-7.0h, -8.0h),
+    half2(-6.0h, -8.0h),
+    half2(-5.0h, -8.0h),
+    half2(-4.0h, -8.0h),
+    half2(-3.0h, -8.0h),
+    half2(-2.0h, -8.0h),
+    half2(-1.0h, -8.0h),
+    half2(0.0h, -8.0h),
+    half2(1.0h, -8.0h),
+    half2(2.0h, -8.0h),
+    half2(3.0h, -8.0h),
+    half2(4.0h, -8.0h),
+    half2(5.0h, -8.0h),
+    half2(6.0h, -8.0h),
+    half2(7.0h, -8.0h),
+    half2(-8.0h, -7.0h),
+    half2(-7.0h, -7.0h),
+    half2(-6.0h, -7.0h),
+    half2(-5.0h, -7.0h),
+    half2(-4.0h, -7.0h),
+    half2(-3.0h, -7.0h),
+    half2(-2.0h, -7.0h),
+    half2(-1.0h, -7.0h),
+    half2(0.0h, -7.0h),
+    half2(1.0h, -7.0h),
+    half2(2.0h, -7.0h),
+    half2(3.0h, -7.0h),
+    half2(4.0h, -7.0h),
+    half2(5.0h, -7.0h),
+    half2(6.0h, -7.0h),
+    half2(7.0h, -7.0h),
+    half2(-8.0h, -6.0h),
+    half2(-7.0h, -6.0h),
+    half2(-6.0h, -6.0h),
+    half2(-5.0h, -6.0h),
+    half2(-4.0h, -6.0h),
+    half2(-3.0h, -6.0h),
+    half2(-2.0h, -6.0h),
+    half2(-1.0h, -6.0h),
+    half2(0.0h, -6.0h),
+    half2(1.0h, -6.0h),
+    half2(2.0h, -6.0h),
+    half2(3.0h, -6.0h),
+    half2(4.0h, -6.0h),
+    half2(5.0h, -6.0h),
+    half2(6.0h, -6.0h),
+    half2(7.0h, -6.0h),
+    half2(-8.0h, -5.0h),
+    half2(-7.0h, -5.0h),
+    half2(-6.0h, -5.0h),
+    half2(-5.0h, -5.0h),
+    half2(-4.0h, -5.0h),
+    half2(-3.0h, -5.0h),
+    half2(-2.0h, -5.0h),
+    half2(-1.0h, -5.0h),
+    half2(0.0h, -5.0h),
+    half2(1.0h, -5.0h),
+    half2(2.0h, -5.0h),
+    half2(3.0h, -5.0h),
+    half2(4.0h, -5.0h),
+    half2(5.0h, -5.0h),
+    half2(6.0h, -5.0h),
+    half2(7.0h, -5.0h),
+    half2(-8.0h, -4.0h),
+    half2(-7.0h, -4.0h),
+    half2(-6.0h, -4.0h),
+    half2(-5.0h, -4.0h),
+    half2(-4.0h, -4.0h),
+    half2(-3.0h, -4.0h),
+    half2(-2.0h, -4.0h),
+    half2(-1.0h, -4.0h),
+    half2(0.0h, -4.0h),
+    half2(1.0h, -4.0h),
+    half2(2.0h, -4.0h),
+    half2(3.0h, -4.0h),
+    half2(4.0h, -4.0h),
+    half2(5.0h, -4.0h),
+    half2(6.0h, -4.0h),
+    half2(7.0h, -4.0h),
+    half2(-8.0h, -3.0h),
+    half2(-7.0h, -3.0h),
+    half2(-6.0h, -3.0h),
+    half2(-5.0h, -3.0h),
+    half2(-4.0h, -3.0h),
+    half2(-3.0h, -3.0h),
+    half2(-2.0h, -3.0h),
+    half2(-1.0h, -3.0h),
+    half2(0.0h, -3.0h),
+    half2(1.0h, -3.0h),
+    half2(2.0h, -3.0h),
+    half2(3.0h, -3.0h),
+    half2(4.0h, -3.0h),
+    half2(5.0h, -3.0h),
+    half2(6.0h, -3.0h),
+    half2(7.0h, -3.0h),
+    half2(-8.0h, -2.0h),
+    half2(-7.0h, -2.0h),
+    half2(-6.0h, -2.0h),
+    half2(-5.0h, -2.0h),
+    half2(-4.0h, -2.0h),
+    half2(-3.0h, -2.0h),
+    half2(-2.0h, -2.0h),
+    half2(-1.0h, -2.0h),
+    half2(0.0h, -2.0h),
+    half2(1.0h, -2.0h),
+    half2(2.0h, -2.0h),
+    half2(3.0h, -2.0h),
+    half2(4.0h, -2.0h),
+    half2(5.0h, -2.0h),
+    half2(6.0h, -2.0h),
+    half2(7.0h, -2.0h),
+    half2(-8.0h, -1.0h),
+    half2(-7.0h, -1.0h),
+    half2(-6.0h, -1.0h),
+    half2(-5.0h, -1.0h),
+    half2(-4.0h, -1.0h),
+    half2(-3.0h, -1.0h),
+    half2(-2.0h, -1.0h),
+    half2(-1.0h, -1.0h),
+    half2(0.0h, -1.0h),
+    half2(1.0h, -1.0h),
+    half2(2.0h, -1.0h),
+    half2(3.0h, -1.0h),
+    half2(4.0h, -1.0h),
+    half2(5.0h, -1.0h),
+    half2(6.0h, -1.0h),
+    half2(7.0h, -1.0h),
+    half2(-8.0h, 0.0h),
+    half2(-7.0h, 0.0h),
+    half2(-6.0h, 0.0h),
+    half2(-5.0h, 0.0h),
+    half2(-4.0h, 0.0h),
+    half2(-3.0h, 0.0h),
+    half2(-2.0h, 0.0h),
+    half2(-1.0h, 0.0h),
+    half2(0.0h, 0.0h),
+    half2(1.0h, 0.0h),
+    half2(2.0h, 0.0h),
+    half2(3.0h, 0.0h),
+    half2(4.0h, 0.0h),
+    half2(5.0h, 0.0h),
+    half2(6.0h, 0.0h),
+    half2(7.0h, 0.0h),
+    half2(-8.0h, 1.0h),
+    half2(-7.0h, 1.0h),
+    half2(-6.0h, 1.0h),
+    half2(-5.0h, 1.0h),
+    half2(-4.0h, 1.0h),
+    half2(-3.0h, 1.0h),
+    half2(-2.0h, 1.0h),
+    half2(-1.0h, 1.0h),
+    half2(0.0h, 1.0h),
+    half2(1.0h, 1.0h),
+    half2(2.0h, 1.0h),
+    half2(3.0h, 1.0h),
+    half2(4.0h, 1.0h),
+    half2(5.0h, 1.0h),
+    half2(6.0h, 1.0h),
+    half2(7.0h, 1.0h),
+    half2(-8.0h, 2.0h),
+    half2(-7.0h, 2.0h),
+    half2(-6.0h, 2.0h),
+    half2(-5.0h, 2.0h),
+    half2(-4.0h, 2.0h),
+    half2(-3.0h, 2.0h),
+    half2(-2.0h, 2.0h),
+    half2(-1.0h, 2.0h),
+    half2(0.0h, 2.0h),
+    half2(1.0h, 2.0h),
+    half2(2.0h, 2.0h),
+    half2(3.0h, 2.0h),
+    half2(4.0h, 2.0h),
+    half2(5.0h, 2.0h),
+    half2(6.0h, 2.0h),
+    half2(7.0h, 2.0h),
+    half2(-8.0h, 3.0h),
+    half2(-7.0h, 3.0h),
+    half2(-6.0h, 3.0h),
+    half2(-5.0h, 3.0h),
+    half2(-4.0h, 3.0h),
+    half2(-3.0h, 3.0h),
+    half2(-2.0h, 3.0h),
+    half2(-1.0h, 3.0h),
+    half2(0.0h, 3.0h),
+    half2(1.0h, 3.0h),
+    half2(2.0h, 3.0h),
+    half2(3.0h, 3.0h),
+    half2(4.0h, 3.0h),
+    half2(5.0h, 3.0h),
+    half2(6.0h, 3.0h),
+    half2(7.0h, 3.0h),
+    half2(-8.0h, 4.0h),
+    half2(-7.0h, 4.0h),
+    half2(-6.0h, 4.0h),
+    half2(-5.0h, 4.0h),
+    half2(-4.0h, 4.0h),
+    half2(-3.0h, 4.0h),
+    half2(-2.0h, 4.0h),
+    half2(-1.0h, 4.0h),
+    half2(0.0h, 4.0h),
+    half2(1.0h, 4.0h),
+    half2(2.0h, 4.0h),
+    half2(3.0h, 4.0h),
+    half2(4.0h, 4.0h),
+    half2(5.0h, 4.0h),
+    half2(6.0h, 4.0h),
+    half2(7.0h, 4.0h),
+    half2(-8.0h, 5.0h),
+    half2(-7.0h, 5.0h),
+    half2(-6.0h, 5.0h),
+    half2(-5.0h, 5.0h),
+    half2(-4.0h, 5.0h),
+    half2(-3.0h, 5.0h),
+    half2(-2.0h, 5.0h),
+    half2(-1.0h, 5.0h),
+    half2(0.0h, 5.0h),
+    half2(1.0h, 5.0h),
+    half2(2.0h, 5.0h),
+    half2(3.0h, 5.0h),
+    half2(4.0h, 5.0h),
+    half2(5.0h, 5.0h),
+    half2(6.0h, 5.0h),
+    half2(7.0h, 5.0h),
+    half2(-8.0h, 6.0h),
+    half2(-7.0h, 6.0h),
+    half2(-6.0h, 6.0h),
+    half2(-5.0h, 6.0h),
+    half2(-4.0h, 6.0h),
+    half2(-3.0h, 6.0h),
+    half2(-2.0h, 6.0h),
+    half2(-1.0h, 6.0h),
+    half2(0.0h, 6.0h),
+    half2(1.0h, 6.0h),
+    half2(2.0h, 6.0h),
+    half2(3.0h, 6.0h),
+    half2(4.0h, 6.0h),
+    half2(5.0h, 6.0h),
+    half2(6.0h, 6.0h),
+    half2(7.0h, 6.0h),
+    half2(-8.0h, 7.0h),
+    half2(-7.0h, 7.0h),
+    half2(-6.0h, 7.0h),
+    half2(-5.0h, 7.0h),
+    half2(-4.0h, 7.0h),
+    half2(-3.0h, 7.0h),
+    half2(-2.0h, 7.0h),
+    half2(-1.0h, 7.0h),
+    half2(0.0h, 7.0h),
+    half2(1.0h, 7.0h),
+    half2(2.0h, 7.0h),
+    half2(3.0h, 7.0h),
+    half2(4.0h, 7.0h),
+    half2(5.0h, 7.0h),
+    half2(6.0h, 7.0h),
+    half2(7.0h, 7.0h),
+};
 
+
+// Q4 chunk GEMM on the half-staging pattern of q27_matmul_t2_mm_h (variant
+// G-prime, docs/plans/2026-07-15-gemm-half-staging.md follow-up; port pre-
+// registered in 2026-07-17-t2-prefill-throughput.md): half tiles, raw Q4
+// codes (-8..+7) and raw int8 activations both integer-exact in half, FLOAT
+// accumulators (mixed-precision MMA). Products are bounded by 8*128 = 1024 <
+// 2048, so every product is exact in half regardless of where the MMA
+// rounds, and float accumulation keeps sums exact to 2^24 — stronger than
+// the float-staged q27_matmul_q4_mm it replaces, whose activation side
+// rounded once per value at staging. The Q4 scale group is 64 columns, so
+// each staged 64-K tile coincides with exactly one weight-scale group
+// (index c0/64, row stride cols/64); activation scales fold per 32-K
+// sub-slab at the flush exactly as in the T2 kernel.
+kernel void q27_matmul_q4_mm_h(
+        device const uchar *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const char *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint2 group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup half Wt[32 * 64];
+    threadgroup half Xt[64 * 16];
+    threadgroup float Sc[4 * 256];
+    const uint row0 = group.x * 32;
+    const uint tok0 = group.y * 16;   // 16-token tile (wide-chunk grid)
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint wrow = tid / 4, wcb = (tid % 4) * 16;
+    device const uchar *wsrc = weights + (ulong)min(row0 + wrow, rlast) * (args.cols / 2);
+    const uint xloc = tid % 16, xcb = (tid / 16) * 8;   // Xt column is tile-local
+    const uint xtok = tok0 + xloc;                       // device rows are global
+    device const char *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * args.cols;
+    const uint rowA = row0 + sg * 8 + lane / 8, rowB = rowA + 4;
+    const ulong wsrowA = (ulong)min(rowA, rlast) * (args.cols / 64);
+    const ulong wsrowB = (ulong)min(rowB, rlast) * (args.cols / 64);
+    simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    float4 racc = 0.0f;
+    threadgroup float *sc = Sc + sg * 256;
+    const uint tokA = tok0 + lane % 8, tokB = tok0 + 8 + lane % 8;
+    for (uint c0 = 0; c0 < args.cols; c0 += 64) {
+        {
+            // 16 columns = 8 bytes per thread: one byte-LUT gather per
+            // nibble pair, low nibble first (matches the float kernel's
+            // LSB-first order). wcb is a multiple of 16 -> half2-aligned.
+            const uint2 wp = *(device const uint2 *)(wsrc + (c0 + wcb) / 2);
+            threadgroup half2 *dst = (threadgroup half2 *)(Wt + wrow * 64 + wcb);
+            dst[0] = q27_q4_half2_lut[wp.x         & 0xffu];
+            dst[1] = q27_q4_half2_lut[(wp.x >>  8) & 0xffu];
+            dst[2] = q27_q4_half2_lut[(wp.x >> 16) & 0xffu];
+            dst[3] = q27_q4_half2_lut[wp.x >> 24         ];
+            dst[4] = q27_q4_half2_lut[wp.y         & 0xffu];
+            dst[5] = q27_q4_half2_lut[(wp.y >>  8) & 0xffu];
+            dst[6] = q27_q4_half2_lut[(wp.y >> 16) & 0xffu];
+            dst[7] = q27_q4_half2_lut[wp.y >> 24         ];
+        }
+        {
+            const char4 xa = *(device const char4 *)(xsrc + c0 + xcb);
+            const char4 xb = *(device const char4 *)(xsrc + c0 + xcb + 4);
+            threadgroup half *dst = Xt + xcb * 16 + xloc;
+            // Raw int8 values: exact in half. The per-token 32-group scale
+            // folds at the flush below; invalid token slots stage clamped
+            // real values whose outputs are never stored.
+            dst[0 * 16] = half(xa.x); dst[1 * 16] = half(xa.y);
+            dst[2 * 16] = half(xa.z); dst[3 * 16] = half(xa.w);
+            dst[4 * 16] = half(xb.x); dst[5 * 16] = half(xb.y);
+            dst[6 * 16] = half(xb.z); dst[7 * 16] = half(xb.w);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const float wsA = float(weight_scales[wsrowA + c0 / 64]);
+        const float wsB = float(weight_scales[wsrowB + c0 / 64]);
+        // The two 32-K sub-slabs (activation-scale groups) accumulate into
+        // separate tile pairs so both fold in ONE barrier region per staged 64.
+        for (uint k8 = 0; k8 < 32; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc1, a, b, acc1);
+        }
+        for (uint k8 = 32; k8 < 64; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc2, a, b, acc2);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc3, a, b, acc3);
+        }
+        simdgroup_store(acc0, sc, 8);
+        simdgroup_store(acc1, sc + 64, 8);
+        simdgroup_store(acc2, sc + 128, 8);
+        simdgroup_store(acc3, sc + 192, 8);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        {
+            const ulong xrow_a = (ulong)min(tokA, args.x_rows - 1) * (args.cols / 32);
+            const ulong xrow_b = (ulong)min(tokB, args.x_rows - 1) * (args.cols / 32);
+            const float xsA0 = x_scales[xrow_a + c0 / 32],     xsB0 = x_scales[xrow_b + c0 / 32];
+            const float xsA1 = x_scales[xrow_a + c0 / 32 + 1], xsB1 = x_scales[xrow_b + c0 / 32 + 1];
+            racc += float4(sc[lane], sc[lane + 32], sc[lane + 64], sc[lane + 96]) *
+                    float4(wsA * xsA0, wsB * xsA0, wsA * xsB0, wsB * xsB0);
+            racc += float4(sc[lane + 128], sc[lane + 160], sc[lane + 192], sc[lane + 224]) *
+                    float4(wsA * xsA1, wsB * xsA1, wsA * xsB1, wsB * xsB1);
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
+    if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
+    if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
+    if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = racc.w;
+}
+
+// PARKED (2026-07-17, never engine-routed): Q8 on the half-staging
+// pattern FAILED the shape suite — 5.5e-4 at the high-cancellation
+// 33x5120 repro vs the 3e-4 bound. Unlike Q4/T2, Q8 PRODUCTS (up to
+// 127*127) exceed half's 2048 exact-integer range, and the failure shows
+// the mixed-precision MMA rounds products at HALF precision, not at the
+// float accumulator's — the empirical answer to the open question the Q4
+// port's exactness argument sidesteps (its products are <= 1024, exact
+// regardless). A split-nibble Q8 staging would restore exactness at 2x
+// the MMA work for a ~8%-of-wall kernel: not worth it. Q8 chunk GEMM
+// stays float-staged; kernel kept as the record of the attempt.
+kernel void q27_matmul_q8_mm_h(
+        device const char *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const char *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint2 group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup half Wt[32 * 64];
+    threadgroup half Xt[64 * 16];
+    threadgroup float Sc[4 * 256];
+    const uint row0 = group.x * 32;
+    const uint tok0 = group.y * 16;   // 16-token tile (wide-chunk grid)
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint wrow = tid / 4, wcb = (tid % 4) * 16;
+    device const char *wsrc = weights + (ulong)min(row0 + wrow, rlast) * args.cols;
+    const uint xloc = tid % 16, xcb = (tid / 16) * 8;   // Xt column is tile-local
+    const uint xtok = tok0 + xloc;                       // device rows are global
+    device const char *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * args.cols;
+    const uint rowA = row0 + sg * 8 + lane / 8, rowB = rowA + 4;
+    const ulong wsrowA = (ulong)min(rowA, rlast) * (args.cols / 128);
+    const ulong wsrowB = (ulong)min(rowB, rlast) * (args.cols / 128);
+    simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    float4 racc = 0.0f;
+    threadgroup float *sc = Sc + sg * 256;
+    const uint tokA = tok0 + lane % 8, tokB = tok0 + 8 + lane % 8;
+    for (uint c0 = 0; c0 < args.cols; c0 += 64) {
+        {
+            const int4 wp = *(device const int4 *)(wsrc + c0 + wcb);
+            const char4 w0 = as_type<char4>(wp.x), w1 = as_type<char4>(wp.y);
+            const char4 w2 = as_type<char4>(wp.z), w3 = as_type<char4>(wp.w);
+            threadgroup half *dst = Wt + wrow * 64 + wcb;
+            dst[0]  = half(w0.x); dst[1]  = half(w0.y); dst[2]  = half(w0.z); dst[3]  = half(w0.w);
+            dst[4]  = half(w1.x); dst[5]  = half(w1.y); dst[6]  = half(w1.z); dst[7]  = half(w1.w);
+            dst[8]  = half(w2.x); dst[9]  = half(w2.y); dst[10] = half(w2.z); dst[11] = half(w2.w);
+            dst[12] = half(w3.x); dst[13] = half(w3.y); dst[14] = half(w3.z); dst[15] = half(w3.w);
+        }
+        {
+            const char4 xa = *(device const char4 *)(xsrc + c0 + xcb);
+            const char4 xb = *(device const char4 *)(xsrc + c0 + xcb + 4);
+            threadgroup half *dst = Xt + xcb * 16 + xloc;
+            dst[0 * 16] = half(xa.x); dst[1 * 16] = half(xa.y);
+            dst[2 * 16] = half(xa.z); dst[3 * 16] = half(xa.w);
+            dst[4 * 16] = half(xb.x); dst[5 * 16] = half(xb.y);
+            dst[6 * 16] = half(xb.z); dst[7 * 16] = half(xb.w);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const float wsA = float(weight_scales[wsrowA + c0 / 128]);
+        const float wsB = float(weight_scales[wsrowB + c0 / 128]);
+        for (uint k8 = 0; k8 < 32; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc1, a, b, acc1);
+        }
+        for (uint k8 = 32; k8 < 64; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc2, a, b, acc2);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc3, a, b, acc3);
+        }
+        simdgroup_store(acc0, sc, 8);
+        simdgroup_store(acc1, sc + 64, 8);
+        simdgroup_store(acc2, sc + 128, 8);
+        simdgroup_store(acc3, sc + 192, 8);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        {
+            const ulong xrow_a = (ulong)min(tokA, args.x_rows - 1) * (args.cols / 32);
+            const ulong xrow_b = (ulong)min(tokB, args.x_rows - 1) * (args.cols / 32);
+            const float xsA0 = x_scales[xrow_a + c0 / 32],     xsB0 = x_scales[xrow_b + c0 / 32];
+            const float xsA1 = x_scales[xrow_a + c0 / 32 + 1], xsB1 = x_scales[xrow_b + c0 / 32 + 1];
+            racc += float4(sc[lane], sc[lane + 32], sc[lane + 64], sc[lane + 96]) *
+                    float4(wsA * xsA0, wsB * xsA0, wsA * xsB0, wsB * xsB0);
+            racc += float4(sc[lane + 128], sc[lane + 160], sc[lane + 192], sc[lane + 224]) *
+                    float4(wsA * xsA1, wsB * xsA1, wsA * xsB1, wsB * xsB1);
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
+    if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
+    if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
+    if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = racc.w;
+}
+
+// Nibble -> 4 binary-code halves (bit j = element j, LSB-first): one
+// constant-memory gather replaces four shift/mask/select chains. Bit b
+// stages (2b-1) as f16 — exact, so the mm kernel's math mirrors mm_h's.
+constant half4 q27_b1_half4_lut[16] = {
+    half4(-1.0h, -1.0h, -1.0h, -1.0h),
+    half4( 1.0h, -1.0h, -1.0h, -1.0h),
+    half4(-1.0h,  1.0h, -1.0h, -1.0h),
+    half4( 1.0h,  1.0h, -1.0h, -1.0h),
+    half4(-1.0h, -1.0h,  1.0h, -1.0h),
+    half4( 1.0h, -1.0h,  1.0h, -1.0h),
+    half4(-1.0h,  1.0h,  1.0h, -1.0h),
+    half4( 1.0h,  1.0h,  1.0h, -1.0h),
+    half4(-1.0h, -1.0h, -1.0h,  1.0h),
+    half4( 1.0h, -1.0h, -1.0h,  1.0h),
+    half4(-1.0h,  1.0h, -1.0h,  1.0h),
+    half4( 1.0h,  1.0h, -1.0h,  1.0h),
+    half4(-1.0h, -1.0h,  1.0h,  1.0h),
+    half4( 1.0h, -1.0h,  1.0h,  1.0h),
+    half4(-1.0h,  1.0h,  1.0h,  1.0h),
+    half4( 1.0h,  1.0h,  1.0h,  1.0h),
+};
+
+// Binary tiled chunk GEMM on the half-staging pattern of q27_matmul_t2_mm_h
+// (the production T2 route): half tiles, {-1,+1} weights and raw int8
+// activations both integer-exact in half, activation scale folded at the
+// per-32-K flush. The staging block reads one ushort (16 code bits) per
+// thread — (c0 + wcb)/8 is even because wcb is a multiple of 16, so the
+// load is ushort-aligned.
+kernel void q27_matmul_b1_mm(
+        device const uchar *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const char *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint2 group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup half Wt[32 * 64];
+    threadgroup half Xt[64 * 16];
+    threadgroup float Sc[4 * 256];
+    const uint row0 = group.x * 32;
+    const uint tok0 = group.y * 16;   // 16-token tile (wide-chunk grid)
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint wrow = tid / 4, wcb = (tid % 4) * 16;
+    device const uchar *wsrc = weights + (ulong)min(row0 + wrow, rlast) * (args.cols / 8);
+    const uint xloc = tid % 16, xcb = (tid / 16) * 8;   // Xt column is tile-local
+    const uint xtok = tok0 + xloc;                       // device rows are global
+    device const char *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * args.cols;
+    const uint rowA = row0 + sg * 8 + lane / 8, rowB = rowA + 4;
+    const ulong wsrowA = (ulong)min(rowA, rlast) * (args.cols / 128);
+    const ulong wsrowB = (ulong)min(rowB, rlast) * (args.cols / 128);
+    simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    float4 racc = 0.0f;
+    threadgroup float *sc = Sc + sg * 256;
+    const uint tokA = tok0 + lane % 8, tokB = tok0 + 8 + lane % 8;
+    for (uint c0 = 0; c0 < args.cols; c0 += 64) {
+        {
+            const ushort wp = *(device const ushort *)(wsrc + (c0 + wcb) / 8);
+            threadgroup half4 *dst = (threadgroup half4 *)(Wt + wrow * 64 + wcb);
+            dst[0] = q27_b1_half4_lut[wp         & 0xfu];
+            dst[1] = q27_b1_half4_lut[(wp >>  4) & 0xfu];
+            dst[2] = q27_b1_half4_lut[(wp >>  8) & 0xfu];
+            dst[3] = q27_b1_half4_lut[wp >> 12        ];
+        }
+        {
+            const char4 xa = *(device const char4 *)(xsrc + c0 + xcb);
+            const char4 xb = *(device const char4 *)(xsrc + c0 + xcb + 4);
+            threadgroup half *dst = Xt + xcb * 16 + xloc;
+            // Raw int8 values: exact in half. The per-token 32-group scale
+            // folds at the flush below; invalid token slots stage clamped
+            // real values whose outputs are never stored.
+            dst[0 * 16] = half(xa.x); dst[1 * 16] = half(xa.y);
+            dst[2 * 16] = half(xa.z); dst[3 * 16] = half(xa.w);
+            dst[4 * 16] = half(xb.x); dst[5 * 16] = half(xb.y);
+            dst[6 * 16] = half(xb.z); dst[7 * 16] = half(xb.w);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const float wsA = float(weight_scales[wsrowA + c0 / 128]);
+        const float wsB = float(weight_scales[wsrowB + c0 / 128]);
+        // Float accumulators keep int8 x {-1,+1} sums exact. The two 32-K
+        // sub-slabs (activation-scale groups) accumulate into separate tile
+        // pairs so both fold in ONE barrier region per staged 64.
+        for (uint k8 = 0; k8 < 32; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc1, a, b, acc1);
+        }
+        for (uint k8 = 32; k8 < 64; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc2, a, b, acc2);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc3, a, b, acc3);
+        }
+        simdgroup_store(acc0, sc, 8);
+        simdgroup_store(acc1, sc + 64, 8);
+        simdgroup_store(acc2, sc + 128, 8);
+        simdgroup_store(acc3, sc + 192, 8);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        {
+            const ulong xrow_a = (ulong)min(tokA, args.x_rows - 1) * (args.cols / 32);
+            const ulong xrow_b = (ulong)min(tokB, args.x_rows - 1) * (args.cols / 32);
+            const float xsA0 = x_scales[xrow_a + c0 / 32],     xsB0 = x_scales[xrow_b + c0 / 32];
+            const float xsA1 = x_scales[xrow_a + c0 / 32 + 1], xsB1 = x_scales[xrow_b + c0 / 32 + 1];
+            racc += float4(sc[lane], sc[lane + 32], sc[lane + 64], sc[lane + 96]) *
+                    float4(wsA * xsA0, wsB * xsA0, wsA * xsB0, wsB * xsB0);
+            racc += float4(sc[lane + 128], sc[lane + 160], sc[lane + 192], sc[lane + 224]) *
+                    float4(wsA * xsA1, wsB * xsA1, wsA * xsB1, wsB * xsB1);
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
+    if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
+    if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
+    if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = racc.w;
+}
+
+
+// ---- A/B/C MMA roofline probes (bench-only, docs/plans/2026-07-16-mma-
+// roofline.md). Same dispatch grid, tile geometry, edge clamps, and
+// physical MMA count as q27_matmul_t2_mm_h (arm C); never engine-routed.
+
+// Arm K — function-constant specialization probe (BaseRT survey probe 2):
+// the production mm_h body with the K dimension baked as a function
+// constant, so the 64-K walk's trip count and every cols-derived address
+// expression are compile-time literals (per-shape specialized PSO). Same
+// math in the same order — output must be bit-identical to arm C.
+constant uint FC_COLS [[function_constant(0)]];
+kernel void q27_mma_roofline_k(
+        device const uchar *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const char *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint2 group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup half Wt[32 * 64];
+    threadgroup half Xt[64 * 16];
+    threadgroup float Sc[4 * 256];
+    const uint row0 = group.x * 32;
+    const uint tok0 = group.y * 16;
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint wrow = tid / 4, wcb = (tid % 4) * 16;
+    device const uchar *wsrc = weights + (ulong)min(row0 + wrow, rlast) * (FC_COLS / 4);
+    const uint xloc = tid % 16, xcb = (tid / 16) * 8;
+    const uint xtok = tok0 + xloc;
+    device const char *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * FC_COLS;
+    const uint rowA = row0 + sg * 8 + lane / 8, rowB = rowA + 4;
+    const ulong wsrowA = (ulong)min(rowA, rlast) * (FC_COLS / 128);
+    const ulong wsrowB = (ulong)min(rowB, rlast) * (FC_COLS / 128);
+    simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    float4 racc = 0.0f;
+    threadgroup float *sc = Sc + sg * 256;
+    const uint tokA = tok0 + lane % 8, tokB = tok0 + 8 + lane % 8;
+    for (uint c0 = 0; c0 < FC_COLS; c0 += 64) {
+        {
+            const uint wp = *(device const uint *)(wsrc + (c0 + wcb) / 4);
+            threadgroup half4 *dst = (threadgroup half4 *)(Wt + wrow * 64 + wcb);
+            dst[0] = q27_t2_half4_lut[wp         & 0xffu];
+            dst[1] = q27_t2_half4_lut[(wp >>  8) & 0xffu];
+            dst[2] = q27_t2_half4_lut[(wp >> 16) & 0xffu];
+            dst[3] = q27_t2_half4_lut[wp >> 24         ];
+        }
+        {
+            const char4 xa = *(device const char4 *)(xsrc + c0 + xcb);
+            const char4 xb = *(device const char4 *)(xsrc + c0 + xcb + 4);
+            threadgroup half *dst = Xt + xcb * 16 + xloc;
+            dst[0 * 16] = half(xa.x); dst[1 * 16] = half(xa.y);
+            dst[2 * 16] = half(xa.z); dst[3 * 16] = half(xa.w);
+            dst[4 * 16] = half(xb.x); dst[5 * 16] = half(xb.y);
+            dst[6 * 16] = half(xb.z); dst[7 * 16] = half(xb.w);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const float wsA = float(weight_scales[wsrowA + c0 / 128]);
+        const float wsB = float(weight_scales[wsrowB + c0 / 128]);
+        for (uint k8 = 0; k8 < 32; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc1, a, b, acc1);
+        }
+        for (uint k8 = 32; k8 < 64; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc2, a, b, acc2);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc3, a, b, acc3);
+        }
+        simdgroup_store(acc0, sc, 8);
+        simdgroup_store(acc1, sc + 64, 8);
+        simdgroup_store(acc2, sc + 128, 8);
+        simdgroup_store(acc3, sc + 192, 8);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        {
+            const ulong xrow_a = (ulong)min(tokA, args.x_rows - 1) * (FC_COLS / 32);
+            const ulong xrow_b = (ulong)min(tokB, args.x_rows - 1) * (FC_COLS / 32);
+            const float xsA0 = x_scales[xrow_a + c0 / 32],     xsB0 = x_scales[xrow_b + c0 / 32];
+            const float xsA1 = x_scales[xrow_a + c0 / 32 + 1], xsB1 = x_scales[xrow_b + c0 / 32 + 1];
+            racc += float4(sc[lane], sc[lane + 32], sc[lane + 64], sc[lane + 96]) *
+                    float4(wsA * xsA0, wsB * xsA0, wsA * xsB0, wsB * xsB0);
+            racc += float4(sc[lane + 128], sc[lane + 160], sc[lane + 192], sc[lane + 224]) *
+                    float4(wsA * xsA1, wsB * xsA1, wsA * xsB1, wsB * xsB1);
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
+    if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
+    if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
+    if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = racc.w;
+}
+
+// Arm F — f16-accumulate probe (docs/plans/2026-07-16-f16acc-probe.md,
+// BaseRT survey import #1): the production mm_h body with half
+// accumulators and a half flush tile. The f16 sums live only within one
+// 64-K slab (|sum| <= 64*127*2, inside half range); the scale-fold and
+// cross-slab accumulation stay f32 in racc, unchanged. Bench-only.
+kernel void q27_mma_roofline_f(
+        device const uchar *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const char *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint2 group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup half Wt[32 * 64];
+    threadgroup half Xt[64 * 16];
+    threadgroup half Sc[4 * 256];
+    const uint row0 = group.x * 32;
+    const uint tok0 = group.y * 16;
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint wrow = tid / 4, wcb = (tid % 4) * 16;
+    device const uchar *wsrc = weights + (ulong)min(row0 + wrow, rlast) * (args.cols / 4);
+    const uint xloc = tid % 16, xcb = (tid / 16) * 8;
+    const uint xtok = tok0 + xloc;
+    device const char *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * args.cols;
+    const uint rowA = row0 + sg * 8 + lane / 8, rowB = rowA + 4;
+    const ulong wsrowA = (ulong)min(rowA, rlast) * (args.cols / 128);
+    const ulong wsrowB = (ulong)min(rowB, rlast) * (args.cols / 128);
+    simdgroup_half8x8 acc0 = make_filled_simdgroup_matrix<half, 8, 8>(0.0h);
+    simdgroup_half8x8 acc1 = make_filled_simdgroup_matrix<half, 8, 8>(0.0h);
+    simdgroup_half8x8 acc2 = make_filled_simdgroup_matrix<half, 8, 8>(0.0h);
+    simdgroup_half8x8 acc3 = make_filled_simdgroup_matrix<half, 8, 8>(0.0h);
+    float4 racc = 0.0f;
+    threadgroup half *sc = Sc + sg * 256;
+    const uint tokA = tok0 + lane % 8, tokB = tok0 + 8 + lane % 8;
+    for (uint c0 = 0; c0 < args.cols; c0 += 64) {
+        {
+            const uint wp = *(device const uint *)(wsrc + (c0 + wcb) / 4);
+            threadgroup half4 *dst = (threadgroup half4 *)(Wt + wrow * 64 + wcb);
+            dst[0] = q27_t2_half4_lut[wp         & 0xffu];
+            dst[1] = q27_t2_half4_lut[(wp >>  8) & 0xffu];
+            dst[2] = q27_t2_half4_lut[(wp >> 16) & 0xffu];
+            dst[3] = q27_t2_half4_lut[wp >> 24         ];
+        }
+        {
+            const char4 xa = *(device const char4 *)(xsrc + c0 + xcb);
+            const char4 xb = *(device const char4 *)(xsrc + c0 + xcb + 4);
+            threadgroup half *dst = Xt + xcb * 16 + xloc;
+            dst[0 * 16] = half(xa.x); dst[1 * 16] = half(xa.y);
+            dst[2 * 16] = half(xa.z); dst[3 * 16] = half(xa.w);
+            dst[4 * 16] = half(xb.x); dst[5 * 16] = half(xb.y);
+            dst[6 * 16] = half(xb.z); dst[7 * 16] = half(xb.w);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const float wsA = float(weight_scales[wsrowA + c0 / 128]);
+        const float wsB = float(weight_scales[wsrowB + c0 / 128]);
+        for (uint k8 = 0; k8 < 32; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc1, a, b, acc1);
+        }
+        for (uint k8 = 32; k8 < 64; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc2, a, b, acc2);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc3, a, b, acc3);
+        }
+        simdgroup_store(acc0, sc, 8);
+        simdgroup_store(acc1, sc + 64, 8);
+        simdgroup_store(acc2, sc + 128, 8);
+        simdgroup_store(acc3, sc + 192, 8);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        {
+            const ulong xrow_a = (ulong)min(tokA, args.x_rows - 1) * (args.cols / 32);
+            const ulong xrow_b = (ulong)min(tokB, args.x_rows - 1) * (args.cols / 32);
+            const float xsA0 = x_scales[xrow_a + c0 / 32],     xsB0 = x_scales[xrow_b + c0 / 32];
+            const float xsA1 = x_scales[xrow_a + c0 / 32 + 1], xsB1 = x_scales[xrow_b + c0 / 32 + 1];
+            racc += float4(sc[lane], sc[lane + 32], sc[lane + 64], sc[lane + 96]) *
+                    float4(wsA * xsA0, wsB * xsA0, wsA * xsB0, wsB * xsB0);
+            racc += float4(sc[lane + 128], sc[lane + 160], sc[lane + 192], sc[lane + 224]) *
+                    float4(wsA * xsA1, wsB * xsA1, wsA * xsB1, wsB * xsB1);
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        acc0 = make_filled_simdgroup_matrix<half, 8, 8>(0.0h);
+        acc1 = make_filled_simdgroup_matrix<half, 8, 8>(0.0h);
+        acc2 = make_filled_simdgroup_matrix<half, 8, 8>(0.0h);
+        acc3 = make_filled_simdgroup_matrix<half, 8, 8>(0.0h);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
+    if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
+    if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
+    if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = racc.w;
+}
+
+// Arm B — half-plumbing roofline: the mm_h body with the packed-trit
+// unpack and int8->half conversion deleted. Operands are already half in
+// device memory and stage into the same threadgroup tiles with the same
+// store pattern, barriers, MMA loops, and per-64-K ws*xs scale-fold flush.
+// B - C isolates unpack/conversion machinery only.
+kernel void q27_mma_roofline_b(
+        device const half *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const half *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint2 group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup half Wt[32 * 64];
+    threadgroup half Xt[64 * 16];
+    threadgroup float Sc[4 * 256];
+    const uint row0 = group.x * 32;
+    const uint tok0 = group.y * 16;
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint wrow = tid / 4, wcb = (tid % 4) * 16;
+    device const half *wsrc = weights + (ulong)min(row0 + wrow, rlast) * args.cols;
+    const uint xloc = tid % 16, xcb = (tid / 16) * 8;
+    const uint xtok = tok0 + xloc;
+    device const half *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * args.cols;
+    const uint rowA = row0 + sg * 8 + lane / 8, rowB = rowA + 4;
+    const ulong wsrowA = (ulong)min(rowA, rlast) * (args.cols / 128);
+    const ulong wsrowB = (ulong)min(rowB, rlast) * (args.cols / 128);
+    simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    float4 racc = 0.0f;
+    threadgroup float *sc = Sc + sg * 256;
+    const uint tokA = tok0 + lane % 8, tokB = tok0 + 8 + lane % 8;
+    for (uint c0 = 0; c0 < args.cols; c0 += 64) {
+        {
+            device const half4 *wp4 = (device const half4 *)(wsrc + c0 + wcb);
+            threadgroup half *dst = Wt + wrow * 64 + wcb;
+            const half4 w0 = wp4[0], w1 = wp4[1], w2 = wp4[2], w3 = wp4[3];
+            dst[0]  = w0.x; dst[1]  = w0.y; dst[2]  = w0.z; dst[3]  = w0.w;
+            dst[4]  = w1.x; dst[5]  = w1.y; dst[6]  = w1.z; dst[7]  = w1.w;
+            dst[8]  = w2.x; dst[9]  = w2.y; dst[10] = w2.z; dst[11] = w2.w;
+            dst[12] = w3.x; dst[13] = w3.y; dst[14] = w3.z; dst[15] = w3.w;
+        }
+        {
+            device const half4 *xp4 = (device const half4 *)(xsrc + c0 + xcb);
+            const half4 xa = xp4[0], xb = xp4[1];
+            threadgroup half *dst = Xt + xcb * 16 + xloc;
+            dst[0 * 16] = xa.x; dst[1 * 16] = xa.y;
+            dst[2 * 16] = xa.z; dst[3 * 16] = xa.w;
+            dst[4 * 16] = xb.x; dst[5 * 16] = xb.y;
+            dst[6 * 16] = xb.z; dst[7 * 16] = xb.w;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const float wsA = float(weight_scales[wsrowA + c0 / 128]);
+        const float wsB = float(weight_scales[wsrowB + c0 / 128]);
+        for (uint k8 = 0; k8 < 32; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc1, a, b, acc1);
+        }
+        for (uint k8 = 32; k8 < 64; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc2, a, b, acc2);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc3, a, b, acc3);
+        }
+        simdgroup_store(acc0, sc, 8);
+        simdgroup_store(acc1, sc + 64, 8);
+        simdgroup_store(acc2, sc + 128, 8);
+        simdgroup_store(acc3, sc + 192, 8);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        {
+            const ulong xrow_a = (ulong)min(tokA, args.x_rows - 1) * (args.cols / 32);
+            const ulong xrow_b = (ulong)min(tokB, args.x_rows - 1) * (args.cols / 32);
+            const float xsA0 = x_scales[xrow_a + c0 / 32],     xsB0 = x_scales[xrow_b + c0 / 32];
+            const float xsA1 = x_scales[xrow_a + c0 / 32 + 1], xsB1 = x_scales[xrow_b + c0 / 32 + 1];
+            racc += float4(sc[lane], sc[lane + 32], sc[lane + 64], sc[lane + 96]) *
+                    float4(wsA * xsA0, wsB * xsA0, wsA * xsB0, wsB * xsB0);
+            racc += float4(sc[lane + 128], sc[lane + 160], sc[lane + 192], sc[lane + 224]) *
+                    float4(wsA * xsA1, wsB * xsA1, wsA * xsB1, wsB * xsB1);
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
+    if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
+    if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
+    if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = racc.w;
+}
+
+// Arm B_eq — equal-traffic no-unpack roofline. Literal arm B streams eight
+// times the weight bytes of C, confounding unpack cost with bandwidth. This
+// variant loads exactly C's device bytes per thread per tile, replicates the
+// values into the same staging stores, and keeps barriers, MMA loops, and the
+// scale-fold flush identical. C/B_eq isolates unpack and conversion ALU at
+// equal traffic; MMA timing is data-independent, so values do not matter.
+kernel void q27_mma_roofline_b_eq(
+        device const half *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const half *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint2 group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup half Wt[32 * 64];
+    threadgroup half Xt[64 * 16];
+    threadgroup float Sc[4 * 256];
+    const uint row0 = group.x * 32;
+    const uint tok0 = group.y * 16;
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint wrow = tid / 4, wcb = (tid % 4) * 16;
+    // Packed-equivalent layout: cols/8 halves per row (= cols/4 bytes, C's
+    // packed weight row size).
+    device const half *wsrc = weights + (ulong)min(row0 + wrow, rlast) * (args.cols / 8);
+    const uint xloc = tid % 16, xcb = (tid / 16) * 8;
+    const uint xtok = tok0 + xloc;
+    device const half *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * (args.cols / 2);
+    const uint rowA = row0 + sg * 8 + lane / 8, rowB = rowA + 4;
+    const ulong wsrowA = (ulong)min(rowA, rlast) * (args.cols / 128);
+    const ulong wsrowB = (ulong)min(rowB, rlast) * (args.cols / 128);
+    simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    float4 racc = 0.0f;
+    threadgroup float *sc = Sc + sg * 256;
+    const uint tokA = tok0 + lane % 8, tokB = tok0 + 8 + lane % 8;
+    for (uint c0 = 0; c0 < args.cols; c0 += 64) {
+        {
+            const half2 w2 = *(device const half2 *)(wsrc + (c0 + wcb) / 8);
+            // Vector stores mirror production staging so the control does not
+            // fall behind the kernel it isolates.
+            threadgroup half4 *dst = (threadgroup half4 *)(Wt + wrow * 64 + wcb);
+            dst[0] = half4(w2.x, w2.y, w2.x, w2.y);
+            dst[1] = half4(w2.x, w2.y, w2.x, w2.y);
+            dst[2] = half4(w2.y, w2.x, w2.y, w2.x);
+            dst[3] = half4(w2.y, w2.x, w2.y, w2.x);
+        }
+        {
+            // Two 4-byte loads match C's two char4 loads per slot; one 8-byte
+            // load would understate load-issue cost.
+            const half2 xa2 = *(device const half2 *)(xsrc + (c0 + xcb) / 2);
+            const half2 xb2 = *(device const half2 *)(xsrc + (c0 + xcb) / 2 + 2);
+            threadgroup half *dst = Xt + xcb * 16 + xloc;
+            dst[0 * 16] = xa2.x; dst[1 * 16] = xa2.y;
+            dst[2 * 16] = xb2.x; dst[3 * 16] = xb2.y;
+            dst[4 * 16] = xb2.y; dst[5 * 16] = xb2.x;
+            dst[6 * 16] = xa2.y; dst[7 * 16] = xa2.x;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const float wsA = float(weight_scales[wsrowA + c0 / 128]);
+        const float wsB = float(weight_scales[wsrowB + c0 / 128]);
+        for (uint k8 = 0; k8 < 32; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc1, a, b, acc1);
+        }
+        for (uint k8 = 32; k8 < 64; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc2, a, b, acc2);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc3, a, b, acc3);
+        }
+        simdgroup_store(acc0, sc, 8);
+        simdgroup_store(acc1, sc + 64, 8);
+        simdgroup_store(acc2, sc + 128, 8);
+        simdgroup_store(acc3, sc + 192, 8);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        {
+            const ulong xrow_a = (ulong)min(tokA, args.x_rows - 1) * (args.cols / 32);
+            const ulong xrow_b = (ulong)min(tokB, args.x_rows - 1) * (args.cols / 32);
+            const float xsA0 = x_scales[xrow_a + c0 / 32],     xsB0 = x_scales[xrow_b + c0 / 32];
+            const float xsA1 = x_scales[xrow_a + c0 / 32 + 1], xsB1 = x_scales[xrow_b + c0 / 32 + 1];
+            racc += float4(sc[lane], sc[lane + 32], sc[lane + 64], sc[lane + 96]) *
+                    float4(wsA * xsA0, wsB * xsA0, wsA * xsB0, wsB * xsB0);
+            racc += float4(sc[lane + 128], sc[lane + 160], sc[lane + 192], sc[lane + 224]) *
+                    float4(wsA * xsA1, wsB * xsA1, wsA * xsB1, wsB * xsB1);
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
+    if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
+    if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
+    if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = racc.w;
+}
+
+// Arm Cx — the pre-converted-activation candidate: production packed-T2
+// weight staging (LUT unpack) with activations already half in device
+// memory (raw int8 values converted once device-side are exact in half,
+// so this candidate would be bit-identical in production; scale still
+// folds at the flush). Cx measures the ceiling of deleting the per-tile
+// char->half converts before building the production pre-pass.
+kernel void q27_mma_roofline_cx(
+        device const uchar *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const half *x [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint2 group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup half Wt[32 * 64];
+    threadgroup half Xt[64 * 16];
+    threadgroup float Sc[4 * 256];
+    const uint row0 = group.x * 32;
+    const uint tok0 = group.y * 16;
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint wrow = tid / 4, wcb = (tid % 4) * 16;
+    device const uchar *wsrc = weights + (ulong)min(row0 + wrow, rlast) * (args.cols / 4);
+    const uint xloc = tid % 16, xcb = (tid / 16) * 8;
+    const uint xtok = tok0 + xloc;
+    device const half *xsrc = x + (ulong)min(xtok, args.x_rows - 1) * args.cols;
+    const uint rowA = row0 + sg * 8 + lane / 8, rowB = rowA + 4;
+    const ulong wsrowA = (ulong)min(rowA, rlast) * (args.cols / 128);
+    const ulong wsrowB = (ulong)min(rowB, rlast) * (args.cols / 128);
+    simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    float4 racc = 0.0f;
+    threadgroup float *sc = Sc + sg * 256;
+    const uint tokA = tok0 + lane % 8, tokB = tok0 + 8 + lane % 8;
+    for (uint c0 = 0; c0 < args.cols; c0 += 64) {
+        {
+            const uint wp = *(device const uint *)(wsrc + (c0 + wcb) / 4);
+            // Exact copy of production weight staging; Cx differs from C only
+            // on the activation side.
+            threadgroup half4 *dst = (threadgroup half4 *)(Wt + wrow * 64 + wcb);
+            dst[0] = q27_t2_half4_lut[wp         & 0xffu];
+            dst[1] = q27_t2_half4_lut[(wp >>  8) & 0xffu];
+            dst[2] = q27_t2_half4_lut[(wp >> 16) & 0xffu];
+            dst[3] = q27_t2_half4_lut[wp >> 24         ];
+        }
+        {
+            const half4 xa = *(device const half4 *)(xsrc + c0 + xcb);
+            const half4 xb = *(device const half4 *)(xsrc + c0 + xcb + 4);
+            threadgroup half *dst = Xt + xcb * 16 + xloc;
+            dst[0 * 16] = xa.x; dst[1 * 16] = xa.y;
+            dst[2 * 16] = xa.z; dst[3 * 16] = xa.w;
+            dst[4 * 16] = xb.x; dst[5 * 16] = xb.y;
+            dst[6 * 16] = xb.z; dst[7 * 16] = xb.w;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        const float wsA = float(weight_scales[wsrowA + c0 / 128]);
+        const float wsB = float(weight_scales[wsrowB + c0 / 128]);
+        for (uint k8 = 0; k8 < 32; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc1, a, b, acc1);
+        }
+        for (uint k8 = 32; k8 < 64; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc2, a, b, acc2);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc3, a, b, acc3);
+        }
+        simdgroup_store(acc0, sc, 8);
+        simdgroup_store(acc1, sc + 64, 8);
+        simdgroup_store(acc2, sc + 128, 8);
+        simdgroup_store(acc3, sc + 192, 8);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        {
+            const ulong xrow_a = (ulong)min(tokA, args.x_rows - 1) * (args.cols / 32);
+            const ulong xrow_b = (ulong)min(tokB, args.x_rows - 1) * (args.cols / 32);
+            const float xsA0 = x_scales[xrow_a + c0 / 32],     xsB0 = x_scales[xrow_b + c0 / 32];
+            const float xsA1 = x_scales[xrow_a + c0 / 32 + 1], xsB1 = x_scales[xrow_b + c0 / 32 + 1];
+            racc += float4(sc[lane], sc[lane + 32], sc[lane + 64], sc[lane + 96]) *
+                    float4(wsA * xsA0, wsB * xsA0, wsA * xsB0, wsB * xsB0);
+            racc += float4(sc[lane + 128], sc[lane + 160], sc[lane + 192], sc[lane + 224]) *
+                    float4(wsA * xsA1, wsB * xsA1, wsA * xsB1, wsB * xsB1);
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = racc.x;
+    if (rowB < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowB] = racc.y;
+    if (rowA < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowA] = racc.z;
+    if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = racc.w;
+}
+
+// ---- Lever 1: direct-RHS chunk GEMM (docs/plans/2026-07-16-lever1-
+// direct-rhs.md; bench-first, never engine-routed until it clears its
+// pre-registered line). Structure per ds4 item 2/3 phase B: stage ONLY the
+// weight tile (64 rows x 32 K, half, byte-LUT unpack), read the RHS
+// directly from device via simdgroup_load, spend threadgroup memory on
+// weights. K-tile = 32 = exactly one activation-scale group, so the
+// per-K-tile flush folds ws(row) * xs(token) onto exact integer partial
+// sums (int8 x trit, same exactness class as mm_h; fold order differs
+// from mm_h so outputs are tolerance-gated, not bit-identical).
+
+// RHS pre-pass: int8 [x_rows, cols] -> half K-major [cols, tokens_pad],
+// raw int8 values (exact in half), zero-padded token slots. args reuse:
+// simdgroups field carries tokens_pad.
+kernel void q27_x_int8_to_half_t(device const char *x [[buffer(0)]],
+                                  device half *xt [[buffer(1)]],
+                                  constant MatmulArgs &args [[buffer(2)]],
+                                  uint gid [[thread_position_in_grid]]) {
+    const uint tokens_pad = args.simdgroups;
+    const uint c = gid / tokens_pad, t = gid % tokens_pad;
+    if (c >= args.cols) return;
+    xt[gid] = t < args.x_rows ? half(x[(ulong)t * args.cols + c]) : half(0.0h);
+}
+
+kernel void q27_matmul_t2_mm_dr(
+        device const uchar *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const half *xt [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint2 group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup half Wt[64 * 32];
+    threadgroup float Sc[8 * 64];      // per-simdgroup 8x8 flush scratch
+    const uint row0 = group.x * 64;
+    const uint tok0 = group.y * 32;
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint tokens_pad = args.simdgroups;   // K-major RHS row stride
+    const uint live = min(32u, args.x_rows - tok0);
+    const uint ncol = (live + 7) / 8;          // live 8-token column fragments
+    const uint wrow = tid / 4, wkb = (tid % 4) * 8;
+    device const uchar *wsrc = weights + (ulong)min(row0 + wrow, rlast) * (args.cols / 4);
+    const uint sgrow0 = (uint)sg * 8;          // this simdgroup's row stripe
+    // Flush mapping: lane owns elements (r = lane/8, t = lane%8) and
+    // (r + 4, t) of each 8x8 tile; racc[col*2 + {0,1}] accumulate them.
+    const uint rA = row0 + sgrow0 + lane / 8, rB = rA + 4;
+    const ulong wsrowA = (ulong)min(rA, rlast) * (args.cols / 128);
+    const ulong wsrowB = (ulong)min(rB, rlast) * (args.cols / 128);
+    float racc[8] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    threadgroup float *sc = Sc + (uint)sg * 64;
+    for (uint c0 = 0; c0 < args.cols; c0 += 32) {
+        {
+            // 8 trits (one ushort) per thread -> two byte-LUT half4 stores;
+            // 256 threads cover the 64x32 tile.
+            const ushort wp = *(device const ushort *)(wsrc + (c0 + wkb) / 4);
+            threadgroup half4 *dst = (threadgroup half4 *)(Wt + wrow * 32 + wkb);
+            dst[0] = q27_t2_half4_lut[wp & 0xffu];
+            dst[1] = q27_t2_half4_lut[wp >> 8];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        simdgroup_float8x8 acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        simdgroup_float8x8 acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+        for (uint k8 = 0; k8 < 32; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + sgrow0 * 32 + k8, 32);
+            device const half *bsrc = xt + (ulong)(c0 + k8) * tokens_pad + tok0;
+            simdgroup_load(b, bsrc, tokens_pad);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            if (ncol > 1) {
+                simdgroup_load(b, bsrc + 8, tokens_pad);
+                simdgroup_multiply_accumulate(acc1, a, b, acc1);
+            }
+            if (ncol > 2) {
+                simdgroup_load(b, bsrc + 16, tokens_pad);
+                simdgroup_multiply_accumulate(acc2, a, b, acc2);
+            }
+            if (ncol > 3) {
+                simdgroup_load(b, bsrc + 24, tokens_pad);
+                simdgroup_multiply_accumulate(acc3, a, b, acc3);
+            }
+        }
+        // Per-K-tile flush: this K-tile is one x-scale group (c0/32) and
+        // sits inside one weight-scale group (c0/128).
+        const float wsA = float(weight_scales[wsrowA + c0 / 128]);
+        const float wsB = float(weight_scales[wsrowB + c0 / 128]);
+        for (uint col = 0; col < ncol; col++) {
+            switch (col) {
+                case 0: simdgroup_store(acc0, sc, 8); break;
+                case 1: simdgroup_store(acc1, sc, 8); break;
+                case 2: simdgroup_store(acc2, sc, 8); break;
+                default: simdgroup_store(acc3, sc, 8); break;
+            }
+            simdgroup_barrier(mem_flags::mem_threadgroup);
+            const uint tok = min(tok0 + col * 8 + lane % 8, args.x_rows - 1);
+            const float xs = x_scales[(ulong)tok * (args.cols / 32) + c0 / 32];
+            racc[col * 2]     += sc[lane]      * wsA * xs;
+            racc[col * 2 + 1] += sc[lane + 32] * wsB * xs;
+            simdgroup_barrier(mem_flags::mem_threadgroup);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    for (uint col = 0; col < ncol; col++) {
+        const uint tok = tok0 + col * 8 + lane % 8;
+        if (tok >= args.x_rows) continue;
+        if (rA < args.rows) out[(ulong)tok * args.rows + rA] = racc[col * 2];
+        if (rB < args.rows) out[(ulong)tok * args.rows + rB] = racc[col * 2 + 1];
+    }
+}
+
+// Lever-1 variant D2: same direct-RHS contract, remapped to cut redundant
+// device B loads. 128 threads = 4 simdgroups; the 64-row x 16-token tile
+// splits into (row-half, token-column) quadrants, so each B fragment is
+// loaded by 2 simdgroups (vs 8 in the row-stripe mapping) and every
+// simdgroup has live work at w = 12. Same K-tile-32 flush and exactness
+// argument as q27_matmul_t2_mm_dr.
+kernel void q27_matmul_t2_mm_dr2(
+        device const uchar *weights [[buffer(0)]], device const half *weight_scales [[buffer(1)]],
+        device const half *xt [[buffer(2)]], device const float *x_scales [[buffer(3)]],
+        device float *out [[buffer(4)]], constant MatmulArgs &args [[buffer(5)]],
+        uint2 group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup half Wt[64 * 32];
+    threadgroup float Sc[4 * 64];
+    const uint row0 = group.x * 64;
+    const uint tok0 = group.y * 16;
+    if (row0 >= args.rows) return;
+    const uint rlast = args.rows - 1;
+    const uint tokens_pad = args.simdgroups;
+    const uint live = min(16u, args.x_rows - tok0);
+    const uint sgrow0 = ((uint)sg / 2) * 32;      // row-half within the tile
+    const uint sgtok = ((uint)sg % 2) * 8;        // token column (8 wide)
+    const bool tok_live = sgtok < live;
+    const uint wrow = tid / 2, wkb = (tid % 2) * 16;
+    device const uchar *wsrc = weights + (ulong)min(row0 + wrow, rlast) * (args.cols / 4);
+    const uint rA = row0 + sgrow0 + lane / 8;     // + 8*stripe below
+    float racc[8] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    threadgroup float *sc = Sc + (uint)sg * 64;
+    for (uint c0 = 0; c0 < args.cols; c0 += 32) {
+        {
+            // One uint (16 trits) per thread -> 4 byte-LUT half4 stores;
+            // 128 threads cover the 64x32 tile.
+            const uint wp = *(device const uint *)(wsrc + (c0 + wkb) / 4);
+            threadgroup half4 *dst = (threadgroup half4 *)(Wt + wrow * 32 + wkb);
+            dst[0] = q27_t2_half4_lut[wp         & 0xffu];
+            dst[1] = q27_t2_half4_lut[(wp >>  8) & 0xffu];
+            dst[2] = q27_t2_half4_lut[(wp >> 16) & 0xffu];
+            dst[3] = q27_t2_half4_lut[wp >> 24         ];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (tok_live) {
+            simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+            simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+            simdgroup_float8x8 acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+            simdgroup_float8x8 acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+            for (uint k8 = 0; k8 < 32; k8 += 8) {
+                simdgroup_half8x8 a, b;
+                simdgroup_load(b, xt + (ulong)(c0 + k8) * tokens_pad + tok0 + sgtok, tokens_pad);
+                simdgroup_load(a, Wt + sgrow0 * 32 + k8, 32);
+                simdgroup_multiply_accumulate(acc0, a, b, acc0);
+                simdgroup_load(a, Wt + (sgrow0 + 8) * 32 + k8, 32);
+                simdgroup_multiply_accumulate(acc1, a, b, acc1);
+                simdgroup_load(a, Wt + (sgrow0 + 16) * 32 + k8, 32);
+                simdgroup_multiply_accumulate(acc2, a, b, acc2);
+                simdgroup_load(a, Wt + (sgrow0 + 24) * 32 + k8, 32);
+                simdgroup_multiply_accumulate(acc3, a, b, acc3);
+            }
+            const uint tok = min(tok0 + sgtok + lane % 8, args.x_rows - 1);
+            const float xs = x_scales[(ulong)tok * (args.cols / 32) + c0 / 32];
+            for (uint stripe = 0; stripe < 4; stripe++) {
+                switch (stripe) {
+                    case 0: simdgroup_store(acc0, sc, 8); break;
+                    case 1: simdgroup_store(acc1, sc, 8); break;
+                    case 2: simdgroup_store(acc2, sc, 8); break;
+                    default: simdgroup_store(acc3, sc, 8); break;
+                }
+                simdgroup_barrier(mem_flags::mem_threadgroup);
+                const uint r0 = rA + stripe * 8, r1 = r0 + 4;
+                const float wsA = float(weight_scales[(ulong)min(r0, rlast) * (args.cols / 128) + c0 / 128]);
+                const float wsB = float(weight_scales[(ulong)min(r1, rlast) * (args.cols / 128) + c0 / 128]);
+                racc[stripe * 2]     += sc[lane]      * wsA * xs;
+                racc[stripe * 2 + 1] += sc[lane + 32] * wsB * xs;
+                simdgroup_barrier(mem_flags::mem_threadgroup);
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    const uint tok = tok0 + sgtok + lane % 8;
+    if (tok >= args.x_rows) return;
+    for (uint stripe = 0; stripe < 4; stripe++) {
+        const uint r0 = rA + stripe * 8, r1 = r0 + 4;
+        if (r0 < args.rows) out[(ulong)tok * args.rows + r0] = racc[stripe * 2];
+        if (r1 < args.rows) out[(ulong)tok * args.rows + r1] = racc[stripe * 2 + 1];
+    }
+}
+
+// Arm A — MMA-core roofline: tiles filled once from an opaque device seed
+// (defeats constant folding), then the SAME per-64-K MMA loop count with
+// accumulators carried across the whole K walk (the acc dependency chain
+// defeats dead-code elimination), one final fold + store with the same
+// row/token edge guards. No per-tile staging, no barriers, no flushes:
+// A - B isolates staging/barrier/flush cadence at equal MMA count.
+kernel void q27_mma_roofline_a(
+        device const half *seed [[buffer(0)]],
+        device float *out [[buffer(1)]], constant MatmulArgs &args [[buffer(2)]],
+        uint2 group [[threadgroup_position_in_grid]],
+        uint tid [[thread_index_in_threadgroup]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup half Wt[32 * 64];
+    threadgroup half Xt[64 * 16];
+    threadgroup float Sc[4 * 64];
+    const uint row0 = group.x * 32;
+    const uint tok0 = group.y * 16;
+    if (row0 >= args.rows) return;
+    for (uint i = tid; i < 32 * 64; i += 128) Wt[i] = seed[i];
+    for (uint i = tid; i < 64 * 16; i += 128) Xt[i] = seed[32 * 64 + i];
+    threadgroup_barrier(mem_flags::mem_threadgroup);   // one-time fill
+    const uint rowA = row0 + sg * 8 + lane / 8, rowB = rowA + 4;
+    const uint tokA = tok0 + lane % 8, tokB = tok0 + 8 + lane % 8;
+    simdgroup_float8x8 acc0 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc1 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc2 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    simdgroup_float8x8 acc3 = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    threadgroup float *sc = Sc + sg * 64;
+    for (uint c0 = 0; c0 < args.cols; c0 += 64) {
+        for (uint k8 = 0; k8 < 32; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc0, a, b, acc0);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc1, a, b, acc1);
+        }
+        for (uint k8 = 32; k8 < 64; k8 += 8) {
+            simdgroup_half8x8 a, b;
+            simdgroup_load(a, Wt + (uint)sg * 8 * 64 + k8, 64);
+            simdgroup_load(b, Xt + k8 * 16, 16);
+            simdgroup_multiply_accumulate(acc2, a, b, acc2);
+            simdgroup_load(b, Xt + k8 * 16 + 8, 16);
+            simdgroup_multiply_accumulate(acc3, a, b, acc3);
+        }
+    }
+    // Single fold: acc0's tile through per-simdgroup scratch, plus a direct
+    // dependency on acc1..acc3 via their stored diagonals so no accumulator
+    // chain is dead.
+    simdgroup_store(acc0, sc, 8);
+    simdgroup_barrier(mem_flags::mem_threadgroup);
+    float r = sc[lane];
+    simdgroup_store(acc1, sc, 8);
+    simdgroup_barrier(mem_flags::mem_threadgroup);
+    r += sc[lane + 32];
+    simdgroup_store(acc2, sc, 8);
+    simdgroup_barrier(mem_flags::mem_threadgroup);
+    r += sc[lane];
+    simdgroup_store(acc3, sc, 8);
+    simdgroup_barrier(mem_flags::mem_threadgroup);
+    r += sc[lane + 32];
+    if (rowA < args.rows && tokA < args.x_rows) out[(ulong)tokA * args.rows + rowA] = r;
+    if (rowB < args.rows && tokB < args.x_rows) out[(ulong)tokB * args.rows + rowB] = r + 1.0f;
+}
 
 // Constrained tool decoding: clear grammar-illegal logits to -inf under a
 // uint32 bitset mask (bit set = legal), so GPU argmax, top-k extraction,
@@ -1612,8 +3753,8 @@ kernel void q27_mask_logits(device float *logits [[buffer(0)]],
 
 // ---- Chunked layer-major prefill (2..96 tokens per dispatch; per-path
 // caps: MTP rounds and NLL/KL teacher forcing at CHUNK_MAX=12, prompt
-// ingestion at PREFILL_CHUNK_MAX=96 and verify chunks at
-// VERIFY_CHUNK_MAX=48 ----
+// ingestion at PREFILL_CHUNK_MAX=96, suffix-burst/oracle verify chunks at
+// VERIFY_CHUNK_MAX=48 — wide-chunk phase A + lever 2) ----
 //
 // These kernels advance a whole token chunk through one operation so the
 // engine can execute prompts layer-major and route projections through the
@@ -1649,6 +3790,19 @@ kernel void q27_embedding_t2_rows(
     out[(ulong)gid.y * args.cols + gid.x] = float(int(code) - 1) * float(scales[si]);
 }
 
+kernel void q27_embedding_b1_rows(
+        device const uchar *weights [[buffer(0)]],
+        device const half *scales   [[buffer(1)]],
+        device float *out           [[buffer(2)]],
+        constant EmbedRowsArgs &args [[buffer(3)]],
+        uint2 gid [[thread_position_in_grid]]) {
+    if (gid.x >= args.cols || gid.y >= args.count) return;
+    const uint token = args.tokens[gid.y];
+    const ulong wi = (ulong)token * args.cols + gid.x;
+    const uint bit = (weights[wi >> 3] >> (wi & 7)) & 1;
+    const ulong si = (ulong)token * (args.cols / 128) + gid.x / 128;
+    out[(ulong)gid.y * args.cols + gid.x] = float(2 * int(bit) - 1) * float(scales[si]);
+}
 
 struct RowsNormArgs { uint n; uint rows; uint groups; float eps; };
 kernel void q27_rmsnorm_rows_quantized(
@@ -2368,6 +4522,96 @@ kernel void q27_kv_store_turbo3_rows(device const float *k [[buffer(0)]],
     }
 }
 
+// KV-codec attribution store (kl-kv instrument): writes the fp16 KV cache,
+// but routes one side (mode 1 = K, mode 2 = V) through the exact turbo3
+// quantizer — normalize, sign flips, butterfly, 8-centroid nearest,
+// half-rounded norm-correction scale — and back through the inverse
+// transform. The engine stays on the fp16 attention kernels throughout, so
+// a KL delta against the fp16 baseline is attributable to that one side's
+// quantization alone.
+// head selects a single KV head for cell-granular attribution (census);
+// ~0u round-trips every head of the selected side. Mode 3 (step-4
+// exception probe) round-trips BOTH sides and reuses head as a per-layer
+// 8-bit exception mask (bit = head*2 + side): set bits stay clean fp16.
+// Mode 4 (fp8-KV control arm) round-trips BOTH sides of every head
+// through the e4m3 grid; head is ignored. Transform-free, so this arm is
+// production-exact — see q27_e4m3_roundtrip.
+// flags: step-2 scaling
+// arms (docs/plans/2026-07-16-kv-codec-step2.md) — SCALE32 keeps the
+// group scale in f32 through the round-trip, FEATURE descales each
+// dimension by aux[scale_off + side/head/dim] before the quantizer and
+// rescales after the inverse transform, STATS stores clean fp16 while
+// accumulating per-feature sum-of-squares for BOTH sides into aux
+// (atomic f32). aux layout: [side(K=0,V=1)][attn_idx][head][256 dims].
+constant uint Q27_ATTRIB_SCALE32 = 1;
+constant uint Q27_ATTRIB_FEATURE = 2;
+constant uint Q27_ATTRIB_STATS   = 4;
+struct TurboAttribArgs { uint position; uint kv_heads; uint tokens; uint mode; uint head;
+                         uint flags; uint scale_off; };
+kernel void q27_kv_store_f16_attrib_rows(device const float *k [[buffer(0)]],
+                                          device const float *v [[buffer(1)]],
+                                          device half *kc [[buffer(2)]],
+                                          device half *vc [[buffer(3)]],
+                                          constant TurboAttribArgs &args [[buffer(4)]],
+                                          device float *aux [[buffer(5)]],
+                                          uint3 group [[threadgroup_position_in_grid]],
+                                          uint j [[thread_index_in_threadgroup]]) {
+    const uint h = group.x >> 1, g = group.x & 1, token = group.z;
+    if (h >= args.kv_heads || group.y >= 2 || token >= args.tokens) return;
+    device const float *src = (group.y ? v : k) +
+        (ulong)token * args.kv_heads * 256 + (ulong)h * 256 + g * 128;
+    device half *dst = (group.y ? vc : kc) +
+        (ulong)(args.position + token) * args.kv_heads * 256 + (ulong)h * 256 + g * 128;
+    const uint aux_at = args.scale_off + group.y * 16384u + h * 256u + g * 128u + j;
+    if (args.flags & Q27_ATTRIB_STATS) {
+        // Stats pass: the stored cache stays clean fp16 (the subject IS the
+        // baseline; its KL rides along as a zero canary) while per-feature
+        // sum-of-squares accumulates for BOTH sides.
+        atomic_fetch_add_explicit((device atomic_float *)&aux[aux_at],
+                                  src[j] * src[j], memory_order_relaxed);
+        dst[j] = half(src[j]);
+        return;
+    }
+    // group.y and h are uniform across the threadgroup, so these early
+    // exits and the barriers below never diverge within a threadgroup.
+    // Mode 3 (step-4 exception probe): quantize BOTH sides unless this
+    // (head, side) bit is set in the per-layer exception mask riding
+    // args.head — bit = head*2 + side, matching census cell numbering.
+    if (args.mode == 4u) { dst[j] = half(q27_e4m3_roundtrip(src[j])); return; }
+    if (args.mode == 3u) {
+        if (args.head & (1u << (h * 2u + group.y))) { dst[j] = half(src[j]); return; }
+    } else if (args.mode != (group.y ? 2u : 1u) ||
+               (args.head != ~0u && h != args.head)) { dst[j] = half(src[j]); return; }
+    const float sj = (args.flags & Q27_ATTRIB_FEATURE) ? aux[aux_at] : 1.0f;
+    threadgroup float xs[128], red[128];
+    const float x0 = src[j] / sj;
+    xs[j] = x0; red[j] = x0 * x0;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint s = 64; s; s >>= 1) {
+        if (j < s) red[j] += red[j + s];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    const float norm = sqrt(red[0]);
+    xs[j] = xs[j] * (norm > 1e-10f ? 1.0f / norm : 0.0f) * float(turbo_s1[j]);
+    turbo_butterfly(xs, j);
+    const uint index = turbo_nearest(xs[j] * turbo_inv_sqrt_128 * float(turbo_s2[j]));
+    red[j] = turbo_centroids[index] * turbo_centroids[index];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    for (uint s = 64; s; s >>= 1) {
+        if (j < s) red[j] += red[j + s];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    // The group scale passes through half exactly as the packed block header
+    // does — unless the SCALE32 arm keeps it f32 to isolate scale precision
+    // from scale structure.
+    const float cn = sqrt(red[0]);
+    const float raw_scale = cn > 1e-10f ? norm / cn : norm;
+    const float scale = (args.flags & Q27_ATTRIB_SCALE32) ? raw_scale : float(half(raw_scale));
+    xs[j] = turbo_centroids[index] * scale * float(turbo_s2[j]);
+    turbo_butterfly(xs, j);
+    dst[j] = half(xs[j] * turbo_inv_sqrt_128 * float(turbo_s1[j]) * sj);
+}
+
 // Chunk-causal turbo3 attention, online-softmax. Mirrors the turbo3 decode
 // kernel exactly — one threadgroup per (query head, chunk token), eight
 // simdgroups striping the token's visible sequence — so a chunk token's
@@ -2742,9 +4986,76 @@ kernel void q27_attention_gqa_merge_rows(device const float *partials [[buffer(0
         out[((ulong)token * args.q_heads + qh) * args.head_dim + d] = acc[i] * inv;
 }
 
-// Token-tiled causal GQA. The production factor-2 route shares each
-// dequantized KV tile across two teacher-forced tokens while preserving each
-// token's arithmetic order and the existing partials merge layout.
+// ---- Cache-block scheduling R1/R1b kernels ----
+// (docs/plans/2026-07-15-cache-block-scheduling.md, Phase 0 results.)
+// R1 (head-major layout) measured 1.00x and is PARKED — its probe kernel
+// stays bench-only (build/metal_attn_bench), never engine-routed. R1b
+// (token-tiled causal, factor 2) measured 2.0x at 32K+ and is production:
+// the causal GQA dispatch routes through the _t2 kernels.
+
+// R1 probe (parked): head-major turbo3 KV layout. Identical math to
+// q27_attention_turbo3_gqa — only the cache addressing changes. Rows of one
+// KV head are contiguous ((kvh * seq_cap + pos) * 100 bytes), so a
+// (kvh, blk) threadgroup streams one ~102 KB run instead of 100 B picks at
+// 400 B stride. Output must be bit-identical to the interleaved kernel on
+// relaid-out data (the bench memcmps before timing).
+struct AttentionGqaHmArgs {
+    uint q_stride; uint seq_len; uint seq_cap; uint q_heads; uint kv_heads;
+    uint head_dim; uint block; uint n_blocks; float scale;
+};
+
+kernel void q27_attention_turbo3_gqa_hm(device const float *q [[buffer(0)]],
+                                         device const uchar *kc [[buffer(1)]],
+                                         device const uchar *vc [[buffer(2)]],
+                                         device float *partials [[buffer(3)]],
+                                         constant AttentionGqaHmArgs &args [[buffer(4)]],
+                                         uint2 group [[threadgroup_position_in_grid]],
+                                         ushort lane [[thread_index_in_simdgroup]],
+                                         ushort sg [[simdgroup_index_in_threadgroup]]) {
+    const uint kvh = group.x, blk = group.y;
+    const uint gqa = args.q_heads / args.kv_heads;
+    if (kvh >= args.kv_heads || blk >= args.n_blocks || sg >= gqa) return;
+    const uint p0 = blk * args.block;
+    const uint p1 = min(p0 + args.block, args.seq_len);
+    const uint qh = kvh * gqa + sg;
+    device const float *qh_ptr = q + (ulong)qh * args.q_stride;
+    const uint tid = (uint)sg * 32 + lane, threads = gqa * 32;
+
+    threadgroup float Kt[8][256], Vt[8][256];
+    float acc[8];
+    for (uint i = 0; i < 8; i++) acc[i] = 0.0f;
+    float m = -INFINITY, l = 0.0f;
+    device const uchar *khead = kc + (ulong)kvh * args.seq_cap * 100;
+    device const uchar *vhead = vc + (ulong)kvh * args.seq_cap * 100;
+    for (uint t0 = p0; t0 < p1; t0 += 8) {
+        const uint rows = min(8u, p1 - t0);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint idx = tid; idx < rows * 256; idx += threads) {
+            const uint r = idx >> 8, d = idx & 255;
+            device const uchar *kb = khead + (ulong)(t0 + r) * 100;
+            device const uchar *vb = vhead + (ulong)(t0 + r) * 100;
+            Kt[r][d] = turbo_dequant(kb + (d >> 7) * 50, d & 127);
+            Vt[r][d] = turbo_dequant(vb + (d >> 7) * 50, d & 127);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint r = 0; r < rows; r++) {
+            float partial = 0.0f;
+            for (uint d = lane; d < 256; d += 32) partial += qh_ptr[d] * Kt[r][d];
+            const float score = simd_sum(partial) * args.scale;
+            const float m_new = max(m, score);
+            const float correction = exp(m - m_new);
+            const float weight = exp(score - m_new);
+            l = l * correction + weight;
+            for (uint d = lane, i = 0; d < 256; d += 32, i++)
+                acc[i] = acc[i] * correction + weight * Vt[r][d];
+            m = m_new;
+        }
+    }
+    device float *ph = partials + ((ulong)qh * args.n_blocks + blk) * 258;
+    if (lane == 0) { ph[0] = m; ph[1] = l; }
+    for (uint d = lane, i = 0; d < 256; d += 32, i++) ph[2 + d] = acc[i];
+}
+
 // R1b: token-tiled causal GQA. TF chunk tokens share one (kvh, blk)
 // threadgroup: each staged 8-row tile is dequantized once and every resident
 // token's per-simdgroup online softmax walks it in token order — the KV
@@ -2771,11 +5082,9 @@ inline void turbo3_causal_gqa_tiled_body(device const float *q,
     if (kvh >= args.kv_heads || tile0 >= args.tokens || sg >= gqa) return;
     const uint live = min(TF, args.tokens - tile0);
     const uint p0 = blk * args.block;
-    // Exclusive sequence length for the deepest live token. `base_len` is
-    // already position + 1, so this includes that token's newest KV row.
-    const uint max_seq_len = args.base_len + tile0 + live - 1;
-    if (p0 >= max_seq_len) return;
-    const uint p1 = min(p0 + args.block, max_seq_len);
+    const uint seq_last = args.base_len + tile0 + live - 1;   // deepest token's visible length
+    if (p0 >= seq_last) return;
+    const uint p1 = min(p0 + args.block, seq_last);
     const uint qh = kvh * gqa + sg;
     const uint tid = (uint)sg * 32 + lane, threads = gqa * 32;
     device const float *qp[TF];
@@ -2836,6 +5145,98 @@ inline void turbo3_causal_gqa_tiled_body(device const float *q,
         for (uint d = lane, i = 0; d < 256; d += 32, i++) ph[2 + d] = acc[f][i];
     }
 }
+
+// R3 probe: barrier-free direct-read block-partial causal GQA attention
+// (docs/plans/2026-07-16-r3-barrier-free-attention.md). The tiled body with
+// the threadgroup staging and both barriers deleted: each lane dequantizes
+// its 8 K dims and 8 V dims per position directly from device into
+// registers, in the same element order (d = lane + 32·i) as the staged
+// kernels — so per-token arithmetic is unchanged and the output is
+// bit-identical to the t2 kernel at equal block size (the bench memcmps
+// before timing). Six simdgroups per threadgroup, one per GQA query head,
+// share nothing; each KV row is read gqa times (~600 B vs 100 B staged),
+// inside the byte range the fp16 A/B proved latency-tolerant. Block size
+// arrives via args.block (host override on the probe entry) — the sweep is
+// the experiment.
+template <uint TF>
+inline void turbo3_causal_gqa_bf_body(device const float *q,
+                                       device const uchar *kc,
+                                       device const uchar *vc,
+                                       device float *partials,
+                                       constant AttentionGqaCausalArgs &args,
+                                       uint3 group, ushort lane, ushort sg) {
+    const uint kvh = group.x, blk = group.y, tile0 = group.z * TF;
+    const uint gqa = args.q_heads / args.kv_heads;
+    if (kvh >= args.kv_heads || tile0 >= args.tokens || sg >= gqa) return;
+    const uint live = min(TF, args.tokens - tile0);
+    const uint p0 = blk * args.block;
+    const uint seq_last = args.base_len + tile0 + live - 1;   // deepest token's visible length
+    if (p0 >= seq_last) return;
+    const uint p1 = min(p0 + args.block, seq_last);
+    const uint qh = kvh * gqa + sg;
+    device const float *qp[TF];
+    for (uint f = 0; f < TF; f++)
+        qp[f] = q + (ulong)(tile0 + min(f, live - 1)) * args.q_row_stride + (ulong)qh * args.q_stride;
+
+    float acc[TF][8];
+    float m[TF], l[TF];
+    for (uint f = 0; f < TF; f++) {
+        m[f] = -INFINITY; l[f] = 0.0f;
+        for (uint i = 0; i < 8; i++) acc[f][i] = 0.0f;
+    }
+    for (uint pos = p0; pos < p1; pos++) {
+        device const uchar *kb = kc + ((ulong)pos * args.kv_heads + kvh) * 2 * 50;
+        device const uchar *vb = vc + ((ulong)pos * args.kv_heads + kvh) * 2 * 50;
+        float kv[8], vv[8];
+        for (uint d = lane, i = 0; d < 256; d += 32, i++)
+            kv[i] = turbo_dequant(kb + (d >> 7) * 50, d & 127);
+        for (uint d = lane, i = 0; d < 256; d += 32, i++)
+            vv[i] = turbo_dequant(vb + (d >> 7) * 50, d & 127);
+        float partial[TF];
+        for (uint f = 0; f < TF; f++) partial[f] = 0.0f;
+        for (uint d = lane, i = 0; d < 256; d += 32, i++) {
+            const float k = kv[i];
+            for (uint f = 0; f < TF; f++) partial[f] += qp[f][d] * k;
+        }
+        float corr[TF], w[TF];
+        bool vis[TF];
+        for (uint f = 0; f < TF; f++) {
+            vis[f] = f < live && pos < args.base_len + tile0 + f;
+            corr[f] = 1.0f; w[f] = 0.0f;
+            if (vis[f]) {
+                const float score = simd_sum(partial[f]) * args.scale;
+                const float m_new = max(m[f], score);
+                corr[f] = exp(m[f] - m_new);            // first iteration: exp(-inf) = 0
+                w[f] = exp(score - m_new);
+                l[f] = l[f] * corr[f] + w[f];
+                m[f] = m_new;
+            }
+        }
+        for (uint i = 0; i < 8; i++) {
+            const float v = vv[i];
+            for (uint f = 0; f < TF; f++)
+                if (vis[f]) acc[f][i] = acc[f][i] * corr[f] + w[f] * v;
+        }
+    }
+    for (uint f = 0; f < live; f++) {
+        if (p0 >= args.base_len + tile0 + f) continue;    // merge never reads this slot
+        device float *ph = partials +
+            (((ulong)(tile0 + f) * args.q_heads + qh) * args.n_blocks_max + blk) * 258;
+        if (lane == 0) { ph[0] = m[f]; ph[1] = l[f]; }
+        for (uint d = lane, i = 0; d < 256; d += 32, i++) ph[2 + d] = acc[f][i];
+    }
+}
+
+kernel void q27_attention_turbo3_causal_gqa_bf2(device const float *q [[buffer(0)]],
+        device const uchar *kc [[buffer(1)]], device const uchar *vc [[buffer(2)]],
+        device float *partials [[buffer(3)]],
+        constant AttentionGqaCausalArgs &args [[buffer(4)]],
+        uint3 group [[threadgroup_position_in_grid]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    turbo3_causal_gqa_bf_body<2>(q, kc, vc, partials, args, group, lane, sg);
+}
+
 kernel void q27_attention_turbo3_causal_gqa_t2(device const float *q [[buffer(0)]],
         device const uchar *kc [[buffer(1)]], device const uchar *vc [[buffer(2)]],
         device float *partials [[buffer(3)]],
@@ -2846,6 +5247,18 @@ kernel void q27_attention_turbo3_causal_gqa_t2(device const float *q [[buffer(0)
     threadgroup float Kt[8][256], Vt[8][256];
     turbo3_causal_gqa_tiled_body<2>(q, kc, vc, partials, args, group, lane, sg, Kt, Vt);
 }
+
+kernel void q27_attention_turbo3_causal_gqa_t4(device const float *q [[buffer(0)]],
+        device const uchar *kc [[buffer(1)]], device const uchar *vc [[buffer(2)]],
+        device float *partials [[buffer(3)]],
+        constant AttentionGqaCausalArgs &args [[buffer(4)]],
+        uint3 group [[threadgroup_position_in_grid]],
+        ushort lane [[thread_index_in_simdgroup]],
+        ushort sg [[simdgroup_index_in_threadgroup]]) {
+    threadgroup float Kt[8][256], Vt[8][256];
+    turbo3_causal_gqa_tiled_body<4>(q, kc, vc, partials, args, group, lane, sg, Kt, Vt);
+}
+
 // fp16 token-tiled causal GQA: the same tiling transform applied to
 // q27_attention_f16_causal_gqa — head_dim-parametric staging and d-loops
 // mirror the untiled kernel expression-for-expression so per-token output
@@ -2864,11 +5277,9 @@ inline void f16_causal_gqa_tiled_body(device const float *q,
     if (kvh >= args.kv_heads || tile0 >= args.tokens || sg >= gqa) return;
     const uint live = min(TF, args.tokens - tile0);
     const uint p0 = blk * args.block;
-    // Exclusive sequence length for the deepest live token. `base_len` is
-    // already position + 1, so this includes that token's newest KV row.
-    const uint max_seq_len = args.base_len + tile0 + live - 1;
-    if (p0 >= max_seq_len) return;
-    const uint p1 = min(p0 + args.block, max_seq_len);
+    const uint seq_last = args.base_len + tile0 + live - 1;
+    if (p0 >= seq_last) return;
+    const uint p1 = min(p0 + args.block, seq_last);
     const uint qh = kvh * gqa + sg;
     const uint tid = (uint)sg * 32 + lane, threads = gqa * 32;
     device const float *qp[TF];

--- a/src/metal/test_metal_engine_contracts.cpp
+++ b/src/metal/test_metal_engine_contracts.cpp
@@ -57,8 +57,8 @@ bool artifact_requires_per_tensor_upload(const char* path, uint64_t max_buffer_l
 } // namespace
 
 int main(int argc, char** argv) {
-    if (argc != 2) {
-        std::fprintf(stderr, "usage: %s model.q27\n", argv[0]);
+    if (argc != 3) {
+        std::fprintf(stderr, "usage: %s OFFICIAL.q27 BONSAI.q27\n", argv[0]);
         return 2;
     }
     try {
@@ -473,8 +473,27 @@ int main(int argc, char** argv) {
             std::fprintf(stderr, "cancelled MTP stream changed retry behavior\n");
             return 1;
         }
+        {
+            q27::MetalEngine bonsai(argv[2], 8, false);
+            if (bonsai.has_mtp())
+                throw std::runtime_error("Bonsai artifact unexpectedly exposed an MTP layer");
+            if (bonsai.chunked_prefill())
+                throw std::runtime_error("Bonsai enabled activation-quantized chunk prefill");
+            bool enable_rejected = false;
+            try {
+                bonsai.set_chunked_prefill(true);
+            } catch (const std::runtime_error&) {
+                enable_rejected = true;
+            }
+            if (!enable_rejected)
+                throw std::runtime_error("Bonsai accepted activation-quantized chunk prefill");
+            (void)bonsai.ingest_prompt({1, 1, 1}, false, true);
+            if (bonsai.position() != 3)
+                throw std::runtime_error("Bonsai serial prefill did not advance");
+        }
 
-        puts("Metal q4s engine contracts: OK");
+
+        puts("Metal q4s and Bonsai engine contracts: OK");
         return 0;
     } catch (const std::exception& error) {
         std::fprintf(stderr, "%s\n", error.what());

--- a/src/metal/test_metal_engine_contracts.cpp
+++ b/src/metal/test_metal_engine_contracts.cpp
@@ -57,8 +57,8 @@ bool artifact_requires_per_tensor_upload(const char* path, uint64_t max_buffer_l
 } // namespace
 
 int main(int argc, char** argv) {
-    if (argc != 3) {
-        std::fprintf(stderr, "usage: %s OFFICIAL.q27 BONSAI.q27\n", argv[0]);
+    if (argc != 2 && argc != 3) {
+        std::fprintf(stderr, "usage: %s OFFICIAL.q27 [BONSAI.q27]\n", argv[0]);
         return 2;
     }
     try {
@@ -473,7 +473,7 @@ int main(int argc, char** argv) {
             std::fprintf(stderr, "cancelled MTP stream changed retry behavior\n");
             return 1;
         }
-        {
+        if (argc == 3) {
             q27::MetalEngine bonsai(argv[2], 8, false);
             if (bonsai.has_mtp())
                 throw std::runtime_error("Bonsai artifact unexpectedly exposed an MTP layer");
@@ -490,10 +490,12 @@ int main(int argc, char** argv) {
             (void)bonsai.ingest_prompt({1, 1, 1}, false, true);
             if (bonsai.position() != 3)
                 throw std::runtime_error("Bonsai serial prefill did not advance");
+            puts("Bonsai engine contracts: OK");
+        } else {
+            puts("Bonsai engine contracts: SKIP (set BONSAI_MODEL to enable)");
         }
 
-
-        puts("Metal q4s and Bonsai engine contracts: OK");
+        puts("Metal q4s engine contracts: OK");
         return 0;
     } catch (const std::exception& error) {
         std::fprintf(stderr, "%s\n", error.what());

--- a/tools/repack.py
+++ b/tools/repack.py
@@ -10,9 +10,9 @@ Usage:
 Ternary source packs (PrismML fork "Q2_0", ggml type 42) are detected
 automatically and repacked losslessly to T2_G128 (quant_policy bonsai-t2-v1);
 see docs/FORMAT.md and docs/metal/plans/2026-07-14-ternary-tier.md for the encoding.
-Binary source packs (fork "Q1_0", ggml type 41, non-dspark arch) likewise
-repack losslessly to B1_G128 (quant_policy bonsai-b1-v1);
-see docs/metal/plans/2026-07-15-binary-tier.md.
+Binary source packs (fork "Q1_0", ggml type 41) likewise repack losslessly
+to B1_G128 (quant_policy bonsai-b1-v1); see
+docs/metal/plans/2026-07-15-binary-tier.md.
 """
 import argparse
 import json
@@ -47,10 +47,10 @@ ALIGN = 256
 
 # dtype 5 is reserved for the parked T3_G128 (never emitted; see FORMAT.md).
 DTYPE_F32, DTYPE_F16, DTYPE_Q8, DTYPE_Q4, DTYPE_T2 = 0, 1, 2, 3, 4
-DTYPE_B1, DTYPE_Q41 = 6, 7
+DTYPE_B1 = 6
 DTYPE_NAMES = {DTYPE_F32: "F32", DTYPE_F16: "F16", DTYPE_Q8: "Q8_G128", DTYPE_Q4: "Q4_G64",
-               DTYPE_T2: "T2_G128", DTYPE_B1: "B1_G128", DTYPE_Q41: "Q4_1_G32"}
-GROUP_Q4, GROUP_Q8, GROUP_T2, GROUP_B1, GROUP_Q41 = 64, 128, 128, 128, 32
+               DTYPE_T2: "T2_G128", DTYPE_B1: "B1_G128"}
+GROUP_Q4, GROUP_Q8, GROUP_T2, GROUP_B1 = 64, 128, 128, 128
 
 
 Q8_EXTRA = None  # set from --q8 (v1.4 sensitivity experiments)
@@ -211,51 +211,6 @@ def repack_b1(t):
     return qs.tobytes(), scales.tobytes()
 
 
-def repack_q41(t):
-    """Mainline Q4_1 tensor -> (data, scales). Lossless byte-copy (Q4_1_G32, dtype 7).
-
-    Source blocks are {fp16 d; fp16 m; uint8 qs[16]} x (n/32); low nibble of
-    qs[j] is element j, high nibble is element j+16, and both decode to
-    q*d + m (dequantize_row_q4_1, mainline layout confirmed at the fork tag).
-    Q4_1_G32 keeps the code bytes verbatim; the scale blob is the contiguous
-    {d, m} fp16 pairs, one pair per 32-element group. Round-trip verified.
-    """
-    shape = tuple(reversed([int(d) for d in t.shape]))
-    rows, cols = int(np.prod(shape[:-1])), shape[-1]
-    if cols % GROUP_Q41 != 0:  # hard contract, must survive python -O (codex P2)
-        raise ValueError(f"{t.name}: cols {cols} not divisible by {GROUP_Q41}")
-    nblocks = rows * cols // GROUP_Q41
-    blocks = np.asarray(t.data).reshape(nblocks, 20)
-    scales = blocks[:, :4].copy()                       # {d, m} fp16 LE pairs
-    qs = np.ascontiguousarray(blocks[:, 4:])            # [nblocks, 16] nibble bytes
-
-    def _deq(code_bytes, dm_bytes, n_rows):
-        # nibble j -> element j (low) / j+16 (high) within each 32-group
-        q = code_bytes.reshape(n_rows, cols // GROUP_Q41, 16)
-        lo = (q & 0x0F).astype(np.float32)
-        hi = (q >> 4).astype(np.float32)
-        elems = np.concatenate([lo, hi], axis=-1)       # [rows, groups, 32]
-        dm = dm_bytes.reshape(n_rows, cols // GROUP_Q41, 2, 2).copy().view(np.float16)
-        d = dm[..., 0, 0].astype(np.float32)[..., None]
-        m = dm[..., 1, 0].astype(np.float32)[..., None]
-        return (elems * d + m).reshape(n_rows, cols)
-
-    qs_rows = qs.reshape(rows, cols // 2)
-    dm_rows = scales.reshape(rows, cols // GROUP_Q41 * 4)
-    step = max(1, (1 << 25) // cols)
-    for r0 in range(0, rows, step):
-        r1 = min(rows, r0 + step)
-        blk = blocks.reshape(rows, cols // GROUP_Q41, 20)[r0:r1]
-        deq_gguf = _deq(np.ascontiguousarray(blk[..., 4:]),
-                        np.ascontiguousarray(blk[..., :4]), r1 - r0)
-        deq_ours = _deq(np.ascontiguousarray(qs_rows[r0:r1]),
-                        np.ascontiguousarray(dm_rows[r0:r1]), r1 - r0)
-        if not np.array_equal(deq_gguf, deq_ours):
-            raise ValueError(f"{t.name}: Q4_1 round-trip mismatch in rows {r0}:{r1}")
-
-    return qs.tobytes(), scales.tobytes()
-
-
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("input")
@@ -278,19 +233,12 @@ def main():
     t0 = time.time()
     r = GGUFReader(args.input)
     ternary = any(t.tensor_type.name == "Q2_0" for t in r.tensors)
-    arch = r.fields["general.architecture"].contents()
-    if isinstance(arch, bytes):
-        arch = arch.decode()
-    dspark = arch == "dspark"
-    if dspark and ternary:
-        raise ValueError("dspark pack unexpectedly contains ternary (Q2_0) tensors")
-    binary = not dspark and any(t.tensor_type.name == "Q1_0" for t in r.tensors)
+    binary = any(t.tensor_type.name == "Q1_0" for t in r.tensors)
     if binary and ternary:
         raise ValueError("pack unexpectedly contains both binary (Q1_0) and ternary (Q2_0) tensors")
 
     meta = {"q27_version": VERSION,
-            "quant_policy": args.tag or ("dspark-q41-v1" if dspark
-                                         else "bonsai-t2-v1" if ternary
+            "quant_policy": args.tag or ("bonsai-t2-v1" if ternary
                                          else "bonsai-b1-v1" if binary
                                          else "v1.4" if args.q8 else "v1.3"),
             "group_q4": GROUP_Q4, "group_q8": GROUP_Q8, "nibble_order": "even=low"}
@@ -298,23 +246,18 @@ def main():
         meta["group_t2"] = GROUP_T2
         meta["t2_codes"] = "0=-1,1=0,2=+1;3 forbidden"
         meta["t2_slot_order"] = "seq-lsb-first"
-    if dspark or binary:
+    if binary:
         # Verbatim fork Q1_0 encoding; see the repack_b1 docstring and the
         # binary-tier plan.
         meta["group_b1"] = GROUP_B1
         meta["b1_codes"] = "1=+d,0=-d"
         meta["b1_bit_order"] = "seq-lsb-first"
-    if dspark:
-        # Verbatim mainline Q4_1 encoding; BF16 sources widen exactly to F32.
-        meta["group_q41"] = GROUP_Q41
-        meta["q41_scales"] = "{d,m} fp16 pairs per group"
-        meta["q41_nibble_order"] = "low=elems 0-15, high=elems 16-31"
     if args.q8:
         meta["q8_extra"] = args.q8
     if args.q4_head:
         meta["q4_head"] = True
     for f in r.fields.values():
-        if f.name.startswith(("qwen35.", "dspark.", "general.architecture", "general.name")):
+        if f.name.startswith(("qwen35.", "general.architecture", "general.name")):
             try:
                 v = f.contents()
                 if isinstance(v, bytes):
@@ -343,10 +286,10 @@ def main():
 
     extra = []
     for t in r.tensors:
-        # MTP draft head copy: only for non-quantized-head packs AND only for
-        # pack types that carry MTP (no MTP in ternary/binary/dspark packs).
+        # MTP draft head copy: only for non-quantized-head packs and pack
+        # types that carry MTP (no MTP in ternary/binary packs).
         if t.name == "output.weight" and not args.q4_head \
-                and not ternary and not dspark and not binary:
+                and not ternary and not binary:
             extra.append(("output_q4.weight", t))
     class _Alias:
         def __init__(self, name, t):
@@ -359,10 +302,8 @@ def main():
         verbatim = None  # (dtype, repack_fn) for lossless byte-copy source types
         if t.tensor_type.name == "Q2_0":
             verbatim = (DTYPE_T2, repack_t2)
-        elif (dspark or binary) and t.tensor_type.name == "Q1_0":
+        elif binary and t.tensor_type.name == "Q1_0":
             verbatim = (DTYPE_B1, repack_b1)
-        elif dspark and t.tensor_type.name == "Q4_1":
-            verbatim = (DTYPE_Q41, repack_q41)
         if verbatim is not None:
             vdt, fn = verbatim
             shape = tuple(reversed([int(d) for d in t.shape]))
@@ -389,14 +330,9 @@ def main():
         if binary and t.tensor_type.name != "F32":
             raise ValueError(f"{t.name}: unexpected source type {t.tensor_type.name} in a "
                              f"binary pack (expected Q1_0 or F32 only)")
-        if dspark and t.tensor_type.name not in ("F32", "BF16"):
-            raise ValueError(f"{t.name}: unexpected source type {t.tensor_type.name} in the "
-                             f"dspark pack (expected Q4_1, Q1_0, BF16, or F32 only)")
         w = to_f32(t)
         n_bytes_in += w.nbytes
-        # dspark: everything not byte-copied above widens exactly to F32
-        # (BF16 -> F32 is lossless); the name policy must not requantize.
-        dt = DTYPE_F32 if dspark else policy(t.name)
+        dt = policy(t.name)
         if dt == DTYPE_Q4 and w.shape[-1] % GROUP_Q4 != 0:
             dt = DTYPE_F16  # fallback, shouldn't happen on this model
         if dt == DTYPE_Q8 and w.shape[-1] % GROUP_Q8 != 0:

--- a/tools/repack.py
+++ b/tools/repack.py
@@ -6,6 +6,13 @@ Usage:
 
 --only limits to tensors matching REGEX (smoke tests).
 --report prints the N worst tensors by relative RMSE after quantization.
+
+Ternary source packs (PrismML fork "Q2_0", ggml type 42) are detected
+automatically and repacked losslessly to T2_G128 (quant_policy bonsai-t2-v1);
+see docs/FORMAT.md and docs/metal/plans/2026-07-14-ternary-tier.md for the encoding.
+Binary source packs (fork "Q1_0", ggml type 41, non-dspark arch) likewise
+repack losslessly to B1_G128 (quant_policy bonsai-b1-v1);
+see docs/metal/plans/2026-07-15-binary-tier.md.
 """
 import argparse
 import json
@@ -15,15 +22,35 @@ import sys
 import time
 
 import numpy as np
+import gguf.constants as _ggc
 from gguf import GGUFReader
+
+# The PrismML fork's types are absent from mainline gguf-py; forge the enum
+# members so GGUFReader can parse their packs. (block_size, type_size) per
+# ggml/src/ggml-common.h at tag prism-b9591-62061f9.
+def _forge_fork_type(name, value, blck, tsize):
+    if value in _ggc.GGMLQuantizationType._value2member_map_:
+        return _ggc.GGMLQuantizationType(value)
+    m = int.__new__(_ggc.GGMLQuantizationType, value)
+    m._name_, m._value_ = name, value
+    _ggc.GGMLQuantizationType._member_map_[name] = m
+    _ggc.GGMLQuantizationType._value2member_map_[value] = m
+    _ggc.GGML_QUANT_SIZES[m] = (blck, tsize)
+    return m
+
+_forge_fork_type("Q2_0", 42, 128, 34)
+_forge_fork_type("Q1_0", 41, 128, 18)
 
 MAGIC = 0x46373251  # "Q27F" LE
 VERSION = 1
 ALIGN = 256
 
-DTYPE_F32, DTYPE_F16, DTYPE_Q8, DTYPE_Q4 = 0, 1, 2, 3
-DTYPE_NAMES = {DTYPE_F32: "F32", DTYPE_F16: "F16", DTYPE_Q8: "Q8_G128", DTYPE_Q4: "Q4_G64"}
-GROUP_Q4, GROUP_Q8 = 64, 128
+# dtype 5 is reserved for the parked T3_G128 (never emitted; see FORMAT.md).
+DTYPE_F32, DTYPE_F16, DTYPE_Q8, DTYPE_Q4, DTYPE_T2 = 0, 1, 2, 3, 4
+DTYPE_B1, DTYPE_Q41 = 6, 7
+DTYPE_NAMES = {DTYPE_F32: "F32", DTYPE_F16: "F16", DTYPE_Q8: "Q8_G128", DTYPE_Q4: "Q4_G64",
+               DTYPE_T2: "T2_G128", DTYPE_B1: "B1_G128", DTYPE_Q41: "Q4_1_G32"}
+GROUP_Q4, GROUP_Q8, GROUP_T2, GROUP_B1, GROUP_Q41 = 64, 128, 128, 128, 32
 
 
 Q8_EXTRA = None  # set from --q8 (v1.4 sensitivity experiments)
@@ -94,6 +121,141 @@ def quant_q8(w: np.ndarray):
     return q.tobytes(), scale.astype(np.float16).tobytes(), deq
 
 
+def repack_t2(t):
+    """Fork Q2_0 tensor -> (data, scales, zero_frac). Lossless byte-copy.
+
+    Source blocks are {fp16 d; uint8 qs[32]} x (n/128); codes are sequential
+    LSB-first 2-bit fields, code c decodes to (c-1)*d. T2_G128 keeps the code
+    bytes verbatim and splits scales into the usual contiguous fp16 blob, so
+    the round-trip is exact by construction — still verified below.
+    Hard-fails on code 3 (+2): the Bonsai packs must be strictly ternary.
+    """
+    shape = tuple(reversed([int(d) for d in t.shape]))  # ne[0] innermost -> last
+    rows, cols = int(np.prod(shape[:-1])), shape[-1]
+    if cols % GROUP_T2 != 0:  # hard contract, must survive python -O (codex P2)
+        raise ValueError(f"{t.name}: cols {cols} not divisible by {GROUP_T2}")
+    nblocks = rows * cols // GROUP_T2
+    blocks = np.asarray(t.data).reshape(nblocks, 34)
+    scales = blocks[:, :2].copy()                       # fp16 LE bytes, [rows, cols/128]
+    qs = np.ascontiguousarray(blocks[:, 2:])            # [nblocks, 32] code bytes
+
+    n_zero = 0
+    for shift in (0, 2, 4, 6):
+        c = (qs >> shift) & 3
+        if np.any(c == 3):
+            raise ValueError(f"{t.name}: code 3 (+2) present — pack is not strictly ternary; "
+                             f"T2_G128 cannot represent it losslessly as ternary")
+        n_zero += int(np.count_nonzero(c == 1))
+    zero_frac = n_zero / (rows * cols)
+
+    # Round-trip gate: dequantize the GGUF blocks per the fork's reference
+    # (dequantize_row_q2_0) and our (data, scales) blobs per FORMAT.md, compare
+    # bit-exact, chunked by rows to bound memory on token_embd.
+    d_f32 = scales.view(np.float16).astype(np.float32).reshape(rows, cols // GROUP_T2)
+    qs_rows = qs.reshape(rows, cols // 4)
+    step = max(1, (1 << 25) // cols)  # ~128 MB f32 per chunk
+    for r0 in range(0, rows, step):
+        r1 = min(rows, r0 + step)
+        blk = blocks.reshape(rows, cols // GROUP_T2, 34)[r0:r1]
+        codes_g = np.stack([(blk[..., 2:] >> s) & 3 for s in (0, 2, 4, 6)],
+                           axis=-1).reshape(r1 - r0, cols)
+        deq_gguf = ((codes_g.astype(np.float32) - 1.0)
+                    * np.repeat(blk[..., :2].copy().view(np.float16).astype(np.float32)
+                                .reshape(r1 - r0, cols // GROUP_T2), GROUP_T2, axis=1))
+        q = qs_rows[r0:r1]
+        codes_o = np.stack([(q >> s) & 3 for s in (0, 2, 4, 6)], axis=-1).reshape(r1 - r0, cols)
+        deq_ours = ((codes_o.astype(np.float32) - 1.0)
+                    * np.repeat(d_f32[r0:r1], GROUP_T2, axis=1))
+        if not np.array_equal(deq_gguf, deq_ours):
+            raise ValueError(f"{t.name}: T2 round-trip mismatch in rows {r0}:{r1}")
+
+    return qs.tobytes(), scales.tobytes(), zero_frac
+
+
+def repack_b1(t):
+    """Fork Q1_0 tensor -> (data, scales). Lossless byte-copy (B1_G128, dtype 6).
+
+    Source blocks are {fp16 d; uint8 qs[16]} x (n/128); bit j of a group lives
+    at qs[j/8] bit (j%8) — sequential LSB-first like type 42 — and decodes to
+    (2b-1)*d (dequantize_row_q1_0 at tag prism-b9591-62061f9). B1_G128 keeps
+    the code bytes verbatim and splits scales into the contiguous fp16 blob,
+    exactly the binary-tier plan's Phase-1 layout. Round-trip verified below.
+    """
+    shape = tuple(reversed([int(d) for d in t.shape]))  # ne[0] innermost -> last
+    rows, cols = int(np.prod(shape[:-1])), shape[-1]
+    if cols % GROUP_B1 != 0:  # hard contract, must survive python -O (codex P2)
+        raise ValueError(f"{t.name}: cols {cols} not divisible by {GROUP_B1}")
+    nblocks = rows * cols // GROUP_B1
+    blocks = np.asarray(t.data).reshape(nblocks, 18)
+    scales = blocks[:, :2].copy()                       # fp16 LE bytes
+    qs = np.ascontiguousarray(blocks[:, 2:])            # [nblocks, 16] code bytes
+
+    d_f32 = scales.view(np.float16).astype(np.float32).reshape(rows, cols // GROUP_B1)
+    qs_rows = qs.reshape(rows, cols // 8)
+    step = max(1, (1 << 25) // cols)  # ~128 MB f32 per chunk
+    for r0 in range(0, rows, step):
+        r1 = min(rows, r0 + step)
+        blk = blocks.reshape(rows, cols // GROUP_B1, 18)[r0:r1]
+        bits_g = np.unpackbits(blk[..., 2:], axis=-1,
+                               bitorder="little").reshape(r1 - r0, cols)
+        deq_gguf = ((bits_g.astype(np.float32) * 2.0 - 1.0)
+                    * np.repeat(blk[..., :2].copy().view(np.float16).astype(np.float32)
+                                .reshape(r1 - r0, cols // GROUP_B1), GROUP_B1, axis=1))
+        bits_o = np.unpackbits(qs_rows[r0:r1], axis=-1,
+                               bitorder="little").reshape(r1 - r0, cols)
+        deq_ours = ((bits_o.astype(np.float32) * 2.0 - 1.0)
+                    * np.repeat(d_f32[r0:r1], GROUP_B1, axis=1))
+        if not np.array_equal(deq_gguf, deq_ours):
+            raise ValueError(f"{t.name}: B1 round-trip mismatch in rows {r0}:{r1}")
+
+    return qs.tobytes(), scales.tobytes()
+
+
+def repack_q41(t):
+    """Mainline Q4_1 tensor -> (data, scales). Lossless byte-copy (Q4_1_G32, dtype 7).
+
+    Source blocks are {fp16 d; fp16 m; uint8 qs[16]} x (n/32); low nibble of
+    qs[j] is element j, high nibble is element j+16, and both decode to
+    q*d + m (dequantize_row_q4_1, mainline layout confirmed at the fork tag).
+    Q4_1_G32 keeps the code bytes verbatim; the scale blob is the contiguous
+    {d, m} fp16 pairs, one pair per 32-element group. Round-trip verified.
+    """
+    shape = tuple(reversed([int(d) for d in t.shape]))
+    rows, cols = int(np.prod(shape[:-1])), shape[-1]
+    if cols % GROUP_Q41 != 0:  # hard contract, must survive python -O (codex P2)
+        raise ValueError(f"{t.name}: cols {cols} not divisible by {GROUP_Q41}")
+    nblocks = rows * cols // GROUP_Q41
+    blocks = np.asarray(t.data).reshape(nblocks, 20)
+    scales = blocks[:, :4].copy()                       # {d, m} fp16 LE pairs
+    qs = np.ascontiguousarray(blocks[:, 4:])            # [nblocks, 16] nibble bytes
+
+    def _deq(code_bytes, dm_bytes, n_rows):
+        # nibble j -> element j (low) / j+16 (high) within each 32-group
+        q = code_bytes.reshape(n_rows, cols // GROUP_Q41, 16)
+        lo = (q & 0x0F).astype(np.float32)
+        hi = (q >> 4).astype(np.float32)
+        elems = np.concatenate([lo, hi], axis=-1)       # [rows, groups, 32]
+        dm = dm_bytes.reshape(n_rows, cols // GROUP_Q41, 2, 2).copy().view(np.float16)
+        d = dm[..., 0, 0].astype(np.float32)[..., None]
+        m = dm[..., 1, 0].astype(np.float32)[..., None]
+        return (elems * d + m).reshape(n_rows, cols)
+
+    qs_rows = qs.reshape(rows, cols // 2)
+    dm_rows = scales.reshape(rows, cols // GROUP_Q41 * 4)
+    step = max(1, (1 << 25) // cols)
+    for r0 in range(0, rows, step):
+        r1 = min(rows, r0 + step)
+        blk = blocks.reshape(rows, cols // GROUP_Q41, 20)[r0:r1]
+        deq_gguf = _deq(np.ascontiguousarray(blk[..., 4:]),
+                        np.ascontiguousarray(blk[..., :4]), r1 - r0)
+        deq_ours = _deq(np.ascontiguousarray(qs_rows[r0:r1]),
+                        np.ascontiguousarray(dm_rows[r0:r1]), r1 - r0)
+        if not np.array_equal(deq_gguf, deq_ours):
+            raise ValueError(f"{t.name}: Q4_1 round-trip mismatch in rows {r0}:{r1}")
+
+    return qs.tobytes(), scales.tobytes()
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("input")
@@ -115,16 +277,44 @@ def main():
 
     t0 = time.time()
     r = GGUFReader(args.input)
+    ternary = any(t.tensor_type.name == "Q2_0" for t in r.tensors)
+    arch = r.fields["general.architecture"].contents()
+    if isinstance(arch, bytes):
+        arch = arch.decode()
+    dspark = arch == "dspark"
+    if dspark and ternary:
+        raise ValueError("dspark pack unexpectedly contains ternary (Q2_0) tensors")
+    binary = not dspark and any(t.tensor_type.name == "Q1_0" for t in r.tensors)
+    if binary and ternary:
+        raise ValueError("pack unexpectedly contains both binary (Q1_0) and ternary (Q2_0) tensors")
 
     meta = {"q27_version": VERSION,
-            "quant_policy": args.tag or ("v1.4" if args.q8 else "v1.3"),
+            "quant_policy": args.tag or ("dspark-q41-v1" if dspark
+                                         else "bonsai-t2-v1" if ternary
+                                         else "bonsai-b1-v1" if binary
+                                         else "v1.4" if args.q8 else "v1.3"),
             "group_q4": GROUP_Q4, "group_q8": GROUP_Q8, "nibble_order": "even=low"}
+    if ternary:
+        meta["group_t2"] = GROUP_T2
+        meta["t2_codes"] = "0=-1,1=0,2=+1;3 forbidden"
+        meta["t2_slot_order"] = "seq-lsb-first"
+    if dspark or binary:
+        # Verbatim fork Q1_0 encoding; see the repack_b1 docstring and the
+        # binary-tier plan.
+        meta["group_b1"] = GROUP_B1
+        meta["b1_codes"] = "1=+d,0=-d"
+        meta["b1_bit_order"] = "seq-lsb-first"
+    if dspark:
+        # Verbatim mainline Q4_1 encoding; BF16 sources widen exactly to F32.
+        meta["group_q41"] = GROUP_Q41
+        meta["q41_scales"] = "{d,m} fp16 pairs per group"
+        meta["q41_nibble_order"] = "low=elems 0-15, high=elems 16-31"
     if args.q8:
         meta["q8_extra"] = args.q8
     if args.q4_head:
         meta["q4_head"] = True
     for f in r.fields.values():
-        if f.name.startswith(("qwen35.", "general.architecture", "general.name")):
+        if f.name.startswith(("qwen35.", "dspark.", "general.architecture", "general.name")):
             try:
                 v = f.contents()
                 if isinstance(v, bytes):
@@ -153,18 +343,60 @@ def main():
 
     extra = []
     for t in r.tensors:
-        if t.name == "output.weight" and not args.q4_head:
+        # MTP draft head copy: only for non-quantized-head packs AND only for
+        # pack types that carry MTP (no MTP in ternary/binary/dspark packs).
+        if t.name == "output.weight" and not args.q4_head \
+                and not ternary and not dspark and not binary:
             extra.append(("output_q4.weight", t))
     class _Alias:
         def __init__(self, name, t):
             self.name, self.tensor_type, self.data, self.shape = name, t.tensor_type, t.data, t.shape
     tensor_iter = list(r.tensors) + [_Alias(n, t) for n, t in extra]
+    zero_fracs = []
     for t in tensor_iter:
         if only and not only.search(t.name):
             continue
+        verbatim = None  # (dtype, repack_fn) for lossless byte-copy source types
+        if t.tensor_type.name == "Q2_0":
+            verbatim = (DTYPE_T2, repack_t2)
+        elif (dspark or binary) and t.tensor_type.name == "Q1_0":
+            verbatim = (DTYPE_B1, repack_b1)
+        elif dspark and t.tensor_type.name == "Q4_1":
+            verbatim = (DTYPE_Q41, repack_q41)
+        if verbatim is not None:
+            vdt, fn = verbatim
+            shape = tuple(reversed([int(d) for d in t.shape]))
+            out = fn(t)
+            if vdt == DTYPE_T2:
+                data, scales, zero_frac = out
+                zero_fracs.append((zero_frac, int(np.prod(shape)), t.name))
+            else:
+                data, scales = out
+            n_bytes_in += int(np.prod(shape)) * 4
+            n_bytes_out += len(data) + len(scales)
+            errors.append((0.0, t.name, DTYPE_NAMES[vdt]))  # lossless, gate-verified
+            data_off = offset
+            offset = (offset + len(data) + ALIGN - 1) // ALIGN * ALIGN
+            scale_off = offset
+            offset = (offset + len(scales) + ALIGN - 1) // ALIGN * ALIGN
+            entries.append((t.name, vdt, shape, data_off, len(data), scale_off, len(scales)))
+            blobs.append((data_off, data))
+            blobs.append((scale_off, scales))
+            continue
+        if ternary and t.tensor_type.name != "F32":
+            raise ValueError(f"{t.name}: unexpected source type {t.tensor_type.name} in a "
+                             f"ternary pack (expected Q2_0 or F32 only)")
+        if binary and t.tensor_type.name != "F32":
+            raise ValueError(f"{t.name}: unexpected source type {t.tensor_type.name} in a "
+                             f"binary pack (expected Q1_0 or F32 only)")
+        if dspark and t.tensor_type.name not in ("F32", "BF16"):
+            raise ValueError(f"{t.name}: unexpected source type {t.tensor_type.name} in the "
+                             f"dspark pack (expected Q4_1, Q1_0, BF16, or F32 only)")
         w = to_f32(t)
         n_bytes_in += w.nbytes
-        dt = policy(t.name)
+        # dspark: everything not byte-copied above widens exactly to F32
+        # (BF16 -> F32 is lossless); the name policy must not requantize.
+        dt = DTYPE_F32 if dspark else policy(t.name)
         if dt == DTYPE_Q4 and w.shape[-1] % GROUP_Q4 != 0:
             dt = DTYPE_F16  # fallback, shouldn't happen on this model
         if dt == DTYPE_Q8 and w.shape[-1] % GROUP_Q8 != 0:
@@ -227,6 +459,15 @@ def main():
     print(f"\nworst {args.report} tensors by relative RMSE:")
     for rmse, name, dtn in errors[:args.report]:
         print(f"  {rmse:.4f}  {dtn:8s} {name}")
+
+    if zero_fracs:
+        total = sum(n for _, n, _ in zero_fracs)
+        mean_zero = sum(z * n for z, n, _ in zero_fracs) / total
+        zero_fracs.sort()
+        print(f"\nT2 slot verification passed on {len(zero_fracs)} tensors "
+              f"({total/1e9:.2f} B ternary weights, {mean_zero:.1%} zeros overall)")
+        print(f"  least sparse: {zero_fracs[0][0]:.1%} {zero_fracs[0][2]}")
+        print(f"  most sparse:  {zero_fracs[-1][0]:.1%} {zero_fracs[-1][2]}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- extend the merged Metal backend and engine with production T2 ternary and B1 binary execution for 64-block Bonsai artifacts
- validate Bonsai quantization policy/layout, run serial float-activation prefill, and fail closed for unsupported chunked-prefill and MTP paths
- restore the lossless PrismML Q2_0/Q1_0 repacker so the exact q27 Bonsai artifact is reproducible from the public Apache-2.0 source pack
- preserve merged official q4s serving behavior and keep Bonsai-only contract coverage optional

## Base and review scope

PR #21 merged as `c82f6642f9c5a1d75b175a11657229638cfed1de`. This branch is based directly on that merge.

Review only these three commits above merged master:

- `aaa6a23fa1e21dc2d8aad6f23465a351d97fe6e1` — Bonsai Metal execution and contracts
- `b91b98b46a7cb9ada82a30ddb2d37707c894351b` — reproducible public-source artifact conversion
- `1b88a20e29d7212ccdd33d4bda2566ae64ba3ae3` — address review findings

Exact source: `1b88a20e29d7212ccdd33d4bda2566ae64ba3ae3`  
Tree: `95b284889e5ff75a51fe77725f2426202759209b`  
Base: `c82f6642f9c5a1d75b175a11657229638cfed1de`

## Review resolution

- `BONSAI_MODEL` is optional again. `test-metal-contracts` always runs the official q4s engine, model, and stream coverage. It passes a Bonsai artifact to the engine-contract binary only when configured; otherwise the binary prints a Bonsai skip notice.
- The unrelated dspark/Q4_1 repack path is removed. `tools/repack.py` now adds only the T2 and B1 source-pack formats named by this PR; dspark input fails closed under the binary source-type contract rather than producing a second format.

The review-fix commit changes only the contract harness and repacker. It does not alter the Metal runtime implementation or shaders reviewed and exercised at `b91b98b4`.

## Reproducible artifact

The required source pack is public, ungated, and Apache-2.0:

- repository: `prism-ml/Ternary-Bonsai-27B-gguf`
- pinned revision: `abbae723028d71be674e71e1a71201a6f43fab22`
- file: `Ternary-Bonsai-27B-Q2_0.gguf`
- source size: `7165121600` bytes
- source MD5: `01493c0ade7d4fee416dfd874cdfcfd1`

```bash
hf download prism-ml/Ternary-Bonsai-27B-gguf \
  Ternary-Bonsai-27B-Q2_0.gguf \
  --revision abbae723028d71be674e71e1a71201a6f43fab22 \
  --local-dir models/ternary-bonsai-27b

python3 tools/repack.py \
  models/ternary-bonsai-27b/Ternary-Bonsai-27B-Q2_0.gguf \
  models/ternary-bonsai-27b/ternary-bonsai-27b-t2.q27
```

Expected output:

- size: `7154196992` bytes
- MD5: `8babb56d67b63f2308f883912a272bb3`

## Verification

Exact review-fix tip `1b88a20e`:

- `build/test_metal_engine_contracts` compiles cleanly with `-Wall -Wextra -Werror`
- the engine-contract binary accepts `OFFICIAL.q27` without a second argument
- `make test-metal-contracts MODEL=...` no longer hard-fails for an unset `BONSAI_MODEL`; it enters the official engine-contract leg
- `python3 -m py_compile tools/repack.py`: PASS
- `git diff --check`: PASS
- no dspark, Q4_1, or Q41 path remains in the proposal
- full repack on an independent Linux host in an isolated `gguf==0.19.0` environment: 851 tensors, 498 T2 tensors slot-verified, 26.89 B ternary weights, 29.7% zeros, output size `7154196992`, MD5 `8babb56d67b63f2308f883912a272bb3`

Metal runtime evidence at unchanged runtime tip `b91b98b4`:

- clean Apple M4 `-Werror` CLI/backend/ops builds
- backend and ops suites pass
- merged official q4s `--validate-only` passes
- maintainer independently confirmed `test-metal-canonical`, `test-metal`, and `test-metal-validation`, including canonical `f301095522174bdb99f75ec840ad1389`
- deterministic Bonsai smoke emits `Paris.` with token-file MD5 `ddae10a2e232f528e20b66dd4e7ad20e`

Generated model artifacts are not committed to the repository.
