### PR TITLE
Port froggeric Qwen3.8 chat template (v22.3) behaviors into the internal renderer

### DIFF
--- a/src/api_common.h
+++ b/src/api_common.h
@@ -313,6 +313,39 @@ inline std::string reasoning_effort_line() {
     return reasoning_effort_line_level(reasoning_effort_env_level());
 }
 
+// v22.3 request-driven template options (items 3/4/5).
+// effort: -1 = env/boot default, else 0 medium, 1 low, 2 xhigh.
+// auto_disable_thinking_with_tools: start thinking OFF when tools are present.
+// tool_format: -1 = boot dialect, 0 json, 1 xml.
+struct TemplateOpts {
+    int effort = -1;
+    bool auto_disable_thinking_with_tools = false;
+    int tool_format = -1;
+};
+inline int effort_string_level(std::string v) {
+    for (auto& c : v) c = (char)tolower((unsigned char)c);
+    if (v == "minimal" || v == "low") return 1;
+    if (v == "xhigh" || v == "high" || v == "max" || v == "ultracode" || v == "extreme") return 2;
+    return 0; // none/off/medium/unknown
+}
+inline TemplateOpts template_opts_from_body(const json& body) {
+    TemplateOpts o;
+    auto read = [&](const json& b) {
+        if (b.contains("reasoning_effort") && b["reasoning_effort"].is_string())
+            o.effort = effort_string_level(b["reasoning_effort"].get<std::string>());
+        if (b.contains("auto_disable_thinking_with_tools") && b["auto_disable_thinking_with_tools"].is_boolean())
+            o.auto_disable_thinking_with_tools = b["auto_disable_thinking_with_tools"].get<bool>();
+        if (b.contains("tool_call_format") && b["tool_call_format"].is_string()) {
+            const std::string f = b["tool_call_format"].get<std::string>();
+            o.tool_format = (f == "json") ? 0 : (f == "xml" ? 1 : -1);
+        }
+    };
+    read(body);
+    if (body.contains("chat_template_kwargs") && body["chat_template_kwargs"].is_object())
+        read(body["chat_template_kwargs"]);
+    return o;
+}
+
 // P1a (2026-08-22): the <|think_*|> toggle markers from the qwen3.8
 // chat_template. Stripping: these are BPE-tokenisable control markers the
 // model is trained to read in user/system content; they must not leak into
@@ -335,8 +368,9 @@ struct ThinkToggles {
     bool thinking = true;
     int effort = 0; // 0 medium, 1 low, 2 xhigh
 };
-inline ThinkToggles scan_think_toggles(const std::vector<Msg>& msgs, bool base_think) {
-    ThinkToggles st{base_think, reasoning_effort_env_level()};
+inline ThinkToggles scan_think_toggles(const std::vector<Msg>& msgs, bool base_think,
+                                       int base_effort = -1) {
+    ThinkToggles st{base_think, base_effort >= 0 ? base_effort : reasoning_effort_env_level()};
     for (const Msg& m : msgs) {
         if (m.role != "system" && m.role != "user") continue;
         if (m.role == "user" && m.content.rfind("<tool_response>", 0) == 0) continue;
@@ -486,7 +520,8 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
                                  bool think = true, size_t* stable_off = nullptr,
                                  size_t* sys_off = nullptr,
                                  const std::string& tool_instruction = {},
-                                 const json* unavailable_tools = nullptr) {
+                                 const json* unavailable_tools = nullptr,
+                                 const TemplateOpts* opts = nullptr) {
     std::string p;
     size_t start = 0;
     std::string sys;
@@ -516,8 +551,13 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
     // thinking/effort state drives BOTH the reasoning_instructions line at the
     // system head and the generation prompt below (mirrors the template's
     // stateful ns_state). Template order: reasoning_instructions FIRST, then
-    // tools, then the client system content.
-    const ThinkToggles tt = scan_think_toggles(msgs, think);
+    // tools, then the client system content. Items 3/4: a request-driven base
+    // effort overrides the env/boot default, and auto_disable_thinking_with_tools
+    // starts thinking OFF when tools are present.
+    bool base_think = think;
+    if (opts && opts->auto_disable_thinking_with_tools && tools.is_array() && !tools.empty())
+        base_think = false;
+    const ThinkToggles tt = scan_think_toggles(msgs, base_think, opts ? opts->effort : -1);
     const std::string effort = tt.thinking ? reasoning_effort_line_level(tt.effort)
                                            : std::string();
     strip_think_markers(sys);
@@ -575,11 +615,11 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
         }
         // normal (non-tool) message
         p += "<|im_start|>" + strip_ctrl(m.role) + "\n";
-        // assistant history reasoning block, jinja format:
-        //   <think>\n...\n</think>\n\n  then the plain content
-        if (m.role == "assistant" && !m.reasoning.empty()) {
-            // v22.3: if the client also sent the think block in text, strip it
-            // so the explicit reasoning is not double-rendered
+        // v22.3 E: EVERY assistant history turn is wrapped in <think>...</think>
+        // (even when reasoning is empty -> an empty think block). If the
+        // client also sent the think block in text, strip it so the block is
+        // not double-rendered.
+        if (m.role == "assistant") {
             strip_leading_think(content);
             p += "<think>\n" + strip_ctrl(m.reasoning) + "\n</think>\n\n";
         }
@@ -622,7 +662,9 @@ inline long request_max_chars(const json& body, const char* key) {
 
 inline std::string tool_call_text(const std::string& name, const json& args,
                                   long max_arg_chars = -1) {
-    std::string a = args.dump();
+    // v22.3 (item 7): a raw string argument is echoed verbatim (not JSON-encoded),
+    // matching the template's `_args = tc.arguments` when arguments is a string.
+    std::string a = args.is_string() ? args.get<std::string>() : args.dump();
     if (max_arg_chars < 0) { // no explicit request value -> env fallback
         const char* e = getenv("Q27_MAX_TOOL_ARG_CHARS");
         max_arg_chars = e ? atol(e) : 0;
@@ -634,6 +676,39 @@ inline std::string tool_call_text(const std::string& name, const json& args,
            "}\n</tool_call>";
 }
 
+// v22.3 (item 6): render an assistant tool call in the PROMPT using the active
+// tool dialect. For the XML dialect use the per-parameter form the template
+// emits (<function=NAME><parameter=K>v</parameter>...</function>); otherwise
+// fall back to the JSON tool_call_text.
+inline std::string tool_call_text_dialect(const std::string& name, const json& args,
+                                          long max_arg_chars = -1) {
+    if (max_arg_chars < 0) { // no explicit request value -> env fallback
+        const char* e = getenv("Q27_MAX_TOOL_ARG_CHARS");
+        max_arg_chars = e ? atol(e) : 0;
+    }
+    if (!tool_dialect_xml()) return tool_call_text(name, args, max_arg_chars);
+    auto trunc = [&](std::string v) -> std::string {
+        if (max_arg_chars > 0 && (long)v.size() > max_arg_chars)
+            return v.substr(0, (size_t)max_arg_chars) + "\n[TRUNCATED - original length " +
+                   std::to_string(v.size()) + " chars]";
+        return v;
+    };
+    std::string s = "<tool_call>\n<function=" + name + ">\n";
+    if (args.is_object()) {
+        for (auto it = args.begin(); it != args.end(); ++it)
+            s += "<parameter=" + it.key() + ">\n" +
+                 trunc(it.value().is_string() ? it.value().get<std::string>()
+                                              : it.value().dump()) +
+                 "\n</parameter>\n";
+    } else if (args.is_string()) {
+        s += trunc(args.get<std::string>()) + "\n";
+    } else {
+        s += trunc(args.dump()) + "\n";
+    }
+    s += "</function>\n</tool_call>";
+    return s;
+}
+
 inline std::string tool_response_text(const std::string& out,
                                       long max_response_chars = -1) {
     std::string o = out;
@@ -641,7 +716,8 @@ inline std::string tool_response_text(const std::string& out,
         const char* e = getenv("Q27_MAX_TOOL_RESPONSE_CHARS");
         max_response_chars = e ? atol(e) : 0;
     }
-    if (max_response_chars > 0 && (long)o.size() > max_response_chars)
+    // v22.3 (item 8): truncation applies only when the dialect is NOT json.
+    if (tool_dialect_xml() && max_response_chars > 0 && (long)o.size() > max_response_chars)
         o = o.substr(0, (size_t)max_response_chars) + "\n[TRUNCATED - original length " +
             std::to_string(o.size()) + " chars]";
     return "<tool_response>\n" + o + "\n</tool_response>";
@@ -1748,10 +1824,10 @@ inline std::vector<Msg> anthropic_msgs(const json& body) {
                 else if (ty == "thinking") think += part.value("thinking", "");
                 else if (ty == "tool_use") {
                     if (!content.empty() && content.back() != '\n') content += "\n";
-                    content += tool_call_text(part.value("name", ""),
-                                              part.contains("input") ? part["input"]
-                                                                     : json::object(),
-                                              max_arg);
+                    content += tool_call_text_dialect(part.value("name", ""),
+                                                      part.contains("input") ? part["input"]
+                                                                             : json::object(),
+                                                      max_arg);
                 } else if (ty == "tool_result") {
                     std::string rc;
                     if (part.contains("content")) {
@@ -1858,7 +1934,7 @@ inline std::vector<Msg> openai_msgs(const json& body) {
                     } else args = fn["arguments"];
                 }
                 if (!content.empty() && content.back() != '\n') content += "\n";
-                content += tool_call_text(name, args, max_arg);
+                content += tool_call_text_dialect(name, args, max_arg);
             }
         }
         if (role == "assistant" && m.contains("reasoning_content")) {

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -839,6 +839,18 @@ inline ThinkCfg resolve_think_cfg(const json& body, bool server_default, bool al
     }
     // some clients send a flat top-level budget_tokens
     if (body.contains("budget_tokens")) take_budget(body["budget_tokens"]);
+    // item 2: reasoning_effort none/off disables thinking end-to-end (engine
+    // think mode, not just the prompt render).
+    auto effort_disable = [&](const json& b) {
+        if (b.contains("reasoning_effort") && b["reasoning_effort"].is_string()) {
+            std::string ev = b["reasoning_effort"].get<std::string>();
+            for (auto& ch : ev) ch = (char)tolower((unsigned char)ch);
+            if (ev == "none" || ev == "off") { c.enabled = false; c.enabled_set = true; }
+        }
+    };
+    effort_disable(body);
+    if (body.contains("chat_template_kwargs") && body["chat_template_kwargs"].is_object())
+        effort_disable(body["chat_template_kwargs"]);
     return c;
 }
 

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -178,7 +178,9 @@ private:
 struct Msg {
     std::string role;      // system | user | assistant
     std::string content;   // flattened text (think blocks already reconstructed)
-    std::string reasoning; // assistant <think> block from history (jinja-compatible)
+    std::string reasoning{}; // assistant <think> block from history (jinja-compatible);
+                             // NSDMI so brace-init sites with 2 fields stay valid under
+                             // -Wmissing-field-initializers (metal_server.cpp, -Werror)
 };
 
 // Tools preamble, verbatim structure from the chat template. `tools` entries

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -6,6 +6,7 @@
 #pragma once
 #include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <condition_variable>
 #include <cstdint>
 #include <cstdio>
@@ -287,19 +288,96 @@ inline bool tool_dialect_xml() {
 // template has no reasoning_effort, so 3.6-family renders stay untouched.
 // Q27_REASONING_EFFORT: xhigh | low | medium (no line, per the template) |
 // off (legacy pre-2026-08-15 rendering, for A/Bs) -- overrides either way.
-inline std::string reasoning_effort_line() {
+// think-effort level: 0 = medium/off (no instruction line), 1 = low, 2 = xhigh.
+inline int reasoning_effort_env_level() {
     const char* e = getenv("Q27_REASONING_EFFORT");
     const std::string v = e ? e : (tool_dialect_xml_default() ? "xhigh" : "off");
-    if (v == "xhigh")
+    return v == "xhigh" ? 2 : (v == "low" ? 1 : 0);
+}
+inline std::string reasoning_effort_line_level(int level) {
+    if (level == 2)
         return "Reasoning effort is set to xhigh. Please think carefully through "
                "the task, validate key assumptions, consider plausible alternatives, "
                "and prioritize correctness, consistency, and clarity in the final "
                "answer.";
-    if (v == "low")
+    if (level == 1)
         return "Reasoning effort is set to low. Keep your thinking brief and "
                "focused, moving directly to the conclusion without unnecessary "
                "elaboration.";
     return ""; // medium (template emits nothing) / off (legacy) / unknown
+}
+inline std::string reasoning_effort_line() {
+    return reasoning_effort_line_level(reasoning_effort_env_level());
+}
+
+// P1a (2026-08-22): the <|think_*|> toggle markers from the qwen3.8
+// chat_template. Stripping: these are BPE-tokenisable control markers the
+// model is trained to read in user/system content; they must not leak into
+// the rendered prompt, and they MUTATE the thinking/effort state forward.
+inline void strip_think_markers(std::string& s) {
+    static const std::string mk[] = {"<|think_off|>", "<|think_on|>",
+                                     "<|think_xhigh|>", "<|think_high|>",
+                                     "<|think_medium|>", "<|think_low|>",
+                                     "<|think_minimal|>"};
+    for (const auto& m : mk)
+        for (size_t p; (p = s.find(m)) != std::string::npos;) s.erase(p, m.size());
+}
+
+// P1a forward-scan of the (flattened) message list for <|think_*|> toggles;
+// returns the final thinking/effort state. Mirrors the template: only
+// system/developer/user roles are scanned (assistant and tool roles are not),
+// and tool responses (user-role, <tool_response>-wrapped) are skipped.
+struct ThinkToggles {
+    bool thinking = true;
+    int effort = 0; // 0 medium, 1 low, 2 xhigh
+};
+inline ThinkToggles scan_think_toggles(const std::vector<Msg>& msgs, bool base_think) {
+    ThinkToggles st{base_think, reasoning_effort_env_level()};
+    for (const Msg& m : msgs) {
+        if (m.role != "system" && m.role != "user") continue;
+        if (m.role == "user" && m.content.rfind("<tool_response>", 0) == 0) continue;
+        const std::string& c = m.content;
+        if (c.find("<|think_off|>") != std::string::npos) st.thinking = false;
+        else if (c.find("<|think_on|>") != std::string::npos) st.thinking = true;
+        else if (c.find("<|think_xhigh|>") != std::string::npos ||
+                 c.find("<|think_high|>") != std::string::npos) {
+            st.thinking = true; st.effort = 2;
+        } else if (c.find("<|think_low|>") != std::string::npos ||
+                   c.find("<|think_minimal|>") != std::string::npos) {
+            st.thinking = true; st.effort = 1;
+        } else if (c.find("<|think_medium|>") != std::string::npos) {
+            st.thinking = true; st.effort = 0;
+        }
+    }
+    return st;
+}
+
+// P1b: tool-response failure detection, mirrored from the qwen3.8
+// chat_template's consecutive-failure tracking. A short (<500) response whose
+// head (80 chars, lowercased) carries an error signature and no '$ '/'took '
+// counts as a failure.
+inline bool is_tool_response_failure(const std::string& content) {
+    if (content.size() >= 500) return false;
+    std::string lower = content.substr(0, 80);
+    for (auto& c : lower) c = (char)tolower((unsigned char)c);
+    if (content.find("$ ") != std::string::npos) return false;
+    if (lower.find("took ") != std::string::npos) return false;
+    static const char* sig[] = {"\"error:\"", "error:", "err!", "fatal:",
+                                "exception:", "traceback", "command not found",
+                                "invalid syntax", "failed to"};
+    for (const char* s : sig)
+        if (lower.find(s) != std::string::npos) return true;
+    return false;
+}
+inline std::string tool_response_warning(int failures) {
+    if (failures >= 2)
+        return "\n\n\u26a0\ufe0f SYSTEM WARNING: " + std::to_string(failures) +
+               " consecutive tool errors detected. Your previous approach is "
+               "incorrect. You MUST use a fundamentally different approach or "
+               "corrected arguments.";
+    return "\n\n\u26a0\ufe0f SYSTEM WARNING: The previous tool call returned an "
+           "error. Diagnose the failure and retry with completely corrected "
+           "arguments.";
 }
 inline std::string tools_preamble(const json& tools) {
     std::string s = "# Tools\n\nYou have access to the following functions:\n\n<tools>";
@@ -368,10 +446,15 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
     const bool has_tools=tools.is_array() && !tools.empty();
     const bool has_unavailable=unavailable_tools && unavailable_tools->is_array() &&
                                !unavailable_tools->empty();
-    // Template order: reasoning_instructions FIRST, then tools, then the
-    // client system content. Thinking-gated exactly like the template
-    // (enable_thinking undefined-or-true).
-    const std::string effort = think ? reasoning_effort_line() : std::string();
+    // P1a: forward-scan the message list for <|think_*|> toggles. The final
+    // thinking/effort state drives BOTH the reasoning_instructions line at the
+    // system head and the generation prompt below (mirrors the template's
+    // stateful ns_state). Template order: reasoning_instructions FIRST, then
+    // tools, then the client system content.
+    const ThinkToggles tt = scan_think_toggles(msgs, think);
+    const std::string effort = tt.thinking ? reasoning_effort_line_level(tt.effort)
+                                           : std::string();
+    strip_think_markers(sys);
     if (has_tools || has_unavailable || !sys.empty() || !tool_instruction.empty() ||
         !effort.empty()) {
         p += "<|im_start|>system\n";
@@ -391,14 +474,25 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
         p += "<|im_end|>\n";
     }
     if (sys_off) *sys_off = p.size();  // 0 when no system block was emitted
+    int tool_failures = 0;
     for (size_t i = start; i < msgs.size(); i++) {
         const Msg& m = msgs[i];
+        std::string content = m.content;
+        // P1b: consecutive tool-error tracking. Tool responses reach this
+        // renderer already <tool_response>-wrapped in a user turn.
+        const bool toolresp = m.role == "user" &&
+                              content.rfind("<tool_response>", 0) == 0;
+        if (toolresp) tool_failures = is_tool_response_failure(content)
+                                          ? tool_failures + 1 : 0;
+        else if (m.role == "user") tool_failures = 0; // plain user resets
         p += "<|im_start|>" + strip_ctrl(m.role) + "\n";
         // assistant history reasoning block, jinja format:
         //   <think>\n...\n</think>\n\n  then the plain content
         if (m.role == "assistant" && !m.reasoning.empty())
             p += "<think>\n" + strip_ctrl(m.reasoning) + "\n</think>\n\n";
-        p += strip_ctrl(m.content) + "<|im_end|>\n";
+        strip_think_markers(content);
+        if (toolresp && tool_failures >= 1) content += tool_response_warning(tool_failures);
+        p += strip_ctrl(content) + "<|im_end|>\n";
     }
     if (stable_off) *stable_off = p.size();
     p += "<|im_start|>assistant\n";
@@ -411,7 +505,9 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
     // StreamSplitter to THINK when think=true so the model's first generated
     // token (already inside the block) routes to the think channel -- mirrors the
     // FORCED tool_choice TOOL pre-seed.
-    if (!think) p += "<think>\n\n</think>\n\n";
+    // P1a: the generation prompt follows the final toggle state, not just the
+    // caller's `think` flag. think=false -> empty CLOSED block; true -> OPEN.
+    if (!tt.thinking) p += "<think>\n\n</think>\n\n";
     else p += "<think>\n";
     return p;
 }

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -293,7 +293,9 @@ inline bool tool_dialect_xml() {
 inline int reasoning_effort_env_level() {
     const char* e = getenv("Q27_REASONING_EFFORT");
     const std::string v = e ? e : (tool_dialect_xml_default() ? "xhigh" : "off");
-    return v == "xhigh" ? 2 : (v == "low" ? 1 : 0);
+    if (v == "low" || v == "minimal") return 1;
+    if (v == "xhigh" || v == "high" || v == "max" || v == "ultracode" || v == "extreme") return 2;
+    return 0; // medium / off / none / unknown
 }
 inline std::string reasoning_effort_line_level(int level) {
     if (level == 2)
@@ -318,8 +320,9 @@ inline std::string reasoning_effort_line() {
 inline void strip_think_markers(std::string& s) {
     static const std::string mk[] = {"<|think_off|>", "<|think_on|>",
                                      "<|think_xhigh|>", "<|think_high|>",
-                                     "<|think_medium|>", "<|think_low|>",
-                                     "<|think_minimal|>"};
+                                     "<|think_ultracode|>", "<|think_extreme|>",
+                                     "<|think_max|>", "<|think_medium|>",
+                                     "<|think_low|>", "<|think_minimal|>"};
     for (const auto& m : mk)
         for (size_t p; (p = s.find(m)) != std::string::npos;) s.erase(p, m.size());
 }
@@ -341,7 +344,10 @@ inline ThinkToggles scan_think_toggles(const std::vector<Msg>& msgs, bool base_t
         if (c.find("<|think_off|>") != std::string::npos) st.thinking = false;
         else if (c.find("<|think_on|>") != std::string::npos) st.thinking = true;
         else if (c.find("<|think_xhigh|>") != std::string::npos ||
-                 c.find("<|think_high|>") != std::string::npos) {
+                 c.find("<|think_high|>") != std::string::npos ||
+                 c.find("<|think_ultracode|>") != std::string::npos ||
+                 c.find("<|think_extreme|>") != std::string::npos ||
+                 c.find("<|think_max|>") != std::string::npos) {
             st.thinking = true; st.effort = 2;
         } else if (c.find("<|think_low|>") != std::string::npos ||
                    c.find("<|think_minimal|>") != std::string::npos) {
@@ -354,21 +360,71 @@ inline ThinkToggles scan_think_toggles(const std::vector<Msg>& msgs, bool base_t
 }
 
 // P1b: tool-response failure detection, mirrored from the qwen3.8
-// chat_template's consecutive-failure tracking. A short (<500) response whose
-// head (80 chars, lowercased) carries an error signature and no '$ '/'took '
-// counts as a failure.
+// chat_template (froggeric v22.3). Suppresses code/grep output and
+// exit-code-0, distinguishes strong vs weak error signatures.
 inline bool is_tool_response_failure(const std::string& content) {
-    if (content.size() >= 500) return false;
-    std::string lower = content.substr(0, 80);
-    for (auto& c : lower) c = (char)tolower((unsigned char)c);
-    if (content.find("$ ") != std::string::npos) return false;
-    if (lower.find("took ") != std::string::npos) return false;
-    static const char* sig[] = {"\"error:\"", "error:", "err!", "fatal:",
-                                "exception:", "traceback", "command not found",
-                                "invalid syntax", "failed to"};
-    for (const char* s : sig)
-        if (lower.find(s) != std::string::npos) return true;
-    return false;
+    std::string full = content;
+    for (auto& c : full) c = (char)tolower((unsigned char)c);
+    const std::string head = full.substr(0, 120);
+    const bool is_code_or_grep =
+        full.find("throw new ") != std::string::npos ||
+        full.find("throw error") != std::string::npos ||
+        full.find("console.error") != std::string::npos ||
+        full.find("logger.error") != std::string::npos ||
+        full.find("logging.error") != std::string::npos ||
+        head.find("import ") != std::string::npos ||
+        head.find("def ") != std::string::npos ||
+        head.find("function ") != std::string::npos;
+    const bool exit_zero =
+        head.find("exit code: 0") != std::string::npos ||
+        head.find("process exited with code 0") != std::string::npos;
+    const bool error_field_ok =
+        head.find("\"error\": null") != std::string::npos ||
+        head.find("\"error\":null") != std::string::npos ||
+        head.find("\"error\": false") != std::string::npos ||
+        head.find("\"error\":false") != std::string::npos ||
+        head.find("\"error\": \"\"") != std::string::npos ||
+        head.find("\"error\":\"\"") != std::string::npos;
+    const bool strong_error =
+        (head.find("\"error\":") != std::string::npos && !error_field_ok) ||
+        head.find("\"status\": \"error\"") != std::string::npos ||
+        head.find("\"status\":\"error\"") != std::string::npos ||
+        head.find("traceback (most recent call last):") != std::string::npos ||
+        head.find("command not found") != std::string::npos ||
+        head.find("invalid syntax") != std::string::npos ||
+        head.find("fatal:") != std::string::npos ||
+        ((head.find("exit code: ") != std::string::npos ||
+          head.find("process exited with code") != std::string::npos) && !exit_zero) ||
+        head.find("exception:") == 0 ||
+        head.find("failed to ") == 0;
+    const bool weak_error =
+        head.find("error:") != std::string::npos ||
+        head.find("err!") != std::string::npos;
+    const bool weak_suppressed =
+        head.find("$ ") != std::string::npos ||
+        head.find("took ") != std::string::npos ||
+        content.size() >= 600;
+    return !is_code_or_grep && (strong_error || (weak_error && !weak_suppressed));
+}
+
+// v22.3: strip a leading think block from content when explicit reasoning is
+// present (avoids double-rendering a block the client also sent in text).
+inline void strip_leading_think(std::string& content) {
+    const char* lead_end = nullptr;
+    if (content.rfind("<think>", 0) == 0 && content.find("</think>") != std::string::npos)
+        lead_end = "</think>";
+    else if (content.rfind("<thinking>", 0) == 0 && content.find("</thinking>") != std::string::npos)
+        lead_end = "</thinking>";
+    else if (content.rfind("</think>", 0) == 0) lead_end = "</think>";
+    else if (content.rfind("</thinking>", 0) == 0) lead_end = "</thinking>";
+    if (!lead_end) return;
+    std::string close(lead_end);
+    size_t p = content.find(close);
+    if (p == std::string::npos) return;
+    content = content.substr(p + close.size());
+    size_t i = 0;
+    while (i < content.size() && content[i] == '\n') i++;
+    content = content.substr(i);
 }
 inline std::string tool_response_warning(int failures) {
     if (failures >= 2)
@@ -434,7 +490,16 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
     std::string p;
     size_t start = 0;
     std::string sys;
-    if (!msgs.empty() && msgs[0].role == "system") { sys = strip_ctrl(msgs[0].content); start = 1; }
+    // v22.3: merge ALL consecutive leading system/developer messages into one
+    // system block (joined with a blank line), mirroring the template's head
+    // loop -- not just messages[0].
+    while (start < msgs.size() &&
+           (msgs[start].role == "system" || msgs[start].role == "developer")) {
+        std::string part = strip_ctrl(msgs[start].content);
+        if (!sys.empty()) sys += "\n\n";
+        sys += part;
+        start++;
+    }
     // Over-refusal fix (2026-07-13, external review): under the no-think
     // serving default a bare request WITH NO SYSTEM PROMPT gives the model
     // zero context AND zero reasoning budget, so it falls to a defensive
@@ -512,8 +577,12 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
         p += "<|im_start|>" + strip_ctrl(m.role) + "\n";
         // assistant history reasoning block, jinja format:
         //   <think>\n...\n</think>\n\n  then the plain content
-        if (m.role == "assistant" && !m.reasoning.empty())
+        if (m.role == "assistant" && !m.reasoning.empty()) {
+            // v22.3: if the client also sent the think block in text, strip it
+            // so the explicit reasoning is not double-rendered
+            strip_leading_think(content);
             p += "<think>\n" + strip_ctrl(m.reasoning) + "\n</think>\n\n";
+        }
         p += strip_ctrl(content) + "<|im_end|>\n";
     }
     if (stable_off) *stable_off = p.size();

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -534,28 +534,47 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
     return p;
 }
 
-inline std::string tool_call_text(const std::string& name, const json& args) {
-    std::string a = args.dump();
-    // P3: Q27_MAX_TOOL_ARG_CHARS truncates a too-long arguments JSON.
-    if (const char* e = getenv("Q27_MAX_TOOL_ARG_CHARS")) {
-        long max = atol(e);
-        if (max > 0 && (long)a.size() > max)
-            a = a.substr(0, (size_t)max) + "\n[TRUNCATED - original length " +
-                std::to_string(a.size()) + " chars]";
+// P3 request-driven truncation: read max_tool_arg_chars / max_tool_response_chars
+// from the request body (top-level or chat_template_kwargs). 0 when absent.
+inline long body_num(const json& v) {
+    if (v.is_number_float()) return (long)v.get<double>();
+    if (v.is_number_integer()) return v.get<long>();
+    if (v.is_number_unsigned()) return (long)v.get<uint64_t>();
+    return 0;
+}
+inline long request_max_chars(const json& body, const char* key) {
+    if (body.contains(key) && body[key].is_number()) return body_num(body[key]);
+    if (body.contains("chat_template_kwargs") && body["chat_template_kwargs"].is_object()) {
+        const auto& k = body["chat_template_kwargs"];
+        if (k.contains(key) && k[key].is_number()) return body_num(k[key]);
     }
+    return -1; // absent -> text helpers fall back to the env vars
+}
+
+inline std::string tool_call_text(const std::string& name, const json& args,
+                                  long max_arg_chars = -1) {
+    std::string a = args.dump();
+    if (max_arg_chars < 0) { // no explicit request value -> env fallback
+        const char* e = getenv("Q27_MAX_TOOL_ARG_CHARS");
+        max_arg_chars = e ? atol(e) : 0;
+    }
+    if (max_arg_chars > 0 && (long)a.size() > max_arg_chars)
+        a = a.substr(0, (size_t)max_arg_chars) + "\n[TRUNCATED - original length " +
+            std::to_string(a.size()) + " chars]";
     return "<tool_call>\n{\"name\": \"" + name + "\", \"arguments\": " + a +
            "}\n</tool_call>";
 }
 
-inline std::string tool_response_text(const std::string& out) {
+inline std::string tool_response_text(const std::string& out,
+                                      long max_response_chars = -1) {
     std::string o = out;
-    // P3: Q27_MAX_TOOL_RESPONSE_CHARS truncates a too-long tool output.
-    if (const char* e = getenv("Q27_MAX_TOOL_RESPONSE_CHARS")) {
-        long max = atol(e);
-        if (max > 0 && (long)o.size() > max)
-            o = o.substr(0, (size_t)max) + "\n[TRUNCATED - original length " +
-                std::to_string(o.size()) + " chars]";
+    if (max_response_chars < 0) { // no explicit request value -> env fallback
+        const char* e = getenv("Q27_MAX_TOOL_RESPONSE_CHARS");
+        max_response_chars = e ? atol(e) : 0;
     }
+    if (max_response_chars > 0 && (long)o.size() > max_response_chars)
+        o = o.substr(0, (size_t)max_response_chars) + "\n[TRUNCATED - original length " +
+            std::to_string(o.size()) + " chars]";
     return "<tool_response>\n" + o + "\n</tool_response>";
 }
 
@@ -1622,6 +1641,9 @@ inline json anthropic_tools_json(const json& body) {
 // model markers, tool_result wrapped in <tool_response>)
 inline std::vector<Msg> anthropic_msgs(const json& body) {
     std::vector<Msg> msgs;
+    // P3: request-driven truncation limits (top-level or chat_template_kwargs)
+    const long max_arg = request_max_chars(body, "max_tool_arg_chars");
+    const long max_resp = request_max_chars(body, "max_tool_response_chars");
     if (body.contains("system")) {
         std::string sys;
         if (body["system"].is_string()) sys = body["system"];
@@ -1659,7 +1681,8 @@ inline std::vector<Msg> anthropic_msgs(const json& body) {
                     if (!content.empty() && content.back() != '\n') content += "\n";
                     content += tool_call_text(part.value("name", ""),
                                               part.contains("input") ? part["input"]
-                                                                     : json::object());
+                                                                     : json::object(),
+                                              max_arg);
                 } else if (ty == "tool_result") {
                     std::string rc;
                     if (part.contains("content")) {
@@ -1670,7 +1693,7 @@ inline std::vector<Msg> anthropic_msgs(const json& body) {
                                     rc += b.value("text", "");
                     }
                     if (!content.empty() && content.back() != '\n') content += "\n";
-                    content += tool_response_text(rc);
+                    content += tool_response_text(rc, max_resp);
                 }
             }
         // reasoning block is emitted by the renderer (chatml_prompt), not
@@ -1728,6 +1751,9 @@ inline json openai_tools_json(const json& body) {
 //     matching the /v1/responses bridge.
 inline std::vector<Msg> openai_msgs(const json& body) {
     std::vector<Msg> msgs;
+    // P3: request-driven truncation limits (top-level or chat_template_kwargs)
+    const long max_arg = request_max_chars(body, "max_tool_arg_chars");
+    const long max_resp = request_max_chars(body, "max_tool_response_chars");
     if (!body.contains("messages") || !body["messages"].is_array()) return msgs;
     for (auto& m : body["messages"]) {
         if (!m.is_object()) continue;
@@ -1742,7 +1768,7 @@ inline std::vector<Msg> openai_msgs(const json& body) {
                         content += part.value("text", "");
         }
         if (role == "tool") {
-            msgs.push_back({"user", tool_response_text(content), {}});
+            msgs.push_back({"user", tool_response_text(content, max_resp), {}});
             continue;
         }
         if (role == "assistant" && m.contains("tool_calls") && m["tool_calls"].is_array()) {
@@ -1763,7 +1789,7 @@ inline std::vector<Msg> openai_msgs(const json& body) {
                     } else args = fn["arguments"];
                 }
                 if (!content.empty() && content.back() != '\n') content += "\n";
-                content += tool_call_text(name, args);
+                content += tool_call_text(name, args, max_arg);
             }
         }
         if (role == "assistant" && m.contains("reasoning_content")) {

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -10,6 +10,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <fstream>
 #include <limits>
 #include <mutex>
@@ -485,13 +486,34 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
         if (toolresp) tool_failures = is_tool_response_failure(content)
                                           ? tool_failures + 1 : 0;
         else if (m.role == "user") tool_failures = 0; // plain user resets
+        strip_think_markers(content);
+        // P2: consecutive tool responses group under ONE user turn, each kept
+        // as its own <tool_response> block (mirrors the template's prev_role
+        // grouping -- no <|im_start|>/<|im_end|> between them).
+        if (toolresp) {
+            const bool prev_toolresp = i > start && msgs[i - 1].role == "user" &&
+                                       msgs[i - 1].content.rfind("<tool_response>", 0) == 0;
+            const bool next_toolresp = i + 1 < msgs.size() && msgs[i + 1].role == "user" &&
+                                       msgs[i + 1].content.rfind("<tool_response>", 0) == 0;
+            if (!prev_toolresp) p += "<|im_start|>user\n";
+            if (tool_failures >= 1) {
+                // warning goes INSIDE the response block, before the closer
+                // (the template emits it between content and </tool_response>)
+                std::string warn = tool_response_warning(tool_failures);
+                size_t close = content.rfind("\n</tool_response>");
+                if (close != std::string::npos) content.insert(close, warn);
+                else content += warn;
+            }
+            p += strip_ctrl(content);
+            p += next_toolresp ? "\n" : "<|im_end|>\n";
+            continue;
+        }
+        // normal (non-tool) message
         p += "<|im_start|>" + strip_ctrl(m.role) + "\n";
         // assistant history reasoning block, jinja format:
         //   <think>\n...\n</think>\n\n  then the plain content
         if (m.role == "assistant" && !m.reasoning.empty())
             p += "<think>\n" + strip_ctrl(m.reasoning) + "\n</think>\n\n";
-        strip_think_markers(content);
-        if (toolresp && tool_failures >= 1) content += tool_response_warning(tool_failures);
         p += strip_ctrl(content) + "<|im_end|>\n";
     }
     if (stable_off) *stable_off = p.size();
@@ -513,12 +535,28 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
 }
 
 inline std::string tool_call_text(const std::string& name, const json& args) {
-    return "<tool_call>\n{\"name\": \"" + name + "\", \"arguments\": " + args.dump() +
+    std::string a = args.dump();
+    // P3: Q27_MAX_TOOL_ARG_CHARS truncates a too-long arguments JSON.
+    if (const char* e = getenv("Q27_MAX_TOOL_ARG_CHARS")) {
+        long max = atol(e);
+        if (max > 0 && (long)a.size() > max)
+            a = a.substr(0, (size_t)max) + "\n[TRUNCATED - original length " +
+                std::to_string(a.size()) + " chars]";
+    }
+    return "<tool_call>\n{\"name\": \"" + name + "\", \"arguments\": " + a +
            "}\n</tool_call>";
 }
 
 inline std::string tool_response_text(const std::string& out) {
-    return "<tool_response>\n" + out + "\n</tool_response>";
+    std::string o = out;
+    // P3: Q27_MAX_TOOL_RESPONSE_CHARS truncates a too-long tool output.
+    if (const char* e = getenv("Q27_MAX_TOOL_RESPONSE_CHARS")) {
+        long max = atol(e);
+        if (max > 0 && (long)o.size() > max)
+            o = o.substr(0, (size_t)max) + "\n[TRUNCATED - original length " +
+                std::to_string(o.size()) + " chars]";
+    }
+    return "<tool_response>\n" + o + "\n</tool_response>";
 }
 
 // Per-request thinking resolution, GATED behind the server's --request-think

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -174,8 +174,9 @@ private:
 };
 
 struct Msg {
-    std::string role;     // system | user | assistant
-    std::string content;  // flattened text (think blocks already reconstructed)
+    std::string role;      // system | user | assistant
+    std::string content;   // flattened text (think blocks already reconstructed)
+    std::string reasoning; // assistant <think> block from history (jinja-compatible)
 };
 
 // Tools preamble, verbatim structure from the chat template. `tools` entries
@@ -390,9 +391,15 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
         p += "<|im_end|>\n";
     }
     if (sys_off) *sys_off = p.size();  // 0 when no system block was emitted
-    for (size_t i = start; i < msgs.size(); i++)
-        p += "<|im_start|>" + strip_ctrl(msgs[i].role) + "\n" + strip_ctrl(msgs[i].content) +
-             "<|im_end|>\n";
+    for (size_t i = start; i < msgs.size(); i++) {
+        const Msg& m = msgs[i];
+        p += "<|im_start|>" + strip_ctrl(m.role) + "\n";
+        // assistant history reasoning block, jinja format:
+        //   <think>\n...\n</think>\n\n  then the plain content
+        if (m.role == "assistant" && !m.reasoning.empty())
+            p += "<think>\n" + strip_ctrl(m.reasoning) + "\n</think>\n\n";
+        p += strip_ctrl(m.content) + "<|im_end|>\n";
+    }
     if (stable_off) *stable_off = p.size();
     p += "<|im_start|>assistant\n";
     // think=false: the empty CLOSED block signals "reasoning done" so the model
@@ -1493,7 +1500,7 @@ inline std::vector<Msg> anthropic_msgs(const json& body) {
                 if (b.is_object() && b.value("type", "") == "text") sys += b.value("text", "");
         if (!sys.empty()) {
             normalize_cc_billing_header(sys);
-            msgs.push_back({"system", sys});
+            msgs.push_back({"system", sys, {}});
         }
     }
     if (!body.contains("messages")) return msgs;
@@ -1506,7 +1513,7 @@ inline std::vector<Msg> anthropic_msgs(const json& body) {
         std::string role = m.value("role", "user"), think, content;
         // guard: const operator[] on a missing key is an abort (json.hpp
         // assertion) -- a content-less message must not kill the server
-        if (!m.contains("content")) { msgs.push_back({role, content}); continue; }
+        if (!m.contains("content")) { msgs.push_back({role, content, {}}); continue; }
         if (m["content"].is_string()) content = m["content"];
         else if (m["content"].is_array())
             for (auto& part : m["content"]) {
@@ -1532,9 +1539,10 @@ inline std::vector<Msg> anthropic_msgs(const json& body) {
                     content += tool_response_text(rc);
                 }
             }
-        if (role == "assistant" && !think.empty())
-            content = "<think>\n" + think + "\n</think>\n" + content;
-        msgs.push_back({role, content});
+        // reasoning block is emitted by the renderer (chatml_prompt), not
+        // flattened here -- keeps the jinja's format and per-message logic
+        // (preserve_reasoning / <|think_*|> toggles) in one place.
+        msgs.push_back({role, content, think});
     }
     return msgs;
 }
@@ -1591,7 +1599,7 @@ inline std::vector<Msg> openai_msgs(const json& body) {
         if (!m.is_object()) continue;
         std::string role = m.value("role", "user");
         if (role == "developer") role = "system";
-        std::string content;
+        std::string content, reasoning;
         if (m.contains("content")) {
             if (m["content"].is_string()) content = m["content"];
             else if (m["content"].is_array())
@@ -1600,7 +1608,7 @@ inline std::vector<Msg> openai_msgs(const json& body) {
                         content += part.value("text", "");
         }
         if (role == "tool") {
-            msgs.push_back({"user", tool_response_text(content)});
+            msgs.push_back({"user", tool_response_text(content), {}});
             continue;
         }
         if (role == "assistant" && m.contains("tool_calls") && m["tool_calls"].is_array()) {
@@ -1624,7 +1632,15 @@ inline std::vector<Msg> openai_msgs(const json& body) {
                 content += tool_call_text(name, args);
             }
         }
-        msgs.push_back({role, content});
+        if (role == "assistant" && m.contains("reasoning_content")) {
+            const json& rc = m["reasoning_content"];
+            if (rc.is_string()) reasoning = rc.get<std::string>();
+            else if (rc.is_array())
+                for (auto& part : rc)
+                    if (part.is_object() && part.value("type", "") == "text")
+                        reasoning += part.value("text", "");
+        }
+        msgs.push_back({role, content, reasoning});
     }
     return msgs;
 }

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -296,7 +296,12 @@ inline int reasoning_effort_env_level() {
     // froggeric v22.3: the safe default is medium (zero injected tokens) to
     // avoid burning the reasoning budget; xhigh/low must be explicitly set.
     const char* e = getenv("Q27_REASONING_EFFORT");
-    const std::string v = e ? e : "medium";
+    // NOTE (PR #37 review): the froggeric-template default of "medium" was
+    // deliberately NOT inherited -- the effective default stays xhigh/off per
+    // boot dialect until a measured benchmark arm justifies the change.
+    // medium remains reachable explicitly (env, reasoning_effort field,
+    // <|think_medium|> tag).
+    const std::string v = e ? e : (tool_dialect_xml_default() ? "xhigh" : "off");
     if (v == "low" || v == "minimal") return 1;
     if (v == "xhigh" || v == "high" || v == "max" || v == "ultracode" || v == "extreme") return 2;
     return 0; // medium / off / none / unknown

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -343,6 +343,15 @@ inline TemplateOpts template_opts_from_body(const json& body) {
     read(body);
     if (body.contains("chat_template_kwargs") && body["chat_template_kwargs"].is_object())
         read(body["chat_template_kwargs"]);
+    // OpenAI Responses effort shapes: output_config / reasoning blocks.
+    for (const char* key : {"reasoning", "output_config"}) {
+        if (!body.contains(key) || !body[key].is_object()) continue;
+        const auto& r = body[key];
+        if (r.contains("effort") && r["effort"].is_string())
+            o.effort = effort_string_level(r["effort"].get<std::string>());
+        if (r.contains("output_effort") && r["output_effort"].is_string())
+            o.effort = effort_string_level(r["output_effort"].get<std::string>());
+    }
     return o;
 }
 
@@ -804,6 +813,23 @@ inline ThinkCfg resolve_think_cfg(const json& body, bool server_default, bool al
         }
         if (t.contains("budget_tokens")) take_budget(t["budget_tokens"]);
     }
+    // OpenAI Responses: reasoning / output_config blocks. Effort is consumed by
+    // TemplateOpts (prompt line); here we handle disabled/enabled + budget.
+    for (const char* key : {"reasoning", "output_config"}) {
+        if (!body.contains(key) || !body[key].is_object()) continue;
+        const auto& r = body[key];
+        if (r.contains("disabled") && r["disabled"].is_boolean()) {
+            c.enabled = !r["disabled"].get<bool>();
+            c.enabled_set = true;
+        } else if (r.contains("enabled") && r["enabled"].is_boolean()) {
+            c.enabled = r["enabled"].get<bool>();
+            c.enabled_set = true;
+        }
+        if (r.contains("budget_tokens")) take_budget(r["budget_tokens"]);
+        if (r.contains("output_budget_tokens")) take_budget(r["output_budget_tokens"]);
+    }
+    // some clients send a flat top-level budget_tokens
+    if (body.contains("budget_tokens")) take_budget(body["budget_tokens"]);
     return c;
 }
 

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -291,8 +291,10 @@ inline bool tool_dialect_xml() {
 // off (legacy pre-2026-08-15 rendering, for A/Bs) -- overrides either way.
 // think-effort level: 0 = medium/off (no instruction line), 1 = low, 2 = xhigh.
 inline int reasoning_effort_env_level() {
+    // froggeric v22.3: the safe default is medium (zero injected tokens) to
+    // avoid burning the reasoning budget; xhigh/low must be explicitly set.
     const char* e = getenv("Q27_REASONING_EFFORT");
-    const std::string v = e ? e : (tool_dialect_xml_default() ? "xhigh" : "off");
+    const std::string v = e ? e : "medium";
     if (v == "low" || v == "minimal") return 1;
     if (v == "xhigh" || v == "high" || v == "max" || v == "ultracode" || v == "extreme") return 2;
     return 0; // medium / off / none / unknown
@@ -321,6 +323,7 @@ struct TemplateOpts {
     int effort = -1;
     bool auto_disable_thinking_with_tools = false;
     int tool_format = -1;
+    bool force_disable_thinking = false; // reasoning_effort = none/off
 };
 inline int effort_string_level(std::string v) {
     for (auto& c : v) c = (char)tolower((unsigned char)c);
@@ -331,8 +334,13 @@ inline int effort_string_level(std::string v) {
 inline TemplateOpts template_opts_from_body(const json& body) {
     TemplateOpts o;
     auto read = [&](const json& b) {
-        if (b.contains("reasoning_effort") && b["reasoning_effort"].is_string())
-            o.effort = effort_string_level(b["reasoning_effort"].get<std::string>());
+        if (b.contains("reasoning_effort") && b["reasoning_effort"].is_string()) {
+            const std::string ev = b["reasoning_effort"].get<std::string>();
+            std::string el = ev;
+            for (auto& c : el) c = (char)tolower((unsigned char)c);
+            if (el == "none" || el == "off") o.force_disable_thinking = true; // item 2
+            o.effort = effort_string_level(ev);
+        }
         if (b.contains("auto_disable_thinking_with_tools") && b["auto_disable_thinking_with_tools"].is_boolean())
             o.auto_disable_thinking_with_tools = b["auto_disable_thinking_with_tools"].get<bool>();
         if (b.contains("tool_call_format") && b["tool_call_format"].is_string()) {
@@ -566,6 +574,7 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
     bool base_think = think;
     if (opts && opts->auto_disable_thinking_with_tools && tools.is_array() && !tools.empty())
         base_think = false;
+    if (opts && opts->force_disable_thinking) base_think = false; // reasoning_effort none/off
     const ThinkToggles tt = scan_think_toggles(msgs, base_think, opts ? opts->effort : -1);
     const std::string effort = tt.thinking ? reasoning_effort_line_level(tt.effort)
                                            : std::string();

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -326,24 +326,29 @@ inline std::string reasoning_effort_line() {
 // effort: -1 = env/boot default, else 0 medium, 1 low, 2 xhigh.
 // auto_disable_thinking_with_tools: start thinking OFF when tools are present.
 // tool_format: -1 = boot dialect, 0 json, 1 xml.
-// Default for the two-tier tool-error escalation. The detector's FP profile
-// is real (grep/diff exit code 1, short 'error: none' summaries fire -- see
-// PR #37 review), so operators get an off switch without losing the default.
+// Default for the two-tier tool-error escalation: OFF per PR #37 review --
+// a direct probe of the detector over realistic benign outputs measured 3/12
+// false positives (grep/diff exit code 1, short 'error: none' summaries), and
+// grep returning 1 on no-match is one of the most common tool results in an
+// agentic loop. Template parity stays one flag away:
+// Q27_TOOL_ERROR_WARNINGS=1 re-enables at boot; a measured arm showing the
+// escalation helps would justify flipping the default back.
 inline bool tool_error_warnings_env_default() {
     const char* e = getenv("Q27_TOOL_ERROR_WARNINGS");
-    if (!e || !*e) return true;
+    if (!e || !*e) return false;
     std::string v = e;
     for (auto& c : v) c = (char)tolower((unsigned char)c);
-    return !(v == "0" || v == "off" || v == "false" || v == "no");
+    return v == "1" || v == "on" || v == "true" || v == "yes";
 }
 struct TemplateOpts {
     int effort = -1;
     bool auto_disable_thinking_with_tools = false;
     int tool_format = -1;
     bool force_disable_thinking = false; // reasoning_effort = none/off
-    // P1b escalation warnings (froggeric Tool Error Recovery). ON by default
-    // (template parity); Q27_TOOL_ERROR_WARNINGS=0 flips the default off, and
-    // the per-request tool_error_warnings field overrides either way.
+    // P1b escalation warnings (froggeric Tool Error Recovery). OFF by default
+    // per PR #37 review (measured 3/12 FP on benign outputs);
+    // Q27_TOOL_ERROR_WARNINGS=1 flips the boot default on, and the
+    // per-request tool_error_warnings field overrides either way.
     bool tool_error_warnings = tool_error_warnings_env_default();
 };
 inline int effort_string_level(std::string v) {
@@ -622,9 +627,11 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
     }
     if (sys_off) *sys_off = p.size();  // 0 when no system block was emitted
     int tool_failures = 0;
-    // P1b off switch: env default (Q27_TOOL_ERROR_WARNINGS) unless the request
-    // carries an explicit tool_error_warnings field (see TemplateOpts).
-    const bool warn_on = !opts || opts->tool_error_warnings;
+    // P1b switch: env/boot default unless the request carries an explicit
+    // tool_error_warnings field (TemplateOpts default member is env-seeded,
+    // so this covers both the nullptr and the populated-opts paths).
+    const bool warn_on = opts ? opts->tool_error_warnings
+                              : tool_error_warnings_env_default();
     for (size_t i = start; i < msgs.size(); i++) {
         const Msg& m = msgs[i];
         std::string content = m.content;

--- a/src/api_common.h
+++ b/src/api_common.h
@@ -326,11 +326,25 @@ inline std::string reasoning_effort_line() {
 // effort: -1 = env/boot default, else 0 medium, 1 low, 2 xhigh.
 // auto_disable_thinking_with_tools: start thinking OFF when tools are present.
 // tool_format: -1 = boot dialect, 0 json, 1 xml.
+// Default for the two-tier tool-error escalation. The detector's FP profile
+// is real (grep/diff exit code 1, short 'error: none' summaries fire -- see
+// PR #37 review), so operators get an off switch without losing the default.
+inline bool tool_error_warnings_env_default() {
+    const char* e = getenv("Q27_TOOL_ERROR_WARNINGS");
+    if (!e || !*e) return true;
+    std::string v = e;
+    for (auto& c : v) c = (char)tolower((unsigned char)c);
+    return !(v == "0" || v == "off" || v == "false" || v == "no");
+}
 struct TemplateOpts {
     int effort = -1;
     bool auto_disable_thinking_with_tools = false;
     int tool_format = -1;
     bool force_disable_thinking = false; // reasoning_effort = none/off
+    // P1b escalation warnings (froggeric Tool Error Recovery). ON by default
+    // (template parity); Q27_TOOL_ERROR_WARNINGS=0 flips the default off, and
+    // the per-request tool_error_warnings field overrides either way.
+    bool tool_error_warnings = tool_error_warnings_env_default();
 };
 inline int effort_string_level(std::string v) {
     for (auto& c : v) c = (char)tolower((unsigned char)c);
@@ -350,6 +364,8 @@ inline TemplateOpts template_opts_from_body(const json& body) {
         }
         if (b.contains("auto_disable_thinking_with_tools") && b["auto_disable_thinking_with_tools"].is_boolean())
             o.auto_disable_thinking_with_tools = b["auto_disable_thinking_with_tools"].get<bool>();
+        if (b.contains("tool_error_warnings") && b["tool_error_warnings"].is_boolean())
+            o.tool_error_warnings = b["tool_error_warnings"].get<bool>(); // P1b off switch
         if (b.contains("tool_call_format") && b["tool_call_format"].is_string()) {
             const std::string f = b["tool_call_format"].get<std::string>();
             o.tool_format = (f == "json") ? 0 : (f == "xml" ? 1 : -1);
@@ -606,6 +622,9 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
     }
     if (sys_off) *sys_off = p.size();  // 0 when no system block was emitted
     int tool_failures = 0;
+    // P1b off switch: env default (Q27_TOOL_ERROR_WARNINGS) unless the request
+    // carries an explicit tool_error_warnings field (see TemplateOpts).
+    const bool warn_on = !opts || opts->tool_error_warnings;
     for (size_t i = start; i < msgs.size(); i++) {
         const Msg& m = msgs[i];
         std::string content = m.content;
@@ -613,7 +632,8 @@ inline std::string chatml_prompt(const std::vector<Msg>& msgs, const json& tools
         // renderer already <tool_response>-wrapped in a user turn.
         const bool toolresp = m.role == "user" &&
                               content.rfind("<tool_response>", 0) == 0;
-        if (toolresp) tool_failures = is_tool_response_failure(content)
+        if (warn_on && toolresp)
+            tool_failures = is_tool_response_failure(content)
                                           ? tool_failures + 1 : 0;
         else if (m.role == "user") tool_failures = 0; // plain user resets
         strip_think_markers(content);

--- a/src/metal/metal_server.cpp
+++ b/src/metal/metal_server.cpp
@@ -2609,7 +2609,8 @@ int main(int argc,char** argv) {
                 think_cfg.budget_set=true;
                 think_cfg.budget=-1;
             }
-            std::string rendered=q27::chatml_prompt(openai_msgs(body),tools,think_req);
+            const q27::TemplateOpts topts=q27::template_opts_from_body(body);
+            std::string rendered=q27::chatml_prompt(openai_msgs(body),tools,think_req,nullptr,nullptr,{},{},&topts);
             if(tchoice.mode==q27::ToolChoice::FORCED) rendered+="<tool_call>\n";
             auto ids=to_u32(runtime.tokenizer.encode(rendered));
             const uint32_t requested_n=max_tokens(body,q27::metal_default_max_tokens(q27::MetalEndpoint::Chat),TokenLimitApi::Chat);
@@ -3017,9 +3018,10 @@ int main(int argc,char** argv) {
             q27::validate_anthropic_tool_choice_thinking(tchoice,think_cfg);
             bool think_req=think_cfg.enabled;
             if(tchoice.mode==q27::ToolChoice::FORCED) think_req=false;
+            const q27::TemplateOpts topts=q27::template_opts_from_body(body);
             std::string rendered=q27::chatml_prompt(
                 q27::anthropic_msgs(body),selected.tools,think_req,nullptr,nullptr,
-                q27::anthropic_tool_choice_instruction(tchoice),&unavailable);
+                q27::anthropic_tool_choice_instruction(tchoice),&unavailable,&topts);
             if(tchoice.mode==q27::ToolChoice::FORCED) rendered+="<tool_call>\n";
             const long input_tokens=(long)runtime.tokenizer.encode(rendered).size();
             if(runtime.trace.enabled())
@@ -3056,9 +3058,10 @@ int main(int argc,char** argv) {
                 think_cfg.budget_set=true;
                 think_cfg.budget=-1;
             }
+            const q27::TemplateOpts topts=q27::template_opts_from_body(body);
             std::string rendered=q27::chatml_prompt(
                 q27::anthropic_msgs(body),tools,think_req,nullptr,nullptr,
-                q27::anthropic_tool_choice_instruction(tchoice),&unavailable);
+                q27::anthropic_tool_choice_instruction(tchoice),&unavailable,&topts);
             if(tchoice.mode==q27::ToolChoice::FORCED) rendered+="<tool_call>\n";
             auto ids=to_u32(runtime.tokenizer.encode(rendered));
             const uint32_t requested_n=max_tokens(body,q27::metal_default_max_tokens(q27::MetalEndpoint::Messages));
@@ -3539,7 +3542,8 @@ int main(int argc,char** argv) {
                 think_cfg.budget_set=true;
                 think_cfg.budget=-1;
             }
-            std::string rendered=q27::chatml_prompt(merged,tools,think_req);
+            const q27::TemplateOpts topts=q27::template_opts_from_body(body);
+            std::string rendered=q27::chatml_prompt(merged,tools,think_req,nullptr,nullptr,{},{},&topts);
             if(tchoice.mode==q27::ToolChoice::FORCED) rendered+="<tool_call>\n";
             auto ids=to_u32(runtime.tokenizer.encode(rendered));
             const uint32_t requested_n=max_tokens(body,q27::metal_default_max_tokens(q27::MetalEndpoint::Responses),TokenLimitApi::Responses);

--- a/src/server.cu
+++ b/src/server.cu
@@ -1907,8 +1907,9 @@ int main(int argc, char** argv) {
             // think block, so suppress the opener when a tool is forced.
             if (tchoice.mode == q27::ToolChoice::FORCED) thinking = false;
             size_t stable_off = 0, sys_off = 0;
+            const q27::TemplateOpts topts=q27::template_opts_from_body(body);
             std::string rendered =
-                q27::chatml_prompt(q27::openai_msgs(body), tools, thinking, &stable_off, &sys_off);
+                q27::chatml_prompt(q27::openai_msgs(body), tools, thinking, &stable_off, &sys_off, {}, {}, &topts);
             // P16b: token length of the system+tools block. Measured with a
             // THIRD encode used only for its length -- the prompt itself is
             // still built from the same two pieces, so no request's bytes
@@ -2553,9 +2554,10 @@ int main(int argc, char** argv) {
             thinking=false;
             tcfg=q27::ThinkCfg{false,-1,false,true};
         }
+        const q27::TemplateOpts topts=q27::template_opts_from_body(body);
         std::string rendered=q27::chatml_prompt(
             q27::anthropic_msgs(body),tools,thinking,stable_off,sys_off,
-            q27::anthropic_tool_choice_instruction(tchoice),&unavailable);
+            q27::anthropic_tool_choice_instruction(tchoice),&unavailable,&topts);
         if(tchoice.mode==q27::ToolChoice::FORCED) rendered+="<tool_call>\n";
         return rendered;
     };
@@ -3297,7 +3299,8 @@ int main(int argc, char** argv) {
             tcfg = q27::ThinkCfg{false, -1, false, true};
         }
         size_t sys_off = 0;
-        std::string rendered = q27::chatml_prompt(merged, tools, thinking, nullptr, &sys_off);
+        const q27::TemplateOpts topts=q27::template_opts_from_body(body);
+        std::string rendered = q27::chatml_prompt(merged, tools, thinking, nullptr, &sys_off, {}, {}, &topts);
         if (tchoice.mode == q27::ToolChoice::FORCED) rendered += "<tool_call>\n";
         std::vector<int> prompt = tok.encode(rendered);
         // P16b applies here even though P16a does not: this shape computes no

--- a/src/test_tokenizer.cpp
+++ b/src/test_tokenizer.cpp
@@ -208,9 +208,10 @@ static int anthropic_api_selftest() {
         expect(msgs.size() == 4 && msgs[1].role == "user" && msgs[1].content == "hello",
                "plain user");
         expect(msgs.size() == 4 && msgs[2].role == "assistant" &&
-                   msgs[2].content == "<think>\nhmm\n</think>\nI'll call a tool.\n"
+                   msgs[2].content == "I'll call a tool.\n"
                                       "<tool_call>\n{\"name\": \"ls\", \"arguments\": "
-                                      "{\"path\":\"/w\"}}\n</tool_call>",
+                                      "{\"path\":\"/w\"}}\n</tool_call>" &&
+                   msgs[2].reasoning == "hmm",
                "assistant think+text+tool_use");
         expect(msgs.size() == 4 && msgs[3].role == "user" &&
                    msgs[3].content == "<tool_response>\na.md\n</tool_response>",
@@ -643,8 +644,8 @@ int main(int argc, char** argv) {
     // right after "<|im_end|>\n" and right before "<|im_start|>assistant\n",
     // and encoding the prefix substring must be deterministic.
     {
-        std::vector<q27::Msg> msgs = {{"system", "S"}, {"user", "hi"},
-                                      {"assistant", "yo"}, {"user", "go"}};
+        std::vector<q27::Msg> msgs = {{"system", "S", {}}, {"user", "hi", {}},
+                                      {"assistant", "yo", {}}, {"user", "go", {}}};
         size_t off = 0;
         std::string r = q27::chatml_prompt(msgs, nlohmann::json::array(), false, &off);
         bool ok = off > 0 && off < r.size() &&

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -737,6 +737,70 @@ static void test_openai_reasoning_content_roundtrip() {
           r2.size() - std::string("<think>\n\n</think>\n\n").size());
 }
 
+// P1a: <|think_*|> toggles must be stripped and must drive the generation
+// prompt + reasoning-instructions line (stateful, mirroring the template).
+static void test_think_toggle_state() {
+    unsetenv("Q27_REASONING_EFFORT");
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    {   // <|think_off|> -> closed gen block even with think=true param
+        json body = {{"messages", json::array({
+            {{"role","user"},{"content","<|think_off|>Just answer."}},
+        })}};
+        auto msgs = q27::openai_msgs(body);
+        std::string r = q27::chatml_prompt(msgs, {}, /*think=*/true);
+        CHECK(r.find("<|think_off|>") == std::string::npos);          // stripped
+        CHECK(r.find("Just answer.") != std::string::npos);
+        CHECK(r.rfind("<think>\n\n</think>\n\n") ==                  // thinking off
+              r.size() - std::string("<think>\n\n</think>\n\n").size());
+    }
+    {   // <|think_on|> with think=false -> OPEN gen block + effort line
+        json body = {{"messages", json::array({
+            {{"role","user"},{"content","<|think_on|>Think hard."}},
+        })}};
+        auto msgs = q27::openai_msgs(body);
+        std::string r = q27::chatml_prompt(msgs, {}, /*think=*/false);
+        CHECK(r.find("<|think_on|>") == std::string::npos);
+        CHECK(r.rfind("<think>\n") == r.size() - std::string("<think>\n").size());
+        CHECK(r.find("Reasoning effort is set to xhigh.") != std::string::npos);
+    }
+    {   // <|think_xhigh|> arms xhigh effort on a no-think base
+        json body = {{"messages", json::array({
+            {{"role","user"},{"content","<|think_xhigh|>Be careful."}},
+        })}};
+        auto msgs = q27::openai_msgs(body);
+        std::string r = q27::chatml_prompt(msgs, {}, /*think=*/false);
+        CHECK(r.find("Reasoning effort is set to xhigh.") != std::string::npos);
+    }
+}
+
+// P1b: consecutive tool-error responses accumulate system warnings.
+static void test_tool_failure_warnings() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    auto tr = [&](const std::string& body) { return "<tool_response>\n" + body + "\n</tool_response>"; };
+    json body = {{"messages", json::array({
+        {{"role","user"},{"content","run the build"}},
+        {{"role","user"},{"content",tr("error: command not found: make")}},
+        {{"role","user"},{"content",tr("fatal: make: no targets")}},
+    })}};
+    auto msgs = q27::openai_msgs(body);
+    std::string r = q27::chatml_prompt(msgs, {}, /*think=*/false);
+    // 1st failure -> diagnose warning
+    CHECK(r.find("SYSTEM WARNING: The previous tool call returned an error.") != std::string::npos);
+    // 2nd consecutive failure -> change-approach warning with count 2
+    CHECK(r.find("2 consecutive tool errors detected. Your previous approach is incorrect.") != std::string::npos);
+    // a plain user turn after resets the counter (no "1 consecutive" survives)
+    json body2 = {{"messages", json::array({
+        {{"role","user"},{"content",tr("error: boom")}},
+        {{"role","user"},{"content","the error is fixed now"}},
+        {{"role","user"},{"content",tr("error: boom again")}},
+    })}};
+    auto msgs2 = q27::openai_msgs(body2);
+    std::string r2 = q27::chatml_prompt(msgs2, {}, /*think=*/false);
+    // only two separate single-failure warnings, no "2 consecutive"
+    CHECK(r2.find("2 consecutive tool errors") == std::string::npos);
+    CHECK(r2.find("The previous tool call returned an error.") != std::string::npos);
+}
+
 static void test_chat_message_plain_text_no_calls() {
     json msg = q27::openai_chat_message_json("hello there", {}, 42);
     CHECK(msg["role"] == "assistant");
@@ -2200,6 +2264,8 @@ int main() {
     test_stream_options_include_usage();
     test_end_to_end_chatml_prompt();
     test_openai_reasoning_content_roundtrip();
+    test_think_toggle_state();
+    test_tool_failure_warnings();
     test_chat_message_plain_text_no_calls();
     test_chat_message_empty_text_no_calls_is_empty_string_not_null();
     test_chat_message_call_no_leftover_text_content_null();

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -872,6 +872,77 @@ static void test_tool_truncation_request_body() {
     CHECK(r0.find("TRUNCATED") == std::string::npos);
 }
 
+// v22.3: multiple leading system/developer messages merge into ONE system block.
+static void test_v223_multi_system_merge() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    json body = {{"messages", json::array({
+        {{"role","system"},{"content","sys one"}},
+        {{"role","system"},{"content","sys two"}},
+        {{"role","user"},{"content","hi"}},
+    })}};
+    auto msgs = q27::openai_msgs(body);
+    std::string r = q27::chatml_prompt(msgs, {}, false);
+    size_t n = 0;
+    for (size_t p = 0; (p = r.find("<|im_start|>system\n", p)) != std::string::npos; ++n, ++p);
+    CHECK(n == 1);                       // both merged into one block
+    CHECK(r.find("sys one\n\nsys two") != std::string::npos); // joined with blank line
+}
+
+// v22.3: new <|think_ultracode|>/extreme/max markers map to xhigh effort.
+static void test_v223_new_think_markers() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    json body = {{"messages", json::array({
+        {{"role","user"},{"content","<|think_ultracode|>deep reasoning"}},
+    })}};
+    auto msgs = q27::openai_msgs(body);
+    std::string r = q27::chatml_prompt(msgs, {}, false);
+    CHECK(r.find("<|think_ultracode|>") == std::string::npos);  // stripped
+    CHECK(r.find("Reasoning effort is set to xhigh.") != std::string::npos);
+}
+
+// v22.3: explicit reasoning + a think block already in content -> no double render.
+static void test_v223_reasoning_dedup() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    json body = {{"messages", json::array({
+        {{"role","user"},{"content","q"}},
+        {{"role","assistant"},{"content","<think>\ninline thinking\n</think>\nFinal answer."},
+            {"reasoning_content","explicit reasoning"}},
+        {{"role","user"},{"content","what did you reason"}},
+    })}};
+    auto msgs = q27::openai_msgs(body);
+    std::string r = q27::chatml_prompt(msgs, {}, false);
+    CHECK(r.find("<think>\nexplicit reasoning\n</think>\n\nFinal answer.") != std::string::npos);
+    CHECK(r.find("inline thinking") == std::string::npos); // inline dup removed
+}
+
+// v22.3: failure detection suppresses code output and exit-code-0.
+static void test_v223_failure_detection() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    auto tr = [&](const std::string& body) { return "<tool_response>\n" + body + "\n</tool_response>"; };
+    {   // code output with console.error is suppressed (not a failure)
+        json b = {{"messages", json::array({
+            {{"role","user"},{"content","run"}},
+            {{"role","tool"},{"content","import os\nconsole.error('boom')\nfunction x() {}"}},
+        })}};
+        std::string r = q27::chatml_prompt(q27::openai_msgs(b), {}, false);
+        CHECK(r.find("SYSTEM WARNING") == std::string::npos);
+    }
+    {   // exit code 0 is not a failure
+        json b = {{"messages", json::array({
+            {{"role","tool"},{"content","exit code: 0\nall good"}},
+        })}};
+        std::string r = q27::chatml_prompt(q27::openai_msgs(b), {}, false);
+        CHECK(r.find("SYSTEM WARNING") == std::string::npos);
+    }
+    {   // nonzero exit code IS a failure
+        json b = {{"messages", json::array({
+            {{"role","tool"},{"content","exit code: 2\nboom"}},
+        })}};
+        std::string r = q27::chatml_prompt(q27::openai_msgs(b), {}, false);
+        CHECK(r.find("SYSTEM WARNING") != std::string::npos);
+    }
+}
+
 static void test_chat_message_plain_text_no_calls() {
     json msg = q27::openai_chat_message_json("hello there", {}, 42);
     CHECK(msg["role"] == "assistant");
@@ -2340,6 +2411,10 @@ int main() {
     test_tool_grouping();
     test_tool_truncation();
     test_tool_truncation_request_body();
+    test_v223_multi_system_merge();
+    test_v223_new_think_markers();
+    test_v223_reasoning_dedup();
+    test_v223_failure_detection();
     test_chat_message_plain_text_no_calls();
     test_chat_message_empty_text_no_calls_is_empty_string_not_null();
     test_chat_message_call_no_leftover_text_content_null();

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -919,7 +919,6 @@ static void test_v223_reasoning_dedup() {
 // v22.3: failure detection suppresses code output and exit-code-0.
 static void test_v223_failure_detection() {
     q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
-    auto tr = [&](const std::string& body) { return "<tool_response>\n" + body + "\n</tool_response>"; };
     {   // code output with console.error is suppressed (not a failure)
         json b = {{"messages", json::array({
             {{"role","user"},{"content","run"}},

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -982,6 +982,23 @@ static void test_request_effort_and_auto_disable() {
     CHECK(r2.find("Reasoning effort is set to low.") != std::string::npos);
 }
 
+// output_config / reasoning (OpenAI Responses) shapes for effort + budget + disabled.
+static void test_output_config_fields() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    json b = {{"messages", json::array({{{"role","user"},{"content","hi"}}})},
+              {"reasoning", {{{"effort","low"}}}},
+              {"output_config", {{"effort","high"},{"budget_tokens",1024},{"disabled",true}}}};
+    auto opts = q27::template_opts_from_body(b);
+    // output_config read after reasoning -> output_config.effort=high wins
+    CHECK(opts.effort == 2);
+    // resolve_think_cfg: disabled -> thinking off; budget 1024 from output_config
+    auto tcfg = q27::resolve_think_cfg(b, /*server_default=*/true, /*allow_request=*/true, -1);
+    CHECK(!tcfg.enabled);              // output_config.disabled
+    CHECK(tcfg.enabled_set);
+    CHECK(tcfg.budget_set);
+    CHECK(tcfg.budget == 1024);        // output_config.budget_tokens
+}
+
 // item 6: XML-dialect assistant tool_calls render as <function=...><parameter=...>
 static void test_xml_tool_call_rendering() {
     q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
@@ -2489,6 +2506,7 @@ int main() {
     test_v223_failure_detection();
     test_unconditional_think_wrap();
     test_request_effort_and_auto_disable();
+    test_output_config_fields();
     test_xml_tool_call_rendering();
     test_truncation_json_dialect_skipped();
     test_chat_message_plain_text_no_calls();

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -801,6 +801,56 @@ static void test_tool_failure_warnings() {
     CHECK(r2.find("The previous tool call returned an error.") != std::string::npos);
 }
 
+// P2: consecutive tool responses group under a single user turn.
+static void test_tool_grouping() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    auto tr = [&](const std::string& body) { return "<tool_response>\n" + body + "\n</tool_response>"; };
+    json body = {{"messages", json::array({
+        {{"role","user"},{"content","run both"}},
+        {{"role","user"},{"content",tr("out A")}},
+        {{"role","user"},{"content",tr("out B")}},
+        {{"role","user"},{"content","all done"}},
+    })}};
+    auto msgs = q27::openai_msgs(body);
+    std::string r = q27::chatml_prompt(msgs, {}, /*think=*/false);
+    // exactly 3 user turns: "run both", the grouped pair, "all done"
+    size_t n = 0;
+    for (size_t p = 0; (p = r.find("<|im_start|>user\n", p)) != std::string::npos; ++n, ++p);
+    CHECK(n == 3);
+    // the pair shares one user turn: grouped marker present, no <|im_end|> between
+    CHECK(r.find("</tool_response>\n<tool_response>") != std::string::npos);
+    CHECK(r.find("out A\n</tool_response><|im_end|>") == std::string::npos);
+}
+
+// P3: Q27_MAX_TOOL_RESPONSE_CHARS / Q27_MAX_TOOL_ARG_CHARS truncate long output.
+static void test_tool_truncation() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    std::string big(100, 'x');
+    {   // response truncation (role "tool" goes through tool_response_text)
+        setenv("Q27_MAX_TOOL_RESPONSE_CHARS", "20", 1);
+        json body = {{"messages", json::array({
+            {{"role","user"},{"content","run it"}},
+            {{"role","tool"},{"content",big}},
+        })}};
+        std::string r = q27::chatml_prompt(q27::openai_msgs(body), {}, false);
+        unsetenv("Q27_MAX_TOOL_RESPONSE_CHARS");
+        CHECK(r.find("TRUNCATED - original length") != std::string::npos);
+        CHECK(r.find(big) == std::string::npos); // long tail gone
+    }
+    {   // arg truncation (assistant tool_calls go through tool_call_text)
+        setenv("Q27_MAX_TOOL_ARG_CHARS", "30", 1);
+        json body = {{"messages", json::array({
+            {{"role","assistant"},{"content","calling"},{"tool_calls", json::array({
+                {{"id","1"},{"type","function"},{"function",{{"name","ls"},
+                    {"arguments", "{\"path\":\"/" + big + "\"}"}}}}
+            })}},
+        })}};
+        std::string r = q27::chatml_prompt(q27::openai_msgs(body), {}, false);
+        unsetenv("Q27_MAX_TOOL_ARG_CHARS");
+        CHECK(r.find("TRUNCATED - original length") != std::string::npos);
+    }
+}
+
 static void test_chat_message_plain_text_no_calls() {
     json msg = q27::openai_chat_message_json("hello there", {}, 42);
     CHECK(msg["role"] == "assistant");
@@ -2266,6 +2316,8 @@ int main() {
     test_openai_reasoning_content_roundtrip();
     test_think_toggle_state();
     test_tool_failure_warnings();
+    test_tool_grouping();
+    test_tool_truncation();
     test_chat_message_plain_text_no_calls();
     test_chat_message_empty_text_no_calls_is_empty_string_not_null();
     test_chat_message_call_no_leftover_text_content_null();

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -700,6 +700,43 @@ static void test_end_to_end_chatml_prompt() {
     CHECK(forced.substr(0, stable_off) == rendered.substr(0, stable_off));
 }
 
+// P0 (2026-08-22): assistant reasoning must NOT be lost on the OpenAI path and
+// must render as a jinja-style <think> block in chatml_prompt.
+static void test_openai_reasoning_content_roundtrip() {
+    json body = {
+        {"messages", json::array({
+            {{"role","user"},{"content","plan the build"}},
+            {{"role","assistant"},{"content","Done."},{"reasoning_content","Let me check the steps."}},
+            {{"role","user"},{"content","go"}},
+        })}
+    };
+    auto msgs = q27::openai_msgs(body);
+    CHECK(msgs.size() == 3);
+    // assistant reasoning was captured, not dropped
+    CHECK(msgs[1].role == "assistant");
+    CHECK(msgs[1].content == "Done.");
+    CHECK(msgs[1].reasoning == "Let me check the steps.");
+    // no reasoning on the non-assistant turns
+    CHECK(msgs[0].reasoning.empty());
+    CHECK(msgs[2].reasoning.empty());
+    // chatml_prompt renders it as a jinja-style <think> block
+    std::string rendered = q27::chatml_prompt(msgs, {}, /*think=*/false);
+    CHECK(rendered.find("<think>\nLet me check the steps.\n</think>\n\n") != std::string::npos);
+    // order: think block comes before the assistant content
+    CHECK(rendered.find("<think>\nLet me check the steps.\n</think>\n\nDone.") != std::string::npos);
+    // absent reasoning_content -> no <think> block injected (regression guard)
+    json body2 = {{"messages", json::array({
+        {{"role","assistant"},{"content","hi"}},
+    })}};
+    auto msgs2 = q27::openai_msgs(body2);
+    CHECK(msgs2[0].reasoning.empty());
+    std::string r2 = q27::chatml_prompt(msgs2, {}, /*think=*/false);
+    // the only <think> block must be the trailing EMPTY generation prompt
+    // (no history reasoning block was injected)
+    CHECK(r2.rfind("<think>\n\n</think>\n\n") ==
+          r2.size() - std::string("<think>\n\n</think>\n\n").size());
+}
+
 static void test_chat_message_plain_text_no_calls() {
     json msg = q27::openai_chat_message_json("hello there", {}, 42);
     CHECK(msg["role"] == "assistant");
@@ -2162,6 +2199,7 @@ int main() {
     test_responses_tool_choice_shapes();
     test_stream_options_include_usage();
     test_end_to_end_chatml_prompt();
+    test_openai_reasoning_content_roundtrip();
     test_chat_message_plain_text_no_calls();
     test_chat_message_empty_text_no_calls_is_empty_string_not_null();
     test_chat_message_call_no_leftover_text_content_null();

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -943,6 +943,78 @@ static void test_v223_failure_detection() {
     }
 }
 
+// v22.3 E: every assistant history turn is wrapped in <think>, even empty.
+static void test_unconditional_think_wrap() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    {   // assistant with no reasoning -> empty think block
+        json b = {{"messages", json::array({
+            {{"role","user"},{"content","q"}},
+            {{"role","assistant"},{"content","just an answer"}},
+        })}};
+        std::string r = q27::chatml_prompt(q27::openai_msgs(b), {}, false);
+        CHECK(r.find("<|im_start|>assistant\n<think>\n\n</think>\n\njust an answer<|im_end|>") != std::string::npos);
+    }
+    {   // assistant with reasoning -> its think block
+        json b = {{"messages", json::array({
+            {{"role","assistant"},{"content","answer"},{"reasoning_content","thought"}},
+        })}};
+        std::string r = q27::chatml_prompt(q27::openai_msgs(b), {}, false);
+        CHECK(r.find("<|im_start|>assistant\n<think>\nthought\n</think>\n\nanswer<|im_end|>") != std::string::npos);
+    }
+}
+
+// Items 3/4: request-driven reasoning_effort + auto_disable_thinking_with_tools.
+static void test_request_effort_and_auto_disable() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    json tools = json::parse(R"([{"type":"function","function":{"name":"R","parameters":{"type":"object"}}}])");
+    json b = {{"messages", json::array({{{"role","user"},{"content","hi"}}})},
+              {"reasoning_effort","low"},
+              {"chat_template_kwargs",{{"auto_disable_thinking_with_tools",true}}}};
+    auto opts = q27::template_opts_from_body(b);
+    CHECK(opts.effort == 1);               // low -> level 1
+    CHECK(opts.auto_disable_thinking_with_tools);
+    auto msgs = q27::openai_msgs(b);
+    // tools present + auto_disable -> thinking off -> no effort line
+    std::string r = q27::chatml_prompt(msgs, tools, /*think=*/true, nullptr, nullptr, {}, {}, &opts);
+    CHECK(r.find("Reasoning effort is set to low.") == std::string::npos);
+    // no tools -> thinking on -> low line
+    std::string r2 = q27::chatml_prompt(msgs, json::array(), /*think=*/true, nullptr, nullptr, {}, {}, &opts);
+    CHECK(r2.find("Reasoning effort is set to low.") != std::string::npos);
+}
+
+// item 6: XML-dialect assistant tool_calls render as <function=...><parameter=...>
+static void test_xml_tool_call_rendering() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    json body = {{"messages", json::array({
+        {{"role","assistant"},{"content","calling"},{"tool_calls", json::array({
+            {{"id","1"},{"type","function"},{"function",{{"name","edit"},
+                {"arguments","{\"path\":\"/x\",\"newText\":\"hi\"}"}}}}
+        })}},
+    })}};
+    auto msgs = q27::openai_msgs(body);
+    std::string r = q27::chatml_prompt(msgs, {}, false);
+    CHECK(r.find("<function=edit>") != std::string::npos);
+    CHECK(r.find("<parameter=path>\n/x\n</parameter>") != std::string::npos);
+    CHECK(r.find("<parameter=newText>\nhi\n</parameter>") != std::string::npos);
+    // JSON dialect keeps the JSON tool_call_text
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen3.6-27B\"}");
+    std::string r2 = q27::chatml_prompt(q27::openai_msgs(body), {}, false);
+    CHECK(r2.find("<function=edit>") == std::string::npos);
+    CHECK(r2.find("<tool_call>\n{\"name\": \"edit\"") != std::string::npos);
+}
+
+// item 8: tool-response truncation applies only in the XML (non-JSON) dialect.
+static void test_truncation_json_dialect_skipped() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen3.6-27B\"}");
+    std::string big(200, 'x');
+    json body = {{"messages", json::array({
+        {{"role","tool"},{"content",big}},
+    })},
+        {"chat_template_kwargs", {{"max_tool_response_chars", 20}}}};
+    std::string r = q27::chatml_prompt(q27::openai_msgs(body), {}, false);
+    CHECK(r.find("TRUNCATED") == std::string::npos); // json dialect: no truncation
+}
+
 static void test_chat_message_plain_text_no_calls() {
     json msg = q27::openai_chat_message_json("hello there", {}, 42);
     CHECK(msg["role"] == "assistant");
@@ -2415,6 +2487,10 @@ int main() {
     test_v223_new_think_markers();
     test_v223_reasoning_dedup();
     test_v223_failure_detection();
+    test_unconditional_think_wrap();
+    test_request_effort_and_auto_disable();
+    test_xml_tool_call_rendering();
+    test_truncation_json_dialect_skipped();
     test_chat_message_plain_text_no_calls();
     test_chat_message_empty_text_no_calls_is_empty_string_not_null();
     test_chat_message_call_no_leftover_text_content_null();

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -1016,6 +1016,9 @@ static void test_medium_default_and_none_off() {
                   {"reasoning_effort","none"}};
         auto opts = q27::template_opts_from_body(b);
         CHECK(opts.force_disable_thinking);
+        // engine think mode must also be off (end-to-end)
+        auto tcfg = q27::resolve_think_cfg(b, /*server_default=*/true, /*allow_request=*/true, -1);
+        CHECK(!tcfg.enabled);
         std::string r = q27::chatml_prompt(q27::openai_msgs(b), json::array(), /*think=*/true, nullptr, nullptr, {}, {}, &opts);
         // closed generation block (thinking off) despite think=true
         CHECK(r.rfind("<think>\n\n</think>\n\n") == r.size() - std::string("<think>\n\n</think>\n\n").size());

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -761,8 +761,9 @@ static void test_think_toggle_state() {
         std::string r = q27::chatml_prompt(msgs, {}, /*think=*/false);
         CHECK(r.find("<|think_on|>") == std::string::npos);
         CHECK(r.rfind("<think>\n") == r.size() - std::string("<think>\n").size());
-        // default effort is medium -> no xhigh line (froggeric v22.3)
-        CHECK(r.find("Reasoning effort") == std::string::npos);
+        // default effort stays xhigh (PR #37 review: froggeric "default medium"
+        // dropped) -> the xhigh line is injected
+        CHECK(r.find("Reasoning effort is set to xhigh.") != std::string::npos);
     }
     {   // <|think_xhigh|> arms xhigh effort on a no-think base
         json body = {{"messages", json::array({
@@ -999,17 +1000,13 @@ static void test_output_config_fields() {
     CHECK(tcfg.budget == 1024);        // output_config.budget_tokens
 }
 
-// items 1+2: default effort is medium (no line); reasoning_effort none/off disables thinking.
-static void test_medium_default_and_none_off() {
+// item 2: reasoning_effort none/off disables thinking (prompt + engine).
+// NOTE: the companion "default effort = medium" change was dropped per PR #37
+// review -- the effective default stays xhigh/off; medium is reachable
+// explicitly. Only the none/off disable behavior is covered here.
+static void test_none_off_disables_thinking() {
     q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
     unsetenv("Q27_REASONING_EFFORT");
-    {   // default medium: thinking on but no effort line
-        json b = {{"messages", json::array({{{"role","user"},{"content","hi"}}})}};
-        auto opts = q27::template_opts_from_body(b);
-        CHECK(opts.effort == -1);      // no request field
-        std::string r = q27::chatml_prompt(q27::openai_msgs(b), json::array(), true);
-        CHECK(r.find("Reasoning effort") == std::string::npos); // medium default
-    }
     {   // reasoning_effort none -> thinking OFF (closed gen prompt, no effort line)
         json b = {{"messages", json::array({{{"role","user"},{"content","hi"}}})},
                   {"reasoning_effort","none"}};
@@ -2538,7 +2535,7 @@ int main() {
     test_unconditional_think_wrap();
     test_request_effort_and_auto_disable();
     test_output_config_fields();
-    test_medium_default_and_none_off();
+    test_none_off_disables_thinking();
     test_xml_tool_call_rendering();
     test_truncation_json_dialect_skipped();
     test_chat_message_plain_text_no_calls();

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -778,14 +778,21 @@ static void test_think_toggle_state() {
 // P1b: consecutive tool-error responses accumulate system warnings.
 static void test_tool_failure_warnings() {
     q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    unsetenv("Q27_TOOL_ERROR_WARNINGS");
     auto tr = [&](const std::string& body) { return "<tool_response>\n" + body + "\n</tool_response>"; };
     json body = {{"messages", json::array({
         {{"role","user"},{"content","run the build"}},
         {{"role","user"},{"content",tr("error: command not found: make")}},
         {{"role","user"},{"content",tr("fatal: make: no targets")}},
     })}};
+    // default is OFF per PR #37 review (measured 3/12 FP on benign outputs):
+    // even two consecutive failures inject no warning when no opts are passed.
     auto msgs = q27::openai_msgs(body);
     std::string r = q27::chatml_prompt(msgs, {}, /*think=*/false);
+    CHECK(r.find("SYSTEM WARNING") == std::string::npos);
+    // env re-enables at boot (template parity is one flag away)
+    setenv("Q27_TOOL_ERROR_WARNINGS", "1", 1);
+    r = q27::chatml_prompt(msgs, {}, /*think=*/false);
     // 1st failure -> diagnose warning
     CHECK(r.find("SYSTEM WARNING: The previous tool call returned an error.") != std::string::npos);
     // 2nd consecutive failure -> change-approach warning with count 2
@@ -801,23 +808,24 @@ static void test_tool_failure_warnings() {
     // only two separate single-failure warnings, no "2 consecutive"
     CHECK(r2.find("2 consecutive tool errors") == std::string::npos);
     CHECK(r2.find("The previous tool call returned an error.") != std::string::npos);
+    unsetenv("Q27_TOOL_ERROR_WARNINGS");
 
-    // P1b off switch (PR #37 review): tool_error_warnings=false suppresses the
-    // escalation warnings entirely (detection skipped, no SYSTEM WARNING).
-    json body3 = {{"messages", body["messages"]}, {"tool_error_warnings", false}};
+    // per-request field (PR #37 review): explicit true wins over the OFF boot
+    // default; explicit false wins over an ON env default.
+    json body3 = {{"messages", body["messages"]}, {"tool_error_warnings", true}};
     auto opts = q27::template_opts_from_body(body3);
-    CHECK(!opts.tool_error_warnings);
+    CHECK(opts.tool_error_warnings);
     std::string r3 = q27::chatml_prompt(q27::openai_msgs(body3), {}, /*think=*/false, nullptr, nullptr, {}, {}, &opts);
-    CHECK(r3.find("SYSTEM WARNING") == std::string::npos);
+    CHECK(r3.find("SYSTEM WARNING") != std::string::npos);   // request overrides boot default
     // chat_template_kwargs carries the field too
     json body4 = {{"messages", body["messages"]},
                   {"chat_template_kwargs",{{"tool_error_warnings",false}}}};
     CHECK(!q27::template_opts_from_body(body4).tool_error_warnings);
-    // explicit true in the request overrides the env default
-    setenv("Q27_TOOL_ERROR_WARNINGS", "0", 1);
-    CHECK(!q27::template_opts_from_body(body).tool_error_warnings);   // env off
-    json body5 = {{"messages", body["messages"]}, {"tool_error_warnings", true}};
-    CHECK(q27::template_opts_from_body(body5).tool_error_warnings);   // request wins
+    // env ON + request false -> request wins
+    setenv("Q27_TOOL_ERROR_WARNINGS", "1", 1);
+    CHECK(q27::template_opts_from_body(body).tool_error_warnings);    // env on
+    json body5 = {{"messages", body["messages"]}, {"tool_error_warnings", false}};
+    CHECK(!q27::template_opts_from_body(body5).tool_error_warnings);  // request wins
     unsetenv("Q27_TOOL_ERROR_WARNINGS");
 }
 
@@ -938,6 +946,10 @@ static void test_v223_reasoning_dedup() {
 // v22.3: failure detection suppresses code output and exit-code-0.
 static void test_v223_failure_detection() {
     q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    // detector-under-renderer checks need the escalation ON (default is OFF
+    // per PR #37 review); the detector itself is covered directly by the
+    // positive cases below firing at all.
+    setenv("Q27_TOOL_ERROR_WARNINGS", "1", 1);
     {   // code output with console.error is suppressed (not a failure)
         json b = {{"messages", json::array({
             {{"role","user"},{"content","run"}},
@@ -960,6 +972,7 @@ static void test_v223_failure_detection() {
         std::string r = q27::chatml_prompt(q27::openai_msgs(b), {}, false);
         CHECK(r.find("SYSTEM WARNING") != std::string::npos);
     }
+    unsetenv("Q27_TOOL_ERROR_WARNINGS");
 }
 
 // v22.3 E: every assistant history turn is wrapped in <think>, even empty.

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -851,6 +851,27 @@ static void test_tool_truncation() {
     }
 }
 
+// P3 request-driven: limits come from chat_template_kwargs in the body, not env.
+static void test_tool_truncation_request_body() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    std::string big(100, 'x');
+    json body = {{"messages", json::array({
+        {{"role","user"},{"content","run it"}},
+        {{"role","tool"},{"content",big}},
+    })},
+        {"chat_template_kwargs", {{"max_tool_response_chars", 20}}}};
+    std::string r = q27::chatml_prompt(q27::openai_msgs(body), {}, false);
+    CHECK(r.find("TRUNCATED - original length") != std::string::npos);
+    // explicit 0 in the body disables truncation even with a huge output
+    json body0 = {{"messages", json::array({
+        {{"role","user"},{"content","run it"}},
+        {{"role","tool"},{"content",big}},
+    })},
+        {"chat_template_kwargs", {{"max_tool_response_chars", 0}}}};
+    std::string r0 = q27::chatml_prompt(q27::openai_msgs(body0), {}, false);
+    CHECK(r0.find("TRUNCATED") == std::string::npos);
+}
+
 static void test_chat_message_plain_text_no_calls() {
     json msg = q27::openai_chat_message_json("hello there", {}, 42);
     CHECK(msg["role"] == "assistant");
@@ -2318,6 +2339,7 @@ int main() {
     test_tool_failure_warnings();
     test_tool_grouping();
     test_tool_truncation();
+    test_tool_truncation_request_body();
     test_chat_message_plain_text_no_calls();
     test_chat_message_empty_text_no_calls_is_empty_string_not_null();
     test_chat_message_call_no_leftover_text_content_null();

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -801,6 +801,24 @@ static void test_tool_failure_warnings() {
     // only two separate single-failure warnings, no "2 consecutive"
     CHECK(r2.find("2 consecutive tool errors") == std::string::npos);
     CHECK(r2.find("The previous tool call returned an error.") != std::string::npos);
+
+    // P1b off switch (PR #37 review): tool_error_warnings=false suppresses the
+    // escalation warnings entirely (detection skipped, no SYSTEM WARNING).
+    json body3 = {{"messages", body["messages"]}, {"tool_error_warnings", false}};
+    auto opts = q27::template_opts_from_body(body3);
+    CHECK(!opts.tool_error_warnings);
+    std::string r3 = q27::chatml_prompt(q27::openai_msgs(body3), {}, /*think=*/false, nullptr, nullptr, {}, {}, &opts);
+    CHECK(r3.find("SYSTEM WARNING") == std::string::npos);
+    // chat_template_kwargs carries the field too
+    json body4 = {{"messages", body["messages"]},
+                  {"chat_template_kwargs",{{"tool_error_warnings",false}}}};
+    CHECK(!q27::template_opts_from_body(body4).tool_error_warnings);
+    // explicit true in the request overrides the env default
+    setenv("Q27_TOOL_ERROR_WARNINGS", "0", 1);
+    CHECK(!q27::template_opts_from_body(body).tool_error_warnings);   // env off
+    json body5 = {{"messages", body["messages"]}, {"tool_error_warnings", true}};
+    CHECK(q27::template_opts_from_body(body5).tool_error_warnings);   // request wins
+    unsetenv("Q27_TOOL_ERROR_WARNINGS");
 }
 
 // P2: consecutive tool responses group under a single user turn.

--- a/tools/test_openai_bridge.cpp
+++ b/tools/test_openai_bridge.cpp
@@ -761,7 +761,8 @@ static void test_think_toggle_state() {
         std::string r = q27::chatml_prompt(msgs, {}, /*think=*/false);
         CHECK(r.find("<|think_on|>") == std::string::npos);
         CHECK(r.rfind("<think>\n") == r.size() - std::string("<think>\n").size());
-        CHECK(r.find("Reasoning effort is set to xhigh.") != std::string::npos);
+        // default effort is medium -> no xhigh line (froggeric v22.3)
+        CHECK(r.find("Reasoning effort") == std::string::npos);
     }
     {   // <|think_xhigh|> arms xhigh effort on a no-think base
         json body = {{"messages", json::array({
@@ -997,6 +998,34 @@ static void test_output_config_fields() {
     CHECK(tcfg.enabled_set);
     CHECK(tcfg.budget_set);
     CHECK(tcfg.budget == 1024);        // output_config.budget_tokens
+}
+
+// items 1+2: default effort is medium (no line); reasoning_effort none/off disables thinking.
+static void test_medium_default_and_none_off() {
+    q27::set_tool_dialect_for_model("{\"general.name\": \"Qwen38 27b Hf\"}");
+    unsetenv("Q27_REASONING_EFFORT");
+    {   // default medium: thinking on but no effort line
+        json b = {{"messages", json::array({{{"role","user"},{"content","hi"}}})}};
+        auto opts = q27::template_opts_from_body(b);
+        CHECK(opts.effort == -1);      // no request field
+        std::string r = q27::chatml_prompt(q27::openai_msgs(b), json::array(), true);
+        CHECK(r.find("Reasoning effort") == std::string::npos); // medium default
+    }
+    {   // reasoning_effort none -> thinking OFF (closed gen prompt, no effort line)
+        json b = {{"messages", json::array({{{"role","user"},{"content","hi"}}})},
+                  {"reasoning_effort","none"}};
+        auto opts = q27::template_opts_from_body(b);
+        CHECK(opts.force_disable_thinking);
+        std::string r = q27::chatml_prompt(q27::openai_msgs(b), json::array(), /*think=*/true, nullptr, nullptr, {}, {}, &opts);
+        // closed generation block (thinking off) despite think=true
+        CHECK(r.rfind("<think>\n\n</think>\n\n") == r.size() - std::string("<think>\n\n</think>\n\n").size());
+    }
+    {   // reasoning_effort off disables thinking too (via chat_template_kwargs)
+        json b = {{"messages", json::array({{{"role","user"},{"content","hi"}}})},
+                  {"chat_template_kwargs",{{"reasoning_effort","off"}}}};
+        auto opts = q27::template_opts_from_body(b);
+        CHECK(opts.force_disable_thinking);
+    }
 }
 
 // item 6: XML-dialect assistant tool_calls render as <function=...><parameter=...>
@@ -2507,6 +2536,7 @@ int main() {
     test_unconditional_think_wrap();
     test_request_effort_and_auto_disable();
     test_output_config_fields();
+    test_medium_default_and_none_off();
     test_xml_tool_call_rendering();
     test_truncation_json_dialect_skipped();
     test_chat_message_plain_text_no_calls();

--- a/tools/test_tool_drift.cpp
+++ b/tools/test_tool_drift.cpp
@@ -321,7 +321,7 @@ static void test_reasoning_effort_line() {
     unsetenv("Q27_REASONING_EFFORT");
     unsetenv("Q27_TOOL_DIALECT");
     auto meta = [](const char* n) { return std::string("{\"general.name\": \"") + n + "\"}"; };
-    std::vector<q27::Msg> msgs = {{"system", "Be terse."}, {"user", "hi"}};
+    std::vector<q27::Msg> msgs = {{"system", "Be terse.", {}}, {"user", "hi", {}}};
     json tools = json::parse(R"([{"type":"function","function":{"name":"Read","parameters":{"type":"object"}}}])");
     const std::string XH = "Reasoning effort is set to xhigh.";
     q27::set_tool_dialect_for_model(meta("Qwen38 27b Hf"));

--- a/tools/test_tool_drift.cpp
+++ b/tools/test_tool_drift.cpp
@@ -316,8 +316,10 @@ static void test_preamble_swaps_with_dialect() {
 }
 
 static void test_reasoning_effort_line() {
-    // froggeric v22.3 (2026-08-22): the default reasoning_effort is medium
-    // (zero injected tokens); xhigh/low must be explicitly requested.
+    // The trained 3.8 template injects the effort line at the HEAD of the
+    // system block when thinking is on, defaulting to xhigh (2026-08-15).
+    // NOTE (PR #37 review): the froggeric "default medium" change was dropped --
+    // the effective default stays xhigh/off; medium is reachable explicitly.
     unsetenv("Q27_REASONING_EFFORT");
     unsetenv("Q27_TOOL_DIALECT");
     auto meta = [](const char* n) { return std::string("{\"general.name\": \"") + n + "\"}"; };
@@ -325,15 +327,10 @@ static void test_reasoning_effort_line() {
     json tools = json::parse(R"([{"type":"function","function":{"name":"Read","parameters":{"type":"object"}}}])");
     const std::string XH = "Reasoning effort is set to xhigh.";
     q27::set_tool_dialect_for_model(meta("Qwen38 27b Hf"));
-    // default = medium -> no effort line even with thinking on
-    ok(q27::chatml_prompt(msgs, tools, /*think=*/true).find("Reasoning effort") == std::string::npos,
-       "effort: default medium emits no line");
-    setenv("Q27_REASONING_EFFORT", "xhigh", 1);
     std::string p = q27::chatml_prompt(msgs, tools, /*think=*/true);
     size_t at = p.find(XH), tools_at = p.find("# Tools");
     ok(at != std::string::npos && tools_at != std::string::npos && at < tools_at,
-       "effort: 3.8+think + xhigh injects xhigh line before # Tools");
-    unsetenv("Q27_REASONING_EFFORT");
+       "effort: 3.8+think injects xhigh line before # Tools");
     ok(q27::chatml_prompt(msgs, tools, /*think=*/false).find(XH) == std::string::npos,
        "effort: no-think render carries no effort line");
     q27::set_tool_dialect_for_model(meta("Qwen3.6-27B"));
@@ -342,7 +339,7 @@ static void test_reasoning_effort_line() {
     q27::set_tool_dialect_for_model(meta("Qwen38 27b Hf"));
     setenv("Q27_REASONING_EFFORT", "off", 1);
     ok(q27::chatml_prompt(msgs, tools, true).find("Reasoning effort") == std::string::npos,
-       "effort: off emits no line");
+       "effort: off restores legacy rendering");
     setenv("Q27_REASONING_EFFORT", "low", 1);
     ok(q27::chatml_prompt(msgs, tools, true).find("Reasoning effort is set to low.") != std::string::npos,
        "effort: low selects the trained low string");

--- a/tools/test_tool_drift.cpp
+++ b/tools/test_tool_drift.cpp
@@ -316,8 +316,8 @@ static void test_preamble_swaps_with_dialect() {
 }
 
 static void test_reasoning_effort_line() {
-    // The trained 3.8 template injects the effort line at the HEAD of the
-    // system block when thinking is on, defaulting to xhigh (2026-08-15).
+    // froggeric v22.3 (2026-08-22): the default reasoning_effort is medium
+    // (zero injected tokens); xhigh/low must be explicitly requested.
     unsetenv("Q27_REASONING_EFFORT");
     unsetenv("Q27_TOOL_DIALECT");
     auto meta = [](const char* n) { return std::string("{\"general.name\": \"") + n + "\"}"; };
@@ -325,10 +325,15 @@ static void test_reasoning_effort_line() {
     json tools = json::parse(R"([{"type":"function","function":{"name":"Read","parameters":{"type":"object"}}}])");
     const std::string XH = "Reasoning effort is set to xhigh.";
     q27::set_tool_dialect_for_model(meta("Qwen38 27b Hf"));
+    // default = medium -> no effort line even with thinking on
+    ok(q27::chatml_prompt(msgs, tools, /*think=*/true).find("Reasoning effort") == std::string::npos,
+       "effort: default medium emits no line");
+    setenv("Q27_REASONING_EFFORT", "xhigh", 1);
     std::string p = q27::chatml_prompt(msgs, tools, /*think=*/true);
     size_t at = p.find(XH), tools_at = p.find("# Tools");
     ok(at != std::string::npos && tools_at != std::string::npos && at < tools_at,
-       "effort: 3.8+think injects xhigh line before # Tools");
+       "effort: 3.8+think + xhigh injects xhigh line before # Tools");
+    unsetenv("Q27_REASONING_EFFORT");
     ok(q27::chatml_prompt(msgs, tools, /*think=*/false).find(XH) == std::string::npos,
        "effort: no-think render carries no effort line");
     q27::set_tool_dialect_for_model(meta("Qwen3.6-27B"));
@@ -337,7 +342,7 @@ static void test_reasoning_effort_line() {
     q27::set_tool_dialect_for_model(meta("Qwen38 27b Hf"));
     setenv("Q27_REASONING_EFFORT", "off", 1);
     ok(q27::chatml_prompt(msgs, tools, true).find("Reasoning effort") == std::string::npos,
-       "effort: off restores legacy rendering");
+       "effort: off emits no line");
     setenv("Q27_REASONING_EFFORT", "low", 1);
     ok(q27::chatml_prompt(msgs, tools, true).find("Reasoning effort is set to low.") != std::string::npos,
        "effort: low selects the trained low string");


### PR DESCRIPTION
## Intent

This PR aligns q27's chat-template renderer with **froggeric's Qwen 3.8 chat template (v22.3)** — [froggeric/Qwen-Fixed-Chat-Templates](https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates) — with the stated goal of achieving **the best integration with agent harnesses** (Claude Code and pi agent in particular): correct history rendering (including reasoning), effective thinking/effort control, robust tool handling, and no context loss across multi-turn loops.

The "v22"/"v22.3" references in the commits refer to the **froggeric template** version, not to a q27 version.

### Upstream reference
Every behavior ported here is documented on the template's model card ([froggeric/Qwen-Fixed-Chat-Templates](https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates)) — this PR is a C++ port of those documented behaviors, not a new design:

| This PR | Documented on the model card |
|---|---|
| ~~Item 1 — default effort `medium~~ **NOT ported (dropped per review)** — q27 keeps its own default; see [Thinking / effort control](#thinking--effort-control) |
| P0 reasoning preservation / dedup | Table row **History Reasoning Extraction** + changelog v22.3 #2 (*Reasoning De-duplication*) |
| E — unconditional think wrap | Kwarg reference §2 (**`preserve_reasoning` & `preserve_thinking`**, default `true`) |
| B — multi-system merge | Table row **Leading System Prompts** (*joined by double newlines*) + changelog v22.2 #3 |
| P1a — inline `<\|think_*\|>` toggles | Technical details §2 (**Upfront Pre-Scan for Control Tags**) + changelog v22.1 #3 |
| Case-insensitive aliases (`high`/`max`/`ultracode`/`extreme` → `xhigh`, …) | Kwarg reference §1 (**API Compatibility Aliases**) + changelog v22.1 #4, v22.2 #2 |
| P1b — two-tier error escalation | Table row **Tool Error Recovery** + technical details §5–**§6 Smart False-Positive Detection** (120-char head, strong vs weak signals) + changelog v22.3 #1 |
| Item 6 — XML tool-call dialect | Technical details §4 (**Native XML Tool Format**) |
| P3 / items 7/8 — truncation, JSON bypass | Kwarg reference §3–§4 (**Dynamic Payload Truncation**: *"Both limiters are disabled automatically when `tool_call_format="json"`"*) |
| Item 2 — `none`/`off` disables thinking | Table row **Non-Reasoning Fast Mode** (*`reasoning_effort="none"`*) + Kwarg §1 |

Template credits: fixes by [Frédéric Guigand (@froggeric)](https://huggingface.co/froggeric); error tiering and test suite by [Juan Calderon-Perez (@g-a-b-y)](https://huggingface.co/g-a-b-y). Apache-2.0.

---

## What it does

The internal renderer (`chatml_prompt`/`api_common.h`) is native C++ (not minijinja): this PR brings the template's **key behaviors** directly into the code, with no added dependencies.

### History rendering
- **P0 — Reasoning preservation (OpenAI path)**: `reasoning_content` on assistant messages is now read on input and rendered as a `<think>...</think>` block in the prompt instead of being silently dropped. Scope correction per review: the Anthropic path was NOT broken — `api_common.h` already re-rendered `thinking` blocks into history (`content = "<think>\n" + think + ...`). The real gap was the OpenAI shape, where `reasoning_content` as a sibling field was never read; this patch adds exactly that.
- **P0 — Dedup**: if the assistant content opens with a think block (`<think>`/`<thinking>`, or an orphan closer `</think>`/`</thinking>`), the leading block is removed before rendering (no double render). With item E the strip is unconditional on every assistant turn: even without explicit `reasoning`, the inline block no longer duplicates the rendered one.
- **E — Unconditional wrap**: every assistant history turn is wrapped in `<think>...</think>` (even empty), matching the template's `preserve_thinking=true`.
- **B — Multi-system merge**: consecutive leading `system`/`developer` messages are merged into a single block (joined with a blank line).

### Thinking / effort control
- **P1a — Inline toggles** `<|think_off|>`, `<|think_on|>`, `<|think_low|>`, `<|think_minimal|>`, `<|think_medium|>`, `<|think_xhigh|>`, `<|think_high|>`, `<|think_ultracode|>`, `<|think_extreme|>`, `<|think_max|>`: scanned before rendering with stateful tracking across messages, stripped from the prompt, and they drive both the `reasoning_instructions` line and the generation prompt.
- **Item 1 — default effort `medium`: DROPPED per review.** The effective default stays `xhigh`/`off` (per boot dialect), so every existing client and benchmark baseline is unchanged. `medium` remains reachable explicitly via `Q27_REASONING_EFFORT=medium`, the `reasoning_effort` request field, or a `<|think_medium|>` tag. Upstream parity for this item is deferred until a measured benchmark arm justifies it (the n=3 arm from 2026-08-19 — mean 0.545 xhigh vs 0.453 medium — supports neither side).
- **Item 2 — `reasoning_effort: none/off` disables thinking** end-to-end (prompt + engine).
- **Case-insensitive aliases**: `high`/`max`/`ultracode`/`extreme` → `xhigh`; `minimal` → `low`; `none`/`off` → disabled.
- **Honored request fields** (with `--request-think`): `reasoning_effort`, `output_config`/`reasoning` (`.effort`/`.output_effort`, `.disabled`/`.enabled`, `.budget_tokens`, `.output_budget_tokens`), top-level `budget_tokens`, `thinking.type`, `enable_thinking`.

### Tools
- **P1b — Two-tier error escalation**: tracks consecutive tool-response failures and injects the system warnings (1st "diagnose and retry", 2+ "fundamentally different approach").
- **P1b — Switch, default OFF** (per review, second round): the escalation is now opt-in — `Q27_TOOL_ERROR_WARNINGS=1` enables it at boot; a per-request boolean `tool_error_warnings` (top-level or `chat_template_kwargs`) overrides either way. When off, failure detection is skipped entirely and no warning is ever injected. Template parity stays one flag away; flipping the default back would require a measured arm showing the escalation helps.
- **Known FP profile** (measured with a direct probe of `is_tool_response_failure`, since session logs are not persisted): over realistic benign outputs, 3/12 false-positive — grep/diff exit code 1 (no-match/differences convention) and short `error: none` summaries fire; recall on true failures is 6/6. See the review reply for details.
- **P1b — Smart false-positive detection** (v22.3): 120-char head, code/grep output suppression (`throw new`, `console.error`, etc.), `exit code` handling (0 = not an error), strong vs weak error.
- **P2 — Grouping**: consecutive tool responses grouped into a single `user` turn.
- **Item 6 — Tool calls in the active dialect**: assistant tool calls in history rendered in XML per-parameter (Qwen's native dialect) or JSON.
- **P3 / items 7/8 — Truncation**: `max_tool_arg_chars` / `max_tool_response_chars` (env or request fields), bypassed in the JSON dialect.

---

## What is NOT included
- **Vision** (`image_pad`/`video_pad`): the server has no vision pipeline.
- **`tool_call_format` per-request**: the constraint grammar and drift parser are boot-level (continuous batching = a single dialect), so the format is selected at boot (`Q27_TOOL_DIALECT` or auto-detect).
- **`preserve_reasoning`/`preserve_thinking` as a request field**: default `true` (current behavior); the off switch is not exposed.

---

## Tests
- New regression tests in `tools/test_openai_bridge.cpp` and updates to `test_tool_drift`/`test_tokenizer`.
- All suites pass (`test_openai_bridge`, `test_chat_completions_integration`, `test_think_resolve`, `test_tool_drift`, `test_toolconstrain`, `test_tokenizer`).
- Verified at runtime with the server (`--think --request-think`): `reasoning_effort none/off` → `reasoning_tokens 0`; `budget_tokens` → cap applied; `output_config.effort` → 200; `reasoning_content`/`thinking` preserved and recalled by the model.

---

## Notes for the reviewer
- **RESOLVED — default effort**: the `xhigh`→`medium` default change originally in `449bee2` has been reverted in `a10246b` per review; the effective default is unchanged from master. No observable behavior change remains around the default.
- **Metal build**: fixed in `7058263` — `Msg::reasoning` now carries an NSDMI (`std::string reasoning{};`) so the eight 2-field brace-init sites in `metal_server.cpp` stay valid under `-Werror -Wmissing-field-initializers`.
- The server must be started with **`--think --request-think`** for the request fields (effort, budget, disabled) to be honored.
- The P0–P3 commits and the v22.3 items are listed individually: the series starts with the port and continues with the v22.3 refinements.

