### PR TITLE
metal: follow cpp-httplib 0.53.1 DataSink rename is_alive -> is_writable

### DIFF
--- a/src/metal/metal_server.cpp
+++ b/src/metal/metal_server.cpp
@@ -2512,7 +2512,7 @@ int main(int argc,char** argv) {
                         auto outcome=runtime.guard_engine([&]{
                             return runtime.run(ids,n,sampling,stops,emit,
                                 std::vector<std::string>{},snap_hint,id,nullptr,false,
-                                [&]{ return sink.is_alive(); });
+                                [&]{ return sink.is_writable(); });
                         });
                         if(outcome.finish==Runtime::Finish::Cancelled) { sink.done(); return false; }
                         // Terminal chunk with a real finish_reason before [DONE]
@@ -2895,7 +2895,7 @@ int main(int argc,char** argv) {
                                     return alive;
                                 },tnames,snap_hint,id,&think_control,
                                 tchoice.mode==q27::ToolChoice::FORCED,
-                                [&]{ return sink.is_alive(); });
+                                [&]{ return sink.is_writable(); });
                         });
                         if(outcome.finish==Runtime::Finish::Cancelled) { sink.done(); return false; }
                         const bool final_tool_incomplete=
@@ -3395,7 +3395,7 @@ int main(int argc,char** argv) {
                                     return alive;
                                 },tnames,snap_hint,mid,&think_control,
                                 tchoice.mode==q27::ToolChoice::FORCED,
-                                [&]{ return sink.is_alive(); });
+                                [&]{ return sink.is_writable(); });
                         });
                         if(outcome.finish==Runtime::Finish::Cancelled) { sink.done(); return false; }
                         const bool final_tool_incomplete=
@@ -4278,7 +4278,7 @@ int main(int argc,char** argv) {
                                     return alive;
                                 },grammar_tool_names,snap_hint,resp_id,&think_control,
                                 tchoice.mode==q27::ToolChoice::FORCED,
-                                [&]{ return sink.is_alive(); });
+                                [&]{ return sink.is_writable(); });
                         });
                         if(outcome.finish==Runtime::Finish::Cancelled) {
                             runtime.trace.event({{"kind","outcome"},{"api","responses"},{"id",resp_id},


### PR DESCRIPTION
a317bc8 vendored cpp-httplib 0.18.3 -> 0.53.1, which renames DataSink::is_alive to DataSink::is_writable (third_party/httplib.h:1432). src/metal/metal_server.cpp still calls sink.is_alive() at four sites, so q27-metal-server does not compile on the current tip.

Renames the four call sites. No behaviour change -- 0.53.1 wires is_writable to the same strm.is_peer_alive() the old field carried.

Worth noting why this survived the vendor bump: every CPU suite and the CUDA build are blind to src/metal/, so 'make test-tools' is fully green on a tree where one of the two backends cannot build at all. A per-backend compile gate would have caught it.

NOT VERIFIED: no Apple-silicon host was available, so this was not compiled. The break is a source-level fact about the vendored header's API (the field does not exist under the old name), and the replacement is the field 0.53.1 defines, but it wants a real 'make metal' before anyone leans on it.