### PR TITLE
stream_split: one unbalanced quote disarmed tool calling for the rest…

### DIFF
--- a/src/markdown_lex.h
+++ b/src/markdown_lex.h
@@ -9,6 +9,19 @@ namespace q27 {
 struct JsonStringLexState {
     bool in_string=false;
     bool escaped=false;
+    // Opt-in, DISPLAY-CLASSIFICATION ONLY (see consume()). Off by default
+    // because the drift chain synthesizes newlines while repairing dropped
+    // openers, and closing a string there would widen which repairs the
+    // parser accepts -- a rescue-boundary decision, not a display one.
+    bool close_string_at_newline=false;
+
+    // State for asking "is a marker in VISIBLE text structural?", where an
+    // unterminated quote must not disarm the rest of the turn.
+    static JsonStringLexState display() {
+        JsonStringLexState s;
+        s.close_string_at_newline=true;
+        return s;
+    }
     // Active containers use their opener. A top-level undecided opener uses
     // 'o'/'a' until the first non-space byte proves it is JSON-like.
     std::string containers;
@@ -58,6 +71,30 @@ struct JsonStringLexState {
         if(in_string) {
             if(ch=='\\') escaped=true;
             else if(ch=='"') in_string=false;
+            // A JSON string cannot contain a RAW newline -- RFC 8259 requires
+            // control characters to be escaped, so `\n` inside a string is two
+            // bytes, never one. An unescaped line break therefore proves the
+            // quote was prose (`I ran echo "---`), not the start of a JSON
+            // value, and the string must be closed here.
+            //
+            // Without this, ONE unbalanced double quote anywhere in a
+            // generation left in_string set for every byte that followed, so
+            // display_text_context_is_executable() reported "not executable"
+            // for the rest of the turn. The next genuine <tool_call> marker
+            // was then classified non-structural and emitted as VISIBLE TEXT
+            // by the guard in stream_split.h -- the call was lost and the raw
+            // marker leaked to the user. An apostrophe-free sentence quoting a
+            // shell command was enough to disarm tool calling for a whole turn.
+            //
+            // Gated on close_string_at_newline: the parser shares this lexer,
+            // and its repair paths synthesize newlines (mode 10 reconstructs a
+            // dropped opener as "...;\n{\"name\": ..."). Applying the rule
+            // there made the chain rescue a second same-line call that
+            // test_openai_bridge deliberately refuses, because an invalid call
+            // followed by a valid one on one line has an ambiguous boundary.
+            // Display classification and rescue boundaries are different
+            // questions; only the former opts in.
+            else if(close_string_at_newline && (ch=='\n' || ch=='\r')) reset_string();
             return;
         }
         if(settle_pending(ch)) return;

--- a/src/stream_split.h
+++ b/src/stream_split.h
@@ -29,7 +29,10 @@ struct StreamSplitter {
     // been emitted since. The next structural opener may need an empty segment
     // to flush consumers' pending tool buffer.
     bool tool_boundary = false;
-    JsonStringLexState text_string_state;
+    // display() enables the unterminated-string-ends-at-newline rule: this
+    // state only ever answers "is this marker structural?", never "where does
+    // a rescued call begin?"
+    JsonStringLexState text_string_state=JsonStringLexState::display();
     MarkdownFenceLexState text_markdown_state;
 
     static constexpr const char* T_OPEN = "<think>";

--- a/tools/test_stream_split.cpp
+++ b/tools/test_stream_split.cpp
@@ -308,5 +308,35 @@ int main() {
                 split_pieces({"reason", "ing", "</think>", "\n\nans"},
                              Chan::THINK),
                 preseeded_want) && ok;
+
+    // An UNBALANCED double quote in prose used to leave the JSON-string lexer
+    // in_string for every byte that followed, so the next genuine <tool_call>
+    // was classified non-structural and emitted as VISIBLE TEXT: the call was
+    // lost and the raw marker leaked to the user. A JSON string cannot contain
+    // a raw newline (RFC 8259), so the quote is prose and the string ends at
+    // the line break.
+    for(bool bytewise : {false, true}) {
+        const char* how = bytewise ? " (bytewise)" : "";
+        ok = expect((std::string("unbalanced quote does not disarm the opener")+how).c_str(),
+                    compact(split(
+                        "I ran echo \"---\nnow calling.\n<tool_call>{\"a\":1}</tool_call>",
+                        bytewise)),
+                    {{Chan::TEXT, "I ran echo \"---\nnow calling.\n"},
+                     {Chan::TOOL, "{\"a\":1}"}}) && ok;
+    }
+
+    // The rule must NOT reopen the fence-skip hole: a marker quoted inside a
+    // fenced block stays visible text, unbalanced quote or not.
+    ok = expect_visible("fenced marker after an unbalanced quote stays text",
+                        "say \"hi\n```\n<tool_call>{\"a\":1}</tool_call>\n",
+                        false) && ok;
+
+    // KNOWN LIMIT, pinned so a change is deliberate: an UNCLOSED fence runs to
+    // the end of the generation, so a real call after it is still refused. The
+    // conservative direction (never execute an echoed marker) is the right
+    // default, but it does cost the turn.
+    ok = expect_visible("unclosed fence still swallows a later call (known limit)",
+                        "here:\n```\ncode\n<tool_call>{\"a\":1}</tool_call>\n",
+                        false) && ok;
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
… of the turn

JsonStringLexState never closed a string on a raw newline, so a single unbalanced double quote in prose left in_string set for every byte that followed. display_text_context_is_executable() then reported "not executable" for the rest of the generation, the next genuine <tool_call> was classified non-structural, and stream_split.h's guard emitted it as VISIBLE TEXT -- the call was lost AND the raw marker leaked to the user:

    I ran echo "---
    now calling.
    <tool_call>{"a":1}</tool_call>      <- marker shown as text, no call

A sentence quoting a shell command was enough. RFC 8259 requires control characters inside a JSON string to be escaped, so "\n" is two bytes and never one: an unescaped line break proves the quote was prose, and the string ends there.

SCOPED TO DISPLAY CLASSIFICATION, deliberately. The parser shares this lexer, and its repair paths synthesize newlines -- mode 10 reconstructs a dropped opener as "...;\n{\"name\": ...". Applying the rule unconditionally made the drift chain rescue a second same-line call that test_openai_bridge refuses on purpose, because an invalid call followed by a valid one on one line has an ambiguous boundary. Widening a rescue boundary is how you execute a call the model did not ask for, so the rule is opt-in via
JsonStringLexState::display(), used only by StreamSplitter's text_string_state. "Is this marker structural?" and "where does a rescued call begin?" are different questions and no longer share an answer.

Does not reopen the fence-skip hole: a marker quoted inside a fenced block stays visible text, unbalanced quote or not. Pinned.

KNOWN LIMIT, now pinned so a change is deliberate: an UNCLOSED fence still runs to the end of the generation, so a real call after it is refused. Conservative direction is right -- never execute an echoed marker -- but it costs the turn.

4 new assertions in test_stream_split (byte-at-a-time and chunked). Full make test-tools green from a clean build.

NOT VERIFIED: not compiled for either backend -- no CUDA and no Apple-silicon host was available. Header-only change exercised by the CPU suites.