### PR TITLE
toolgram XML: re-engage on bare <function=, fix on_pending_xml guards (#35)

### DIFF
--- a/src/toolconstrain.h
+++ b/src/toolconstrain.h
@@ -19,6 +19,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -33,6 +34,29 @@ struct BasicToolConstrainer {
     std::vector<int>* host2dev = nullptr;
     bool enabled = false, active = false;
     bool pool_dead = false; // sticky: mask pool filled up this request
+    // Q27_TG_REENGAGE (XML dialect): re-engage the grammar on a bare
+    // <function= opener (no <tool_call> wrapper) during scan_round -- the
+    // wrapper-less 3.8 drift class AND the remainder of a body whose mid-call
+    // reject just dropped the constraint (signalnine/q27#35). DEFAULT ON for
+    // the XML dialect: wrapper-only engagement was the default that let the
+    // observed corruption through. False-positive blast radius is bounded and
+    // self-limiting -- engagement auto-disengages at the first non-conforming
+    // byte and emitted bytes are never rewound, so prose that merely QUOTES
+    // the dialect (<function=...> in an answer) is only ever steered if it
+    // forms a full well-formed call, and simply disengages otherwise. Set
+    // Q27_TG_REENGAGE=0 to restore the old wrapper-only behaviour (the A/B
+    // escape hatch); "1"/unset selects the default. XML-specific by design:
+    // the XML wrapper-less drift form is a distinctive tag, while the JSON
+    // drift form is a bare {...} whose "{" trigger would constrain JSON the
+    // model writes in prose (configs, code samples) -- so JSON wrapper-less
+    // drift is recovered at PARSE time (api_common.h drift modes) instead,
+    // and the JSON path stays wrapper-only here.
+    // NOTE (scope, signalnine/q27#35): this is RECOVERY + correctness only --
+    // it cannot stop a byte that the grammar would reject from being
+    // SELECTED and emitted under a stale/host mask (the '!' sample-time gap).
+    // That gap is tracked separately in #35; re-engage just makes a dropped
+    // bare/wrapper-less call constrain properly once its opener is seen.
+    bool reengage_bare = false;
     ToolGrammar tg;
     ToolGrammar staged_state; // grammar state whose mask is in verify slot 0
     ToolGrammarXml staged_state_xml; // parallel for the XML dialect (P11 on_drafts)
@@ -52,6 +76,7 @@ struct BasicToolConstrainer {
         tail.clear();
         names = std::move(n);
         dialect_xml = false;
+        reengage_bare = false;
         params_per_name.clear();
         required_per_name.clear();
     }
@@ -78,6 +103,9 @@ struct BasicToolConstrainer {
         dialect_xml = dialect_xml_;
         params_per_name = std::move(pp);
         required_per_name = std::move(rq);
+        // default ON for XML; Q27_TG_REENGAGE=0 opts out (A/B hatch)
+        const char* e = getenv("Q27_TG_REENGAGE");
+        reengage_bare = dialect_xml_ && (!e || strcmp(e, "0") != 0);
         if (dialect_xml_) tg_xml.reset(names, params_per_name, required_per_name);
     }
     // pool id for grammar state g's legal-token mask (-1 if pool full)
@@ -208,6 +236,12 @@ struct BasicToolConstrainer {
         apply(peek);
     }
     void on_pending_xml(int id) {
+        // Guards were missing here vs on_pending above (issue #35) -- an
+        // XML-PATH-ONLY bug: the JSON path (on_pending) already had them. The
+        // XML path instead advanced the stale reset-state grammar over a
+        // pending token whose bytes happened to look like a <function...>
+        // opener and could STAGE+ACTIVATE a mask while inactive.
+        if (!enabled || !active || id < 0) return;
         ToolGrammarXml peek = tg_xml;
         for (char c : tok->decode_one(id))
             if (!peek.advance(c)) return;
@@ -237,6 +271,56 @@ struct BasicToolConstrainer {
             std::string bytes = tok->decode_one(em[j]);
             tail += bytes;
             if (tail.size() > 64) tail.erase(0, tail.size() - 64);
+            // Bare-<function= re-engage (XML dialect, default-on; see
+            // reengage_bare). Mirrors the <tool_call> trigger: engage only
+            // when the opener COMPLETES within this token, reset+feed the
+            // remainder (which starts at the '<' so the WS0 grammar sees the
+            // real opener), then stage and truncate exactly like the wrapped
+            // path. Sits BEFORE the <tool_call> branch so a stream that
+            // returns to wrapped form re-engages seamlessly. JSON has no
+            // equivalent arm here: its wrapper-less drift is a bare {...}
+            // recovered at parse time, not constrained in-stream.
+            if (dialect_xml && reengage_bare) {
+                size_t bp = tail.rfind("<function=");
+                // fire when the opener COMPLETES within this token (mirror of
+                // the <tool_call> test: skip only when it ended earlier)
+                if (bp != std::string::npos &&
+                    bp + 9 > tail.size() - bytes.size()) {
+                    std::string rem = tail.substr(bp);
+                    tg_xml.reset(names, params_per_name, required_per_name);
+                    active = true;
+                    engaged++;
+                    fprintf(stderr, "[toolgram] re-engaged (bare <function=, rem=%zu)\n",
+                            rem.size());
+                    bool rem_ok = true;
+                    for (char c : rem)
+                        if (!tg_xml.advance(c)) {
+                            char why[64];
+                            snprintf(why, sizeof why,
+                                     "bare-entry byte 0x%02x rejected",
+                                     (unsigned char)c);
+                            drop(why);
+                            rem_ok = false;
+                            break;
+                        }
+                    if (!rem_ok) {
+                        if (pool_dead) return -1;
+                        continue;
+                    }
+                    if (tg_xml.closed()) {
+                        active = false;
+                        fprintf(stderr, "[toolgram] bare call closed within entry token\n");
+                        continue;
+                    }
+                    apply(tg_xml);
+                    if (!active) {
+                        if (pool_dead) return -1;
+                        continue;
+                    }
+                    skip_feed = j + 1;
+                    return j + 1;
+                }
+            }
             size_t pos = tail.rfind("<tool_call>");
             // engage only when the marker COMPLETES within this token; any
             // remainder bytes after it already belong to the call body

--- a/tools/test_toolconstrain.cpp
+++ b/tools/test_toolconstrain.cpp
@@ -621,6 +621,169 @@ static void test_required_keys_extractor() {
     CHECK(keys.size() == 2 && keys[0].size() == 2);
 }
 
+// signalnine/q27#35: the live corruption. The 3.8 model opened a spurious
+// second <parameter=edits!! in a <function=edit> call; the schema-aware XML
+// grammar accepts the entire valid prefix and dies deterministically at the
+// FIRST '!' (0x21) of the junk key (byte 133 of the exact logged sequence).
+// Regex-embedded in the suite so the sample-time leak (the '!' reaching the
+// stream at all) is a regression someone has to explain, not rediscover.
+static void test_issue35_key_junk_suffix_rejected() {
+    using q27::ToolGrammarXml;
+    const std::vector<std::string> names = {"edit"};
+    const std::vector<std::vector<std::string>> params = {{"edits", "path"}};
+    const std::vector<std::vector<std::string>> required = {{"path"}};
+    // the valid prefix feeds cleanly...
+    {
+        ToolGrammarXml g;
+        g.reset(names, params, required);
+        CHECK(g.advance_str("<function=edit>\n<parameter=edits>\n"
+                            "[{\"newText\": \"# Plan\"}]\n</parameter>\n"));
+        // ...then the junk KEY suffix dies at '!', exactly as observed
+        CHECK(!g.advance_str("<parameter=edits!!"));
+    }
+    // byte-level: from KEY with key_pref "edits", '!' is the first illegal
+    // byte -- nothing before it, nothing after it, no recovery
+    {
+        ToolGrammarXml g;
+        g.reset(names, params, required);
+        CHECK(g.advance_str("<function=edit>\n<parameter=edits>\n"
+                            "[]\n</parameter>\n<parameter=edits"));
+        CHECK(!g.advance('!'));
+        CHECK(!g.advance_str("!\""));
+    }
+}
+
+// signalnine/q27#35: Q27_TG_REENGAGE=1 (XML dialect) re-engages the grammar
+// on a bare <function= opener (wrapper-less drift + post-drop recovery), and
+// the re-engaged stream constrains to completion like the wrapped path.
+static void test_issue35_bare_function_reengage() {
+    FakeEngine eng;
+    // tokenizer whose vocab holds the split stream: the bare <function= call
+    // opened in token 0, closed in token 1
+    FakeTok t2;
+    t2.vocab = {"<function=bash>\n<parameter=command>\nls\n</param",
+                "eter>\n</function>\n"};
+    q27::ToolMaskCache<q27::ToolGrammar> cache;
+    q27::ToolMaskCache<q27::ToolGrammarXml> cache_xml;
+    cache.init(&t2.vocab, T_CLOSER);
+    cache_xml.init(&t2.vocab, T_CLOSER);
+    std::vector<int> host2dev;
+    TC tc;
+    tc.eng = &eng;
+    tc.tok = &t2;
+    tc.cache = &cache;
+    tc.cache_xml = &cache_xml;
+    tc.host2dev = &host2dev;
+    tc.enabled = true;
+
+    // re-engage is DEFAULT ON for the XML dialect (no env needed)
+    std::vector<std::vector<std::string>> pp = {{"command"}};
+    std::vector<std::vector<std::string>> rq = {{}};
+    tc.begin({"bash"}, pp, rq, /*dialect_xml=*/true);
+
+    int em[2] = {0, 1};
+    int m = tc.scan_round(em, 2);
+    // re-engage at token 0, truncating the round to 1
+    CHECK(m == 1);
+    CHECK(tc.engaged == 1);
+    CHECK(tc.active);
+    // a mask must have been staged via set_tool_constraint
+    bool staged = false;
+    for (int id : eng.constraint_log)
+        if (id >= 0) staged = true;
+    CHECK(staged);
+    // feed the closing token: grammar reaches </function> (bare calls have no
+    // </tool_call>, so active stays on through DONE_ -- the host disengages
+    // at generation end; the machine must at least report done()). skip_feed
+    // suppresses this round's kept tokens, so clear it as the engine does
+    // once the next round's emission begins.
+    tc.skip_feed = 0;
+    tc.on_id(1);
+    CHECK(!tc.active || tc.tg_xml.done());
+
+    // Q27_TG_REENGAGE=0 restores wrapper-only behaviour: no bare re-engage
+    setenv("Q27_TG_REENGAGE", "0", 1);
+    tc.begin({"bash"}, pp, rq, /*dialect_xml=*/true);
+    int em2[1] = {0};
+    CHECK(tc.scan_round(em2, 1) == -1); // no re-engage, no truncation
+    CHECK(!tc.active);
+    unsetenv("Q27_TG_REENGAGE");
+}
+
+// signalnine/q27#35: default-on re-engage is SELF-LIMITING on prose that
+// merely QUOTES the dialect. A bare <function=bash> in an answer engages the
+// grammar (the <function= completion is real), but the first non-conforming
+// byte that follows must auto-disengage and leave NO lingering tool mask --
+// the constraint must not stick to the stream and steer the rest of a prose
+// answer. This is the blast-radius regression for the default-on decision.
+static void test_issue35_bare_prose_self_limits() {
+    FakeEngine eng;
+    // token 0 opens the quoted call; token 1 is ordinary prose the grammar
+    // rejects (at GT1: 'j' is not the '<' it expects after <function=bash>)
+    FakeTok t2;
+    t2.vocab = {"<function=bash>\n", "just an example, not a real call\n"};
+    q27::ToolMaskCache<q27::ToolGrammar> cache;
+    q27::ToolMaskCache<q27::ToolGrammarXml> cache_xml;
+    cache.init(&t2.vocab, T_CLOSER);
+    cache_xml.init(&t2.vocab, T_CLOSER);
+    std::vector<int> host2dev;
+    TC tc;
+    tc.eng = &eng;
+    tc.tok = &t2;
+    tc.cache = &cache;
+    tc.cache_xml = &cache_xml;
+    tc.host2dev = &host2dev;
+    tc.enabled = true;
+    std::vector<std::vector<std::string>> pp = {{"command"}};
+    std::vector<std::vector<std::string>> rq = {{}};
+    tc.begin({"bash"}, pp, rq, /*dialect_xml=*/true);
+
+    // the quoted opener DOES engage (default-on), staging a mask...
+    int em[1] = {0};
+    int m = tc.scan_round(em, 1);
+    CHECK(m == 1);
+    CHECK(tc.active);
+    CHECK(!eng.constraint_log.empty() && eng.constraint_log.back() >= 0);
+    // ...but the following prose must auto-disengage and release the mask:
+    // set_tool_constraint(-1) and active back off -- no lingering constraint
+    tc.skip_feed = 0;
+    tc.on_id(1);
+    CHECK(!tc.active);
+    CHECK(!eng.constraint_log.empty() && eng.constraint_log.back() == -1);
+}
+
+// signalnine/q27#35: on_pending_xml must NOT stage/activate a constraint when
+// the constrainer is inactive -- the missing guards let a pending token whose
+// bytes merely LOOK like <function...> (prose quoting the dialect) arm the
+// mask. Regression: purely by calling on_pending_xml while inactive, no
+// set_tool_constraint call may appear in the engine log.
+static void test_issue35_on_pending_xml_guards() {
+    FakeTok tok = mk_tok();
+    FakeEngine eng;
+    FakeTok t2;
+    t2.vocab = {"<function=bash>\n"};
+    q27::ToolMaskCache<q27::ToolGrammar> cache;
+    q27::ToolMaskCache<q27::ToolGrammarXml> cache_xml;
+    cache.init(&tok.vocab, T_CLOSER);
+    cache_xml.init(&tok.vocab, T_CLOSER);
+    std::vector<int> host2dev;
+    TC tc;
+    tc.eng = &eng;
+    tc.tok = &t2;
+    tc.cache = &cache;
+    tc.cache_xml = &cache_xml;
+    tc.host2dev = &host2dev;
+    tc.enabled = true;
+    std::vector<std::vector<std::string>> pp = {{"command"}};
+    tc.begin({"bash"}, pp, /*dialect_xml=*/true);
+    CHECK(!tc.active);
+    eng.constraint_log.clear();
+    // pending token that advances the reset-state grammar into NAME phase
+    tc.on_pending_xml(0);
+    CHECK(eng.constraint_log.empty()); // guarded: no mask staged, no activation
+    CHECK(!tc.active);
+}
+
 int main() {
     test_c1_engage_truncate_midround();
     test_c2_marker_spans_rounds();
@@ -641,6 +804,10 @@ int main() {
     test_xml_constrainer_dialect_dispatch();
     test_xml_required_args_enforced();
     test_required_keys_extractor();
+    test_issue35_key_junk_suffix_rejected();
+    test_issue35_bare_function_reengage();
+    test_issue35_bare_prose_self_limits();
+    test_issue35_on_pending_xml_guards();
     if (fails) {
         fprintf(stderr, "test_toolconstrain: %d FAILED\n", fails);
         return 1;


### PR DESCRIPTION
Fixes signalnine/q27#35.

## What broke

The 3.8 model opened a spurious second `<parameter=edits!!` in a `<function=edit>`
call. The schema-aware `ToolGrammarXml` rejects the '!' at KEY state, but:
1. the '!' reached the stream at all (sample-time gap, tracked in #35),
2. `drop()` then disengaged the constraint for the rest of the call, and
3. `parse_bare_tool_calls` had no drift mode for the `edits!!"` key shape, so
   `[drift] UN-RESCUED` and the call came back to the client as text in a 200
   -- the agent lost the tool call.

Live evidence: 4x `[toolgram] disengaged: byte 0x21 rejected`, 3x
`[drift] UN-RESCUED` in one session.

## This PR (host-side, CPU-gated)

1. **`scan_round` re-engages the XML grammar on a bare `<function=` opener --
   DEFAULT ON** (only for the XML dialect): the wrapper-less 3.8 drift class AND
   the remainder of a body whose mid-call reject dropped the constraint. The
   wrapper-only default was exactly what let the observed corruption through.
   `Q27_TG_REENGAGE=0` restores the old wrapper-only behaviour (A/B escape
   hatch). Mirrors the `<tool_call>` trigger exactly (complete-within-token,
   reset+feed rem, stage, truncate). **XML-specific by design** -- JSON
   wrapper-less drift is a bare `{...}` whose '\{' trigger would constrain
   JSON-in-prose, so JSON stays wrapper-only and is recovered at parse time.
   False-positive blast radius is bounded and self-limiting: auto-disengage at
   the first non-conforming byte, emitted bytes are never rewound, so prose
   quoting the dialect is only steered if it forms a full well-formed call.
2. **`on_pending_xml` missing guards fixed** -- an XML-PATH-ONLY bug: the JSON
   path (`on_pending`) already had `enabled/active/id` guards; the XML path
   could stage + ACTIVATE a mask while inactive by advancing the stale
   reset-state grammar over a pending token that merely looks like
   `<function...>`.
3. **Regression tests** in `tools/test_toolconstrain.cpp`: the exact live byte
   sequence dies at byte 133 ('!'), bare-`<function=` re-engages and constrains
   to completion (default-on, and no-op under `=0`), and inactive
   `on_pending_xml` no longer arms a mask.

## Verification

- `make test-tools`: 0 FAIL (incl. 3 new tests)
- `q27-server` rebuilds clean under nvcc (CUDA 13.3)
- Kernels untouched (host-side only); GPU gates not run here because the
  serving 5090 is fully occupied -- can be run off-hours on a free card.

The one change from the original plan: re-engage went from opt-in to
default-on after review -- wrapper-only engagement was the default that let the
bug through, and the env-gated A/B showed the only risk (constraining prose
that quotes the dialect) is self-limiting.