### PR TITLE
toolgram: XML dialect for --constrain-tools; enclosure result guard; tail recovery

### DIFF
--- a/docs/BUILDLOG.md
+++ b/docs/BUILDLOG.md
@@ -14025,3 +14025,166 @@ both channels can reach it.
 
 Both backends green: `make test-tools` under gcc on haight and clang on the M4,
 `q27-metal-server` links clean under `-Werror`.
+
+## 2026-08-21: the hallucinated-result guard was vetoing REAL calls -- presence is not enclosure
+
+Follow-on to (d). The report was the same sentence as always -- "sometimes I
+still see `<parameter=` / `</function>` in the output" -- but this time the
+bytes recovered cleanly when replayed in isolation and died in the session. The
+difference was the CONTEXT they arrived in, not the call.
+
+**The shape.** A perfectly recoverable mode-21 openerless call, in a tail that
+also quoted an earlier step's output:
+
+```
+Here is what the build printed:
+<output>make: all targets up to date</output>
+
+Now I'll fix the import.
+<parameter=filePath>
+/code/fileaction.go
+</parameter>
+<parameter=newString>
+import "bytes"
+</parameter>
+</function>
+```
+
+The hallucinated-result guard was a **whole-string** `find("<result>")` /
+`find("<output>")` gating the ENTIRE mode 17/20/21/22 block. One quoted
+`<output>` anywhere in the segment -- prose, a fenced transcript, a prior
+step's result -- and every recovery below it was skipped. The call was sitting
+right there, fully formed, and the guard threw the chain away.
+
+Worth recording precisely because 2026-08-20 (b) **ruled this guard out as a
+hypothesis**: "the hallucinated-result guard (no `<result>`/`<output>` in any
+capture)". That was true of those captures and false as a general claim. The
+instrument was a corpus of failures that had already been collected; a failure
+mode whose trigger is *the presence of a tag none of the captures contained*
+cannot appear in it. Third variant of the same lesson from (b), (c) and (d):
+**absence of evidence in a catalogue built from past failures is not evidence
+of absence.**
+
+### The obvious repair does not work, and it is worth saying why
+
+The first instinct is "scope the guard to the call span", and the first
+implementation of that scopes the wrong end: search for a complete
+`<output>...</output>` from **position 0** up to `span_end`. That bounds the END
+of the window and leaves the START at the beginning of the segment, so a closed
+block *before* the call is still inside the window and still vetoes it --
+precisely the bug, unchanged. Worse, dropping the coarse outer guard while
+replacing it with a span check that only covers mode 21 leaves modes 20 and 22
+(and the wrapped variant) with no protection at all, so three previously-pinned
+negatives start promoting invented output to calls.
+
+Recorded because the half-fix is more dangerous than the bug: it trades a
+dropped call for an EXECUTED hallucination, and it looks like progress.
+
+### The rule: enclosure, not presence
+
+Lexical presence cannot separate the two cases, because both have a complete
+`<output>...</output>` block before the call span. The discriminator is
+structural -- does the result element *contain* the candidate call?
+
+```
+(a) a <result>/<output> tag INSIDE the span      -> invented output posing as a
+                                                    parameter value; refuse
+(b) the span begins inside an UNCLOSED such tag  -> the "call" is part of the
+                                                    invented result block; refuse
+otherwise (every block closed before the span)   -> prior context; ACCEPT
+```
+
+(b) is what catches the genuine hallucinated shapes: the model opens `<result>`
+and never closes it, so the `<tool_name>`/`<parameter=` span it emits afterwards
+is enclosed by it. That is why the real negatives keep refusing while the quoted
+`<output>` case now recovers -- the two differ by exactly one closing tag.
+Depth counting rather than a last-open scan, so `closed, then reopened` still
+reads as enclosed.
+
+Extracted as `hallucinated_result_around(s, begin, end)` and applied to every
+mode that promotes dialect to a call -- 16, 17a, 17b, 20, 21, 22 -- each against
+its OWN span, instead of one coarse veto over all of them. Mode 16 was carrying
+a second copy of the whole-string guard and had the identical latent bug; it is
+on the shared helper now.
+
+### Measured
+
+`test_tool_drift` 124 -> 151 assertions, the new ones red before the change.
+They pin the rule directly (closed-before-span is context, unclosed-before-span
+and in-span are not, closed-then-reopened is enclosed, fully-closed nesting is
+context) plus the mode-16 loosening in BOTH directions: a closed `<output>`
+before a `<function>`-wrapped call no longer kills it, an unclosed `<result>`
+enclosing one still refuses.
+
+Full `make test-tools` green under gcc: drift (tolerant and strict), corpus,
+openai bridge, chat-completions integration, think-resolve, stream-split,
+toolconstrain.
+
+**No live-generation A/B is claimed for this change.** The fixtures are the
+reported bytes, and the fix is a pure parser predicate, but the survey harness
+needs a GPU host this work was not done on -- so the live tables in (b)/(c)/(d)
+have no counterpart here. Anyone with the survey running should expect the
+UNPARSED column to fall on transcripts that quote tool output, and nothing else
+to move.
+
+### Also on this branch
+
+**Unclosed-`<tool_call>` tail recovery.** `bb60661` routed a CLOSED wrapped
+TOOL segment through the drift chain but left the unclosed one as raw text.
+`recover_unclosed_tool_tail()` now routes that tail too, with
+`allow_eof_repair=false` -- an inner call whose JSON/XML is COMPLETE and merely
+lost its `</tool_call>` to truncation recovers, while a value cut mid-parse
+stays text. Executing half a Write is still refused. Wired at all six handler
+sites (chat, chat-stream, messages, messages-stream, responses,
+responses-stream). Defence-in-depth: both this and
+`resolve_ordered_tool_segments` now refuse a call whose `source_begin` is npos
+or overlaps the emitted cursor, because `substr(cursor, begin - cursor)` would
+underflow to SIZE_MAX and throw inside the request handler. Mode 20 also stamps
+per-call spans now instead of only first/last, which is what made middle calls
+npos in the first place.
+
+**XML-dialect toolgram.** `--constrain-tools` only ever spoke the 3.6 JSON body
+format, so on an XML-trained 3.8 the grammar fought the model's own trained
+emission. `ToolGrammarXml` constrains the body to
+`<function=NAME><parameter=KEY>VALUE</parameter></function>` instead, schema-
+aware: the parameter-key allowlist switches to that tool's declared parameters
+once the name completes. `<` inside a value is legal ONLY as the start of
+`</parameter>` or `</function>`, so a model reaching for `<result>` or a nested
+`<function=` hits a dead state and the decoder masks it out -- **the chimera
+from (d) is prevented at the source rather than refused after the fact.**
+`ToolMaskCache` is templated on the grammar so both dialects share the caching
+and the allowlist-in-cache-key isolation (R1) unchanged. Metal stays JSON-only
+and warns once when it would matter, rather than silently no-opping.
+
+**Vendored cpp-httplib 0.18.3 -> 0.53.1.** 0.53.1 renames `DataSink::is_alive`
+-> `is_writable`; the four Metal call sites follow. The two cannot ship apart --
+the vendor bump alone leaves `q27-metal-server` uncompilable.
+
+### Metal does not currently compile on master, and no suite can tell you
+
+Separable from everything above, found while rebasing onto it: `a317bc8`
+vendored cpp-httplib 0.53.1, which renames `DataSink::is_alive` to
+`is_writable`, but `src/metal/metal_server.cpp` still calls `sink.is_alive()` at
+four sites. `q27-metal-server` does not build on the current tip. Sent
+separately as a four-line change, since it stands on its own and should not
+queue behind a parser review.
+
+What IS here is the other half of the same file: `ToolMaskCache` is templated on
+the grammar now (below), so Metal's `q27::ToolMaskCache mask_cache;` needs its
+template argument or that backend stops compiling for a second, unrelated
+reason.
+
+The reason it went unnoticed is the part worth keeping: **every CPU suite and
+the CUDA build are blind to that file.** `make test-tools` is fully green on a
+tree where one of the two backends cannot build at all, so the vendor bump
+looked clean by every gate that runs by default. Same failure shape as (b), (c)
+and (d) one more time -- the instrument cannot see the thing, so the thing reads
+as absent. A per-backend compile gate is cheaper than the next occurrence;
+`make test-tools` covers the tree it can build, not the tree.
+
+**Not verified here:** neither backend was compiled for this entry -- no CUDA
+and no Apple-silicon host was available. The `is_alive` -> `is_writable` break
+is a source-level fact about the vendored header's API, and the CUDA-side
+changes are header-only C++ exercised by the CPU suites, but
+`build/q27-server` and `q27-metal-server` both still want a real compile before
+anyone leans on this.

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -270,10 +270,13 @@ inline bool tool_dialect_xml() {
     if (d) return !strcmp(d, "xml");
     return tool_dialect_xml_default();
 }
-// Q27_TOOL_DIALECT=xml swaps the calling instruction for the dialect the
-// checkpoint was trained on (see parse_native_xml_call above). Default stays
-// JSON: 3.6 complied with it well, and the A/B that would justify flipping the
-// default is exactly what this knob exists to run.
+// Q27_TOOL_DIALECT=xml|json overrides either direction. The DEFAULT is now
+// auto-selected from the artifact's general.name (see
+// set_tool_dialect_for_model above): 3.8-family checkpoints boot as XML
+// (their trained format -- the 08-14 A/B showed zero drift rescues under
+// XML vs four under JSON), and 3.6-family boot as JSON (3.6 demonstrably
+// complies with JSON). The knob exists for A/Bs and for fine-tunes whose
+// general.name normalization misses the "qwen38" substring.
 
 // Reasoning-effort instruction (Qwen3.8 chat_template.jinja): with thinking
 // enabled the trained template injects this line at the HEAD of the system
@@ -2042,6 +2045,57 @@ inline OpenAIToolSelection select_openai_tools(const json& body,const ToolChoice
     return selected;
 }
 
+// Per-tool parameter-key extraction, aligned with OpenAIToolSelection::names.
+// Used by the XML-dialect toolgram (--constrain-tools on Qwen3.8) to build
+// its schema-aware parameter-key allowlist: only declared property names are
+// legal as <parameter=...> keys, which is what stops the model from
+// emitting undeclared keys in its XML tool body. Returns one vector per tool,
+// in the same order as `selected.names`; tools whose parameters block is
+// missing/malformed get an empty list (the grammar then accepts any key for
+// that tool -- a permissive fallback for malformed schemas rather than a
+// silent rejection of the whole request).
+inline std::vector<std::vector<std::string>>
+tool_param_keys_per_name(const OpenAIToolSelection& selected) {
+    std::vector<std::vector<std::string>> out;
+    out.reserve(selected.tools.size());
+    for (const auto& t : selected.tools) {
+        std::vector<std::string> keys;
+        if (t.contains("function") && t["function"].contains("parameters") &&
+            t["function"]["parameters"].contains("properties") &&
+            t["function"]["parameters"]["properties"].is_object()) {
+            for (auto it = t["function"]["parameters"]["properties"].begin();
+                 it != t["function"]["parameters"]["properties"].end(); ++it) {
+                keys.push_back(it.key());
+            }
+        }
+        out.push_back(std::move(keys));
+    }
+    return out;
+}
+
+// json-array overload (for callers that already moved `tools` out of the
+// selection; the two backends' selected-tools arrays are both aligned with
+// tool_names_v).
+inline std::vector<std::vector<std::string>>
+tool_param_keys_per_name(const json& tools) {
+    std::vector<std::vector<std::string>> out;
+    if (!tools.is_array()) return out;
+    out.reserve(tools.size());
+    for (const auto& t : tools) {
+        std::vector<std::string> keys;
+        if (t.contains("function") && t["function"].contains("parameters") &&
+            t["function"]["parameters"].contains("properties") &&
+            t["function"]["parameters"]["properties"].is_object()) {
+            for (auto it = t["function"]["parameters"]["properties"].begin();
+                 it != t["function"]["parameters"]["properties"].end(); ++it) {
+                keys.push_back(it.key());
+            }
+        }
+        out.push_back(std::move(keys));
+    }
+    return out;
+}
+
 // Anthropic counts every declaration even when tool_choice narrows eligibility.
 // The inactive block keeps that accounting while leaving only selected schemas
 // in the callable interface. This choice-specific system prompt is intentional:
@@ -2190,6 +2244,13 @@ inline bool parse_native_xml_call(const std::string& seg, ToolCall& tc) {
         // `</parameter>` before the first real `<parameter=` is ignored by the
         // scan below, which searches forward for the opener.
         size_t ns = b + 6;
+        // Tolerate the name on the NEXT line after `<name>` -- a real
+        // emission (and this harness's mangled tool transport) can open
+        // `<name>` and drop the identifier on the following line. The old
+        // code read "up to the first newline", yielding an EMPTY name and
+        // refusing the whole call. Mirror parse_function_opener's leading-
+        // whitespace skip so `<name>\nbash\n<parameter=...>` -> name="bash".
+        while (ns < seg.size() && isspace((unsigned char)seg[ns])) ns++;
         size_t ne = seg.find('\n', ns);
         if (ne == std::string::npos) ne = seg.size();
         tc.name = seg.substr(ns, ne - ns);
@@ -3172,6 +3233,72 @@ inline bool looks_like_intended_tool_call(const std::string& text_in) {
            text_in.find("<tool_name>") != std::string::npos;
 }
 
+// HALLUCINATED-RESULT RULE (2026-08-21, unified).
+//
+// Qwen3.8 does not only degrade its tool-call wrapper -- it also invents tool
+// RESULTS wearing the very same tags:
+//
+//   <tool_calls>\n<result>\n<name>Read</name>\n<output>\nfile contents\n</output>
+//   \n<tool_name>\n<parameter=file_path>\n/w/x\n</parameter>\n</function>
+//
+// Promoting that to a call feeds the model's own fiction back as though a tool
+// had produced it, so every dialect recovery has to refuse it. The original
+// guard was a WHOLE-STRING `find("<result>")` over the entire segment, which
+// is both too weak and too strong:
+//
+//   too strong -- a legitimate call preceded by an unrelated, already-CLOSED
+//   `<output>make: up to date</output>` (a quoted result from a prior step,
+//   ordinary prose in an agent transcript) was thrown away wholesale. That is
+//   the production leak behind "sometimes I still see <parameter= / </function>
+//   in the output": the real call was sitting right there and the guard
+//   vetoed the whole recovery chain.
+//
+//   too weak -- it says nothing about WHERE the tags sit, so it cannot
+//   distinguish the two cases at all; it just refuses both.
+//
+// The discriminator is STRUCTURAL, not lexical: does the result element
+// *contain* the candidate call?
+//
+//   (a) a <result>/<output> tag INSIDE the span  -> invented output is being
+//       passed off as a parameter value; refuse.
+//   (b) the span begins INSIDE an unclosed <result>/<output> element -> the
+//       "call" is part of the invented result block; refuse.
+//   otherwise -> every result block is closed before the call starts, so it is
+//       prior context, not a wrapper around this call; ACCEPT.
+//
+// (b) is what catches the real hallucinated shapes above: the model opens
+// <result> and never closes it, so the <tool_name>/<parameter= span it later
+// emits is enclosed by it. (a) catches the inverse -- a well-formed-looking
+// call whose parameter VALUE is a fabricated <result>.
+//
+// Nesting is handled by depth counting rather than a last-open scan, so a
+// closed block followed by an open one still reads as enclosed.
+inline bool hallucinated_result_around(const std::string& s, size_t begin, size_t end) {
+    if (begin == std::string::npos) return false;
+    if (end == std::string::npos || end > s.size()) end = s.size();
+    static const char* const kTags[2][2] = {{"<result>", "</result>"},
+                                            {"<output>", "</output>"}};
+    for (const auto& tg : kTags) {
+        const std::string open = tg[0], close = tg[1];
+        // (a) either tag of the pair occurring within [begin, end)
+        for (const std::string& t : {open, close}) {
+            size_t p = s.find(t, begin);
+            if (p != std::string::npos && p < end) return true;
+        }
+        // (b) unbalanced open before begin == the span is enclosed by it
+        long depth = 0;
+        size_t i = 0;
+        while (i < begin) {
+            size_t o = s.find(open, i), c = s.find(close, i);
+            if (o >= begin && c >= begin) break; // (npos included)
+            if (o < c) { depth++; i = o + open.size(); }
+            else { if (depth > 0) depth--; i = c + close.size(); }
+        }
+        if (depth > 0) return true;
+    }
+    return false;
+}
+
 inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
                                                    std::string* prefix,
                                                    const json* tools = nullptr,
@@ -3379,8 +3506,7 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
         static const std::string FN_OPEN = "<function>";
         size_t p = text_in.find(FN_OPEN);
         if (p != std::string::npos && tools && tools->is_array() &&
-            text_in.find("<result>") == std::string::npos &&
-            text_in.find("<output>") == std::string::npos) {
+            !hallucinated_result_around(text_in, p, text_in.size())) {
             size_t ob = text_in.find('{', p + FN_OPEN.size());
             if (ob != std::string::npos) {
                 std::string body = text_in.substr(ob);
@@ -3428,11 +3554,14 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
     //         {"name": "Write",\n<parameter=file_path>\n/x\n</parameter>\n<parameter=content>\n...
     // (a) reuses parse_native_xml_call on the spanned substring. (b) extracts
     // the name from the JSON head and hands the rest to the XML parameter
-    // walk. Both engage only on a declared name; anything carrying <result> or
-    // <output> stays text (the hallucinated-result rule).
-    if (tools && tools->is_array() &&
-        text_in.find("<result>") == std::string::npos &&
-        text_in.find("<output>") == std::string::npos) {
+    // walk. Both engage only on a declared name.
+    //
+    // Hallucinated-result protection (2026-08-21): the outer whole-string
+    // find for <result>/<output> that used to gate this entire block is gone;
+    // each mode below now applies hallucinated_result_around() to its OWN
+    // candidate span. See that helper for why enclosure -- not mere presence
+    // -- is the correct test.
+    if (tools && tools->is_array()) {
         auto declared = [&](const std::string& nm) {
             for (const auto& t : *tools)
                 if (t.contains("function") &&
@@ -3455,10 +3584,11 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
             std::string span = text_in.substr(fb);
             size_t fe = span.find("</function>");
             if (fe != std::string::npos) span = span.substr(0, fe + 11);
-            if (parse_native_xml_call(span, tc) && declared(tc.name)) {
+            const size_t fb_end = fe != std::string::npos ? fb + fe + 11 : text_in.size();
+            if (!hallucinated_result_around(text_in, fb, fb_end) &&
+                parse_native_xml_call(span, tc) && declared(tc.name)) {
                 tc.source_begin = fb;
-                tc.source_end = fe != std::string::npos ? fb + fe + 11
-                                                        : text_in.size();
+                tc.source_end = fb_end;
                 if (prefix) *prefix = text_in.substr(0, fb);
                 if (remaining_text) *remaining_text = "";
                 fprintf(stderr, "[q27] bare native-dialect call recovered: %s\n", tc.name.c_str());
@@ -3475,7 +3605,8 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
                 size_t q2 = q1 == std::string::npos ? q1 : text_in.find('"', q1 + 1);
                 if (q2 != std::string::npos && q2 < pp) {
                     const std::string nm = text_in.substr(q1 + 1, q2 - q1 - 1);
-                    if (declared(nm)) {
+                    if (declared(nm) &&
+                        !hallucinated_result_around(text_in, jb, text_in.size())) {
                         // reuse the XML walk by synthesizing a well-formed span;
                         // a missing final </parameter> is tolerated by closing at EOF
                         std::string span = "<function=" + nm + ">\n" + text_in.substr(pp);
@@ -3510,15 +3641,18 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
         // for JSON mode 6, including its refuse-on-tie rule. A wrong tool is
         // worse than an un-rescued one, so inference failure leaves it as text.
         //
-        // The <result>/<output> guard above is what keeps this off the
+        // hallucinated_result_around() is what keeps this off the
         // HALLUCINATED-RESULT shape (<tool_calls><result><name>X</name>
-        // <output>...), which mode 16 pins with a negative fixture: those are
-        // invented tool OUTPUT, and promoting them to calls would feed the
-        // model's own fiction back as if a tool had produced it.
+        // <output>...<tool_name><parameter=...), which mode 16 pins with a
+        // negative fixture: those are invented tool OUTPUT, and promoting them
+        // to calls would feed the model's own fiction back as if a tool had
+        // produced it. That shape leaves <result> UNCLOSED, so the per-call
+        // span below reads as enclosed by it and is refused -- while a batch
+        // that merely follows a closed <output> block still recovers.
         {
             static const std::string TN = "<tool_name>";
             std::vector<ToolCall> batch;
-            size_t scan = 0, first_begin = std::string::npos;
+            size_t scan = 0;
             while (true) {
                 size_t tn = text_in.find(TN, scan);
                 if (tn == std::string::npos) break;
@@ -3538,20 +3672,36 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
                                    text_in.substr(after, end - after);
                 if (span.find("</function>") == std::string::npos) span += "\n</function>";
                 ToolCall tc;
+                if (hallucinated_result_around(text_in, tn, end)) {
+                    fprintf(stderr, "[q27] drift mode 20: hallucinated <result>/<output> "
+                                    "block encloses the call, refusing\n");
+                    continue;
+                }
                 if (!parse_native_xml_call(span, tc) || tc.arguments.empty()) continue;
                 const std::string nm = infer_tool_name(*tools, tc.arguments);
                 if (nm.empty() || !declared(nm)) continue;
                 tc.name = nm;
                 tc.ok = true;
-                if (first_begin == std::string::npos) first_begin = tn;
+                // STAMP PER-CALL spans (review 2026-08-20): the prior code
+                // only set batch.front().source_begin and batch.back().source_end,
+                // leaving middle calls with source_begin == npos. The unclosed-tail
+                // recovery (recover_unclosed_tool_tail) and the closed-wrapper
+                // resolver (resolve_ordered_tool_segments) both compute
+                // `raw.substr(cursor, c.source_begin - cursor)`; an npos middle
+                // call underflows to SIZE_MAX and substr throws out_of_range
+                // inside the request handler. Stamp every call so the gaps
+                // between calls and the trailing text after the last call are
+                // represented correctly.
+                tc.source_begin = tn;
+                tc.source_end = end;
                 batch.push_back(std::move(tc));
                 scan = end;
             }
             if (!batch.empty()) {
-                batch.front().source_begin = first_begin;
-                batch.back().source_end = text_in.size();
-                if (prefix) *prefix = text_in.substr(0, first_begin);
-                if (remaining_text) *remaining_text = "";
+                if (prefix) *prefix = text_in.substr(0, batch.front().source_begin);
+                // trailing text after the last call's region stays visible as
+                // text (the prior override glued it to the last call's source_end)
+                if (remaining_text) *remaining_text = text_in.substr(batch.back().source_end);
                 fprintf(stderr, "[q27] drift mode 20: recovered %zu nameless <tool_name> call(s)\n",
                         batch.size());
                 return batch;
@@ -3583,6 +3733,20 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
             size_t fe = ps == std::string::npos ? std::string::npos
                                                 : text_in.find("</function>", ps);
             if (fe != std::string::npos) {
+                // Scoped hallucinated-result guard (2026-08-21). The span is
+                // [ps, fe+11) -- the parameter list itself. A <result>/<output>
+                // tag inside it, or an unclosed one enclosing it, is invented
+                // output and refused; one that opened AND closed before ps is
+                // prior context and must not veto this call. (The first attempt
+                // at this scoped it only at the END, so a closed block earlier
+                // in the tail still killed the call -- the very leak it meant
+                // to fix.)
+                const size_t span_end = fe + 11;
+                if (hallucinated_result_around(text_in, ps, span_end)) {
+                    fprintf(stderr,
+                            "[q27] drift mode 21: hallucinated <result>/<output> "
+                            "block in the parameter span, refusing\n");
+                } else {
                 std::string span =
                     "<function=q27_unnamed>\n" + text_in.substr(ps, fe + 11 - ps);
                 ToolCall tc;
@@ -3600,6 +3764,7 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
                                 nm.c_str());
                         return std::vector<ToolCall>{std::move(tc)};
                     }
+                }
                 }
             }
         }
@@ -3648,6 +3813,12 @@ inline std::vector<ToolCall> parse_bare_tool_calls(const std::string& text_in,
                 ToolCall tc;
                 const std::string span =
                     "<function=" + nm + ">\n" + text_in.substr(nxt, fe + FC.size() - nxt);
+                if (hallucinated_result_around(text_in, ps, fe + FC.size())) {
+                    fprintf(stderr, "[q27] drift mode 22: hallucinated <result>/<output> "
+                                    "block encloses the call, refusing\n");
+                    cur = fe + FC.size();
+                    continue;
+                }
                 if (parse_native_xml_call(span, tc) && !tc.arguments.empty()) {
                     tc.name = nm;
                     tc.ok = true;
@@ -4332,6 +4503,58 @@ inline std::string take_unclosed_final_tool_segment(
     return raw;
 }
 
+// Route an UNCLOSED-<tool_call> tail (wrapper stripped, generation truncated)
+// through the drift chain. Complements bb60661, which routed a CLOSED-wrapped
+// TOOL segment through parse_bare_tool_calls but deliberately left the unclosed
+// one as raw text. Same safety bar that commit documented:
+//
+//   "no EOF repair, because a closed wrapper means drift rather than
+//    truncation, and an unclosed one is removed upstream by
+//    take_unclosed_final_tool_segment. Executing half a Write stays refused."
+//
+// allow_eof_repair=false inside means only bytes the parser accepts as a
+// well-formed call execute: an inner call whose JSON/XML is COMPLETE (its
+// </tool_call> merely never arrived because the generation was cut) recovers on
+// mode 1 / the native dialect, while a value genuinely cut mid-parse (a
+// partial Write) is rejected and shown as text. That is the same refusal
+// boundary that protects the closed-wrapper path, just reached from the tail.
+//
+// emit_call returns true when the call was accepted (recovered++), false to
+// leave its bytes as text (ineligible / refused -- never re-runs the chain, so
+// tool_choice / disable_parallel_tool_use rejections can't be resurrected).
+// Returns the number of accepted calls.
+template<class EmitText, class EmitCall>
+inline size_t recover_unclosed_tool_tail(const std::string& raw,
+    const json* tools, EmitText emit_text, EmitCall emit_call) {
+    if(raw.empty()) return 0;
+    if(!tools || !tools->is_array() || tools->empty()){
+        emit_text(raw); return 0;
+    }
+    std::string pre; // parse_bare_tool_calls writes here; we use cursor/source_begin instead (see comment above)
+    auto calls=parse_bare_tool_calls(raw,&pre,tools,true,false,nullptr);
+    if(calls.empty()){ emit_text(raw); return 0; }
+    size_t cursor=0,recovered=0;
+    for(auto& c:calls){
+        // defense-in-depth (review 2026-08-20): mode 20 now stamps per-call
+        // spans, but if any future drift mode returns a batch with a missing
+        // source_begin (npos) or a span that overlaps the cursor we've already
+        // emitted, raw.substr(cursor, c.source_begin-cursor) would underflow
+        // to SIZE_MAX and throw out_of_range inside the request handler.
+        // Refuse to emit such a call -- dump the remaining tail as text and
+        // stop -- rather than crash.
+        if (c.source_begin == std::string::npos || c.source_begin < cursor) {
+            emit_text(raw.substr(cursor));
+            break;
+        }
+        emit_text(raw.substr(cursor,c.source_begin-cursor));
+        cursor=c.source_end;
+        if(emit_call(c)) recovered++;
+        else emit_text(c.raw);
+    }
+    emit_text(raw.substr(cursor));
+    return recovered;
+}
+
 // Resolve generated text and wrapped calls in generation order. This matters
 // when parallel calls are disabled: a bare call emitted before a later wrapped
 // call must win, and rejected or malformed bytes must remain visible as text.
@@ -4350,6 +4573,14 @@ inline OrderedToolOutput resolve_ordered_tool_segments(
         if(calls.empty()) { out.append_visible_text(raw); return; }
         size_t cursor=0;
         for(auto& call:calls) {
+            // defense-in-depth (review 2026-08-20): see recover_unclosed_tool_tail.
+            // If any drift mode hands us a call with an unset source_begin
+            // (npos) or an overlapping span, substr() would throw; dump the
+            // remaining tail as visible text and stop.
+            if (call.source_begin == std::string::npos || call.source_begin < cursor) {
+                out.append_visible_text(raw.substr(cursor));
+                break;
+            }
             out.append_visible_text(raw.substr(cursor,call.source_begin-cursor));
             cursor=call.source_end;
             if(eligible(call.name,out.calls.size())) {

--- a/src/metal/metal_server.cpp
+++ b/src/metal/metal_server.cpp
@@ -664,7 +664,7 @@ struct Runtime {
     // default for speed). --think flips the profile to prefilling an open
     // think tag. Either way, per-request fields override (resolve_think).
     std::vector<std::string> vocab_bytes_v;
-    q27::ToolMaskCache mask_cache;
+    q27::ToolMaskCache<q27::ToolGrammar> mask_cache;
     DiskSnapshotStore snapstore{&snap_peek_adapter,&snap_hash_sha1};
     TraceLog trace;
     std::string model_name,model_sha1_cache,boot_id,server_sha1,tokenizer_name,tokenizer_sha1;
@@ -1710,6 +1710,24 @@ struct Runtime {
         tc.enabled=q27::metal_tool_constraint_enabled(
             constrain_tools,!tool_names.empty(),sampling.temperature==0.0f,
             effective_speculation_width(sampling,bounded_reasoning),forced_tool_choice);
+        // Metal is still on the 1-arg tc.begin (JSON grammar only) -- it has
+        // no parallel cache_xml and the filtered tools JSON isn't threaded
+        // through to this site. If the model is XML-trained (Qwen3.8) and
+        // --constrain-tools is on, the JSON grammar dead-states on the first
+        // body byte ('<', where JSON expects '{') and the constraint drops
+        // cleanly. No crash, but the feature silently no-ops. Warn once so
+        // it's visible (review 2026-08-20).
+        if (tc.enabled && q27::tool_dialect_xml()) {
+            static bool warned = false;
+            if (!warned) {
+                warned = true;
+                fprintf(stderr,
+                        "[metal] WARNING: --constrain-tools + XML-dialect model "
+                        "(Qwen3.8) is not wired on Metal -- constraint will "
+                        "disengage on the first body byte. CUDA path uses "
+                        "ToolGrammarXml and works correctly; Metal is JSON-only.\n");
+            }
+        }
         {
             auto gpu=lease_now();
             tc.begin(tool_names);

--- a/src/server.cu
+++ b/src/server.cu
@@ -1154,8 +1154,14 @@ int main(int argc, char** argv) {
     // P7 shared mask cache (mutated only from generation callbacks, which
     // run while holding the GPU gate; pool ids are per-slot)
     std::vector<std::string> vocab_bytes_v = tok.vocab_bytes();
-    q27::ToolMaskCache tool_mask_cache;
+    q27::ToolMaskCache<q27::ToolGrammar> tool_mask_cache;
     tool_mask_cache.init(&vocab_bytes_v, tok.token_id("</tool_call>"));
+    // Parallel cache for the XML-dialect toolgram (3.8 trained format);
+    // --constrain-tools routes the body through whichever matches the
+    // model's dialect (tool_dialect_xml). Same vocabulary / closer; distinct
+    // masks (different grammar signatures).
+    q27::ToolMaskCache<q27::ToolGrammarXml> tool_mask_cache_xml;
+    tool_mask_cache_xml.init(&vocab_bytes_v, tok.token_id("</tool_call>"));
     if (constrain_tools)
         fprintf(stderr, "constrain-tools: grammar-locked <tool_call> bodies (open=%d close=%d)\n",
                 tok.token_id("<tool_call>"), tok.token_id("</tool_call>"));
@@ -2047,7 +2053,7 @@ int main(int argc, char** argv) {
                 else segments.emplace_back(ch, t);
             };
             ToolConstrainer tc;
-            tc.eng = &eng; tc.tok = &tok; tc.cache = &tool_mask_cache;
+            tc.eng = &eng; tc.tok = &tok; tc.cache = &tool_mask_cache; tc.cache_xml = &tool_mask_cache_xml;
             tc.host2dev = &sl.tool_mask_host2dev;
             // FORCED requests are prompt-injected past the <tool_call> marker
             // (above) -- scan_round's engage trigger scans GENERATED text for
@@ -2056,7 +2062,8 @@ int main(int argc, char** argv) {
             // comment); AUTO (the default) and NONE are unaffected.
             tc.enabled = constrain_tools && tchoice.mode != q27::ToolChoice::FORCED &&
                         eng.samp.inv_temp <= 0.f; // constrained+sampled is Phase 3
-            tc.begin(tool_names_v);
+            auto params_per_name = q27::tool_param_keys_per_name(tools);
+            tc.begin(tool_names_v, params_per_name, q27::tool_dialect_xml());
             // FORCED: the opener was injected into the PROMPT, not generated,
             // so the splitter must start already inside the TOOL channel or
             // the call body would be read back as ordinary text.
@@ -2123,7 +2130,21 @@ int main(int argc, char** argv) {
                     return q27::tool_choice_allows_call(
                         tchoice, allowed_tool_names, name, accepted);
                 });
-            ordered.text+=unclosed_tool;
+            // unclosed-<tool_call> tail: recover COMPLETE inner calls the same
+            // way bb60661 recovers closed ones, without EOF repair (see the
+            // helper). Only finished inner JSON executes; a partial Write stays
+            // text.
+            ordered.recovered += q27::recover_unclosed_tool_tail(
+                unclosed_tool, tools.is_array() && !tools.empty() ? &tools : nullptr,
+                [&](const std::string& t) { ordered.append_visible_text(t); },
+                [&](q27::ToolCall c) {
+                    if (!c.ok || !q27::tool_choice_allows_call(
+                            tchoice, allowed_tool_names, c.name,
+                            ordered.calls.size()))
+                        return false;
+                    ordered.append_tool_call(std::move(c));
+                    return true;
+                });
             std::string tx = ordered.text;
             std::vector<q27::ToolCall> eligible_calls = std::move(ordered.calls);
             if (ordered.recovered)
@@ -2257,11 +2278,12 @@ int main(int argc, char** argv) {
                 // mechanical twin of the /v1/messages SSE handler above.
                 const std::string cid = "chatcmpl-q27-" + std::to_string(rid);
                 ToolConstrainer tc;
-                tc.eng = &eng; tc.tok = &tok; tc.cache = &tool_mask_cache;
+                tc.eng = &eng; tc.tok = &tok; tc.cache = &tool_mask_cache; tc.cache_xml = &tool_mask_cache_xml;
                 tc.host2dev = &sl.tool_mask_host2dev;
                 tc.enabled = constrain_tools && tchoice.mode != q27::ToolChoice::FORCED &&
                             eng.samp.inv_temp <= 0.f; // constrained+sampled is Phase 3
-                tc.begin(tool_names_v);
+                auto params_per_name = q27::tool_param_keys_per_name(tools);
+                tc.begin(tool_names_v, params_per_name, q27::tool_dialect_xml());
                 StreamSplitter sp;
                 q27::ThinkBudgetState tb{think_budget};
                 Engine::DecodeTask bt;
@@ -2395,8 +2417,16 @@ int main(int argc, char** argv) {
                 for (auto& [ch, t] : sp.flush()) emit_seg(ch, t);
                 if (!tool_buf.empty()) {
                     if (final_tool_incomplete) {
-                        emit_text(tool_buf);
+                        // recover COMPLETE inner calls from the truncated
+                        // wrapper; no EOF repair, so a partial Write stays text.
+                        const size_t rec = q27::recover_unclosed_tool_tail(
+                            tool_buf, has_tools ? &tools : nullptr,
+                            emit_text, emit_call);
                         tool_buf.clear();
+                        if (rec)
+                            fprintf(stderr,
+                                    "[tool-fallback] %zu drifted call(s) recovered (oai-stream truncated wrapper)\n",
+                                    rec);
                     } else emit_tool();
                 }
                 if (!final_tool_incomplete)
@@ -2631,11 +2661,12 @@ int main(int argc, char** argv) {
                 else segments.emplace_back(ch, t);
             };
             ToolConstrainer tc;
-            tc.eng = &eng; tc.tok = &tok; tc.cache = &tool_mask_cache;
+            tc.eng = &eng; tc.tok = &tok; tc.cache = &tool_mask_cache; tc.cache_xml = &tool_mask_cache_xml;
             tc.host2dev = &sl.tool_mask_host2dev;
             tc.enabled = constrain_tools && tchoice.mode!=q27::ToolChoice::FORCED &&
                          eng.samp.inv_temp <= 0.f; // constrained+sampled is Phase 3
-            tc.begin(tool_names_v);
+            auto params_per_name = q27::tool_param_keys_per_name(tools);
+            tc.begin(tool_names_v, params_per_name, q27::tool_dialect_xml());
             eng.on_pending = [&](int id) { tc.on_pending(id); };
             eng.on_drafts = [&](const int* dr) { tc.on_drafts(dr); };
             eng.on_round = [&](const int* em, int nr) {
@@ -2697,7 +2728,19 @@ int main(int argc, char** argv) {
                     return q27::tool_choice_allows_call(
                         tchoice,allowed_tool_names,name,accepted);
                 });
-            ordered.append_visible_text(unclosed_tool);
+            // unclosed-<tool_call> tail: recover COMPLETE inner calls (bb60661
+            // style), no EOF repair -- a partial Write stays text.
+            ordered.recovered += q27::recover_unclosed_tool_tail(
+                unclosed_tool, tools.is_array() && !tools.empty() ? &tools : nullptr,
+                [&](const std::string& t) { ordered.append_visible_text(t); },
+                [&](q27::ToolCall c) {
+                    if (!c.ok || !q27::tool_choice_allows_call(
+                            tchoice,allowed_tool_names,c.name,
+                            ordered.calls.size()))
+                        return false;
+                    ordered.append_tool_call(std::move(c));
+                    return true;
+                });
             json content = json::array();
             std::string th = q27::strip_ws2(ordered.reasoning);
             if (!th.empty())
@@ -2763,11 +2806,12 @@ int main(int argc, char** argv) {
                 const int nm = limits.n_max;
                 const int think_budget = limits.budget;
                 ToolConstrainer tc;
-                tc.eng = &eng; tc.tok = &tok; tc.cache = &tool_mask_cache;
+                tc.eng = &eng; tc.tok = &tok; tc.cache = &tool_mask_cache; tc.cache_xml = &tool_mask_cache_xml;
                 tc.host2dev = &sl.tool_mask_host2dev;
                 tc.enabled = constrain_tools && tchoice.mode!=q27::ToolChoice::FORCED &&
                              eng.samp.inv_temp <= 0.f; // constrained+sampled is Phase 3
-                tc.begin(tool_names_v);
+                auto params_per_name = q27::tool_param_keys_per_name(tools);
+                tc.begin(tool_names_v, params_per_name, q27::tool_dialect_xml());
                 int block_counter = 0, tool_counter = 0;
                 bool any_call = false;
                 bool alive = true; // cleared when a write fails (client disconnected)
@@ -2938,8 +2982,14 @@ int main(int argc, char** argv) {
                 for (auto& [ch, t] : sp.flush()) emit_seg(ch, t);
                 if (!tool_buf.empty()) {
                     if (final_tool_incomplete) {
-                        emit_text(tool_buf);
+                        const size_t rec = q27::recover_unclosed_tool_tail(
+                            tool_buf, has_tools ? &tools : nullptr,
+                            emit_text, emit_call);
                         tool_buf.clear();
+                        if (rec)
+                            fprintf(stderr,
+                                    "[tool-fallback] %zu drifted call(s) recovered (stream truncated wrapper)\n",
+                                    rec);
                     } else emit_tool();
                 }
                 if(!final_tool_incomplete)
@@ -3424,9 +3474,26 @@ int main(int argc, char** argv) {
             for (auto& [ch, t] : sp.flush()) route(ch, t);
             if (!ctx->tool_buf.empty()) {
                 if (unfinished_tool_wrapper) {
-                    push_text(ctx->tool_buf,true);
+                    // recover COMPLETE inner calls from the truncated wrapper
+                    // (bb60661 for the unclosed tail); no EOF repair, so a
+                    // partial Write stays text. Residual is incomplete text.
+                    const size_t rec = q27::recover_unclosed_tool_tail(
+                        ctx->tool_buf, tools.is_array() && !tools.empty() ? &tools : nullptr,
+                        [&](const std::string& t) { push_text(t, true); },
+                        [&](q27::ToolCall c) -> bool {
+                            if (!c.ok || !q27::tool_choice_allows_call(
+                                    response_choice, eligible_call_names,
+                                    c.name, tool_counter))
+                                return false;
+                            emit_tool(std::move(c));
+                            return true;
+                        });
                     ctx->tool_buf.clear();
-                    ctx->tool_tail=false;
+                    ctx->tool_tail = rec != 0;
+                    if (rec)
+                        fprintf(stderr,
+                                "[tool-fallback] %zu drifted call(s) recovered (responses truncated wrapper)\n",
+                                rec);
                 } else flush_tool();
             }
             flush_think();
@@ -3857,9 +3924,18 @@ int main(int argc, char** argv) {
                 for (auto& [ch, t] : sp.flush()) route(ch, t);
                 if (!tool_buf.empty()) {
                     if (unfinished_tool_wrapper) {
-                        append_text(tool_buf);
+                        // recover COMPLETE inner calls (bb60661 for the
+                        // unclosed tail); no EOF repair -- partial Write stays
+                        // text.
+                        const size_t rec = q27::recover_unclosed_tool_tail(
+                            tool_buf, tools.is_array() && !tools.empty() ? &tools : nullptr,
+                            append_text, emit_call);
                         tool_buf.clear();
-                        output_tool_tail=false;
+                        output_tool_tail = rec != 0;
+                        if (rec)
+                            fprintf(stderr,
+                                    "[tool-fallback] %zu drifted call(s) recovered (responses-stream truncated wrapper)\n",
+                                    rec);
                     } else flush_tool();
                 }
                 flush_think();

--- a/src/test_tokenizer.cpp
+++ b/src/test_tokenizer.cpp
@@ -720,7 +720,7 @@ int main(int argc, char** argv) {
                                           "abc", "\n",  "}",    " ",      "</tool_call>",
                                           ""};
         const int CLOSER = 9, CTRL = 10;
-        q27::ToolMaskCache mc;
+        q27::ToolMaskCache<q27::ToolGrammar> mc;
         mc.init(&vocab, CLOSER);
         q27::ToolGrammar g;
         g.reset({"write", "view"});
@@ -749,7 +749,7 @@ int main(int argc, char** argv) {
     {
         auto vb = tok.vocab_bytes();
         int closer = tok.token_id("</tool_call>");
-        q27::ToolMaskCache mc;
+        q27::ToolMaskCache<q27::ToolGrammar> mc;
         mc.init(&vb, closer);
         q27::ToolGrammar g;
         g.reset({"write", "view", "ls", "bash", "grep", "glob", "edit"});

--- a/src/toolconstrain.h
+++ b/src/toolconstrain.h
@@ -28,13 +28,18 @@ template <class EngineT, class TokT>
 struct BasicToolConstrainer {
     EngineT* eng = nullptr;
     const TokT* tok = nullptr;
-    ToolMaskCache* cache = nullptr;
+    ToolMaskCache<ToolGrammar>* cache = nullptr;
+    ToolMaskCache<ToolGrammarXml>* cache_xml = nullptr; // parallel cache for the XML dialect
     std::vector<int>* host2dev = nullptr;
     bool enabled = false, active = false;
     bool pool_dead = false; // sticky: mask pool filled up this request
     ToolGrammar tg;
     ToolGrammar staged_state; // grammar state whose mask is in verify slot 0
+    ToolGrammarXml staged_state_xml; // parallel for the XML dialect (P11 on_drafts)
+    ToolGrammarXml tg_xml;     // XML-dialect sibling (3.8 trained format)
     std::vector<std::string> names;
+    std::vector<std::vector<std::string>> params_per_name; // per-tool param-key allowlists (XML)
+    bool dialect_xml = false;  // select XML grammar (ToolGrammarXml) vs JSON (ToolGrammar)
     std::string tail; // rolling decoded-text window for the opener trigger
     int skip_feed = 0; // round tokens already consumed by scan_round
     long engaged = 0, disengaged = 0, pool_drops = 0, rebinds = 0;
@@ -45,6 +50,22 @@ struct BasicToolConstrainer {
         skip_feed = 0;
         tail.clear();
         names = std::move(n);
+        dialect_xml = false;
+        params_per_name.clear();
+    }
+    // Schema + dialect aware begin: pass params_per_name aligned with `n` and
+    // dialect_xml=true to constrain the body with ToolGrammarXml (the 3.8
+    // trained format); dialect_xml=false (default) keeps the JSON body
+    // grammar. The XML grammar switches its parameter-key allowlist when the
+    // tool name completes (reset's params_per_name), so callers MUST supply
+    // the schema for the prevention to bite.
+    void begin(std::vector<std::string> n,
+               std::vector<std::vector<std::string>> pp,
+               bool dialect_xml_) {
+        begin(std::move(n));
+        dialect_xml = dialect_xml_;
+        params_per_name = std::move(pp);
+        if (dialect_xml_) tg_xml.reset(names, params_per_name);
     }
     // pool id for grammar state g's legal-token mask (-1 if pool full)
     int mask_id(const ToolGrammar& g) {
@@ -71,6 +92,37 @@ struct BasicToolConstrainer {
         if (slot < 0) slot = eng->mask_pool_add(cache->mask(ci).data());
         return slot;
     }
+    // XML-dialect twin of mask_id (mirrors the same host2dev / split-brain
+    // machinery, but against the parallel ToolMaskCache<ToolGrammarXml>).
+    // Guard (review 2026-08-20): if cache_xml is null (caller forgot to wire
+    // it -- the 3-arg begin does NOT check this), bail with pool-dead so the
+    // constrainer disengages cleanly instead of crashing on a null deref. The
+    // intended production wiring sets tc.cache_xml alongside tc.cache in
+    // server.cu (and metal_server.cpp); this guard makes that wiring
+    // mandatory rather than load-bearing.
+    int mask_id(const ToolGrammarXml& g) {
+        if (!cache_xml) {
+            if (!active) {
+                fprintf(stderr, "[toolgram-xml] mask_id called with cache_xml=null "
+                                "-- 3-arg begin(names, params, /*dialect_xml=*/true) "
+                                "requires tc.cache_xml to be assigned (see server.cu)\n");
+            }
+            pool_drops++;
+            pool_dead = true;
+            return -1;
+        }
+        int ci = cache_xml->get(g);
+        if ((int)host2dev->size() <= ci) host2dev->resize(ci + 1, -2);
+        int& slot = (*host2dev)[ci];
+        if (slot >= 0 && slot >= eng->mask_pool_used) {
+            fprintf(stderr, "[toolgram-xml] stale mask id %d >= pool %d -- re-uploading\n", slot,
+                    eng->mask_pool_used);
+            rebinds++;
+            slot = -2;
+        }
+        if (slot < 0) slot = eng->mask_pool_add(cache_xml->mask(ci).data());
+        return slot;
+    }
     void apply(const ToolGrammar& g) {
         int slot = mask_id(g);
         if (slot < 0) {
@@ -82,12 +134,25 @@ struct BasicToolConstrainer {
         staged_state = g; // P11: on_drafts advances from here for lanes 1-4
         eng->set_tool_constraint(slot);
     }
+    // XML-dialect twin of apply.
+    void apply(const ToolGrammarXml& g) {
+        int slot = mask_id(g);
+        if (slot < 0) {
+            pool_drops++;
+            pool_dead = true;
+            drop("mask pool full (constraint off for the rest of this request)");
+            return;
+        }
+        staged_state_xml = g;
+        eng->set_tool_constraint(slot);
+    }
     // P11: mid-round, given the 4 draft tokens, stage per-lane masks. Lane 0 =
     // staged_state (the pending position, legal set already correct); lane k =
     // that state advanced over drafts d1..dk. If a draft is grammar-illegal,
     // remaining lanes reuse the last legal mask -- moot, since acceptance
     // breaks at that lane anyway (its verify argmax is legal != the draft).
     void on_drafts(const int* dr) {
+        if (dialect_xml) { on_drafts_xml(dr); return; }
         int ids[5];
         ToolGrammar c = staged_state;
         ids[0] = mask_id(c);
@@ -102,13 +167,37 @@ struct BasicToolConstrainer {
         if (ids[0] < 0) return; // pool exhausted; verify keeps prior masks
         eng->set_tool_masks5(ids);
     }
+    // XML twin of on_drafts (same semantics, ToolGrammarXml).
+    void on_drafts_xml(const int* dr) {
+        int ids[5];
+        ToolGrammarXml c = staged_state_xml;
+        ids[0] = mask_id(c);
+        bool alive = true;
+        for (int k = 1; k <= 4; k++) {
+            if (alive)
+                for (char ch : tok->decode_one(dr[k - 1]))
+                    if (!c.advance(ch)) { alive = false; break; }
+            ids[k] = alive ? mask_id(c) : ids[k - 1];
+            if (ids[k] < 0) ids[k] = ids[k - 1] < 0 ? ids[0] : ids[k - 1];
+        }
+        if (ids[0] < 0) return;
+        eng->set_tool_masks5(ids);
+    }
     // Stage next round's slot-0 mask: the constrained lane decides the token
     // AFTER the pending one, so simulate the pending token on a copy first.
     void on_pending(int id) {
         if (!enabled || !active || id < 0) return;
+        if (dialect_xml) { on_pending_xml(id); return; }
         ToolGrammar peek = tg;
         for (char c : tok->decode_one(id))
             if (!peek.advance(c)) return; // entry-race pending; on_id will drop
+        if (peek.closed()) { eng->set_tool_constraint(-1); return; }
+        apply(peek);
+    }
+    void on_pending_xml(int id) {
+        ToolGrammarXml peek = tg_xml;
+        for (char c : tok->decode_one(id))
+            if (!peek.advance(c)) return;
         if (peek.closed()) { eng->set_tool_constraint(-1); return; }
         apply(peek);
     }
@@ -140,10 +229,12 @@ struct BasicToolConstrainer {
             // remainder bytes after it already belong to the call body
             if (pos == std::string::npos || pos + 11 <= tail.size() - bytes.size()) continue;
             std::string rem = tail.substr(pos + 11);
-            tg.reset(names);
+            if (dialect_xml) tg_xml.reset(names, params_per_name);
+            else tg.reset(names);
             active = true;
             engaged++;
-            fprintf(stderr, "[toolgram] engaged (rem=%zu)\n", rem.size());
+            fprintf(stderr, "[toolgram] engaged (rem=%zu, dialect=%s)\n",
+                    rem.size(), dialect_xml ? "xml" : "json");
             if (getenv("Q27_TG_TRACE")) {
                 std::string t2 = tail;
                 for (auto& ch : t2)
@@ -152,7 +243,7 @@ struct BasicToolConstrainer {
             }
             bool rem_ok = true;
             for (char c : rem)
-                if (!tg.advance(c)) {
+                if ((dialect_xml ? tg_xml.advance(c) : tg.advance(c)) == false) {
                     char why[64];
                     snprintf(why, sizeof why, "entry byte 0x%02x rejected", (unsigned char)c);
                     drop(why);
@@ -160,15 +251,13 @@ struct BasicToolConstrainer {
                     break;
                 }
             if (!rem_ok) continue; // keep scanning; a later marker may engage
-            if (tg.closed()) {
-                // the whole call completed inside this token's remainder --
-                // nothing left to constrain (and a closed-state mask must
-                // never be staged). Post-call text continues unconstrained.
+            if (dialect_xml ? tg_xml.closed() : tg.closed()) {
                 active = false;
                 fprintf(stderr, "[toolgram] call closed within entry token\n");
                 continue;
             }
-            apply(tg);
+            if (dialect_xml) apply(tg_xml);
+            else apply(tg);
             if (!active) {
                 // pool-full drop inside apply: stickiness must hold from this
                 // token on -- a later marker whose entry mask happens to be
@@ -195,13 +284,13 @@ struct BasicToolConstrainer {
             fprintf(stderr, "[tg-trace] feed: %s\n", t2.c_str());
         }
         for (char c : bytes)
-            if (!tg.advance(c)) {
+            if (!(dialect_xml ? tg_xml.advance(c) : tg.advance(c))) {
                 char why[64];
                 snprintf(why, sizeof why, "byte 0x%02x rejected", (unsigned char)c);
                 drop(why);
                 return;
             }
-        if (tg.closed()) {
+        if (dialect_xml ? tg_xml.closed() : tg.closed()) {
             eng->set_tool_constraint(-1);
             active = false;
             tail.clear();

--- a/src/toolgram.h
+++ b/src/toolgram.h
@@ -389,7 +389,12 @@ struct ToolGrammar {
 // state. Masks are append-only (stable indices -> device-resident pool in
 // phase 2/3). Wiring rules encoded here: the </tool_call> closer id is legal
 // iff done(); EOS is never legal inside the grammar (enforcement disengages
-// after the closer, upstream).
+// after the closer, upstream). Templated on the grammar type so the same
+// caching machinery serves both the JSON dialect (ToolGrammar) and the XML
+// dialect (ToolGrammarXml); both expose signature() + token_ok() so the body
+// is identical. Instantiated explicitly at the call sites (server, metal,
+// tests) since the vocabulary cache is owned per-engine.
+template <class G>
 struct ToolMaskCache {
     // vocab: decoded byte strings per token id (specials included verbatim)
     void init(const std::vector<std::string>* vocab, int closer_id) {
@@ -399,7 +404,7 @@ struct ToolMaskCache {
     }
 
     // returns stable mask index for the grammar's current state
-    int get(const ToolGrammar& g) {
+    int get(const G& g) {
         std::string sig = g.signature();
         auto it = index_.find(sig);
         if (it != index_.end()) return it->second;
@@ -443,6 +448,305 @@ struct ToolMaskCache {
     std::unordered_map<std::string, int> index_;
     std::unordered_map<std::string, int> content_; // bitset bytes -> index
     std::vector<std::vector<uint32_t>> masks_;
+};
+
+// XML-dialect sibling of ToolGrammar. The JSON machine above constrains the
+// body inside <tool_call>...</tool_call> to the 3.6/JSON format
+// (`{"name":..., "arguments":...}`); this one constrains it to the 3.8-
+// trained XML format
+// (`<function=NAME><parameter=KEY>VALUE</parameter>...</function>`), so
+// `--constrain-tools` can be enabled on Qwen3.8 without the grammar fighting
+// the model's trained emission.
+//
+// Schema-aware: when the full tool name matches, the parameter-key allowlist
+// switches to that tool's declared parameters (params_per_name overload of
+// reset). The names-only overload leaves parameter keys unrestricted -- a
+// permissive fallback for callers that don't carry the schema.
+//
+// Values are multi-line free text. `<` inside a value is legal ONLY as the
+// start of `</parameter>` or `</function>`; `</tool_call>` inside a value is
+// rejected (the value must close via `</parameter>` then the function via
+// `</function>` then the body via `</tool_call>`). That is the prevention:
+// a model that tries to write `<result>`, a stray `<function=...>`, or any
+// other nested tag, hits a dead state and the decoder masks it out. This is
+// what stops drift modes like the live chimera `{"name":"bash",</parameter>
+// </function>` at the source rather than leaving the parser to refuse an
+// unrecoverable call.
+//
+// Same external surface as ToolGrammar (reset/advance/advance_str/token_ok/
+// done/closed/signature) so the templated ToolMaskCache<G> works unchanged.
+struct ToolGrammarXml {
+    // names-only reset (no schema): parameter keys unrestricted
+    void reset(const std::vector<std::string>& tool_names) {
+        reset(tool_names, {});
+    }
+    // schema-aware reset: params_per_name aligned with tool_names
+    void reset(const std::vector<std::string>& tool_names,
+               const std::vector<std::vector<std::string>>& params_per_name) {
+        names_ = tool_names;
+        params_per_name_ = params_per_name;
+        std::vector<std::string> sorted = tool_names;
+        std::sort(sorted.begin(), sorted.end());
+        names_key_.clear();
+        for (auto& n : sorted) { names_key_ += n; names_key_ += '\x1f'; }
+        cur_params_key_.clear();
+        cur_name_idx_ = -1;
+        st_ = WS0;
+        name_pref_.clear();
+        key_pref_.clear();
+        lit_word_.clear();
+        lit_ = 0;
+        dead_ = false;
+    }
+
+    bool advance(char c) {
+        if (dead_) return false;
+        if (!step(c)) { dead_ = true; return false; }
+        return true;
+    }
+    bool advance_str(const std::string& s) {
+        for (char c : s)
+            if (!advance(c)) return false;
+        return true;
+    }
+    // body fully consumed (after </function> + ws); </tool_call> sampleable
+    bool done() const {
+        return !dead_ && (st_ == DONE_ || st_ == CT_CLOSE || st_ == CLOSED_);
+    }
+    bool closed() const { return !dead_ && st_ == CLOSED_; }
+    bool token_ok(const std::string& s) const {
+        ToolGrammarXml copy = *this;
+        return copy.advance_str(s);
+    }
+
+  private:
+    enum St {
+        WS0,            // ws before first element; first element MUST be <function
+        FUNC_LT,        // consumed '<', expect 'f' for <function
+        FUNC_LIT,       // matching 'function'
+        FUNC_EQ,        // '='
+        NAME,           // tool name (allowlist prefix), term '>'
+        GT1,            // '>' after name
+        WS1,            // ws after function opener, before next tag
+        PARAM_LT,       // consumed '<', expect 'p' (<parameter) or '/' (closer)
+        PARAM_LIT,      // matching 'parameter'
+        PARAM_EQ,       // '='
+        KEY,            // param key (allowlist vs cur tool params), term '>'
+        GT2,            // '>' after key
+        VAL,            // value body (printable + ws)
+        VAL_LT,         // VAL saw '<'; expect '/' only (closer)
+        SLASH,          // consumed '</', pick closer: 'p'-></parameter>, 'f'-></function>
+        PARAM_CLOSE,    // matching '</parameter>'
+        FUNC_CLOSE,     // matching '</function>'
+        DONE_,          // ws after </function>; </tool_call> sampleable
+        CT_CLOSE,       // matching '</tool_call>'
+        CLOSED_         // past closer
+    };
+
+    static bool is_ws(char c) {
+        return c == ' ' || c == '\n' || c == '\r' || c == '\t';
+    }
+    static bool val_byte(char c) {
+        // value byte: printable (>= 0x20) and not '<' (handled separately)
+        return (unsigned char)c >= 0x20 && c != '<';
+    }
+
+    bool step(char c) {
+        switch (st_) {
+            case WS0:
+                if (is_ws(c)) return true;
+                if (c == '<') { st_ = FUNC_LT; return true; }
+                return false;
+            case FUNC_LT:
+                // first element: only <function legal (empty body handled by
+                // engagement's "call closed within entry token")
+                if (c == 'f') { lit_word_ = "function"; lit_ = 1; st_ = FUNC_LIT; return true; }
+                return false;
+            case FUNC_LIT:
+                if (lit_ < lit_word_.size()) {
+                    if (c != lit_word_[lit_]) return false;
+                    lit_++;
+                    if (lit_ == lit_word_.size()) st_ = FUNC_EQ;
+                    return true;
+                }
+                return false;
+            case FUNC_EQ:
+                if (is_ws(c)) return true;
+                if (c == '=') { st_ = NAME; name_pref_.clear(); return true; }
+                return false;
+            case NAME: {
+                if (c == '>') {
+                    for (size_t i = 0; i < names_.size(); i++)
+                        if (names_[i] == name_pref_) {
+                            cur_name_idx_ = (int)i;
+                            cur_params_key_.clear();
+                            if (i < params_per_name_.size()) {
+                                auto pk = params_per_name_[i];
+                                std::sort(pk.begin(), pk.end());
+                                for (auto& k : pk) { cur_params_key_ += k; cur_params_key_ += '\x1f'; }
+                            }
+                            st_ = GT1;
+                            return true;
+                        }
+                    return false; // undeclared tool name
+                }
+                std::string next = name_pref_ + c;
+                for (auto& n : names_)
+                    if (n.compare(0, next.size(), next) == 0 && next.size() <= n.size()) {
+                        name_pref_ = next;
+                        return true;
+                    }
+                return false;
+            }
+            case GT1:
+                if (is_ws(c)) return true;
+                if (c == '<') { st_ = PARAM_LT; return true; }
+                return false;
+            case WS1:
+                if (is_ws(c)) return true;
+                if (c == '<') { st_ = PARAM_LT; return true; }
+                return false;
+            case PARAM_LT:
+                if (c == 'p') { lit_word_ = "parameter"; lit_ = 1; st_ = PARAM_LIT; return true; }
+                if (c == '/') { st_ = SLASH; return true; }
+                return false;
+            case PARAM_LIT:
+                if (lit_ < lit_word_.size()) {
+                    if (c != lit_word_[lit_]) return false;
+                    lit_++;
+                    if (lit_ == lit_word_.size()) st_ = PARAM_EQ;
+                    return true;
+                }
+                return false;
+            case PARAM_EQ:
+                if (is_ws(c)) return true;
+                if (c == '=') { st_ = KEY; key_pref_.clear(); return true; }
+                return false;
+            case KEY: {
+                if (c == '>') {
+                    if (cur_params_key_.empty()) {
+                        // no schema: permissive (accept any exact key)
+                        st_ = GT2;
+                        return true;
+                    }
+                    if (cur_name_idx_ >= 0 && cur_name_idx_ < (int)params_per_name_.size()) {
+                        for (auto& k : params_per_name_[cur_name_idx_])
+                            if (k == key_pref_) { st_ = GT2; return true; }
+                    }
+                    return false;
+                }
+                std::string next = key_pref_ + c;
+                if (cur_params_key_.empty()) {
+                    key_pref_ = next;
+                    return true;
+                }
+                bool ok = false;
+                if (cur_name_idx_ >= 0 && cur_name_idx_ < (int)params_per_name_.size()) {
+                    for (auto& k : params_per_name_[cur_name_idx_])
+                        if (k.compare(0, next.size(), next) == 0 && next.size() <= k.size()) {
+                            ok = true; break;
+                        }
+                }
+                if (!ok) return false;
+                key_pref_ = next;
+                return true;
+            }
+            case GT2:
+                if (is_ws(c)) return true;
+                st_ = VAL;
+                return step(c);
+            case VAL:
+                if (is_ws(c)) return true;
+                if (val_byte(c)) return true;
+                if (c == '<') { st_ = VAL_LT; return true; }
+                return false;
+            case VAL_LT:
+                // inside a value: only closer legal, so '</' only
+                if (c == '/') { st_ = SLASH; return true; }
+                return false;
+            case SLASH:
+                if (c == 'p') { lit_word_ = "</parameter>"; lit_ = 3; st_ = PARAM_CLOSE; return true; }
+                if (c == 'f') { lit_word_ = "</function>"; lit_ = 3; st_ = FUNC_CLOSE; return true; }
+                return false;
+            case PARAM_CLOSE:
+                if (lit_ < lit_word_.size()) {
+                    if (c != lit_word_[lit_]) return false;
+                    lit_++;
+                    if (lit_ == lit_word_.size()) st_ = WS1;
+                    return true;
+                }
+                return false;
+            case FUNC_CLOSE:
+                if (lit_ < lit_word_.size()) {
+                    if (c != lit_word_[lit_]) return false;
+                    lit_++;
+                    if (lit_ == lit_word_.size()) st_ = DONE_;
+                    return true;
+                }
+                return false;
+            case DONE_:
+                if (is_ws(c)) return true;
+                if (c == '<') { lit_word_ = "</tool_call>"; lit_ = 1; st_ = CT_CLOSE; return true; }
+                return false;
+            case CT_CLOSE:
+                if (lit_ < lit_word_.size()) {
+                    if (c != lit_word_[lit_]) return false;
+                    lit_++;
+                    if (lit_ == lit_word_.size()) st_ = CLOSED_;
+                    return true;
+                }
+                return false;
+            case CLOSED_:
+                return true;
+        }
+        return false;
+    }
+
+    std::vector<std::string> names_;
+    std::vector<std::vector<std::string>> params_per_name_;
+    std::string names_key_;
+    std::string cur_params_key_;
+    std::string name_pref_;
+    std::string key_pref_;
+    std::string lit_word_;
+    int cur_name_idx_ = -1;
+    size_t lit_ = 0;
+    St st_ = WS0;
+    bool dead_ = false;
+
+  public:
+    // Same signature scheme as ToolGrammar: state + lit progress + allowlist
+    // components only where token legality depends on them. NAME depends on
+    // names_key_ + name_pref_; KEY depends on cur_params_key_ + key_pref_;
+    // literal-match states depend on lit_. Argument/closer states never
+    // re-enter the allowlist branches.
+    std::string signature() const {
+        std::string s;
+        s += (char)('a' + (int)st_);
+        s += dead_ ? '!' : '.';
+        if (st_ == NAME) {
+            s += '|';
+            s += name_pref_;
+            s += '|';
+            s += names_key_;
+        } else if (st_ == KEY) {
+            s += '|';
+            s += key_pref_;
+            s += '|';
+            s += cur_params_key_;
+        } else if (st_ == FUNC_LIT || st_ == PARAM_LIT) {
+            s += '|';
+            s += std::to_string(lit_);
+            s += '|';
+            s += lit_word_;
+        } else if (st_ == PARAM_CLOSE || st_ == FUNC_CLOSE || st_ == CT_CLOSE) {
+            s += '|';
+            s += std::to_string(lit_);
+            s += '|';
+            s += lit_word_;
+        }
+        return s;
+    }
 };
 
 } // namespace q27

--- a/tools/constrain_e2e.cu
+++ b/tools/constrain_e2e.cu
@@ -97,7 +97,7 @@ int main(int argc, char** argv) {
     }
 
     std::vector<std::string> vocab = tok.vocab_bytes();
-    q27::ToolMaskCache cache;
+    q27::ToolMaskCache<q27::ToolGrammar> cache;
     cache.init(&vocab, tok.token_id("</tool_call>"));
     std::vector<int> host2dev;
     q27::BasicToolConstrainer<Engine, q27::Tokenizer> tc;

--- a/tools/test_chat_completions_integration.cpp
+++ b/tools/test_chat_completions_integration.cpp
@@ -439,7 +439,7 @@ static PreparedAnthropicPrompt prepare_anthropic_prompt_for_test(
 static void run_request(FakeTok& tok, std::string served_name, bool no_think_srv,
                         bool constrain_tools, bool sampled_on, int max_prompt,
                         int max_slot_ctx, std::atomic<long>& req_counter,
-                        q27::ToolMaskCache& tool_mask_cache, std::vector<Slot>& slots,
+                        q27::ToolMaskCache<q27::ToolGrammar>& tool_mask_cache, std::vector<Slot>& slots,
                         const json& body, bool chat, bool batch = false,
                         int budget_flag = 0) {
     const int EOS = tok.eos();
@@ -1256,8 +1256,8 @@ static std::vector<Slot> fresh_slots() {
     return slots;
 }
 
-static q27::ToolMaskCache fresh_cache(std::vector<std::string>& vocab_bytes) {
-    q27::ToolMaskCache c;
+static q27::ToolMaskCache<q27::ToolGrammar> fresh_cache(std::vector<std::string>& vocab_bytes) {
+    q27::ToolMaskCache<q27::ToolGrammar> c;
     c.init(&vocab_bytes, -1); // </tool_call> id unused (constrain_tools off in these tests)
     return c;
 }

--- a/tools/test_tool_drift.cpp
+++ b/tools/test_tool_drift.cpp
@@ -125,6 +125,64 @@ static void test_mode16_and_15_variants() {
         "</result>\n</tool_calls>";
     auto v3 = q27::parse_bare_tool_calls(halluc, &pre, &tools);
     ok(v3.empty(), "hallucinated <result>/<output> block is NOT rescued as a call");
+
+    // ...but the rule is ENCLOSURE, not mere presence (2026-08-21). A result
+    // block that opened AND closed before the call is prior context -- a
+    // quoted result from an earlier step -- and must not veto the real call
+    // that follows it. The old whole-string guard threw this away.
+    std::string after_closed_output =
+        "The last command printed:\n<output>total 0</output>\n\nNow listing again.\n\n"
+        "<function>\n{\"name\": \"Bash\", \"arguments\": {\"command\": \"ls -la\"}}";
+    auto v4 = q27::parse_bare_tool_calls(after_closed_output, &pre, &tools);
+    ok(v4.size() == 1 && v4[0].name == "Bash" &&
+           v4[0].arguments.value("command", std::string()) == "ls -la",
+       "mode16: a CLOSED <output> block before the wrapper does not kill the call");
+    ok(pre.find("total 0") != std::string::npos,
+       "mode16: the quoted result stays in the visible prefix");
+
+    // and the converse: an UNCLOSED <result> enclosing the wrapper is an
+    // invented result block, so the JSON inside it stays text.
+    std::string enclosed =
+        "<result>\n<function>\n{\"name\": \"Bash\", \"arguments\": {\"command\": \"ls\"}}";
+    auto v5 = q27::parse_bare_tool_calls(enclosed, &pre, &tools);
+    ok(v5.empty(), "mode16: an unclosed <result> enclosing the wrapper refuses");
+}
+
+// The enclosure rule itself (hallucinated_result_around), independent of any
+// one drift mode: closed-before-span is context, unclosed-before-span or
+// in-span is invented output.
+static void test_hallucinated_result_enclosure_rule() {
+    using q27::hallucinated_result_around;
+    const std::string closed_before = "<output>x</output>\nCALL";
+    ok(!hallucinated_result_around(closed_before, closed_before.find("CALL"),
+                                   closed_before.size()),
+       "enclosure: closed block before the span is prior context");
+
+    const std::string open_before = "<result>\nCALL";
+    ok(hallucinated_result_around(open_before, open_before.find("CALL"),
+                                  open_before.size()),
+       "enclosure: unclosed block before the span encloses it");
+
+    const std::string in_span = "CALL <result>fake</result>";
+    ok(hallucinated_result_around(in_span, 0, in_span.size()),
+       "enclosure: a block inside the span is invented output");
+
+    // closed, then reopened: still enclosed (depth counting, not last-open)
+    const std::string reopened = "<output>a</output>\n<output>\nCALL";
+    ok(hallucinated_result_around(reopened, reopened.rfind("CALL"), reopened.size()),
+       "enclosure: closed-then-reopened still reads as enclosed");
+
+    // nested same-tag pairs fully closed before the span
+    const std::string nested_closed = "<result><result>a</result></result>CALL";
+    ok(!hallucinated_result_around(nested_closed, nested_closed.find("CALL"),
+                                   nested_closed.size()),
+       "enclosure: fully-closed nested pairs before the span are context");
+
+    // no tags at all, and the npos guard
+    ok(!hallucinated_result_around("plain text", 0, 10),
+       "enclosure: text with no result tags is clean");
+    ok(!hallucinated_result_around("<result>x", std::string::npos, std::string::npos),
+       "enclosure: npos span begin is not flagged");
 }
 
 // Native XML dialect (2026-08-14): the format Qwen3.8's chat template trains.
@@ -238,6 +296,23 @@ static void test_dialect_default_keying() {
     ok(q27::tool_dialect_xml(), "dialect: env xml overrides a 3.6 model");
     unsetenv("Q27_TOOL_DIALECT");
     q27::tool_dialect_xml_default() = false;   // leave global state clean
+}
+
+static void test_preamble_swaps_with_dialect() {
+    unsetenv("Q27_TOOL_DIALECT");
+    q27::tool_dialect_xml_default() = true;
+    json tools = json::array({tool("bash", {{"command", true}})});
+    std::string pre = q27::tools_preamble(tools);
+    ok(pre.find("<tool_call>") != std::string::npos &&
+       pre.find("<function=") != std::string::npos,
+       "preamble: xml dialect emits XML-format instructions");
+    q27::tool_dialect_xml_default() = false;
+    pre = q27::tools_preamble(tools);
+    ok(pre.find("{\"name\":") != std::string::npos &&
+       pre.find("<function=") == std::string::npos,
+       "preamble: json dialect emits JSON-format instructions");
+    q27::tool_dialect_xml_default() = false;   // clean up
+    unsetenv("Q27_TOOL_DIALECT");
 }
 
 static void test_reasoning_effort_line() {
@@ -475,6 +550,59 @@ static void test_mode21_openerless_params() {
        "mode21: an explicit <function= opener still resolves to Bash");
 }
 
+// Regression (2026-08-21): the <result>/<output> hallucinated-result guard is a
+// WHOLE-STRING find, but it gates the entire mode 17/20/21 recovery block. So an
+// openerless <parameter=...> + </function> call (mode 21) in a tail that ALSO
+// contains an unrelated <output> or <result> anywhere -- a quoted command result,
+// a prior hallucinated block in the same segment -- bails the whole chain and the
+// real call leaks through as plain text. This is the "sometimes I still see
+// <parameter= / </function>" report. The guard must be scoped to the parameter
+// span, not the whole tail.
+static void test_mode21_guard_scoped_to_span() {
+    json tools = json::array({tool("FileAction", {{"filePath", true}, {"newString", false}}),
+                              tool("Bash", {{"command", true}, {"description", false}})});
+
+    // 1. The leak: a real openerless call, with an unrelated <output> block
+    //    EARLIER in the same tail (e.g. a quoted result from a prior step).
+    //    Today the whole-string guard sees <output> and skips mode 21 entirely.
+    {
+        const std::string raw =
+            "Here is what the build printed:\n"
+            "<output>make: all targets up to date</output>\n\n"
+            "Now I'll fix the import.\n"
+            "<parameter=filePath>\n/code/fileaction.go\n</parameter>\n"
+            "<parameter=newString>\nimport \"bytes\"\n</parameter>\n</function>";
+        std::string pre;
+        auto v = q27::parse_bare_tool_calls(raw, &pre, &tools);
+        ok(v.size() == 1 && v[0].name == "FileAction" &&
+               v[0].arguments.value("filePath", std::string()) == "/code/fileaction.go",
+           "mode21: an unrelated <output> earlier in the tail must not kill the call");
+    }
+
+    // 2. Same, with <result> as the contaminant.
+    {
+        const std::string raw =
+            "<result>previous step output</result>\n"
+            "<parameter=filePath>\n/code/x.go\n</parameter>\n</function>";
+        std::string pre;
+        auto v = q27::parse_bare_tool_calls(raw, &pre, &tools);
+        ok(v.size() == 1 && v[0].name == "FileAction",
+           "mode21: an unrelated <result> earlier in the tail must not kill the call");
+    }
+
+    // 3. The guard must STILL bite where it belongs: a hallucinated tool RESULT
+    //    inside the span (<parameter> wrapping <result>/<output>) is invented
+    //    output, not a call. This is the behavior the guard exists to protect.
+    {
+        const std::string raw =
+            "<parameter=filePath>\n<result>fake</result>\n</parameter>\n</function>";
+        std::string pre;
+        auto v = q27::parse_bare_tool_calls(raw, &pre, &tools);
+        ok(v.empty(),
+           "mode21: <result> INSIDE the parameter span still refuses (hallucinated result)");
+    }
+}
+
 static void test_mode18_bare_name_opener() {
     q27::ToolCall tc;
     ok(q27::parse_native_xml_call(
@@ -504,6 +632,19 @@ static void test_mode18_bare_name_opener() {
            t4.name == "Read" &&
            t4.arguments.value("file_path", std::string()) == "/x/y.py",
        "mode18: bare <name> without the stray closer");
+    // Mode-18 gap (found via pi's mangled tool transport): the name opens
+    // `<name>` but lands on the NEXT line. Pre-fix this read an empty name
+    // and refused the whole call. Corroborating <parameter= present, so this
+    // must rescue -- and must NOT swallow an identical opener with no dialect.
+    q27::ToolCall t5;
+    ok(q27::parse_native_xml_call("<name>\nbash\n</parameter>\n"
+                                  "<parameter=command>\nls /code\n</parameter>\n", t5) &&
+           t5.ok && t5.name == "bash" &&
+           t5.arguments.value("command", std::string()) == "ls /code",
+       "mode18-FIX: name on the line after <name> is still recognized");
+    q27::ToolCall t6;
+    ok(!q27::parse_native_xml_call("<name>\njust prose, no dialect follows", t6),
+       "mode18-FIX: name-on-next-line with no dialect is NOT a call");
 }
 
 static void test_mode14_tool_name_xml_dialect() {
@@ -1150,6 +1291,166 @@ static void test_intended_tool_call_detector() {
        "detector: ordinary prose is NOT flagged");
 }
 
+// Unclosed-<tool_call> tail recovery (completes bb60661). When the generation
+// is cut INSIDE <tool_call>...</tool_call>, the splitter stays on the TOOL
+// channel; the server pulls that last segment off with
+// take_unclosed_final_tool_segment and used to dump it to visible text raw, so
+// a call whose inner JSON was COMPLETE (only the </tool_call> never arrived)
+// was lost. recover_unclosed_tool_tail routes it through the drift chain with
+// allow_eof_repair=false: COMPLETE inner calls recover, a value genuinely cut
+// mid-parse (a partial Write) stays text.
+static void test_unclosed_tool_tail_recovery() {
+    json tools = json::array({tool("Read", {{"file_path", true}}),
+                              tool("Write", {{"content", true}, {"file_path", true}})});
+
+    // The server's own flow: split the raw bytes, and when the trailing
+    // channel is TOOL (wrapper unclosed) pull the tail off and recover it.
+    auto server_flow = [&](const std::string& raw, bool has_tools,
+                           bool (*accept)(const q27::ToolCall&) = nullptr) {
+        q27::StreamSplitter sp;
+        std::vector<std::pair<q27::StreamSplitter::Chan, std::string>> segments;
+        auto route = [&](q27::StreamSplitter::Chan ch, const std::string& t) {
+            if (t.empty()) {
+                if (ch != q27::StreamSplitter::TOOL && !segments.empty() &&
+                    segments.back().first == q27::StreamSplitter::TOOL)
+                    segments.emplace_back(ch, std::string());
+                return;
+            }
+            if (!segments.empty() && segments.back().first == ch) segments.back().second += t;
+            else segments.emplace_back(ch, t);
+        };
+        for (auto& p : sp.feed(raw)) route(p.first, p.second);
+        for (auto& p : sp.flush()) route(p.first, p.second);
+        const bool tail_unclosed =
+            !segments.empty() && segments.back().first == q27::StreamSplitter::TOOL;
+        std::string unclosed =
+            q27::take_unclosed_final_tool_segment(segments, tail_unclosed);
+        q27::OrderedToolOutput out;
+        size_t rec = q27::recover_unclosed_tool_tail(
+            unclosed, has_tools ? &tools : nullptr,
+            [&](const std::string& t) { out.append_visible_text(t); },
+            [&](q27::ToolCall c) {
+                if (accept && !accept(c)) return false;
+                out.append_tool_call(std::move(c));
+                return true;
+            });
+        return std::make_pair(rec, out);
+    };
+
+    // 1. COMPLETE inner JSON, </tool_call> never arrived -> recovered (mode 1).
+    {
+        auto [rec, out] = server_flow(
+            "<tool_call>\n{\"name\":\"Read\",\"arguments\":{\"file_path\":\"/x\"}}\n",
+            true);
+        ok(rec == 1 && out.calls.size() == 1 && out.calls[0].name == "Read",
+           "unclosed: complete inner JSON recovers from the unclosed tail");
+    }
+
+    // 2. Truncated mid-value (a partial Write) -> NOT recovered, stays text.
+    //    mode 2/12 EOF repair is disabled here: this is the safety bar.
+    {
+        auto [rec, out] = server_flow(
+            "<tool_call>\n{\"name\":\"Write\",\"arguments\":{\"file_path\":\"/x\",\"content\":\"trun",
+            true);
+        ok(rec == 0 && out.calls.empty() &&
+               out.text.find("content\":\"trun") != std::string::npos,
+           "unclosed: partial Write stays text (no half-execution)");
+    }
+
+    // 3. No tools configured -> stays text, nothing recovered.
+    {
+        auto [rec, out] = server_flow(
+            "<tool_call>\n{\"name\":\"Read\",\"arguments\":{\"file_path\":\"/x\"}}\n",
+            false);
+        ok(rec == 0 && out.calls.empty(), "unclosed: no tools -> stays text");
+    }
+
+    // 4. Rejected call (caller refuses it) stays text, not re-run.
+    {
+        auto [rec, out] = server_flow(
+            "<tool_call>\n{\"name\":\"Read\",\"arguments\":{\"file_path\":\"/x\"}}\n",
+            true, [](const q27::ToolCall&) { return false; });
+        ok(rec == 0 && out.calls.empty() &&
+               out.text.find("\"name\":\"Read\"") != std::string::npos,
+           "unclosed: a refused call stays text and is not resurrected");
+    }
+
+    // 5. Native-dialect inner (model omitted the final </parameter>, the exact
+    //    shape that broke vLLM's regex parser) -> recovers even unclosed.
+    {
+        json t2 = json::array({tool("get_weather", {{"location", true}, {"unit", true}})});
+        std::string raw = "<tool_call>\n<function=get_weather>\n<parameter=location>\nTokyo\n";
+        raw += "</parameter>\n<parameter=unit>\ncelsius\n";
+        q27::StreamSplitter sp;
+        std::vector<std::pair<q27::StreamSplitter::Chan, std::string>> segments;
+        for (auto& p : sp.feed(raw)) segments.push_back(p);
+        for (auto& p : sp.flush()) segments.push_back(p);
+        std::string unclosed = q27::take_unclosed_final_tool_segment(
+            segments, !segments.empty() &&
+                           segments.back().first == q27::StreamSplitter::TOOL);
+        q27::OrderedToolOutput out;
+        size_t rec = q27::recover_unclosed_tool_tail(
+            unclosed, &t2,
+            [&](const std::string& t) { out.append_visible_text(t); },
+            [&](q27::ToolCall c) { out.append_tool_call(std::move(c)); return true; });
+        ok(rec == 1 && out.calls.size() == 1 &&
+               out.calls[0].arguments.value("unit", std::string()) == "celsius",
+           "unclosed: native-dialect omitted-</parameter> recovers (vLLM shape)");
+    }
+}
+
+// Regression for the mode-20 npos underflow (review 2026-08-20): mode 20
+// (nameless <tool_name> batch) used to only stamp batch.front().source_begin
+// and batch.back().source_end, so middle calls carried npos and the
+// unclosed-tail / closed-wrapper resolvers' `raw.substr(cursor,
+// c.source_begin-cursor)` underflowed to SIZE_MAX and threw out_of_range
+// inside the request handler. After stamping per-call spans, every call has
+// a usable source range and the recovery loop slices cleanly. This test
+// would CRASH before the fix.
+static void test_mode20_multicall_span_stamping() {
+    json tools = json::array({tool("Read", {{"file_path", true}}),
+                              tool("Write", {{"content", true}, {"file_path", true}})});
+    // two nameless <tool_name> calls in one batch (mode 20 path)
+    std::string raw =
+        "<tool_calls>\n<tool_name>\n<parameter=file_path>/a</parameter>\n</function>"
+        "\n<tool>\n<tool_name>\n<parameter=content>x</parameter>\n"
+        "<parameter=file_path>/b</parameter>\n</function>";
+    std::string pre, residual;
+    auto calls = q27::parse_bare_tool_calls(raw, &pre, &tools);
+    ok(calls.size() == 2,
+       "mode20: two nameless <tool_name> calls parse into two ToolCalls");
+    if (calls.size() == 2) {
+        ok(calls[0].source_begin != std::string::npos &&
+           calls[0].source_end != std::string::npos &&
+           calls[1].source_begin != std::string::npos &&
+           calls[1].source_end != std::string::npos,
+           "mode20: per-call source spans are stamped (not npos middle)");
+        ok(calls[0].source_end <= calls[1].source_begin,
+           "mode20: call spans are ordered and non-overlapping");
+    }
+    // recover_unclosed_tool_tail must not throw on the middle call.
+    bool threw = false;
+    std::string threw_what;
+    q27::OrderedToolOutput out;
+    try {
+        q27::recover_unclosed_tool_tail(
+            raw, &tools,
+            [&](const std::string& t) { out.append_visible_text(t); },
+            [&](q27::ToolCall c) { out.append_tool_call(std::move(c)); return true; });
+    } catch (const std::exception& e) {
+        threw = true; threw_what = e.what();
+    }
+    ok(!threw,
+       "mode20: recover_unclosed_tool_tail does not throw on the stamped spans");
+    if (threw) printf("    threw: %s\n", threw_what.c_str());
+    // Trailing text after the last call's region becomes visible as text
+    // (the prior override glued it into back().source_end; the stamping fix
+    // exposes it as remaining_text via append_visible_text).
+    ok(out.text.find("/b") != std::string::npos ||
+       out.calls.size() == 2,
+       "mode20: trailing gap is either emitted as text or absorbed by the calls");
+}
+
 // N7. tool_strict() is a process-lifetime memo, so the strict leg cannot share
 // a run with the tests above; main() dispatches on the env var and `make
 // test-tools` invokes the binary a second time with Q27_TOOL_STRICT=1.
@@ -1176,20 +1477,25 @@ int main() {
     test_json_fused_opener_shapes();
     test_mode22_parameter_as_opener();
     test_intended_tool_call_detector();
+    test_unclosed_tool_tail_recovery();
+    test_mode20_multicall_span_stamping();
     test_mode13_truncated_mid_escape();
     test_function_arguments_unterminated();
     test_think_mode_drift();
     test_dialect_default_keying();
+    test_preamble_swaps_with_dialect();
     test_reasoning_effort_line();
     test_native_xml_dialect();
     test_mode18_bare_name_opener();
     test_mode19_attribute_opener();
     test_mode20_nameless_tool_name();
     test_mode21_openerless_params();
+    test_mode21_guard_scoped_to_span();
     test_quoted_name_normalization();
     test_mode14_tool_name_xml_dialect();
     test_mode15_name_tag_bare_args();
     test_mode16_and_15_variants();
+    test_hallucinated_result_enclosure_rule();
     json tools = json::array();
     tools.push_back(tool("Write", {{"content", true}, {"file_path", true}}));
     tools.push_back(tool("Read", {{"file_path", true}}));

--- a/tools/test_toolconstrain.cpp
+++ b/tools/test_toolconstrain.cpp
@@ -77,7 +77,7 @@ static FakeTok mk_tok() {
 struct Rig {
     FakeTok tok = mk_tok();
     FakeEngine eng;
-    q27::ToolMaskCache cache;
+    q27::ToolMaskCache<q27::ToolGrammar> cache;
     std::vector<int> host2dev;
     TC tc;
     Rig() {
@@ -265,7 +265,7 @@ static void test_closer_disengages() {
 // entry, so request B could be steered into request A's tool names.
 static void test_r1_allowlist_in_cache_key() {
     FakeTok tok = mk_tok();
-    q27::ToolMaskCache cache;
+    q27::ToolMaskCache<q27::ToolGrammar> cache;
     cache.init(&tok.vocab, T_CLOSER);
     q27::ToolGrammar ga, gb;
     ga.reset({"get_project"});
@@ -294,7 +294,7 @@ static void test_r1_allowlist_in_cache_key() {
 // one pool entry per argument state instead of exhausting the 512-entry pool.
 static void test_r3_no_mask_duplication_across_allowlists() {
     FakeTok tok = mk_tok();
-    q27::ToolMaskCache cache;
+    q27::ToolMaskCache<q27::ToolGrammar> cache;
     cache.init(&tok.vocab, T_CLOSER);
     q27::ToolGrammar ga, gb;
     ga.reset({"get_project"});
@@ -359,6 +359,176 @@ static void test_r2_strict_json() {
     CHECK(!accepts_args("{\"\\uZZ00\": 1}"));
 }
 
+// XML-dialect grammar (ToolGrammarXml): valid bodies accept; drift / chimera
+// / undeclared names / undeclared param keys / garbage `<` inside values all
+// rejected. This is the prevention that would have stopped the live chimera
+// `{"name":"bash",\n</parameter>\n</function>` at the source rather than
+// leaving the parser to refuse an unrecoverable call.
+static void test_xml_grammar_valid_and_prevention() {
+    using q27::ToolGrammarXml;
+    std::vector<std::string> names = {"bash", "Read"};
+    std::vector<std::vector<std::string>> params = {{"command"}, {"file_path"}};
+
+    // 1. valid full call, schema-aware
+    {
+        ToolGrammarXml g; g.reset(names, params);
+        CHECK(g.advance_str("\n<function=bash>\n<parameter=command>\ngit status\n</parameter>\n</function>\n"));
+        CHECK(g.done());
+        CHECK(g.advance_str("</tool_call>"));
+        CHECK(g.closed());
+    }
+    // 2. valid call, no schema (permissive keys)
+    {
+        ToolGrammarXml g; g.reset(names);
+        CHECK(g.advance_str("\n<function=Read>\n<parameter=file_path>/x.ts</parameter>\n</function>\n"));
+        CHECK(g.done());
+    }
+    // 3. undeclared tool name -> dead
+    {
+        ToolGrammarXml g; g.reset(names, params);
+        CHECK(!g.advance_str("<function=Delete>\n<parameter=path>/x</parameter>\n</function>\n"));
+    }
+    // 4. undeclared param key for declared tool (schema) -> dead
+    {
+        ToolGrammarXml g; g.reset(names, params);
+        CHECK(!g.advance_str("<function=bash>\n<parameter=evil>\nrm -rf /\n</parameter>\n</function>\n"));
+    }
+    // 5. garbage `<...>` inside a value -> dead (only closers legal in VAL)
+    {
+        ToolGrammarXml g; g.reset(names, params);
+        CHECK(!g.advance_str("<function=Read>\n<parameter=file_path>\n<result>x</result>\n</parameter>\n</function>\n"));
+    }
+    // 6. JSON chimera head as the first body byte -> dead (grammar never sees JSON)
+    {
+        ToolGrammarXml g; g.reset(names, params);
+        CHECK(!g.advance_str("{\"name\":\"bash\",\n</parameter>\n</function>\n"));
+    }
+    // 7. bare `<parameter` before any `<function` -> dead
+    {
+        ToolGrammarXml g; g.reset(names, params);
+        CHECK(!g.advance_str("<parameter=command>ls</parameter>"));
+    }
+    // 8. nested `<function>` -> dead
+    {
+        ToolGrammarXml g; g.reset(names, params);
+        CHECK(!g.advance_str("<function=Read>\n<function=bash>\n</function>\n</function>\n"));
+    }
+    // 9. multi-line value body (the whole point of VAL)
+    {
+        ToolGrammarXml g; g.reset(names, params);
+        CHECK(g.advance_str("<function=bash>\n<parameter=command>\nline1\nline2\n</parameter>\n</function>\n"));
+        CHECK(g.done());
+    }
+    // 10. tool-name prefix (still building): advance is fine, done is false
+    {
+        ToolGrammarXml g; g.reset(names, params);
+        CHECK(g.advance_str("<function=ba"));
+        CHECK(!g.done());
+    }
+    // 11. signature differs across allowlists once we're in NAME (cache-key
+    //     isolation, R1 for XML). At WS0 (post-reset) the signature carries
+    //     no allowlist component -- must advance first.
+    {
+        ToolGrammarXml ga, gb;
+        ga.reset({"get_project"});
+        gb.reset({"run_tests"});
+        CHECK(ga.advance_str("<function=get"));
+        CHECK(gb.advance_str("<function=run"));
+        CHECK(ga.signature() != gb.signature());
+    }
+}
+
+// XML mask cache: the templated ToolMaskCache<ToolGrammarXml> reuses the
+// same caching machinery; name-allowlist keying must isolate tool sets so
+// request B cannot inherit request A's tool names (review R1, the JSON
+// fix ported verbatim to the XML grammar via the template parameter).
+static void test_xml_cache_allowlist_in_key() {
+    // Build a tiny vocab: the XML bytes we need to keep legal/illegal.
+    // Names: "bash", "Read". Params (schema): bash->command, Read->file_path.
+    std::vector<std::string> vocab = {
+        "bash",       // 0 -- tool name candidate (allowlisted)
+        "Read",       // 1
+        "evil",       // 2 -- undeclared name -> illegal at NAME
+        "<parameter=",// 3
+        "command",    // 4 -- param key for bash
+        "file_path",  // 5 -- param key for Read
+        "badkey",     // 6 -- undeclared key
+        "\n",         // 7
+        "<",          // 8
+        "function",   // 9
+        "=",          // 10
+        ">",          // 11
+        "/",          // 12
+        "parameter",  // 13
+    };
+    // closer: "</tool_call>" -- legal iff done()
+    std::string closer = "</tool_call>";
+    vocab.push_back(closer); // 14
+
+    int closer_id = 14;
+    q27::ToolMaskCache<q27::ToolGrammarXml> cache;
+    cache.init(&vocab, closer_id);
+
+    q27::ToolGrammarXml ga; ga.reset({"bash"}, {{"command"}});
+    q27::ToolGrammarXml gb; gb.reset({"Read"}, {{"file_path"}});
+
+    CHECK(ga.advance_str("<function="));
+    CHECK(gb.advance_str("<function="));
+    CHECK(ga.signature() != gb.signature());
+    int ia = cache.get(ga), ib = cache.get(gb);
+    CHECK(ia != ib);
+    // 'bash' (0) legal under ga at its NAME state, illegal under gb
+    const auto& ma = cache.mask(ia);
+    const auto& mb = cache.mask(ib);
+    CHECK(ma[0 >> 5] & (1u << (0 & 31)));
+    CHECK(!(mb[0 >> 5] & (1u << (0 & 31))));
+}
+
+// Constrainer dialect dispatch: the constrainer must carry both grammars /
+// both caches and select via dialect_xml. We verify the wiring (fields set,
+// dialect branches reachable) directly rather than driving scan_round with a
+// JSON-shaped vocab (the FakeTok vocab carries JSON marker bytes, not XML
+// body bytes, so a token-by-token XML scan_round would always drop). The
+// end-to-end prevention is proven by test_xml_grammar_valid_and_prevention
+// against the real grammar; the dispatch itself is a one-line branch in
+// scan_round/on_id/on_pending/on_drafts whose correctness reduces to "the
+// right grammar object is touched," which we check here.
+static void test_xml_constrainer_dialect_dispatch() {
+    FakeTok tok = mk_tok();
+    FakeEngine eng;
+    TC tc;
+    tc.eng = &eng;
+    tc.tok = &tok;
+    q27::ToolMaskCache<q27::ToolGrammar> cache;
+    q27::ToolMaskCache<q27::ToolGrammarXml> cache_xml;
+    cache.init(&tok.vocab, T_CLOSER);
+    cache_xml.init(&tok.vocab, T_CLOSER);
+    tc.cache = &cache;
+    tc.cache_xml = &cache_xml;
+
+    // JSON leg (regression guard): dialect_xml false, cache_xml left unused.
+    tc.begin({"bash"}, {}, /*dialect_xml=*/false);
+    CHECK(!tc.dialect_xml);
+    CHECK(tc.params_per_name.empty());
+
+    // XML leg: dialect_xml true, params_per_name populated.
+    std::vector<std::vector<std::string>> pp = {{"command"}};
+    tc.begin({"bash"}, pp, /*dialect_xml=*/true);
+    CHECK(tc.dialect_xml);
+    CHECK(tc.params_per_name.size() == 1);
+    CHECK(tc.params_per_name[0].size() == 1);
+    // The XML grammar must have been reset with the schema so its
+    // parameter-key allowlist is active (this is the prevention).
+    q27::ToolGrammarXml& g = tc.tg_xml;
+    // A legal XML body advances; an undeclared param key rejects.
+    CHECK(g.advance_str("<function=bash>\n<parameter=command>\nls\n</parameter>\n</function>\n"));
+    CHECK(g.done());
+    // schema-aware rejection
+    q27::ToolGrammarXml g2;
+    g2.reset({"bash"}, pp);
+    CHECK(!g2.advance_str("<function=bash>\n<parameter=evil>\nrm -rf /\n</parameter>\n</function>\n"));
+}
+
 int main() {
     test_c1_engage_truncate_midround();
     test_c2_marker_spans_rounds();
@@ -374,6 +544,9 @@ int main() {
     test_r1_allowlist_in_cache_key();
     test_r2_strict_json();
     test_r3_no_mask_duplication_across_allowlists();
+    test_xml_grammar_valid_and_prevention();
+    test_xml_cache_allowlist_in_key();
+    test_xml_constrainer_dialect_dispatch();
     if (fails) {
         fprintf(stderr, "test_toolconstrain: %d FAILED\n", fails);
         return 1;


### PR DESCRIPTION
> Part of a set of independent tool-call parser fixes: #31, #32, #28 (no ordering between them) and #33 (depends on #28). This one can merge on its own.

Three related tool-call parsing fixes for Qwen3.8's XML dialect.

The metal `is_alive` -> `is_writable` rename this originally depended on has already landed as `c578411`, so this applies to current `master` on its own. It touches `src/metal/metal_server.cpp` only to give `ToolMaskCache` its template argument (item 3).

## 1. The hallucinated-result guard was vetoing REAL calls

The guard was a whole-string `find("<result>")` / `find("<output>")` gating the entire mode 17/20/21/22 recovery block, so one quoted `<output>` anywhere in a segment -- prose, a fenced transcript, a prior step's result -- skipped every recovery below it and a fully-formed mode-21 call leaked out as plain text:

```
Here is what the build printed:
<output>make: all targets up to date</output>

Now I'll fix the import.
<parameter=filePath>
/code/fileaction.go
</parameter>
<parameter=newString>
import "bytes"
</parameter>
</function>
```

Presence cannot discriminate: this and the genuine hallucinated-result shape BOTH contain a complete `<output>...</output>` block before the call span. The test is structural -- does the result element CONTAIN the candidate call?

```
(a) a <result>/<output> tag INSIDE the span      -> invented output posing as a
                                                    parameter value; refuse
(b) the span begins inside an UNCLOSED such tag  -> the call is part of the
                                                    invented result block; refuse
otherwise (every block closed before the span)   -> prior context; ACCEPT
```

(b) is what catches the real shapes: the model opens `<result>` and never closes it, so the `<tool_name>` / `<parameter=` span that follows is enclosed by it. The two cases differ by exactly one closing tag. Depth counting, not a last-open scan, so closed-then-reopened still reads as enclosed.

Extracted as `hallucinated_result_around()` and applied per-mode against each mode's OWN span (16, 17a, 17b, 20, 21, 22) instead of one coarse veto over all of them. Mode 16 carried a second copy of the whole-string guard with the same latent bug and is on the shared helper now.

**Note for review:** scoping only the END of the search window does NOT fix this -- a closed block before the call is still inside the window and still vetoes it. And dropping the coarse guard while replacing it with a mode-21-only check strips modes 20/22 of protection, trading a dropped call for an EXECUTED hallucination. Both are pinned by tests.

## 2. Unclosed-`<tool_call>` tail recovery

bb60661 routed a CLOSED wrapped TOOL segment through the drift chain but left the unclosed one as raw text. `recover_unclosed_tool_tail()` now routes that tail too, with `allow_eof_repair=false`: an inner call whose JSON/XML is COMPLETE and merely lost its `</tool_call>` to truncation recovers, while a value cut mid-parse stays text. Executing half a Write is still refused. Wired at all six handler sites (chat, chat-stream, messages, messages-stream, responses, responses-stream).

Defence-in-depth: this and `resolve_ordered_tool_segments` now refuse a call whose `source_begin` is npos or overlaps the emitted cursor, because `substr(cursor, begin - cursor)` would underflow to `SIZE_MAX` and throw inside the request handler. Mode 20 stamps per-call spans rather than only first/last, which is what left middle calls at npos.

## 3. XML-dialect toolgram

`--constrain-tools` only spoke the 3.6 JSON body format, so on an XML-trained 3.8 the grammar fought the model's own trained emission. `ToolGrammarXml` constrains the body to `<function=NAME><parameter=KEY>VALUE</parameter></function>` instead, schema-aware: the parameter-key allowlist switches to that tool's declared parameters once the name completes. `<` inside a value is legal ONLY as the start of `</parameter>` or `</function>`, so a model reaching for `<result>` or a nested `<function=` hits a dead state and the decoder masks it out -- the JSON/XML chimera is prevented at the source rather than refused after the fact.

`ToolMaskCache` is templated on the grammar so both dialects share the caching and the allowlist-in-cache-key isolation (R1) unchanged. Metal stays JSON-only and warns once when it would matter instead of silently no-opping.

## Testing

`test_tool_drift` 124 -> 151 assertions, new ones red before the change; `test_toolconstrain` covers the XML grammar, its cache keying and dialect dispatch. Full `make test-tools` green under gcc.

**NOT VERIFIED:** no live-generation A/B (the survey harness needs a GPU host this work was not done on), and neither backend was compiled -- no CUDA and no Apple-silicon machine was available. The changes outside `src/metal/` are header-only C++ exercised by the CPU suites, but `build/q27-server` and `q27-metal-server` both want a real compile before anyone leans on this.

BUILDLOG entry included, per the log's convention for parser changes.
