### PR TITLE
stream_split: an in-value </tool_call> is provisional, not the closer

### DIFF
--- a/docs/BUILDLOG.md
+++ b/docs/BUILDLOG.md
@@ -14025,3 +14025,84 @@ both channels can reach it.
 
 Both backends green: `make test-tools` under gcc on haight and clang on the M4,
 `q27-metal-server` links clean under `-Werror`.
+
+## 2026-08-22: the dialect has no escaping, so writing ABOUT a tool call destroyed the tool call
+
+The document describing this bug was truncated at 651 bytes BY this bug, mid
+sentence, exactly where it was about to type `</tool_call>`. That is the whole
+report.
+
+The XML dialect provides no escape mechanism, so a call whose parameter value
+legitimately contains the protocol's own bytes -- a doc, a verifier, a bug
+write-up -- collides with the channel delimiter:
+
+```
+<tool_call>
+<function=write>
+<parameter=content>
+The model emitted:
+```
+<tool_call>
+{"name":"bash"}
+</tool_call>          <-- StreamSplitter closed the TOOL channel HERE
+```
+and never closed it.
+</parameter>
+</function>
+</tool_call>
+```
+
+`StreamSplitter`'s TOOL branch was a bare `hold.find("</tool_call>")`. The TEXT
+channel has careful structural-vs-inert logic (that is what keeps a fenced
+example from firing a call); the TOOL channel had none at all. So the call was
+cut at the inner tag, failed to parse, recovered NOTHING, and the trailing
+`</parameter></function>` leaked as visible text -- `calls=0`. Measured on
+master and on every branch: the model's own diagnosis in the live session was
+right, "the harness is interpreting it as its own delimiter".
+
+### Why the obvious fix is wrong
+
+"Ignore `</tool_call>` inside a parameter value" breaks a case that works
+today. Models routinely FORGET the final `</parameter>` and close with
+`</tool_call>`; `parse_native_xml_call` tolerates exactly that (the 2026-08-15
+EOF leniency). Ignoring the tag there means never closing, and the call is lost
+in the other direction.
+
+The two cases are indistinguishable at the moment the tag arrives, and become
+distinguishable later: if the value CLOSES afterwards, the tag was content; if
+the generation ENDS first, the tag was the closer.
+
+### The rule: provisional closers
+
+An in-value `</tool_call>` is PROVISIONAL. Bytes from it are HELD rather than
+emitted, so the decision stays open until the evidence arrives. A subsequent
+`</parameter>`/`</function>` proves it was content and the held bytes are
+released; `flush()` reaching end-of-generation with one still pending promotes
+it to the real closer and splits exactly where the old code did. Both cases now
+work, and nothing had to be guessed at the point of ambiguity.
+
+The value-state machine also has to survive feed() boundaries. The TOOL channel
+previously held back only a partial `</tool_call>`, so a `<parameter=` split
+across two tokens was never seen, `tool_in_value` stayed false, and the next
+in-value `</tool_call>` read as structural. That made the whole fix a
+whole-string-only fix -- it passed on one-shot input and failed on real
+streaming, which is the only mode that matters. `tool_keep()` now holds back a
+partial prefix of any of the four dialect markers, plus an unterminated
+`<parameter=` opener whose `>` has not arrived. Every fixture is pinned at
+chunk sizes 1, 5 and whole-string, because chunk=whole would have shipped this
+broken.
+
+### Measured
+
+7 new assertions in `test_stream_split`: content-with-closers recovers with the
+value byte-identical (bytewise and chunked), an unterminated value still
+promotes its provisional to the closer, trailing bytes after a promoted closer
+route to TEXT, a split `<parameter=` opener keeps its state, and a
+zero-parameter call closes immediately. Full `make test-tools` green from a
+clean build, and the four earlier live reproductions re-verified unchanged.
+
+Known limit, unchanged: this reasons about the XML dialect's value spans. A JSON
+dialect body whose string value contains `</tool_call>` has the same collision
+and is not covered.
+
+NOT VERIFIED: neither backend compiled -- no CUDA and no Apple-silicon host.

--- a/src/stream_split.h
+++ b/src/stream_split.h
@@ -33,12 +33,86 @@ struct StreamSplitter {
     // state only ever answers "is this marker structural?", never "where does
     // a rescued call begin?"
     JsonStringLexState text_string_state=JsonStringLexState::display();
+    // Are we inside a <parameter=KEY>...</parameter> VALUE in the TOOL channel?
+    // Advanced over every TOOL byte as it leaves `hold`, because the decision
+    // below needs state the emitted bytes have already carried away.
+    bool tool_in_value=false;
     MarkdownFenceLexState text_markdown_state;
 
     static constexpr const char* T_OPEN = "<think>";
     static constexpr const char* T_CLOSE = "</think>";
     static constexpr const char* C_OPEN = "<tool_call>";
     static constexpr const char* C_CLOSE = "</tool_call>";
+    static constexpr const char* P_OPEN = "<parameter=";
+    static constexpr const char* P_CLOSE = "</parameter>";
+    static constexpr const char* F_CLOSE = "</function>";
+
+    // Advance tool_in_value over TOOL bytes that are about to be emitted.
+    void advance_tool_value(const std::string& s) {
+        size_t i=0;
+        while(i<s.size()) {
+            if(!tool_in_value) {
+                size_t a=s.find(P_OPEN,i);
+                if(a==std::string::npos) return;
+                size_t gt=s.find('>',a+strlen(P_OPEN));
+                if(gt==std::string::npos) return;  // opener split across feeds
+                tool_in_value=true; i=gt+1;
+            } else {
+                size_t e=s.find(P_CLOSE,i), f=s.find(F_CLOSE,i);
+                size_t end=std::min(e,f);
+                if(end==std::string::npos) return;
+                tool_in_value=false;
+                i=end+(end==e?strlen(P_CLOSE):strlen(F_CLOSE));
+            }
+        }
+    }
+
+    // Find the STRUCTURAL </tool_call> in `h`, i.e. one that is not sitting
+    // inside a parameter value. Returns npos if there is none yet, and sets
+    // *pending to the first </tool_call> inside a value that has NOT closed --
+    // a PROVISIONAL closer.
+    //
+    // The XML dialect has no escaping, so a call that legitimately writes about
+    // the protocol (a doc, a verifier, this BUILDLOG) puts a literal
+    // </tool_call> inside <parameter=content>. Closing the channel at that byte
+    // truncated the call, lost it entirely, and leaked the trailing
+    // </parameter></function> as visible text.
+    //
+    // But a model that FORGETS </parameter> and closes with </tool_call> is a
+    // real, working case today (api_common tolerates the missing final
+    // </parameter> at EOF). So an in-value </tool_call> cannot simply be
+    // ignored: it is provisional. If the value later closes, it was content;
+    // if generation ends first, it was the closer after all. flush() resolves
+    // it that way, and until then those bytes are held rather than emitted, so
+    // the choice is still open when the answer arrives.
+    size_t structural_tool_close(const std::string& h, bool in_value,
+                                 size_t* pending) const {
+        *pending=std::string::npos;
+        size_t i=0;
+        while(i<h.size()) {
+            if(!in_value) {
+                size_t a=h.find(P_OPEN,i), b=h.find(C_CLOSE,i);
+                if(b!=std::string::npos && (a==std::string::npos || b<a)) return b;
+                if(a==std::string::npos) return std::string::npos;
+                size_t gt=h.find('>',a+strlen(P_OPEN));
+                if(gt==std::string::npos) return std::string::npos;
+                in_value=true; i=gt+1;
+            } else {
+                size_t e=h.find(P_CLOSE,i), f=h.find(F_CLOSE,i), c=h.find(C_CLOSE,i);
+                size_t end=std::min(e,f);
+                if(c!=std::string::npos && c<end) {
+                    if(*pending==std::string::npos) *pending=c;
+                    i=c+strlen(C_CLOSE);
+                    continue;
+                }
+                if(end==std::string::npos) return std::string::npos; // value open
+                *pending=std::string::npos; // value closed -> those were content
+                in_value=false;
+                i=end+(end==e?strlen(P_CLOSE):strlen(F_CLOSE));
+            }
+        }
+        return std::string::npos;
+    }
 
     std::vector<std::pair<Chan, std::string>> feed(const std::string& piece) {
         hold += piece;
@@ -89,7 +163,24 @@ struct StreamSplitter {
                 break;
             }
             const char* closer = chan == THINK ? T_CLOSE : C_CLOSE;
-            size_t p = hold.find(closer);
+            size_t pending = std::string::npos;
+            size_t p = chan == TOOL
+                          ? structural_tool_close(hold, tool_in_value, &pending)
+                          : hold.find(closer);
+            if (chan == TOOL && p == std::string::npos &&
+                pending != std::string::npos) {
+                // a provisional closer is open: emit only the bytes before it
+                // and hold the rest until the value closes (content) or the
+                // generation ends (flush() promotes it to the real closer)
+                if (pending) {
+                    std::string head = hold.substr(0, pending);
+                    advance_tool_value(head);
+                    out.push_back({TOOL, std::move(head)});
+                    hold.erase(0, pending);
+                    tool_boundary = false;
+                }
+                break;
+            }
             if (p != std::string::npos) {
                 if (p > 0) {
                     out.push_back({chan, hold.substr(0, p)});
@@ -99,10 +190,12 @@ struct StreamSplitter {
                 }
                 hold.erase(0, p + strlen(closer));
                 tool_boundary = (chan == TOOL);
+                if (chan == TOOL) tool_in_value = false;
                 chan = TEXT;
                 continue;
             }
-            if (emit_head(out, tail_keep(closer))) tool_boundary = false;
+            if (emit_head(out, chan == TOOL ? tool_keep() : tail_keep(closer)))
+                tool_boundary = false;
             break;
         }
         return out;
@@ -110,6 +203,28 @@ struct StreamSplitter {
 
     std::vector<std::pair<Chan, std::string>> flush() {
         std::vector<std::pair<Chan, std::string>> out;
+        if (chan == TOOL && !hold.empty()) {
+            // Resolve a provisional closer: the generation ended without the
+            // value closing, so that in-value </tool_call> WAS the closer (the
+            // model dropped its </parameter>). Split there, exactly as the
+            // pre-existing behaviour did, so that working case is preserved.
+            size_t pending=std::string::npos;
+            if (structural_tool_close(hold,tool_in_value,&pending)==std::string::npos &&
+                pending!=std::string::npos) {
+                if (pending) out.push_back({TOOL, hold.substr(0,pending)});
+                std::string rest=hold.substr(pending+strlen(C_CLOSE));
+                hold.clear();
+                tool_in_value=false;
+                chan=TEXT;
+                if (!rest.empty()) {
+                    consume_display_text_context(
+                        text_string_state,text_markdown_state,rest);
+                    out.push_back({TEXT,std::move(rest)});
+                }
+                tool_boundary=false;
+                return out;
+            }
+        }
         if (!hold.empty()) {
             if (chan == TEXT)
                 consume_display_text_context(
@@ -132,6 +247,27 @@ struct StreamSplitter {
         hold.erase(0,count);
     }
 
+    // How many trailing TOOL bytes must stay in `hold` for the value-state
+    // machine to stay correct across feed() boundaries. The TEXT channel does
+    // the same thing for its markers; the TOOL channel used to hold back only a
+    // partial </tool_call>, so a <parameter= split across two tokens was never
+    // recognised, tool_in_value stayed false, and the next </tool_call> inside
+    // that value read as structural -- the bug, but only when streaming.
+    size_t tool_keep() const {
+        size_t k = tail_keep(C_CLOSE);
+        k = std::max(k, tail_keep(P_OPEN));
+        k = std::max(k, tail_keep(P_CLOSE));
+        k = std::max(k, tail_keep(F_CLOSE));
+        if (!tool_in_value) {
+            // an opener whose '>' has not arrived yet: hold from the opener, or
+            // advance_tool_value() would consume it without flipping the flag
+            size_t a = hold.rfind(P_OPEN);
+            if (a != std::string::npos &&
+                hold.find('>', a + strlen(P_OPEN)) == std::string::npos)
+                k = std::max(k, hold.size() - a);
+        }
+        return k;
+    }
     size_t tail_keep(const char* marker) const {
         size_t mlen = strlen(marker);
         size_t maxk = std::min(hold.size(), mlen - 1);
@@ -144,7 +280,9 @@ struct StreamSplitter {
         const size_t count=hold.size()-keep;
         if (chan == TEXT) emit_text_head(out,count);
         else {
-            out.push_back({chan, hold.substr(0,count)});
+            std::string seg=hold.substr(0,count);
+            if (chan == TOOL) advance_tool_value(seg);
+            out.push_back({chan, std::move(seg)});
             hold.erase(0,count);
         }
         return true;

--- a/tools/test_stream_split.cpp
+++ b/tools/test_stream_split.cpp
@@ -338,5 +338,50 @@ int main() {
     ok = expect_visible("unclosed fence still swallows a later call (known limit)",
                         "here:\n```\ncode\n<tool_call>{\"a\":1}</tool_call>\n",
                         false) && ok;
+
+    // BUG 6 (2026-08-22): the XML dialect has no escaping, so a call that
+    // legitimately writes ABOUT the protocol puts a literal </tool_call> inside
+    // <parameter=content>. Closing the TOOL channel at that byte truncated the
+    // call, lost it entirely, and leaked the trailing </parameter></function> as
+    // visible text. The doc describing this very bug was itself cut at 651
+    // bytes by it. An in-value </tool_call> is now PROVISIONAL: content if the
+    // value closes, the real closer if generation ends first.
+    {
+        const std::string body =
+            "<function=write>\n<parameter=path>\n/d.md\n</parameter>\n"
+            "<parameter=content>\nsaw </tool_call> in the log\n</parameter>\n</function>\n";
+        for (bool bytewise : {false, true}) {
+            const char* how = bytewise ? " (bytewise)" : "";
+            ok = expect((std::string("in-value </tool_call> is content, not the closer")+how).c_str(),
+                        compact(split("<tool_call>\n"+body+"</tool_call>", bytewise)),
+                        {{Chan::TOOL, "\n"+body}}) && ok;
+        }
+    }
+    // ...but a model that FORGOT </parameter> and closed with </tool_call> is a
+    // real working case: at EOF the provisional IS the closer. Preserved.
+    {
+        const std::string raw =
+            "<tool_call>\n<function=write>\n<parameter=content>\nhello\n</tool_call>";
+        for (bool bytewise : {false, true}) {
+            const char* how = bytewise ? " (bytewise)" : "";
+            ok = expect((std::string("unterminated value: provisional becomes the closer")+how).c_str(),
+                        compact(split(raw, bytewise)),
+                        {{Chan::TOOL, "\n<function=write>\n<parameter=content>\nhello\n"}}) && ok;
+        }
+    }
+    // trailing text after a promoted provisional closer stays TEXT
+    ok = expect("promoted provisional: trailing bytes route to TEXT",
+                compact(split("<tool_call>\n<parameter=content>\nx\n</tool_call>tail", false)),
+                {{Chan::TOOL, "\n<parameter=content>\nx\n"}, {Chan::TEXT, "tail"}}) && ok;
+    // a <parameter= opener SPLIT across feeds must not lose the value state
+    ok = expect("split <parameter= opener keeps value state",
+                compact(split_pieces({"<tool_call>\n<param", "eter=content>\nsaw </tool",
+                                      "_call> here\n</parameter>\n</function>\n", "</tool_call>"})),
+                {{Chan::TOOL, "\n<parameter=content>\nsaw </tool_call> here\n"
+                              "</parameter>\n</function>\n"}}) && ok;
+    // no parameters at all: the closer is structural immediately
+    ok = expect("no parameters: closer is structural",
+                compact(split("<tool_call>\n<function=ls>\n</function>\n</tool_call>", false)),
+                {{Chan::TOOL, "\n<function=ls>\n</function>\n"}}) && ok;
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
> Part of a set of independent tool-call parser fixes: #31, #32, #28 (no ordering between them) and #33 (depends on #28). This one can merge on its own.

The XML dialect has no escape mechanism, so a tool call whose parameter value legitimately contains the protocol's own bytes — a doc, a verifier, a bug write-up — collided with the channel delimiter and was destroyed.

**The document describing this bug was itself truncated at 651 bytes by this bug**, mid-sentence, exactly where it was about to type the closing tag. That is the whole report.

## The failure

````
<tool_call>
<function=write>
<parameter=content>
The model emitted:
```
<tool_call>
{"name":"bash"}
</tool_call>          <-- StreamSplitter closed the TOOL channel HERE
```
and never closed it.
</parameter>
</function>
</tool_call>
````

`StreamSplitter`'s TOOL branch was a bare `hold.find("</tool_call>")`. The TEXT channel has careful structural-vs-inert logic — that is what stops a fenced example from firing a call — but the TOOL channel had none at all. So the call was cut at the inner tag, failed to parse, recovered **nothing** (`calls=0`), and the trailing `</parameter></function>` leaked as visible text.

Reproduced deterministically on `master`. The model's own diagnosis in the live session was correct: *"the harness is interpreting it as its own delimiter."*

## Why the obvious fix is wrong

"Ignore `</tool_call>` inside a parameter value" breaks a case that works today. Models routinely **forget** the final `</parameter>` and close with `</tool_call>`; `parse_native_xml_call` tolerates exactly that (the 2026-08-15 EOF leniency). Ignoring the tag there means the call never closes and is lost in the other direction.

The two cases are indistinguishable *at the moment the tag arrives*, and become distinguishable later:

- if the value **closes** afterwards → the tag was content
- if the generation **ends** first → the tag was the closer

## The rule: provisional closers

An in-value `</tool_call>` is **provisional**. Bytes from it are **held rather than emitted**, so the decision stays open until the evidence arrives. A subsequent `</parameter>` or `</function>` proves it was content and releases the held bytes; `flush()` reaching end-of-generation with one still pending promotes it to the real closer and splits exactly where the old code did. Both cases work, and nothing is guessed at the point of ambiguity.

## The streaming half, which nearly shipped broken

The value-state machine also has to survive `feed()` boundaries. The TOOL channel previously held back only a partial `</tool_call>`, so a `<parameter=` split across two tokens was never recognised, `tool_in_value` stayed false, and the next in-value `</tool_call>` read as structural.

My first version therefore passed on whole-string input and **failed at chunk sizes 1 and 5** — content truncated, closers still leaking. That would have been a fix that works in tests and does nothing in production, since streaming is the only mode that matters.

`tool_keep()` now holds back a partial prefix of any of the four dialect markers, plus an unterminated `<parameter=` opener whose `>` has not arrived. **Every fixture is pinned at chunk 1, 5 and whole-string**, because whole-string-only would have shipped this broken.

## Testing

7 new assertions in `test_stream_split`: content-with-closers recovers with the value byte-identical (chunked and bytewise), an unterminated value still promotes its provisional to the closer, trailing bytes after a promoted closer route to TEXT, a split `<parameter=` opener keeps its state, and a zero-parameter call closes immediately. Full `make test-tools` green from a clean build.

## Notes

- Independent of the other open PRs; no conflicts.
- **Known limit:** this reasons about the XML dialect's value spans. A JSON-dialect body whose string value contains `</tool_call>` has the same collision and is **not** covered.
- **Review focus:** this changes closer detection on every request, which is the riskiest surface in the splitter. Worth attention on large `content` values and under batching.
- **Not verified:** neither backend compiled — no CUDA and no Apple-silicon host available.
