### PR TITLE
repack: support split Qwen3.8 base and MTP GGUFs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NVCCFLAGS ?= -O2 -std=c++17 -gencode arch=compute_86,code=sm_86 \
              -gencode arch=compute_89,code=sm_89 \
              -gencode arch=compute_120,code=sm_120 -Xcompiler -Wall
 
-.PHONY: all clean test-inspect test-metal-backend metal-engine test-metal-contracts test-metal test-metal-canonical check-chat-extract check-responses-integration
+.PHONY: all clean test-inspect test-repack test-metal-backend metal-engine test-metal-contracts test-metal test-metal-canonical check-chat-extract check-responses-integration
 all: build/inspect build/test_sampling build/test_kernels build/test_argmax_tie build/q27 build/q27-server build/test_tokenizer build/test_stream_split build/test_tool_drift build/test_tool_drift_corpus build/test_think_resolve build/test_openai_bridge build/test_chat_completions_integration build/test_depthctl build/test_toolconstrain
 build/q27: src/engine.cu src/engine.cuh src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp \
            src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/device_model.h src/loader.h src/cuda_common.h src/depthctl.h src/prefix_cache.h src/prefix_ram.h | build
@@ -25,6 +25,9 @@ build/test_loader_contracts: src/test_loader_contracts.cpp src/loader.cpp src/lo
 test-inspect: build/inspect build/test_loader_contracts
 	python3 tools/test_inspect.py ./build/inspect
 	./build/test_loader_contracts
+
+test-repack:
+	python3 tools/test_repack_split.py
 
 build/test_sampling: src/test_sampling.cpp src/sampling.h | build
 	$(CXX) $(CXXFLAGS) src/test_sampling.cpp -o $@

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CXX       ?= g++
 CXXFLAGS  ?= -O2 -std=c++17 -Wall -Wextra
+PYTHON    ?= python3
 NVCC      ?= /usr/local/cuda/bin/nvcc
 # sm_120 = RTX 5090, sm_89 = RTX 4090/Ada (needs CUDA 12.4+ for e4m3 MMA),
 # sm_86 = RTX 3090 (fallback device for tests)
@@ -26,8 +27,10 @@ test-inspect: build/inspect build/test_loader_contracts
 	python3 tools/test_inspect.py ./build/inspect
 	./build/test_loader_contracts
 
-test-repack:
-	python3 tools/test_repack_split.py
+test-repack: tools/repack.py tools/test_repack_split.py tools/test_repack_split_e2e.py \
+             tools/requirements-repack-test.txt
+	$(PYTHON) tools/test_repack_split.py
+	$(PYTHON) tools/test_repack_split_e2e.py
 
 build/test_sampling: src/test_sampling.cpp src/sampling.h | build
 	$(CXX) $(CXXFLAGS) src/test_sampling.cpp -o $@

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -187,49 +187,40 @@ for k in sorted(set(a) | set(b)):
 
 ## Recon log
 
-### Qwen3.8 (2026-08-05, pre-release)
+### Qwen3.8-27B release
 
-Announced 2026-08-03 alongside Qwen3.8-Max (2.4T total / 95B active), open
-weights promised "next week". No architecture disclosed: dense vs MoE, context
-length and layer shape are all unstated. Recon at the time of writing, ordered
-by strength of evidence.
+The released `Qwen/Qwen3.8-27B` checkpoint is a repack, not an engine port.
+`tools/check_checkpoint.py Qwen/Qwen3.8-27B` passes every CUDA and Metal
+constant plus the non-constant shape gates. The config still declares
+`Qwen3_5ForConditionalGeneration` / `qwen3_5`; compared with
+`Qwen/Qwen3.6-27B`, the only flattened config difference is the recorded
+`transformers_version`.
 
-**vLLM already loads a Qwen3.8 checkpoint through the Qwen3.5 class.**
-[vllm-project/vllm#50068](https://github.com/vllm-project/vllm/pull/50068)
-touches only `models/qwen3_5.py` and exposes Gated DeltaNet cache metadata
-"so text-only Qwen3.5-compatible checkpoints such as Qwen3.8 Max FP8 can
-initialize through the causal LM path". The diff reads
-`linear_num_key_heads`, `linear_num_value_heads`, `linear_key_head_dim`,
-`linear_value_head_dim` and `linear_conv_kernel_dim` -- the same config
-surface as the table above. The author reports validating it on a two-node
-ROCm TP=8/PP=2 deployment, so real weights were involved. This is Max, not
-the 27B, but it dates the generation's architecture.
+The Hugging Face safetensor indexes have the same 1,199 tensor names and the
+same aggregate byte count. The released GGUF layout is different, however:
+`ggml-org/Qwen3.8-27B-GGUF` publishes the 64 base blocks and the MTP block as
+separate standalone files rather than GGUF split shards. The base BF16 has 851
+tensors and `qwen35.block_count=64`; the MTP BF16 has 18 tensors and
+`qwen35.block_count=65`. Three MTP-file tensors duplicate the base embedding,
+normalization, and output head; the other 15 are `blk.64.*`.
 
-**The last point release changed nothing structural at the 27B slot.**
-Diffing `Qwen3.5-27B` against `Qwen3.6-27B` with the script above: every
-shape in the checklist is identical, both still declare
-`architectures: ["Qwen3_5ForConditionalGeneration"]` and
-`model_type: qwen3_5`, and the only diffs are serialization
-(`bos_token_id` and `pad_token_id` written out, `mlp_only_layers` dropped,
-`output_gate_type: swish` and `partial_rotary_factor` hoisted to explicit,
-newer `transformers_version`). A 3.x point release in this family has been a
-retrain rather than a re-architecture.
+`tools/repack.py --mtp` joins those views, rejects mixed checkpoints and
+unexpected overlaps, keeps the primary copy of the three shared tensors, and
+takes the MTP architecture metadata so the output validates as 65 blocks:
 
-**Nobody is building a new class.** `transformers/main` carries `qwen3_5`,
-`qwen3_5_moe` and `qwen3_next`, with no `qwen3_6` or `qwen3_8` directory;
-3.6 rode `qwen3_5` and recent commits on it are generic refactors. llama.cpp
-has no Qwen3.8 issue or PR.
+```sh
+tools/repack.py Qwen3.8-27B-BF16.gguf qwen38-27b-mtp-q4s.q27 \
+  --mtp mtp-Qwen3.8-27B-BF16.gguf --q4-head --tag q4s-v1
+tools/export_tokenizer.py Qwen3.8-27B-BF16.gguf qwen38-27b-mtp.tok
+```
 
-**Nothing on the Hub yet.** The two `Qwen3.8-27B` repos that exist
-(`huginnfork/...-FP8` and `...-NVFP4A16`, created 2026-08-05) contain
-`.gitattributes` and `README.md` and nothing else; the card says so itself.
-No config to read.
+The vision encoder remains out of scope. It is published as a separate
+`mmproj` GGUF and does not change the text graph q27 implements. Qwen3.8 adds
+chat-template controls such as `reasoning_effort`; the token inventory and
+ChatML control IDs used by q27 remain compatible, while those optional template
+features are not exposed by q27's hand-written prompt renderer.
 
-Weakest signal, noted for completeness: Unsloth's claim that it runs on 17 GB
-is what a 27B dense at 4 bits costs, and lands between the q4s (15.46 GB) and
-default (17.73 GB) tiers.
-
-**Conclusion.** Convergent evidence that Qwen3.8 stays on the `qwen3_5` graph,
-and no evidence either way on whether the 27B slot stays dense. Treat the
-checklist as unverified until the real config lands, then run the diff before
-downloading weights.
+No runtime or kernel source changes are required. The remaining work for any
+new Qwen3.8 artifact is checkpoint-specific: repack it, export its tokenizer,
+derive a new canonical, and run the normal numerical and serving gates rather
+than reusing Qwen3.6 quality claims.

--- a/tools/repack.py
+++ b/tools/repack.py
@@ -217,13 +217,12 @@ def _field_value(reader, name):
     if field is None:
         return None
     value = field.contents()
-    if isinstance(value, bytes):
-        return value.decode()
-    return value
+    return value.decode() if isinstance(value, bytes) else value
 
 
 def _tensor_signature(tensor):
     return tensor.tensor_type.name, tuple(int(d) for d in tensor.shape)
+
 
 def _tensor_data_equal(left, right):
     left_bytes = np.asarray(left.data).view(np.uint8).reshape(-1)
@@ -235,25 +234,208 @@ def _tensor_data_equal(left, right):
                for off in range(0, left_bytes.size, chunk))
 
 
+def _qwen35_base_tensor_specs():
+    # Source GGUF shapes in ordinary row-major order; GGUFReader exposes them
+    # reversed, so _require_exact_specs reverses before comparing. These are
+    # the same frozen Qwen3.8 dimensions enforced by both runtimes.
+    embd, ffn, vocab = 5120, 17408, 248320
+    head, n_head, n_kv = 256, 24, 4
+    specs = {
+        "token_embd.weight": ("BF16", (vocab, embd)),
+        "output_norm.weight": ("F32", (embd,)),
+        "output.weight": ("BF16", (vocab, embd)),
+    }
+    for layer in range(64):
+        prefix = f"blk.{layer}."
+        specs.update({
+            prefix + "attn_norm.weight": ("F32", (embd,)),
+            prefix + "post_attention_norm.weight": ("F32", (embd,)),
+            prefix + "ffn_gate.weight": ("BF16", (ffn, embd)),
+            prefix + "ffn_up.weight": ("BF16", (ffn, embd)),
+            prefix + "ffn_down.weight": ("BF16", (embd, ffn)),
+        })
+        if layer % 4 == 3:
+            specs.update({
+                prefix + "attn_q.weight": ("BF16", (2 * n_head * head, embd)),
+                prefix + "attn_k.weight": ("BF16", (n_kv * head, embd)),
+                prefix + "attn_v.weight": ("BF16", (n_kv * head, embd)),
+                prefix + "attn_output.weight": ("BF16", (embd, n_head * head)),
+                prefix + "attn_q_norm.weight": ("F32", (head,)),
+                prefix + "attn_k_norm.weight": ("F32", (head,)),
+            })
+        else:
+            specs.update({
+                prefix + "attn_qkv.weight": ("BF16", (10240, embd)),
+                prefix + "attn_gate.weight": ("BF16", (6144, embd)),
+                prefix + "ssm_alpha.weight": ("BF16", (48, embd)),
+                prefix + "ssm_beta.weight": ("BF16", (48, embd)),
+                prefix + "ssm_a": ("F32", (48,)),
+                prefix + "ssm_dt.bias": ("F32", (48,)),
+                prefix + "ssm_conv1d.weight": ("F32", (10240, 4)),
+                prefix + "ssm_norm.weight": ("F32", (128,)),
+                prefix + "ssm_out.weight": ("BF16", (embd, 6144)),
+            })
+    assert len(specs) == 851
+    return specs
+
+
+def _qwen35_mtp_tensor_specs():
+    embd, ffn, head, n_head, n_kv = 5120, 17408, 256, 24, 4
+    prefix = "blk.64."
+    specs = {
+        prefix + "nextn.enorm.weight": ("F32", (embd,)),
+        prefix + "nextn.hnorm.weight": ("F32", (embd,)),
+        prefix + "nextn.shared_head_norm.weight": ("F32", (embd,)),
+        prefix + "nextn.eh_proj.weight": ("BF16", (embd, 2 * embd)),
+        prefix + "attn_norm.weight": ("F32", (embd,)),
+        prefix + "post_attention_norm.weight": ("F32", (embd,)),
+        prefix + "attn_q_norm.weight": ("F32", (head,)),
+        prefix + "attn_k_norm.weight": ("F32", (head,)),
+        prefix + "attn_q.weight": ("BF16", (2 * n_head * head, embd)),
+        prefix + "attn_k.weight": ("BF16", (n_kv * head, embd)),
+        prefix + "attn_v.weight": ("BF16", (n_kv * head, embd)),
+        prefix + "attn_output.weight": ("BF16", (embd, n_head * head)),
+        prefix + "ffn_gate.weight": ("BF16", (ffn, embd)),
+        prefix + "ffn_up.weight": ("BF16", (ffn, embd)),
+        prefix + "ffn_down.weight": ("BF16", (embd, ffn)),
+    }
+    assert len(specs) == 15
+    return specs
+
+
+QWEN35_BASE_SPECS = _qwen35_base_tensor_specs()
+QWEN35_MTP_SPECS = _qwen35_mtp_tensor_specs()
+QWEN35_BASE_TENSORS = frozenset(QWEN35_BASE_SPECS)
+QWEN35_MTP_TENSORS = frozenset(QWEN35_MTP_SPECS)
+QWEN35_REQUIRED_METADATA = {
+    "qwen35.embedding_length": 5120,
+    "qwen35.feed_forward_length": 17408,
+    "qwen35.attention.head_count": 24,
+    "qwen35.attention.head_count_kv": 4,
+    "qwen35.attention.key_length": 256,
+    "qwen35.attention.value_length": 256,
+    "qwen35.ssm.state_size": 128,
+    "qwen35.ssm.group_count": 16,
+    "qwen35.ssm.inner_size": 6144,
+    "qwen35.context_length": 262144,
+    "qwen35.rope.dimension_count": 64,
+    "qwen35.ssm.conv_kernel": 4,
+    "qwen35.ssm.time_step_rank": 48,
+    "qwen35.full_attention_interval": 4,
+    "qwen35.rope.freq_base": 10000000.0,
+    "qwen35.attention.layer_norm_rms_epsilon": 0.000001,
+    "qwen35.rope.dimension_sections": [11, 11, 10, 0],
+}
+
+
+def _normalized_metadata(value):
+    if isinstance(value, bytes):
+        return value.decode()
+    if isinstance(value, np.ndarray):
+        return [_normalized_metadata(item) for item in value.tolist()]
+    if isinstance(value, (list, tuple)):
+        return [_normalized_metadata(item) for item in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _exact_uint(value, expected):
+    value = _normalized_metadata(value)
+    return isinstance(value, int) and not isinstance(value, bool) and value == expected
+
+
+def _require_qwen38_metadata(reader, label):
+    for name, expected in QWEN35_REQUIRED_METADATA.items():
+        actual = _field_value(reader, name)
+        if actual is None:
+            raise ValueError(f"--mtp {label} is missing architecture metadata: {name}")
+        actual = _normalized_metadata(actual)
+        if isinstance(expected, int):
+            matches = _exact_uint(actual, expected)
+        elif isinstance(expected, float):
+            matches = (isinstance(actual, float) and
+                       (abs(actual - expected) <= 1e-12
+                        if name == "qwen35.attention.layer_norm_rms_epsilon"
+                        else actual == expected))
+        elif isinstance(expected, list):
+            matches = (isinstance(actual, list) and
+                       all(isinstance(item, int) and not isinstance(item, bool)
+                           for item in actual) and actual == expected)
+        else:
+            matches = type(actual) is type(expected) and actual == expected
+        if not matches:
+            raise ValueError(
+                f"--mtp {label} architecture metadata mismatch: "
+                f"{name}: {actual!r} != {expected!r}")
+
+
+def _check_split_architecture_metadata(primary, companion):
+    allowed = {"qwen35.block_count", "qwen35.nextn_predict_layers"}
+    primary_fields = {name: _normalized_metadata(field.contents())
+                      for name, field in primary.fields.items()
+                      if name.startswith("qwen35.") and name not in allowed}
+    companion_fields = {name: _normalized_metadata(field.contents())
+                        for name, field in companion.fields.items()
+                        if name.startswith("qwen35.") and name not in allowed}
+    if primary_fields != companion_fields:
+        differing = sorted(set(primary_fields) ^ set(companion_fields) |
+                           {name for name in set(primary_fields) & set(companion_fields)
+                            if primary_fields[name] != companion_fields[name]})
+        raise ValueError("--mtp architecture metadata mismatch: " + ", ".join(differing))
+
+
+def _require_exact_manifest(label, actual, expected):
+    missing = expected - actual
+    unexpected = actual - expected
+    if missing or unexpected:
+        parts = []
+        if missing:
+            parts.append(f"missing {len(missing)} ({', '.join(sorted(missing)[:4])})")
+        if unexpected:
+            parts.append(f"unexpected {len(unexpected)} ({', '.join(sorted(unexpected)[:4])})")
+        raise ValueError(f"{label} tensor manifest mismatch: " + "; ".join(parts))
+
+
+def _require_exact_specs(label, tensors_by_name, expected_specs):
+    _require_exact_manifest(label, set(tensors_by_name), set(expected_specs))
+    for name, (expected_type, expected_shape) in expected_specs.items():
+        tensor = tensors_by_name[name]
+        actual_type = tensor.tensor_type.name
+        actual_shape = tuple(reversed(tuple(int(d) for d in tensor.shape)))
+        if actual_type != expected_type or actual_shape != expected_shape:
+            raise ValueError(
+                f"{label} tensor spec mismatch: {name}: "
+                f"{actual_type} {actual_shape} != {expected_type} {expected_shape}")
+
+
 def merge_mtp_tensors(primary, companion):
-    """Join llama.cpp's --no-mtp and --mtp GGUF views without duplicates."""
+    """Join ggml-org's Qwen3.8 base and MTP GGUF views fail-closed."""
     if _field_value(primary, "general.architecture") != "qwen35":
         raise ValueError("--mtp requires a qwen35 primary GGUF")
     if _field_value(companion, "general.architecture") != "qwen35":
         raise ValueError("--mtp companion is not a qwen35 GGUF")
     primary_name = _field_value(primary, "general.name")
     companion_name = _field_value(companion, "general.name")
-    if primary_name and companion_name and primary_name != companion_name:
+    if not isinstance(primary_name, str) or not primary_name.strip():
+        raise ValueError("--mtp primary is missing general.name")
+    if not isinstance(companion_name, str) or not companion_name.strip():
+        raise ValueError("--mtp companion is missing general.name")
+    if primary_name != companion_name:
         raise ValueError(f"--mtp checkpoint mismatch: {primary_name!r} != {companion_name!r}")
-    if _field_value(primary, "qwen35.block_count") != 64:
+    if not _exact_uint(_field_value(primary, "qwen35.block_count"), 64):
         raise ValueError("--mtp primary must contain the 64 base blocks")
-    if (_field_value(companion, "qwen35.block_count") != 65
-            or _field_value(companion, "qwen35.nextn_predict_layers") != 1):
+    if (not _exact_uint(_field_value(companion, "qwen35.block_count"), 65)
+            or not _exact_uint(_field_value(companion, "qwen35.nextn_predict_layers"), 1)):
         raise ValueError("--mtp companion must describe one MTP layer (block_count=65)")
+    _require_qwen38_metadata(primary, "primary")
+    _require_qwen38_metadata(companion, "companion")
+    _check_split_architecture_metadata(primary, companion)
 
     primary_by_name = {t.name: t for t in primary.tensors}
     if len(primary_by_name) != len(primary.tensors):
         raise ValueError("primary GGUF contains duplicate tensor names")
+    _require_exact_specs("primary", primary_by_name, QWEN35_BASE_SPECS)
     companion_by_name = {t.name: t for t in companion.tensors}
     if len(companion_by_name) != len(companion.tensors):
         raise ValueError("MTP GGUF contains duplicate tensor names")
@@ -264,6 +446,10 @@ def merge_mtp_tensors(primary, companion):
     if unexpected:
         raise ValueError("--mtp companion overlaps primary tensors: "
                          + ", ".join(sorted(unexpected)))
+    if shared != allowed_shared:
+        missing = allowed_shared - shared
+        raise ValueError("--mtp companion is missing shared tensors: "
+                         + ", ".join(sorted(missing)))
     for name in shared:
         if _tensor_signature(primary_by_name[name]) != _tensor_signature(companion_by_name[name]):
             raise ValueError(f"--mtp shared tensor shape/type mismatch: {name}")
@@ -271,8 +457,10 @@ def merge_mtp_tensors(primary, companion):
             raise ValueError(f"--mtp shared tensor contents differ: {name}")
 
     mtp_only = [t for t in companion.tensors if t.name not in primary_by_name]
-    if not mtp_only or any(not t.name.startswith("blk.64.") for t in mtp_only):
-        raise ValueError("--mtp companion must add only blk.64 tensors")
+    mtp_by_name = {t.name: t for t in mtp_only}
+    _require_exact_specs("MTP", mtp_by_name, QWEN35_MTP_SPECS)
+    _require_exact_manifest("companion", set(companion_by_name),
+                            allowed_shared | QWEN35_MTP_TENSORS)
     return list(primary.tensors) + mtp_only
 
 
@@ -301,10 +489,18 @@ def main():
     r = GGUFReader(args.input)
     mtp_reader = GGUFReader(args.mtp) if args.mtp else None
     source_tensors = merge_mtp_tensors(r, mtp_reader) if mtp_reader else list(r.tensors)
+    arch = _field_value(r, "general.architecture")
+    if not isinstance(arch, str) or not arch:
+        raise ValueError("source GGUF is missing general.architecture")
     ternary = any(t.tensor_type.name == "Q2_0" for t in source_tensors)
     binary = any(t.tensor_type.name == "Q1_0" for t in source_tensors)
-    if mtp_reader and (ternary or binary):
-        raise ValueError("--mtp is only supported for BF16/F16/F32 source GGUFs")
+    if mtp_reader:
+        bad_types = sorted({t.tensor_type.name for t in source_tensors
+                            if t.tensor_type.name not in ("BF16", "F32")})
+        if bad_types:
+            raise ValueError("--mtp requires the pinned BF16 GGUF layout "
+                             "(BF16 matrices/F32 scalars); found "
+                             + ", ".join(bad_types))
     if binary and ternary:
         raise ValueError("pack unexpectedly contains both binary (Q1_0) and ternary (Q2_0) tensors")
     if (not mtp_reader and not ternary and not binary
@@ -331,17 +527,21 @@ def main():
         meta["q8_extra"] = args.q8
     if args.q4_head:
         meta["q4_head"] = True
-    metadata_readers = (r, mtp_reader) if mtp_reader else (r,)
-    for metadata_reader in metadata_readers:
-        for f in metadata_reader.fields.values():
-            if f.name.startswith(("qwen35.", "general.architecture", "general.name")):
-                try:
-                    v = f.contents()
-                    if isinstance(v, bytes):
-                        v = v.decode()
-                    meta[f.name] = v
-                except Exception:
-                    pass
+    # The primary owns every architectural field. Split validation proved the
+    # companion matches; only its intentional 65-block/MTP declarations may
+    # override the 64-block base view.
+    for f in r.fields.values():
+        if f.name.startswith(("qwen35.", "general.architecture", "general.name")):
+            try:
+                v = f.contents()
+                if isinstance(v, bytes):
+                    v = v.decode()
+                meta[f.name] = v
+            except Exception:
+                pass
+    if mtp_reader:
+        meta["qwen35.block_count"] = 65
+        meta["qwen35.nextn_predict_layers"] = 1
     # layer map
     attn_layers, ssm_layers = set(), set()
     for t in source_tensors:

--- a/tools/repack.py
+++ b/tools/repack.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""Repack a BF16 GGUF into the q27 v1 format (see docs/FORMAT.md).
+"""Repack BF16 GGUF weights into the q27 v1 format (see docs/FORMAT.md).
 
 Usage:
-  repack.py input.gguf output.q27 [--only REGEX] [--report N]
+  repack.py input.gguf output.q27 [--mtp mtp.gguf] [--only REGEX] [--report N]
 
+--mtp joins the companion MTP GGUF emitted by current llama.cpp conversions;
+the primary GGUF supplies blocks 0..63 and the companion supplies block 64.
 --only limits to tensors matching REGEX (smoke tests).
 --report prints the N worst tensors by relative RMSE after quantization.
 
@@ -210,11 +212,76 @@ def repack_b1(t):
 
     return qs.tobytes(), scales.tobytes()
 
+def _field_value(reader, name):
+    field = reader.fields.get(name)
+    if field is None:
+        return None
+    value = field.contents()
+    if isinstance(value, bytes):
+        return value.decode()
+    return value
+
+
+def _tensor_signature(tensor):
+    return tensor.tensor_type.name, tuple(int(d) for d in tensor.shape)
+
+def _tensor_data_equal(left, right):
+    left_bytes = np.asarray(left.data).view(np.uint8).reshape(-1)
+    right_bytes = np.asarray(right.data).view(np.uint8).reshape(-1)
+    if left_bytes.size != right_bytes.size:
+        return False
+    chunk = 64 * 1024 * 1024
+    return all(np.array_equal(left_bytes[off:off + chunk], right_bytes[off:off + chunk])
+               for off in range(0, left_bytes.size, chunk))
+
+
+def merge_mtp_tensors(primary, companion):
+    """Join llama.cpp's --no-mtp and --mtp GGUF views without duplicates."""
+    if _field_value(primary, "general.architecture") != "qwen35":
+        raise ValueError("--mtp requires a qwen35 primary GGUF")
+    if _field_value(companion, "general.architecture") != "qwen35":
+        raise ValueError("--mtp companion is not a qwen35 GGUF")
+    primary_name = _field_value(primary, "general.name")
+    companion_name = _field_value(companion, "general.name")
+    if primary_name and companion_name and primary_name != companion_name:
+        raise ValueError(f"--mtp checkpoint mismatch: {primary_name!r} != {companion_name!r}")
+    if _field_value(primary, "qwen35.block_count") != 64:
+        raise ValueError("--mtp primary must contain the 64 base blocks")
+    if (_field_value(companion, "qwen35.block_count") != 65
+            or _field_value(companion, "qwen35.nextn_predict_layers") != 1):
+        raise ValueError("--mtp companion must describe one MTP layer (block_count=65)")
+
+    primary_by_name = {t.name: t for t in primary.tensors}
+    if len(primary_by_name) != len(primary.tensors):
+        raise ValueError("primary GGUF contains duplicate tensor names")
+    companion_by_name = {t.name: t for t in companion.tensors}
+    if len(companion_by_name) != len(companion.tensors):
+        raise ValueError("MTP GGUF contains duplicate tensor names")
+
+    allowed_shared = {"token_embd.weight", "output_norm.weight", "output.weight"}
+    shared = set(primary_by_name) & set(companion_by_name)
+    unexpected = shared - allowed_shared
+    if unexpected:
+        raise ValueError("--mtp companion overlaps primary tensors: "
+                         + ", ".join(sorted(unexpected)))
+    for name in shared:
+        if _tensor_signature(primary_by_name[name]) != _tensor_signature(companion_by_name[name]):
+            raise ValueError(f"--mtp shared tensor shape/type mismatch: {name}")
+        if not _tensor_data_equal(primary_by_name[name], companion_by_name[name]):
+            raise ValueError(f"--mtp shared tensor contents differ: {name}")
+
+    mtp_only = [t for t in companion.tensors if t.name not in primary_by_name]
+    if not mtp_only or any(not t.name.startswith("blk.64.") for t in mtp_only):
+        raise ValueError("--mtp companion must add only blk.64 tensors")
+    return list(primary.tensors) + mtp_only
+
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("input")
     ap.add_argument("output")
+    ap.add_argument("--mtp", default=None,
+                    help="companion BF16 MTP GGUF (llama.cpp --mtp output)")
     ap.add_argument("--only", default=None)
     ap.add_argument("--report", type=int, default=15)
     ap.add_argument("--q8", default=None,
@@ -232,10 +299,18 @@ def main():
 
     t0 = time.time()
     r = GGUFReader(args.input)
-    ternary = any(t.tensor_type.name == "Q2_0" for t in r.tensors)
-    binary = any(t.tensor_type.name == "Q1_0" for t in r.tensors)
+    mtp_reader = GGUFReader(args.mtp) if args.mtp else None
+    source_tensors = merge_mtp_tensors(r, mtp_reader) if mtp_reader else list(r.tensors)
+    ternary = any(t.tensor_type.name == "Q2_0" for t in source_tensors)
+    binary = any(t.tensor_type.name == "Q1_0" for t in source_tensors)
+    if mtp_reader and (ternary or binary):
+        raise ValueError("--mtp is only supported for BF16/F16/F32 source GGUFs")
     if binary and ternary:
         raise ValueError("pack unexpectedly contains both binary (Q1_0) and ternary (Q2_0) tensors")
+    if (not mtp_reader and not ternary and not binary
+            and _field_value(r, "general.architecture") == "qwen35"
+            and _field_value(r, "qwen35.block_count") == 64):
+        raise ValueError("base-only qwen35 GGUF: supply its companion with --mtp")
 
     meta = {"q27_version": VERSION,
             "quant_policy": args.tag or ("bonsai-t2-v1" if ternary
@@ -256,18 +331,20 @@ def main():
         meta["q8_extra"] = args.q8
     if args.q4_head:
         meta["q4_head"] = True
-    for f in r.fields.values():
-        if f.name.startswith(("qwen35.", "general.architecture", "general.name")):
-            try:
-                v = f.contents()
-                if isinstance(v, bytes):
-                    v = v.decode()
-                meta[f.name] = v
-            except Exception:
-                pass
+    metadata_readers = (r, mtp_reader) if mtp_reader else (r,)
+    for metadata_reader in metadata_readers:
+        for f in metadata_reader.fields.values():
+            if f.name.startswith(("qwen35.", "general.architecture", "general.name")):
+                try:
+                    v = f.contents()
+                    if isinstance(v, bytes):
+                        v = v.decode()
+                    meta[f.name] = v
+                except Exception:
+                    pass
     # layer map
     attn_layers, ssm_layers = set(), set()
-    for t in r.tensors:
+    for t in source_tensors:
         if t.name.startswith("blk."):
             n = int(t.name.split(".")[1])
             leaf = t.name.split(".", 2)[2]
@@ -285,7 +362,7 @@ def main():
     n_bytes_in = n_bytes_out = 0
 
     extra = []
-    for t in r.tensors:
+    for t in source_tensors:
         # MTP draft head copy: only for non-quantized-head packs and pack
         # types that carry MTP (no MTP in ternary/binary packs).
         if t.name == "output.weight" and not args.q4_head \
@@ -294,7 +371,7 @@ def main():
     class _Alias:
         def __init__(self, name, t):
             self.name, self.tensor_type, self.data, self.shape = name, t.tensor_type, t.data, t.shape
-    tensor_iter = list(r.tensors) + [_Alias(n, t) for n, t in extra]
+    tensor_iter = source_tensors + [_Alias(n, t) for n, t in extra]
     zero_fracs = []
     for t in tensor_iter:
         if only and not only.search(t.name):

--- a/tools/requirements-repack-test.txt
+++ b/tools/requirements-repack-test.txt
@@ -1,0 +1,21 @@
+# Hash-locked Qwen3.8 repack/test environment for Apple-silicon release runners.
+# Supported interpreters: CPython 3.12-3.14. Install with:
+# gguf declares network/progress extras that this local reader/writer path never
+# imports. --no-deps is intentional; PyYAML is the one eager gguf import.
+#   python3 -m pip install --no-deps --require-hashes -r tools/requirements-repack-test.txt
+numpy==2.5.1 \
+    --hash=sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1 \
+    --hash=sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0 \
+    --hash=sha256:30b44a6b53a7ae63c54c089a8726e5563ed302716c5b7ccc85afade40b0e7ff6 \
+    --hash=sha256:6165343f81b56ef8f514f396989e529b61d9dc709b99421b07e9f3e698e2287d \
+    --hash=sha256:32985c896d897419ef8da6917872d80b78ad0ea26d85b23245c7366ffde76d75 \
+    --hash=sha256:efd736408cc97c79b9e6917338dfc8f06013b2274f992e96b1d9a81a71e2a2c2 \
+    --hash=sha256:a33276be12fa045805f477f22482088b66bb758ffbe89a9d21457de863a32e22 \
+    --hash=sha256:f089d7b00756190aacf1f5d34bdfc8c3c430ac82b4f868f8cede73380460fce7
+gguf==0.19.0 \
+    --hash=sha256:70bcd10edfe697fb2dad6e40af2234b9d8ece9a41a99761405121ebda1c3c1cd
+PyYAML==6.0.3 \
+    --hash=sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0 \
+    --hash=sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1 \
+    --hash=sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310 \
+    --hash=sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba

--- a/tools/test_repack_split.py
+++ b/tools/test_repack_split.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Contract checks for joining llama.cpp base and MTP GGUF views."""
+
+import importlib.util
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location("q27_repack", Path(__file__).with_name("repack.py"))
+repack = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(repack)
+
+
+class Field:
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+    def contents(self):
+        return self.value
+
+
+class TensorType:
+    name = "BF16"
+
+
+class Tensor:
+    def __init__(self, name, shape=(5120,), data=b"\0"):
+        self.name = name
+        self.shape = shape
+        self.tensor_type = TensorType()
+        self.data = repack.np.frombuffer(data, dtype=repack.np.uint8)
+
+
+class Reader:
+    def __init__(self, name, block_count, tensors, nextn=None):
+        values = {
+            "general.architecture": "qwen35",
+            "general.name": name,
+            "qwen35.block_count": block_count,
+        }
+        if nextn is not None:
+            values["qwen35.nextn_predict_layers"] = nextn
+        self.fields = {key: Field(key, value) for key, value in values.items()}
+        self.tensors = tensors
+
+
+def expect_error(message, primary, companion):
+    try:
+        repack.merge_mtp_tensors(primary, companion)
+    except ValueError as error:
+        assert message in str(error), error
+    else:
+        raise AssertionError(f"expected ValueError containing {message!r}")
+
+
+shared = [Tensor("token_embd.weight"), Tensor("output_norm.weight"), Tensor("output.weight")]
+primary = Reader("Qwen3.8-27B", 64, shared + [Tensor("blk.0.attn_q.weight")])
+companion = Reader("Qwen3.8-27B", 65, shared + [Tensor("blk.64.attn_q.weight")], nextn=1)
+merged = repack.merge_mtp_tensors(primary, companion)
+assert [tensor.name for tensor in merged] == [
+    "token_embd.weight",
+    "output_norm.weight",
+    "output.weight",
+    "blk.0.attn_q.weight",
+    "blk.64.attn_q.weight",
+]
+
+expect_error(
+    "checkpoint mismatch",
+    primary,
+    Reader("Qwen3.6-27B", 65, shared + [Tensor("blk.64.attn_q.weight")], nextn=1),
+)
+expect_error(
+    "overlaps primary tensors",
+    primary,
+    Reader("Qwen3.8-27B", 65, shared + [Tensor("blk.0.attn_q.weight")], nextn=1),
+)
+expect_error(
+    "shape/type mismatch",
+    primary,
+    Reader(
+        "Qwen3.8-27B",
+        65,
+        [Tensor("output.weight", shape=(4096,)), Tensor("blk.64.attn_q.weight")],
+        nextn=1,
+    ),
+)
+expect_error(
+    "contents differ",
+    primary,
+    Reader(
+        "Qwen3.8-27B",
+        65,
+        [Tensor("output.weight", data=b"\1"), Tensor("blk.64.attn_q.weight")],
+        nextn=1,
+    ),
+)
+
+print("split MTP GGUF merge contracts: PASS")

--- a/tools/test_repack_split.py
+++ b/tools/test_repack_split.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Contract checks for joining llama.cpp base and MTP GGUF views."""
+"""Helper-level contracts for joining standalone Qwen3.8 base and MTP GGUFs."""
 
 import importlib.util
 from pathlib import Path
 
 
-spec = importlib.util.spec_from_file_location("q27_repack", Path(__file__).with_name("repack.py"))
+spec = importlib.util.spec_from_file_location(
+    "q27_repack", Path(__file__).with_name("repack.py"))
 repack = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(repack)
 
@@ -20,23 +21,33 @@ class Field:
 
 
 class TensorType:
-    name = "BF16"
+    def __init__(self, name):
+        self.name = name
 
 
 class Tensor:
-    def __init__(self, name, shape=(5120,), data=b"\0"):
+    def __init__(self, name, shape=None, data=b"\0", dtype=None):
         self.name = name
-        self.shape = shape
-        self.tensor_type = TensorType()
+        expected = (repack.QWEN35_BASE_SPECS.get(name) or
+                    repack.QWEN35_MTP_SPECS.get(name))
+        expected_type, expected_shape = expected or ("BF16", (5120,))
+        q27_shape = shape or expected_shape
+        self.shape = tuple(reversed(q27_shape))
+        self.tensor_type = TensorType(dtype or expected_type)
         self.data = repack.np.frombuffer(data, dtype=repack.np.uint8)
 
 
 class Reader:
-    def __init__(self, name, block_count, tensors, nextn=None):
+    def __init__(self, name, block_count, tensors, nextn=None, arch="qwen35",
+                 metadata=None, complete_metadata=True):
+        architecture = (dict(repack.QWEN35_REQUIRED_METADATA)
+                        if complete_metadata else {})
+        architecture.update(metadata or {})
         values = {
-            "general.architecture": "qwen35",
+            "general.architecture": arch,
             "general.name": name,
             "qwen35.block_count": block_count,
+            **architecture,
         }
         if nextn is not None:
             values["qwen35.nextn_predict_layers"] = nextn
@@ -53,47 +64,127 @@ def expect_error(message, primary, companion):
         raise AssertionError(f"expected ValueError containing {message!r}")
 
 
-shared = [Tensor("token_embd.weight"), Tensor("output_norm.weight"), Tensor("output.weight")]
-primary = Reader("Qwen3.8-27B", 64, shared + [Tensor("blk.0.attn_q.weight")])
-companion = Reader("Qwen3.8-27B", 65, shared + [Tensor("blk.64.attn_q.weight")], nextn=1)
-merged = repack.merge_mtp_tensors(primary, companion)
-assert [tensor.name for tensor in merged] == [
-    "token_embd.weight",
-    "output_norm.weight",
-    "output.weight",
-    "blk.0.attn_q.weight",
-    "blk.64.attn_q.weight",
-]
+def tensors_for(names):
+    return [Tensor(name) for name in sorted(names)]
 
-expect_error(
-    "checkpoint mismatch",
-    primary,
-    Reader("Qwen3.6-27B", 65, shared + [Tensor("blk.64.attn_q.weight")], nextn=1),
-)
-expect_error(
-    "overlaps primary tensors",
-    primary,
-    Reader("Qwen3.8-27B", 65, shared + [Tensor("blk.0.attn_q.weight")], nextn=1),
-)
-expect_error(
-    "shape/type mismatch",
-    primary,
-    Reader(
-        "Qwen3.8-27B",
-        65,
-        [Tensor("output.weight", shape=(4096,)), Tensor("blk.64.attn_q.weight")],
-        nextn=1,
-    ),
-)
-expect_error(
-    "contents differ",
-    primary,
-    Reader(
-        "Qwen3.8-27B",
-        65,
-        [Tensor("output.weight", data=b"\1"), Tensor("blk.64.attn_q.weight")],
-        nextn=1,
-    ),
-)
 
-print("split MTP GGUF merge contracts: PASS")
+def companion_tensors(*, output=None, omit_shared=(), extras=()):
+    shared = {
+        "token_embd.weight": Tensor("token_embd.weight"),
+        "output_norm.weight": Tensor("output_norm.weight"),
+        "output.weight": output or Tensor("output.weight"),
+    }
+    return ([tensor for name, tensor in shared.items() if name not in omit_shared]
+            + tensors_for(repack.QWEN35_MTP_TENSORS) + list(extras))
+
+
+def main():
+    assert len(repack.QWEN35_BASE_SPECS) == 851
+    assert len(repack.QWEN35_MTP_SPECS) == 15
+    assert repack.QWEN35_BASE_SPECS["token_embd.weight"] == (
+        "BF16", (248320, 5120))
+    assert repack.QWEN35_BASE_SPECS["blk.3.attn_q.weight"] == (
+        "BF16", (12288, 5120))
+    assert repack.QWEN35_MTP_SPECS["blk.64.nextn.eh_proj.weight"] == (
+        "BF16", (5120, 10240))
+
+    primary = Reader("Qwen3.8-27B", 64,
+                     tensors_for(repack.QWEN35_BASE_TENSORS),
+                     metadata={"qwen35.embedding_length": 5120})
+    companion = Reader("Qwen3.8-27B", 65, companion_tensors(), nextn=1,
+                       metadata={"qwen35.embedding_length": 5120})
+    merged = repack.merge_mtp_tensors(primary, companion)
+    assert len(merged) == 866
+    assert {tensor.name for tensor in merged} == (
+        repack.QWEN35_BASE_TENSORS | repack.QWEN35_MTP_TENSORS)
+
+    expect_error(
+        "qwen35 primary",
+        Reader("Qwen3.8-27B", 64, tensors_for(repack.QWEN35_BASE_TENSORS),
+               arch="llama"), companion)
+    expect_error(
+        "missing general.name",
+        Reader(None, 64, tensors_for(repack.QWEN35_BASE_TENSORS),
+               metadata={"qwen35.embedding_length": 5120}), companion)
+    expect_error(
+        "missing architecture metadata",
+        Reader("Qwen3.8-27B", 64, tensors_for(repack.QWEN35_BASE_TENSORS),
+               complete_metadata=False), companion)
+    expect_error(
+        "checkpoint mismatch",
+        primary,
+        Reader("Qwen3.6-27B", 65, companion_tensors(), nextn=1,
+               metadata={"qwen35.embedding_length": 5120}),
+    )
+    expect_error(
+        "architecture metadata mismatch",
+        primary,
+        Reader("Qwen3.8-27B", 65, companion_tensors(), nextn=1,
+               metadata={"qwen35.embedding_length": 4096}),
+    )
+    expect_error(
+        "architecture metadata mismatch",
+        primary,
+        Reader("Qwen3.8-27B", 65, companion_tensors(), nextn=1,
+               metadata={"qwen35.embedding_length": 5120.0}),
+    )
+    expect_error(
+        "primary tensor manifest mismatch",
+        Reader("Qwen3.8-27B", 64,
+               tensors_for(repack.QWEN35_BASE_TENSORS - {"blk.0.ssm_out.weight"}),
+               metadata={"qwen35.embedding_length": 5120}),
+        companion,
+    )
+    malformed_primary = tensors_for(repack.QWEN35_BASE_TENSORS)
+    malformed_primary = [
+        Tensor(tensor.name, shape=(1,))
+        if tensor.name == "blk.0.ssm_out.weight" else tensor
+        for tensor in malformed_primary
+    ]
+    expect_error(
+        "primary tensor spec mismatch",
+        Reader("Qwen3.8-27B", 64, malformed_primary,
+               metadata={"qwen35.embedding_length": 5120}),
+        companion,
+    )
+    expect_error(
+        "overlaps primary tensors",
+        primary,
+        Reader("Qwen3.8-27B", 65,
+               companion_tensors(extras=[Tensor("blk.0.attn_norm.weight")]), nextn=1,
+               metadata={"qwen35.embedding_length": 5120}),
+    )
+    expect_error(
+        "missing shared tensors",
+        primary,
+        Reader("Qwen3.8-27B", 65,
+               companion_tensors(omit_shared={"token_embd.weight"}), nextn=1,
+               metadata={"qwen35.embedding_length": 5120}),
+    )
+    expect_error(
+        "shape/type mismatch",
+        primary,
+        Reader("Qwen3.8-27B", 65,
+               companion_tensors(output=Tensor("output.weight", shape=(4096,))), nextn=1,
+               metadata={"qwen35.embedding_length": 5120}),
+    )
+    expect_error(
+        "contents differ",
+        primary,
+        Reader("Qwen3.8-27B", 65,
+               companion_tensors(output=Tensor("output.weight", data=b"\1")), nextn=1,
+               metadata={"qwen35.embedding_length": 5120}),
+    )
+    expect_error(
+        "MTP tensor manifest mismatch",
+        primary,
+        Reader("Qwen3.8-27B", 65,
+               companion_tensors(extras=[Tensor("blk.64.unexpected.weight")]), nextn=1,
+               metadata={"qwen35.embedding_length": 5120}),
+    )
+
+    print("split MTP GGUF merge contracts: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_repack_split_e2e.py
+++ b/tools/test_repack_split_e2e.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""End-to-end CLI fixture for Qwen3.8 standalone base + MTP GGUF input."""
+
+import importlib.util
+import json
+from pathlib import Path
+import struct
+import subprocess
+import sys
+import tempfile
+
+import numpy as np
+from gguf import GGUFWriter
+
+
+ROOT = Path(__file__).resolve().parent.parent
+REPACK = ROOT / "tools" / "repack.py"
+SPEC = importlib.util.spec_from_file_location("q27_repack_e2e", REPACK)
+repack = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(repack)
+MAGIC = 0x46373251
+
+
+def write_gguf(path, block_count, tensors, *, nextn=None):
+    writer = GGUFWriter(path, "qwen35")
+    writer.add_name("Qwen3.8-27B")
+    writer.add_block_count(block_count)
+    if nextn is not None:
+        writer.add_uint32("qwen35.nextn_predict_layers", nextn)
+    for name, value in repack.QWEN35_REQUIRED_METADATA.items():
+        if isinstance(value, list):
+            writer.add_array(name, value)
+        elif isinstance(value, float):
+            writer.add_float32(name, value)
+        else:
+            writer.add_uint32(name, value)
+    for name, tensor in tensors:
+        writer.add_tensor(name, tensor)
+    writer.write_header_to_file()
+    writer.write_kv_data_to_file()
+    writer.write_tensors_to_file()
+    writer.close()
+
+
+def read_q27(path):
+    with path.open("rb") as stream:
+        magic, version, count, meta_size = struct.unpack("<IIII", stream.read(16))
+        assert magic == MAGIC and version == 1
+        metadata = json.loads(stream.read(meta_size))
+        entries = {}
+        for _ in range(count):
+            name_size, = struct.unpack("<H", stream.read(2))
+            name = stream.read(name_size).decode()
+            dtype, rank = struct.unpack("<BB", stream.read(2))
+            shape = tuple(struct.unpack("<Q", stream.read(8))[0]
+                          for _ in range(rank))
+            offsets = struct.unpack("<QQQQ", stream.read(32))
+            assert name not in entries
+            entries[name] = {"dtype": dtype, "shape": shape, "offsets": offsets}
+    return metadata, entries
+
+
+def main():
+    with tempfile.TemporaryDirectory(prefix="q27-repack-split-e2e.") as raw:
+        work = Path(raw)
+        base = work / "Qwen3.8-27B-BF16.gguf"
+        mtp = work / "mtp-Qwen3.8-27B-BF16.gguf"
+        output = work / "candidate.q27"
+        launcher = work / "fixture_repack_cli.py"
+        # Keep the serialized fixture tiny while exercising repack.main's real
+        # argparse/GGUF/output path. Helper-level tests exercise the immutable
+        # production dimensions; this wrapper scales only fixture dimensions.
+        launcher.write_text(f'''\
+import importlib.util
+spec = importlib.util.spec_from_file_location("q27_repack_fixture", {str(REPACK)!r})
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+module.QWEN35_BASE_SPECS = {{name: ("F32", (128,)) for name in module.QWEN35_BASE_TENSORS}}
+module.QWEN35_MTP_SPECS = {{name: ("F32", (128,)) for name in module.QWEN35_MTP_TENSORS}}
+module.main()
+''', encoding="utf-8")
+
+        shared_values = {
+            "token_embd.weight": np.linspace(-1, 1, 128, dtype=np.float32),
+            "output_norm.weight": np.linspace(0, 1, 128, dtype=np.float32),
+            "output.weight": np.linspace(-2, 2, 128, dtype=np.float32),
+        }
+
+        def fixture_tensor(name):
+            return shared_values.get(
+                name, np.linspace(-3, 3, 128, dtype=np.float32))
+
+        shared = [(name, shared_values[name]) for name in shared_values]
+        base_only = sorted(repack.QWEN35_BASE_TENSORS - set(shared_values))
+        mtp_only = sorted(repack.QWEN35_MTP_TENSORS)
+        write_gguf(base, 64, shared + [
+            (name, fixture_tensor(name)) for name in base_only
+        ])
+        write_gguf(mtp, 65, shared + [
+            (name, fixture_tensor(name)) for name in mtp_only
+        ], nextn=1)
+
+        rejected = subprocess.run(
+            [sys.executable, str(launcher), str(base), str(output), "--q4-head"],
+            text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+        assert rejected.returncode != 0, rejected.stdout
+        assert "base-only qwen35 GGUF" in rejected.stderr, rejected.stderr
+        assert not output.exists()
+
+        subprocess.run([
+            sys.executable, str(launcher), str(base), str(output),
+            "--mtp", str(mtp), "--q4-head", "--tag", "q38-split-e2e-v1",
+            "--report", "0",
+        ], check=True)
+        metadata, entries = read_q27(output)
+        assert metadata["general.architecture"] == "qwen35"
+        assert metadata["general.name"] == "Qwen3.8-27B"
+        assert metadata["qwen35.block_count"] == 65
+        assert metadata["qwen35.nextn_predict_layers"] == 1
+        assert metadata["quant_policy"] == "q38-split-e2e-v1"
+        assert len(entries) == 866
+        assert set(entries) == (repack.QWEN35_BASE_TENSORS |
+                                repack.QWEN35_MTP_TENSORS)
+        assert entries["output.weight"]["dtype"] == 3  # Q4_G64 (--q4-head)
+        assert entries["blk.64.attn_q.weight"]["dtype"] == 2  # Q8_G128
+        assert entries["output_norm.weight"]["dtype"] == 0  # F32
+
+    print("split MTP GGUF end-to-end repack: PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- accept Qwen3.8's separate 64-block base GGUF plus 65-block MTP companion
- merge only the validated `blk.64.*` MTP tensors while requiring byte-identical shared tensors
- fail closed on checkpoint identity, metadata, tensor manifest, shape/type, and overlap drift
- preserve the existing single-file and non-Qwen3.8 repack paths

The production source pair used to exercise this path is pinned in the tests/docs to:

- `ggml-org/Qwen3.8-27B-GGUF@0669b98607d47046c7c2b3f801011d54a08cfccf`
- base SHA-256 `5a3eedc837bcbd1365cdbf5b71e698df3122e76586ba872f07ce3ed4a9bfa97e`
- MTP SHA-256 `5723e551c4ee2b8c11933d687f445800521047edc39769bee6e3c78c4e141ace`

## Gates

- `make test-repack`
- helper-level malformed metadata/manifest/shape/type/shared-content cases
- end-to-end CLI fixture: split GGUF input → 866-tensor q27 output
- clean hash-locked virtualenv (`numpy==2.5.1`, `gguf==0.19.0`, `PyYAML==6.0.3`)
- Codex autoreview: patch correct, no actionable findings

The archived release baseline remains frozen separately; this PR is the focused rebase on current upstream master.
