### PR TITLE
drift mode 18: recognize tool name on the line after <name>

### DIFF
--- a/src/api_common.h
+++ b/src/api_common.h
@@ -2190,6 +2190,13 @@ inline bool parse_native_xml_call(const std::string& seg, ToolCall& tc) {
         // `</parameter>` before the first real `<parameter=` is ignored by the
         // scan below, which searches forward for the opener.
         size_t ns = b + 6;
+        // Tolerate the name on the NEXT line after `<name>` -- a real
+        // emission (and this harness's mangled tool transport) can open
+        // `<name>` and drop the identifier on the following line. The old
+        // code read "up to the first newline", yielding an EMPTY name and
+        // refusing the whole call. Mirror parse_function_opener's leading-
+        // whitespace skip so `<name>\nbash\n<parameter=...>` -> name="bash".
+        while (ns < seg.size() && isspace((unsigned char)seg[ns])) ns++;
         size_t ne = seg.find('\n', ns);
         if (ne == std::string::npos) ne = seg.size();
         tc.name = seg.substr(ns, ne - ns);

--- a/tools/test_tool_drift.cpp
+++ b/tools/test_tool_drift.cpp
@@ -504,6 +504,19 @@ static void test_mode18_bare_name_opener() {
            t4.name == "Read" &&
            t4.arguments.value("file_path", std::string()) == "/x/y.py",
        "mode18: bare <name> without the stray closer");
+    // Mode-18 gap (found via pi's mangled tool transport): the name opens
+    // `<name>` but lands on the NEXT line. Pre-fix this read an empty name
+    // and refused the whole call. Corroborating <parameter= present, so this
+    // must rescue -- and must NOT swallow an identical opener with no dialect.
+    q27::ToolCall t5;
+    ok(q27::parse_native_xml_call("<name>\nbash\n</parameter>\n"
+                                  "<parameter=command>\nls /code\n</parameter>\n", t5) &&
+           t5.ok && t5.name == "bash" &&
+           t5.arguments.value("command", std::string()) == "ls /code",
+       "mode18-FIX: name on the line after <name> is still recognized");
+    q27::ToolCall t6;
+    ok(!q27::parse_native_xml_call("<name>\njust prose, no dialect follows", t6),
+       "mode18-FIX: name-on-next-line with no dialect is NOT a call");
 }
 
 static void test_mode14_tool_name_xml_dialect() {


### PR DESCRIPTION
## Bug

q27's drift mode-18 handler refuses a tool call when the identifier lands on the **line after** `<name>`:

```
<name>
bash
<parameter=command>ls /code</parameter>
```

`parse_native_xml_call` read the name as *"everything up to the first newline after `<name>`"* — with a newline there, the name came out **empty** and `if (tc.name.empty()) return false;` dumped a real tool call into the text channel. The agent sees a final turn with no `tool_use` and stops with the work unfinished.

Found via pi's mangled tool transport feeding the exact bytes through `parse_native_xml_call` / `parse_tool_call` / `parse_bare_tool_calls`. The culprit was isolated by A/B cases: the stray `</parameter>` before the first `<parameter=` was **not** the blocker (already tolerated) — the **newline after `<name>`** was.

## Fix

`src/api_common.h`: skip leading whitespace/newlines after `<name>` before reading the identifier, mirroring `parse_function_opener`. Corroboration (`<parameter=` or `</function>`) is still required, so ordinary prose opening with `<name>` is untouched.

## Tests

`tools/test_tool_drift.cpp` +2 assertions:
- name-on-next-line with `<parameter=` recovers as `bash` (was refused)
- same opener with no dialect still refuses (`<name>\njust prose`) — confirms no prose false-positive

`test_tool_drift`: 126 PASS / 0 FAIL. `make test-tools`: exit 0.