### PR TITLE
parser: a repeated <tool_call> opener must not become the user's answer

### DIFF
--- a/src/api_common.h
+++ b/src/api_common.h
@@ -4322,6 +4322,42 @@ struct OrderedToolOutput {
     }
 };
 
+// A TOOL body that recovered NOTHING and consists only of dialect control
+// bytes carries no information for the user -- showing it just leaks protocol.
+//
+// The shape that made this necessary (2026-08-22, live): the model emitted the
+// opener TWICE and then hit EOS --
+//
+//   <tool_call>          <- structural; the splitter erases it, enters TOOL
+//   <tool_call>          <- inside TOOL only "</tool_call>" delimits, so this
+//   (EOS)                   is BODY CONTENT, not a marker
+//
+// unfinished_tool_wrapper() reports false (it detects length/budget truncation,
+// not EOS-inside-wrapper), so the unclosed-tail path never runs. emit_tool()
+// then fails to parse, the drift chain finds nothing, and the fallback prints
+// ToolCall::raw -- which IS the literal string "<tool_call>". The user's
+// visible answer for the whole turn was that one marker.
+//
+// Deliberately NARROW: whitespace plus <tool_call>/</tool_call> only. Dialect
+// tags that can carry a payload (<function=...>, <parameter=...>) are NOT
+// stripped, because a body containing those is a malformed CALL whose bytes the
+// user may need to see -- that is drift, and drift stays visible. This only
+// suppresses residue that is provably content-free.
+//
+// The turn is lost either way; this decides what the user sees, and callers log
+// so the loss is not silent.
+inline bool only_dialect_control_bytes(const std::string& s) {
+    size_t i=0;
+    bool saw_marker=false;
+    while(i<s.size()) {
+        if(isspace((unsigned char)s[i])) { i++; continue; }
+        if(s.compare(i,11,"<tool_call>")==0) { i+=11; saw_marker=true; continue; }
+        if(s.compare(i,12,"</tool_call>")==0) { i+=12; saw_marker=true; continue; }
+        return false;
+    }
+    return saw_marker; // pure whitespace is not this function's business
+}
+
 inline std::string take_unclosed_final_tool_segment(
     std::vector<std::pair<StreamSplitter::Chan,std::string>>& segments,
     bool wrapper_incomplete) {
@@ -4400,6 +4436,13 @@ inline OrderedToolOutput resolve_ordered_tool_segments(
         // No EOF repair: the wrapper closed, so this is drift, not truncation.
         // A wrapper that did NOT close was already removed by
         // take_unclosed_final_tool_segment before this loop.
+        if(only_dialect_control_bytes(body)) {
+            fprintf(stderr,"[q27] tool body was dialect control bytes only "
+                           "(%zu B, e.g. a repeated <tool_call> opener) -- "
+                           "turn produced no call; suppressed from visible text\n",
+                    body.size());
+            continue;
+        }
         append_text(body,false);
     }
     flush_pending_text(true);

--- a/src/server.cu
+++ b/src/server.cu
@@ -2321,7 +2321,17 @@ int main(int argc, char** argv) {
                     auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
                     tool_buf.clear();
                     if (!c.ok) {
-                        if (!classify_bare(c.raw,true,emit_text)) emit_text(c.raw);
+                        if (!classify_bare(c.raw,true,emit_text)) {
+                            // dialect control bytes only (a repeated <tool_call>
+                            // opener at EOS) -- no call, and echoing the marker
+                            // is worse than saying nothing. Logged, not silent.
+                            if (q27::only_dialect_control_bytes(c.raw))
+                                fprintf(stderr,
+                                    "[q27] tool body was dialect control bytes only "
+                                    "(%zu B) -- no call; suppressed from visible text\n",
+                                    c.raw.size());
+                            else emit_text(c.raw);
+                        }
                     } else if (!emit_call(c)) emit_text(c.raw);
                 };
                 auto emit_seg = [&](StreamSplitter::Chan ch, const std::string& t) {
@@ -2867,7 +2877,17 @@ int main(int argc, char** argv) {
                     auto c = q27::parse_tool_call(q27::strip_ws2(tool_buf));
                     tool_buf.clear();
                     if (!c.ok) {
-                        if (!classify_bare(c.raw,true,emit_text)) emit_text(c.raw);
+                        if (!classify_bare(c.raw,true,emit_text)) {
+                            // dialect control bytes only (a repeated <tool_call>
+                            // opener at EOS) -- no call, and echoing the marker
+                            // is worse than saying nothing. Logged, not silent.
+                            if (q27::only_dialect_control_bytes(c.raw))
+                                fprintf(stderr,
+                                    "[q27] tool body was dialect control bytes only "
+                                    "(%zu B) -- no call; suppressed from visible text\n",
+                                    c.raw.size());
+                            else emit_text(c.raw);
+                        }
                     } else if (!emit_call(c)) emit_text(c.raw);
                 };
                 bool forced_control_token = false;

--- a/tools/test_tool_drift.cpp
+++ b/tools/test_tool_drift.cpp
@@ -1163,6 +1163,54 @@ static void test_tool_segment_strict_leg() {
        "strict: a refused TOOL segment is NOT routed through the drift chain");
 }
 
+// Live failure 2026-08-22: after 8 clean tool calls the model emitted the
+// OPENER TWICE and hit EOS. The splitter consumes the first (structural) and
+// enters the TOOL channel; inside TOOL only "</tool_call>" delimits, so the
+// second opener is BODY CONTENT. unfinished_tool_wrapper() reports false (it
+// detects length/budget truncation, not EOS-inside-wrapper), so the tail path
+// never runs, and the fallback printed ToolCall::raw -- the literal string
+// "<tool_call>" became the user's entire visible answer for the turn.
+static void test_repeated_opener_is_not_shown_as_text() {
+    json tools = json::array({tool("bash", {{"command", true}})});
+
+    for (const char* raw : {"<tool_call><tool_call>",
+                            "<tool_call>\n<tool_call>",
+                            "<tool_call>\n\n<tool_call>\n",
+                            "<tool_call><tool_call><tool_call>"}) {
+        auto out = resolve_stream(raw, &tools);
+        ok(out.calls.empty() && out.text.find("<tool_call>") == std::string::npos,
+           "repeated opener: no call, and the marker is not shown as text");
+    }
+
+    // The predicate itself. NARROW on purpose: dialect tags that can carry a
+    // payload are NOT control-only, because a body containing them is drift
+    // whose bytes the user may need to see.
+    ok(q27::only_dialect_control_bytes("<tool_call>"), "control-only: bare opener");
+    ok(q27::only_dialect_control_bytes(" \n</tool_call>\t"), "control-only: closer + ws");
+    ok(q27::only_dialect_control_bytes("<tool_call>\n</tool_call>"),
+       "control-only: opener + closer");
+    ok(!q27::only_dialect_control_bytes("   \n\t "),
+       "control-only: pure whitespace is NOT claimed");
+    ok(!q27::only_dialect_control_bytes("<function=bash>"),
+       "control-only: a payload-bearing dialect tag is drift, stays visible");
+    ok(!q27::only_dialect_control_bytes("<tool_call>{\"name\":\"bash\"}"),
+       "control-only: real content alongside a marker stays visible");
+
+    // A malformed body that is NOT control-only must still reach the user.
+    {
+        auto out = resolve_stream("<tool_call>\n{\"nam\": \"bas\", oops\n</tool_call>", &tools);
+        ok(out.calls.empty() && out.text.find("oops") != std::string::npos,
+           "malformed body still visible (suppression did not overreach)");
+    }
+    // and a well-formed call is unaffected
+    {
+        auto out = resolve_stream(
+            "<tool_call>\n{\"name\":\"bash\",\"arguments\":{\"command\":\"ls\"}}\n</tool_call>", &tools);
+        ok(out.calls.size() == 1 && out.calls[0].name == "bash",
+           "well-formed wrapped call unaffected by the suppression");
+    }
+}
+
 int main() {
     if (getenv("Q27_TOOL_STRICT")) {
         test_tool_segment_strict_leg();
@@ -1190,6 +1238,7 @@ int main() {
     test_mode14_tool_name_xml_dialect();
     test_mode15_name_tag_bare_args();
     test_mode16_and_15_variants();
+    test_repeated_opener_is_not_shown_as_text();
     json tools = json::array();
     tools.push_back(tool("Write", {{"content", true}, {"file_path", true}}));
     tools.push_back(tool("Read", {{"file_path", true}}));


### PR DESCRIPTION
> Part of a set of independent tool-call parser fixes: #31, #32, #28 (no ordering between them) and #33 (depends on #28). This one can merge on its own.

A repeated `<tool_call>` opener became the user's entire visible answer for a turn.

## The live failure

Session `01a026cd` (`rid chatcmpl-q27-8`): after 8 clean tool calls the model emitted the opener **twice** and hit EOS at 14 tokens. The whole visible assistant message was the literal string `<tool_call>`, with no tool call and `stopReason: "stop"`.

```
<tool_call>     <- structural: the splitter erases it, enters the TOOL channel
<tool_call>     <- inside TOOL only "</tool_call>" delimits, so this is BODY CONTENT
(EOS)
```

## Why it reaches the user

- `unfinished_tool_wrapper()` reports **false** here — it detects length/budget truncation, not EOS-inside-wrapper — so `take_unclosed_final_tool_segment()` and the tail-recovery path never run.
- `emit_tool()` then fails to parse, the drift chain finds nothing, and the fallback prints `ToolCall::raw`.
- `tc.raw = seg` (`api_common.h`) is the body verbatim, and the body **is** the literal string `<tool_call>`.

So the marker was never leaked by the splitter — it arrived as body content. A single opener is handled correctly; two is the trigger. Three leaks two of them.

## The fix

`only_dialect_control_bytes()`, applied at the two fallback points — `resolve_ordered_tool_segments()`'s TOOL branch and the streaming `emit_tool()` in both `server.cu` handlers — with a stderr line so the lost turn is not silent.

**Narrow by construction:** whitespace plus `<tool_call>`/`</tool_call>` only. Tags that can carry a payload (`<function=...>`, `<parameter=...>`) are **not** stripped, because a body containing those is a malformed *call* whose bytes the user may need to see. Drift stays visible; only provably content-free residue is suppressed. Pinned in both directions — a malformed body still reaches the user, a well-formed call is unaffected.

## Deliberately not done

This does **not** widen `unfinished_tool_wrapper()` to treat "channel is TOOL at EOS" as unfinished. That is arguably the more general fix, but finish detection gates every request, and the currently-*working* case (unclosed wrapper, complete JSON, EOS) already recovers through `emit_tool()`. Rerouting it through the no-EOF-repair tail path risks regressing it. Recorded as an open question rather than changed blind.

## Scope

The turn is still lost — a model that emits two openers and stops has produced nothing executable. This decides only what the user sees, and that it gets logged.

## Testing

13 new assertions in `test_tool_drift` (the repeated-opener shapes, the predicate's boundaries in both directions, and a malformed body that must still be visible). Full `make test-tools` green from a clean build.

## Notes

- Independent of the other open PRs; no conflicts.
- **Not verified:** neither backend compiled — no CUDA and no Apple-silicon host available.
