### PR TITLE
server: /metrics Prometheus endpoint (opt-in via --enable-metrics)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ build/test_manifest: tools/test_manifest.cu src/engine.cuh src/kv_pool.h src/pre
 	        build/pf4.o -o $@
 
 
-build/q27-server: src/server.cu src/engine.cuh src/kv_pool.h src/prefill_arena.h src/conductor.h src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu \
+build/q27-server: src/server.cu src/engine.cuh src/metrics.h src/kv_pool.h src/prefill_arena.h src/conductor.h src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu \
                   src/device_model.cu src/loader.cpp src/tokenizer.cpp src/api_common.h src/drift_capture.h src/stream_split.h src/markdown_lex.h \
                   src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/cuda_common.h src/toolgram.h \
                   src/depthctl.h src/toolconstrain.h src/tokenizer.h src/prefix_cache.h src/prefix_ram.h third_party/httplib.h build/pf4.o | build
@@ -293,7 +293,7 @@ build/i8g64_test: tools/i8g64_test.cu src/i8g64.cuh | build
 # zoo for every build, so the w8 delta is now small -- kept for the widest
 # fits (the historical role-set + 12x-zoo savings are engine-wide now).
 # Same sources, own binary.
-build/q27-server-w8: src/server.cu src/engine.cuh src/kv_pool.h src/prefill_arena.h src/conductor.h src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu \
+build/q27-server-w8: src/server.cu src/engine.cuh src/metrics.h src/kv_pool.h src/prefill_arena.h src/conductor.h src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu \
                      src/device_model.cu src/loader.cpp src/tokenizer.cpp src/api_common.h src/drift_capture.h src/stream_split.h src/markdown_lex.h \
                      src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/cuda_common.h src/toolgram.h \
                      src/depthctl.h src/toolconstrain.h src/tokenizer.h src/prefix_cache.h src/prefix_ram.h third_party/httplib.h build/pf4.o | build
@@ -318,7 +318,7 @@ build/fused_smoke: tools/fused_smoke.cu src/engine.cuh src/kv_pool.h src/prefill
 	        src/spec3.cu src/vgemm.cu src/device_model.cu src/loader.cpp build/pf4.o -o $@
 
 # w16 serving build (batch mode's natural target; was hand-built since part 10)
-build/q27-server-w16: src/server.cu src/engine.cuh src/kv_pool.h src/prefill_arena.h src/conductor.h src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu \
+build/q27-server-w16: src/server.cu src/engine.cuh src/metrics.h src/kv_pool.h src/prefill_arena.h src/conductor.h src/blocks.cu src/prefill.cu src/kernels.cu src/spec3.cu src/vgemm.cu \
                       src/device_model.cu src/loader.cpp src/tokenizer.cpp src/api_common.h src/drift_capture.h src/stream_split.h src/markdown_lex.h \
                       src/blocks.cuh src/kernels.cuh src/spec3.cuh src/prefill.cuh src/fdmma.cuh src/turbo3.cuh src/turbo5.cuh src/cuda_common.h src/toolgram.h \
                       src/depthctl.h src/toolconstrain.h src/tokenizer.h src/prefix_cache.h src/prefix_ram.h src/kv_pool.h src/prefill_arena.h third_party/httplib.h build/pf4.o | build

--- a/README.md
+++ b/README.md
@@ -334,6 +334,15 @@ tier above it (`--prefix-cache-ram-gb`) is off by default on measured grounds.
 containers) all add keys; both `Authorization: Bearer` and `x-api-key` work.
 Binding non-loopback with no key warns but is not refused.
 
+**Metrics**: `--enable-metrics` (opt-in, default off) exposes `GET /metrics`
+in Prometheus text exposition -- per-API request/token counters, prefill
+computed/cached split, TTFT/E2E/ITL latency histograms, live token counters
+(dashboard tok/s moves *during* generation, not only at request end),
+KV/prefix-cache/inflight gauges, and the MTP accept-ratio lanes. Auth-exempt
+like `/health`; 404 and zero bookkeeping cost when the flag is absent.
+Series reference and consumer recipes:
+[docs/metrics-endpoint.md](docs/metrics-endpoint.md).
+
 **Thinking**: the default profile is no-think (prefills an empty
 `<think></think>`); `--think` flips it. Per-request control is opt-in behind
 `--request-think` so a harness that sends `enable_thinking:true` cannot

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -262,7 +262,10 @@ to match).
 | **llama mainline** (no spec) | 62.0 t/s | 120 s | 12/12 | 12/12 |
 
 (vLLM decode is aggregate from `/metrics` deltas — `generation_tokens_total` /
-`inter_token_latency_seconds_sum`; the others are per-`[req]` telemetry.)
+`inter_token_latency_seconds_sum`; the others are per-`[req]` telemetry.
+q27 now exposes the same delta-accounting surface on its own `/metrics`
+under `--enable-metrics` — `q27_*_tokens_processed_total` and the
+`q27_*_seconds` histograms; see docs/metrics-endpoint.md.)
 
 The five engines decompose the gap cleanly (all same model + MTP head available):
 

--- a/docs/BUILDLOG.md
+++ b/docs/BUILDLOG.md
@@ -15492,3 +15492,64 @@ tool is re-emitted as text by the flush path (both directions are tracked
 tests). Verified through the real splitter+router at chunk sizes 1/3/7/64;
 test-tools green, corpus-check 159/159, gcc+ASan fuzz 250k clean, server.cu
 compiles under nvcc.
+
+## 2026-08-30 (a): `/metrics` (Prometheus), live token counters, sampled-path accept telemetry
+
+One serving-telemetry branch (`feat/metrics-endpoint`), everything opt-in
+behind a new `--enable-metrics` flag (default off: the route is not
+registered -- 404, `/health` untouched -- and per-request bookkeeping is
+skipped entirely).
+
+**The endpoint.** `GET /metrics` renders the Prometheus text exposition from
+a new `src/metrics.h`: per-API (`api=` chat/completions/messages/responses)
+counters -- requests, errors, prompt tokens, the prefill computed/cached
+split (ds4 convention: the headline prefill number is computed tokens), decode
+tokens, queue-wait -- plus three latency histograms (TTFT = `pf_ms`; E2E =
+arrival -> generation-complete at the `[req]` point, not last byte; ITL =
+per-request `dec_ms/dec`, observed only when `dec > 0`), and gauges
+(inflight slots, slots total, KV-pool occupancy, prefix-cache entries,
+uptime). One observation per generation request at the `[req]` point,
+`end=error` included, so `/metrics` counts match the log line-for-line.
+`/v1/models` also grew `max_model_len` (max slot ctx) in this branch.
+
+**Live token counters.** `gs.dec`/`gs.prompt` stamp only at generation
+completion, so completion-based totals are step functions: a poller watching
+a 2000-token decode reads 0 t/s the whole way and +2000 at the end. The
+engine now carries `live_decoded` / `live_prefill_computed` /
+`live_prefill_cached` atomics -- bumped at the single delivery point
+(`post_round` per delivered token; `generate_prefill`'s success exit for
+prefill, so failed prefills count nothing) -- exposed unlabeled as
+`q27_*_tokens_processed_total`. At rest they equal the labeled totals; under
+load a poller sees real-time tok/s (measured 79 -> 115 t/s during
+generation where the step counter showed 0, then 1023).
+
+**Sampled-path accept telemetry.** The MTP lane counters
+(`gate_lane_fired/acc` -> `q27_spec_accept_ratio`) were greedy-only:
+`spec_sample_round` deliberately updated nothing, so a sampled-only profile
+(`--temp 1.0`, the measured recipe) read a constant 0 despite speculating
+~2.3 tokens/round. Both sampled paths (solo `spec_sample_round`, fused
+`commit_outcome(sampled=true)`) now mirror the greedy lane accounting --
+monitoring-only, no dctl/EMA feed (sampled ceiling fixed at 4, adaptive
+depth is greedy-only). Sampled traffic measures 0.42-0.74 by mix.
+
+**Four review catches, all fixed on-branch.** (1) Histogram scrapes could
+tear: `observe()` bumps separate atomics and `render()` read them
+line-by-line, so a completion mid-render left `+Inf != _count` and consumers
+dropped the quantiles (three null tiles for one poll under traffic).
+Histograms are seqlocked now -- writer CAS-es into an odd seq (critical
+section: three relaxed atomics), reader retries on a torn read; verified
+115/115 invariant-clean scrapes under continuous traffic across three
+rounds. (2) Histogram tails were too short for real work -- a 24 s 60k-token
+prefill landed in the `+Inf` tail, which consumers report as no data: TTFT
+now to 60 s, E2E to 300 s, ITL to 100 ms. (3) `queue_wait` and the
+`_sum` lines rendered at six significant digits (`%g`), which rounds away
+microsecond deltas once totals grow and corrupts `rate()` on long-running
+servers: `%.6f`. (4) The Makefile server rules did not depend on
+`src/metrics.h`, so header-only edits silently produced stale binaries --
+hit in practice during the review.
+
+`q27_preemptions_total` is an honest constant 0: admission is FIFO, running
+requests are never preempted; dashboards should treat 0 as healthy. Design
+reference: `docs/metrics-endpoint.md`. Security posture of the new
+auth-exempt route dispositioned in the SECURITY-MODEL addendum of the same
+date.

--- a/docs/SECURITY-MODEL.md
+++ b/docs/SECURITY-MODEL.md
@@ -368,3 +368,17 @@ forges each case). A malicious file in the cache directory cannot make the
 server continue a conversation whose tokens the requester did not supply --
 though anyone who can WRITE to that directory can already do far worse to the
 process, and is outside the model here as elsewhere.
+
+## Addendum 2026-08-30: the /metrics surface
+
+`--enable-metrics` (default off) adds an auth-exempt `GET /metrics`
+(Prometheus text exposition; see `docs/metrics-endpoint.md`). Disposition:
+metadata-only telemetry -- request and token counters, latency histograms,
+occupancy gauges, server uptime. No prompt text, no generated tokens, no
+conversation state reaches the endpoint, and the prefix cache's on-disk
+content is not readable through it. It widens the unauthenticated surface
+the same way `/health` does -- an on-path observer learns that this is a
+q27 server and how busy it is -- so it stays opt-in and rides on the same
+loopback / api-key posture as everything else. When the flag is absent the
+route is not registered at all (404). Nothing in this addendum re-activates
+or weakens the dispositions above.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -106,6 +106,12 @@ this trade; q27 currently sits at the permissive end.
   documented together in the README for that reason.
 - `--api-key` comparison is constant-time (`secure_compare`), deliberately
   without early exit on length or first difference.
+- `--enable-metrics` (default off) adds an auth-exempt `GET /metrics`,
+  reachable without a key for the same reason `/health` is: pollers scrape
+  without credentials. It exposes operational metadata only -- request and
+  token counters, latency histograms, occupancy gauges, uptime -- never
+  prompt text or generated content. Without the flag the route does not
+  exist (404).
 - No auth by default is a loopback-only assumption. Do not expose the port.
 
 ## Reporting

--- a/docs/metrics-endpoint.md
+++ b/docs/metrics-endpoint.md
@@ -1,0 +1,195 @@
+# /metrics -- Prometheus text exposition
+
+**Status:** implemented 2026-08-30 on `feat/metrics-endpoint`. Opt-in via
+`--enable-metrics` (default off). Auth-exempt like `/health`. This document
+is the reference for every series, the observation semantics, and the
+consumer contract; `src/metrics.h` is the implementation and the comment
+blocks there mirror this document.
+
+## Posture
+
+- **Off by default.** Without `--enable-metrics` the handler is never
+  registered (`GET /metrics` -> 404; `/health` stays 200) and the per-request
+  bookkeeping is skipped entirely -- a deployment that does not want metrics
+  keeps the zero-overhead shape. With the flag, behavior is identical to what
+  is documented here.
+- **Auth-exempt when enabled**, same rule as `/health`: infra pollers
+  (Prometheus and any text-exposition scraper) reach it without a key. A
+  401/403 would make a poller mark the backend unreachable and blank every
+  tile. The
+  endpoint carries metadata-scale telemetry only -- counts, latencies,
+  occupancy, uptime -- never prompt text or generated content.
+- **One scrape = one consistent picture.** Histograms are seqlocked so a
+  scrape can never see a torn update (the `+Inf == _count` invariant
+  Prometheus consumers rely on holds under traffic; the reader retries on a
+  torn read, at worst one poll shows a null quantile and the next heals).
+  Slot/KV gauges are snapshotted under the server's `route_m`.
+
+## The series
+
+Per-API label `api=` -- `chat` (OpenAI `/v1/chat/completions`),
+`completions` (`/v1/completions`), `messages` (Anthropic `/v1/messages`),
+`responses` (OpenAI Responses; the internal spellings oai/cmpl/anth/resp
+map via `api_from_str` in `metrics.h`):
+
+| Series | Type | Meaning |
+|---|---|---|
+| `q27_requests_total` | counter | Generation requests ([req] universe) |
+| `q27_requests_errors_total` | counter | Requests ending `end=error` |
+| `q27_prompt_tokens_total` | counter | Prompt tokens sent to prefill (incl. cached) |
+| `q27_prefill_computed_tokens_total` | counter | Prompt tokens actually computed |
+| `q27_prefill_cached_tokens_total` | counter | Prompt tokens served from cache (RAM/ckpt/disk) |
+| `q27_decode_tokens_total` | counter | Generated tokens delivered |
+| `q27_queue_wait_seconds_total` | counter | Sum of slot-claim wait (µs-resolution, `%.6f`) |
+| `q27_ttft_seconds` | histogram | Pre-fill wall per request (first-token proxy) |
+| `q27_e2e_seconds` | histogram | Request arrival -> generation complete |
+| `q27_itl_seconds` | histogram | Per-request mean inter-token latency |
+| `q27_requests_inflight` | gauge | Slots currently claimed |
+| `q27_slots_total` | gauge | Configured serving slots |
+| `q27_kv_usage_perc` | gauge | Paged KV pool occupancy, 0-1 (omitted if pool off) |
+| `q27_prefix_cache_entries` | gauge | Persistent prefix cache entries (omitted if off) |
+| `q27_spec_draft_tokens_total` | counter | MTP draft lanes fired (accept gate) |
+| `q27_spec_accepted_tokens_total` | counter | MTP draft lanes accepted |
+| `q27_spec_accept_ratio` | gauge | `accepted / drafted` (0 when nothing speculated) |
+| `q27_decode_tokens_processed_total` | counter | Live decode tokens (unlabeled) |
+| `q27_prefill_computed_tokens_processed_total` | counter | Live prefill computed (unlabeled) |
+| `q27_prefill_cached_tokens_processed_total` | counter | Live prefill cached (unlabeled) |
+| `q27_preemptions_total` | counter | Constant 0 -- see "Why preemptions is 0" |
+| `q27_uptime_seconds` | gauge | Server uptime |
+
+Sample scrape:
+
+```
+# HELP q27_ttft_seconds Pre-fill wall per request (first-token latency proxy).
+# TYPE q27_ttft_seconds histogram
+q27_ttft_seconds_bucket{api="chat",le="0.010"} 0
+...
+q27_ttft_seconds_bucket{api="chat",le="60.000"} 11
+q27_ttft_seconds_bucket{api="chat",le="+Inf"} 11
+q27_ttft_seconds_sum{api="chat"} 53.123456
+q27_ttft_seconds_count{api="chat"} 11
+```
+
+## Observation semantics
+
+**Universe.** One `observe()` per generation request, at the point the
+`[req]` telemetry line fires -- when `GenStats` is final, errors included
+(`end=error` lands in both `requests_total` and `errors_total`). Counts
+derived from `/metrics` therefore match the `[req]` log line-for-line.
+
+**The computed/cached split** follows the ds4 convention: the headline
+prefill number is *computed* tokens (`prompt - hit - pfx`); cached tokens
+(snapshot/ckpt/disk restores) are the complementary series. Both are exposed
+because they answer different questions: computed = GPU work done, cached =
+prefix reuse working.
+
+**Latency definitions** (and why they are not interchangeable with other
+engines'):
+
+- **TTFT = `pf_ms`**, the prefill wall. Under prompt-seeded thinking the
+  first *visible* token can arrive later than prefill + one decode step;
+  this measures the engine's prefill, which is the quantity that scales
+  with context and cache state.
+- **E2E = arrival -> generation complete**, stamped at the `[req]` point
+  (generation done), *not* last-byte: client write time is not model work.
+- **ITL = `dec_ms / dec` per request**, observed only when `dec > 0`
+  (a zero-token request has no inter-token latency to average). The
+  histogram's `_count` is therefore the count of requests with at least one
+  decoded token, not the request count.
+
+**Histogram shape.** Fixed finite edges in seconds plus the implicit `+Inf`
+bucket, rendered cumulative as Prometheus expects. The tails are sized for
+real observations, not for symmetry: TTFT to 60 s, E2E to 300 s, ITL to
+100 ms -- a 60k-token prefill takes ~25 s and must land in a finite bucket,
+otherwise p95 quantiles fall into `+Inf` and consumers report "no data".
+`_sum` is integer microseconds at rest and rendered `%.6f`: `%g`'s six
+significant digits would round away microsecond deltas once totals grow,
+corrupting `rate()` on long-running servers.
+
+## Live vs completion counters
+
+The per-api totals above stamp at request completion. That is the correct
+accounting for `rate()` over idle-then-burst traffic, but it is a step
+function: during a 2000-token decode every poll reads the same value and a
+dashboard shows 0 t/s, then +2000 at the end. The `*_processed_total`
+series exist for dashboards instead: the engine bumps
+`live_decoded` per delivered token at the single delivery point
+(`post_round`, covering the solo, sampled and conductor-fused paths) and
+`live_prefill_{computed,cached}` at `generate_prefill`'s success exit, so a
+poller sees progress *during* generation (measured: 79 -> 115 t/s
+real-time where the step counter showed 0 then 1023).
+
+They are unlabeled (the engine does not know the API shape) and cumulative;
+at rest they equal the sum of the labeled per-api totals, so consumers can
+diff them against the labeled counters to detect in-flight work.
+
+## MTP accept telemetry
+
+`q27_spec_draft_tokens_total` / `q27_spec_accepted_tokens_total` count
+confidence-gate lanes: lane `j` is "fired" when the round drafted through
+depth `j` under the margin gate, "accepted" when the round committed at
+least `j+1` tokens. The ratio gauge is the cumulative acceptance.
+
+Both decode modes feed it. The greedy path (`spec_round`) always did; the
+sampled path (`spec_sample_round`, and the conductor's fused
+`commit_outcome(sampled=true)`) deliberately updated nothing, which made the
+ratio read a constant 0 on sampled-only serving profiles -- the measured
+recipe runs `--temp 1.0`, so that was the normal case, not an edge case.
+Both sampled paths now mirror the greedy lane accounting, monitoring-only:
+no depth-controller or EMA feed, because the sampled ceiling is fixed at 4
+and adaptive depth is greedy-only. Expect 0.4-0.75 depending on request mix;
+0 with traffic flowing means the gate never fired (e.g. `Q27_PMIN=0`).
+
+**Why preemptions is an honest 0.** q27's admission is a FIFO queue: a
+request that finds no free slot waits (visible in
+`q27_queue_wait_seconds_total`), and a running request is never evicted.
+`q27_preemptions_total` is therefore a constant-0 counter, not a stub:
+dashboards can read it and a non-zero value would mean a code path regressed
+into preemption. Dashboards should treat 0 as healthy, not as missing data.
+
+## Consumers
+
+**Prometheus** (scrape every 5-15 s):
+
+```yaml
+scrape_configs:
+  - job_name: q27
+    static_configs:
+      - targets: ["gpu-host:8080"]
+```
+
+Useful queries:
+
+```promql
+rate(q27_decode_tokens_processed_total[1m])            # live decode tok/s
+rate(q27_prefill_computed_tokens_processed_total[1m])  # live prefill tok/s
+histogram_quantile(0.95, rate(q27_ttft_seconds_bucket[5m]))
+q27_spec_accept_ratio                                   # MTP acceptance
+1 - (rate(q27_prefill_cached_tokens_total[5m]) /
+     rate(q27_prompt_tokens_total[5m]))                 # cache miss fraction
+```
+
+**Custom dashboards / scrapers.** The intended mapping: live tok/s from
+`rate()` of the `*_processed_total` counters (they move during generation;
+the per-api totals are step functions that only stamp at request end),
+TTFT/E2E/ITL percentiles from the histograms via `histogram_quantile`, cache
+health from the computed/cached prefill split, and preemptions read as a
+regression alarm -- 0 is the healthy steady state, q27 never preempts.
+
+**Raw:**
+
+```
+curl -s http://127.0.0.1:8080/metrics | grep ^q27_
+```
+
+## Precision notes
+
+- Counters are `unsigned long long` atomics; a scrape can at worst miss one
+  in-flight increment on a single series (self-corrects next poll). No
+  cross-series invariant exists between them, so partial reads are harmless.
+- The MTP lane counters (`gate_lane_fired/acc`) are plain per-engine longs
+  written by decode threads without atomics; reads are approximate-atomic on
+  x86-64 and monotonic, accepted for monitoring (documented at the handler).
+- The histogram seqlock guarantees the `+Inf == _count` invariant and a
+  coherent `sum/count` pair per scrape; it never blocks the decode path
+  (writer critical section: three relaxed atomics).

--- a/src/engine.cuh
+++ b/src/engine.cuh
@@ -685,6 +685,16 @@ struct Engine {
     // Gives the live yields p(acc_j | fired_j) that the two marginals above
     // cannot reconstruct (docs/acceptance-gate-design.md).
     long gate_lane_fired[W_MAX] = {}, gate_lane_acc[W_MAX] = {}; // [j 1..W_MAX-1]; 0 unused
+    // Live token counters (2026-08-30, /metrics): incremented as tokens are
+    // PRODUCED (decode per delivered token in post_round, prefill at the
+    // success exit of generate_prefill), so a scrape sees decode/prefill
+    // progress during generation instead of only at request completion (the
+    // completion-based totals live in GenStats/gs). Unlabeled: the engine
+    // does not know the API shape. Relaxed ordering -- a monotonic counter
+    // for monitoring, stale by at most one poll is fine.
+    std::atomic<unsigned long long> live_decoded{0};
+    std::atomic<unsigned long long> live_prefill_computed{0};
+    std::atomic<unsigned long long> live_prefill_cached{0};
     // Phase 2 (sampling): the sampled set -- identical draft half, sampled
     // (rejection) verify tail. Captured only when the sampler kernels are warm.
     cudaGraphExec_t spec_sample_graph = nullptr;
@@ -4326,7 +4336,10 @@ struct Engine {
                 finish_decode(t, "client-stop");
                 return false;
             }
-            if (!t.round_forced) t.emitted++;
+            if (!t.round_forced) {
+                t.emitted++;
+                live_decoded.fetch_add(1, std::memory_order_relaxed);
+            }
         }
         t.round_forced = false;
         if (!t.sampling && on_pending) on_pending(last_pending);
@@ -4628,6 +4641,12 @@ struct Engine {
         CUDA_CHECK(cudaMemcpyAsync(h_next, x1, N_EMBD * 4, cudaMemcpyDeviceToDevice, stm));
         int P = (int)prompt.size() - 1;
         CUDA_CHECK(cudaMemcpyAsync(d_P, &P, 4, cudaMemcpyHostToDevice, stm));
+        // Live prefill counters: computed = gs.pf (NP - cached base), cached
+        // = gs.hit (prefix restored from snapshot/ckpt/disk). Mirrors the
+        // completion-based split (prompt - hit - pfx / hit + pfx) so the
+        // sparkDash cached/uncached tiles stay live during prefill.
+        live_prefill_computed.fetch_add((unsigned long long)gs.pf, std::memory_order_relaxed);
+        live_prefill_cached.fetch_add((unsigned long long)gs.hit, std::memory_order_relaxed);
         *P_out = P;
         return true;
     }

--- a/src/engine.cuh
+++ b/src/engine.cuh
@@ -4672,8 +4672,9 @@ struct Engine {
         CUDA_CHECK(cudaMemcpyAsync(d_P, &P, 4, cudaMemcpyHostToDevice, stm));
         // Live prefill counters: computed = gs.pf (NP - cached base), cached
         // = gs.hit (prefix restored from snapshot/ckpt/disk). Mirrors the
-        // completion-based split (prompt - hit - pfx / hit + pfx) so the
-        // sparkDash cached/uncached tiles stay live during prefill.
+        // completion-based split (prompt - hit - pfx / hit + pfx) so
+        // consumers of that split see progress during prefill, not only at
+        // request end.
         live_prefill_computed.fetch_add((unsigned long long)gs.pf, std::memory_order_relaxed);
         live_prefill_cached.fetch_add((unsigned long long)gs.hit, std::memory_order_relaxed);
         *P_out = P;

--- a/src/engine.cuh
+++ b/src/engine.cuh
@@ -3141,6 +3141,18 @@ struct Engine {
         for (int k = 0; k < n; k++) emit[k] = oc[1 + k];
         if (sampled) {
             last_pending = oc[6]; // sampled outcome: {n, t1..t5, pending}
+            // Accept-gate telemetry for FUSED sampled rounds (monitoring
+            // only; sampled rounds never feed dctl/EMA -- fixed ceiling 4).
+            if (gate_cap >= 0) {
+                int cap = gate_cap < vw - 1 ? gate_cap : vw - 1; // trim clamp
+                gate_cap_hist[cap]++;
+                gate_n_hist[n]++;
+                if (n <= W_MAX) gate_joint[cap][n]++;
+                for (int j = 1; j <= cap; j++) {
+                    gate_lane_fired[j]++;
+                    if (n >= j + 1) gate_lane_acc[j]++;
+                }
+            }
         } else {
             last_pending = oc[OUTCOME_INTS - 1];
             sfx_valid = true;
@@ -3192,6 +3204,7 @@ struct Engine {
             samp_first = false;
             q27k::sample_g(logits, VOCAB, d_samp, d_nuc, d_pos, 0, d_token, d_amax, stm);
         }
+        int gated_cap = -1; // accept-gate telemetry: set in the gated branches below
         if (pmin_theta > 0.f) {
             // P14 confidence-gated sampled round -- mirror spec_round's gated
             // branch. The sampled tail is 4-draft this phase, so ALWAYS draft
@@ -3224,6 +3237,7 @@ struct Engine {
                 for (int k = launched; k < W && k < md_used; k++)
                     CUDA_CHECK(cudaGraphLaunch(draft_step_graph[k], stm));
                 CUDA_CHECK(cudaGraphLaunch(verify_sample_graph_w[W], stm));
+                gated_cap = cap;
             } else {
                 // Q27_DEXIT=0: monolithic depth-4 gated draft (A/B baseline).
                 cudaGraphExec_t dg = (gate_maxd >= 5) ? draft_graph_lo : draft_graph;
@@ -3236,6 +3250,7 @@ struct Engine {
                 assert(cap <= 4);
                 int W = cap + 1 < 2 ? 2 : cap + 1; // no width-1 gemv; floor at 2
                 CUDA_CHECK(cudaGraphLaunch(verify_sample_graph_w[W], stm));
+                gated_cap = cap;
             }
             // P13 EMA (sat/yield) is NOT updated from sampled rounds this phase
             // (sampled ceiling is fixed at 4); adaptive-maxd applies to greedy only.
@@ -3249,6 +3264,20 @@ struct Engine {
         for (int k = 0; k < n; k++) emit[k] = oc[1 + k];
         last_pending = oc[6];
         fold_pending = n - 1; // M1: folded in post_round (after on_round truncation)
+        // Accept-gate telemetry for sampled rounds (monitoring only; sampled
+        // rounds never feed dctl/EMA -- the sampled ceiling is fixed at 4).
+        // Mirrors the greedy block in spec_round/commit_outcome so the
+        // /metrics spec counters (and the [req] gch/gnh/glf/gla) populate
+        // under sampled traffic too.
+        if (gated_cap >= 0) {
+            gate_cap_hist[gated_cap]++;
+            gate_n_hist[n]++;
+            if (n <= W_MAX) gate_joint[gated_cap][n]++;
+            for (int j = 1; j <= gated_cap; j++) {
+                gate_lane_fired[j]++;
+                if (n >= j + 1) gate_lane_acc[j]++;
+            }
+        }
         return n;
     }
     int last_pending = -1;

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -5,10 +5,11 @@
 // derive rates with rate()/delta()); latency percentiles come from
 // histograms (cumulative buckets, +Inf == count by construction).
 //
-// Naming: q27_* series only, no ds4_/vllm_ compatibility aliases -- the
-// stock sparkDash parser keys on those exact prefixes and will not pick
-// these up; a Prometheus/Grafana setup (or an extended sparkDash parser)
-// is the intended consumer.
+// Naming: q27_* series only, no ds4_/vllm_ compatibility aliases. The
+// semantics are q27's own (computed/cached prefill split, gate-lane MTP
+// accounting, FIFO no-preemption), versioned by this engine; borrowing
+// another project's metric names to reuse its dashboards would couple
+// this wire format to prefixes it does not own and drift against.
 //
 // Thread contract: observe() runs on request threads, render() on the
 // httplib serving thread. Everything shared is std::atomic; histograms
@@ -60,8 +61,8 @@ struct Histogram {
     // Seqlock: even = quiescent, odd = an observe() is mid-update. The
     // reader (render) retries until it reads all fields under an unchanged
     // seq, so one scrape can never see a torn update -- in particular the
-    // +Inf-bucket == count invariant that Prometheus consumers (and the
-    // sparkDash parser) refuse to work without. Writers CAS into the odd
+    // +Inf-bucket == count invariant that Prometheus consumers refuse to
+    // work without. Writers CAS into the odd
     // state; the critical section is three relaxed atomics (nanoseconds),
     // so both the writer spin and the reader retry are negligible.
     std::atomic<long long> seq = 0;
@@ -314,8 +315,8 @@ struct Metrics {
                             "Prefill tokens served from cache (live, cumulative).",
                             g.live_prefill_cached);
         // q27 never preempts: admission is a FIFO queue, so this counter is
-        // honest at 0 (sparkDash's Preempts tile reads it, tooltip: "zero is
-        // normal when the server is comfortable").
+        // honestly 0. Non-zero would mean a code path regressed into
+        // preemption; dashboards should treat 0 as healthy, not missing.
         emit_counter_scalar("q27_preemptions_total",
                             "Cumulative preemptions (q27 never preempts; FIFO queue).", 0);
         emit_gauge("q27_spec_accept_ratio",

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -96,6 +96,11 @@ struct GaugeSnapshot {
     int prefix_cache_entries = -1; // -1 = prefix cache disabled -> omit
     ull spec_draft = 0;            // cumulative MTP lanes fired (engines)
     ull spec_accepted = 0;         // cumulative MTP lanes accepted
+    // Live engine token counters (summed across slots): progress visible
+    // DURING generation, unlike the completion-based per-api counters.
+    ull live_decoded = 0;
+    ull live_prefill_computed = 0;
+    ull live_prefill_cached = 0;
     double uptime_seconds = 0.0;
 };
 
@@ -229,6 +234,19 @@ struct Metrics {
         emit_counter_scalar("q27_spec_accepted_tokens_total",
                             "Cumulative MTP draft lanes accepted (accept gate).",
                             g.spec_accepted);
+        // Live (in-progress) token counters, unlabeled. These move while a
+        // request is generating, so rate()/delta() consumers see real-time
+        // tok/s instead of a completion-time step. At rest they equal the
+        // per-api totals above.
+        emit_counter_scalar("q27_decode_tokens_processed_total",
+                            "Tokens delivered during decode (live, cumulative).",
+                            g.live_decoded);
+        emit_counter_scalar("q27_prefill_computed_tokens_processed_total",
+                            "Prefill tokens computed (live, cumulative).",
+                            g.live_prefill_computed);
+        emit_counter_scalar("q27_prefill_cached_tokens_processed_total",
+                            "Prefill tokens served from cache (live, cumulative).",
+                            g.live_prefill_cached);
         // q27 never preempts: admission is a FIFO queue, so this counter is
         // honest at 0 (sparkDash's Preempts tile reads it, tooltip: "zero is
         // normal when the server is comfortable").

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -1,0 +1,242 @@
+// metrics.h -- q27 Prometheus text-exposition metrics for GET /metrics.
+//
+// One observation per generation request, accumulated where the [req] line
+// fires (gs is final there). Counters are monotonic (Prometheus consumers
+// derive rates with rate()/delta()); latency percentiles come from
+// histograms (cumulative buckets, +Inf == count by construction).
+//
+// Naming: q27_* series only, no ds4_/vllm_ compatibility aliases -- the
+// stock sparkDash parser keys on those exact prefixes and will not pick
+// these up; a Prometheus/Grafana setup (or an extended sparkDash parser)
+// is the intended consumer.
+//
+// Thread contract: observe() runs on request threads, render() on the
+// httplib serving thread. Everything shared is std::atomic; the gauge
+// snapshot (inflight slots, KV pool, spec counters) is assembled by the
+// caller under the server's route_m.
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+namespace q27 {
+namespace metrics {
+
+using ull = unsigned long long;
+
+// API-shape label. Internal rt.api spellings (oai/cmpl/anth/resp) map to
+// the public names below via api_from_str.
+enum Api : int { ApiChat = 0, ApiCompletions, ApiMessages, ApiResponses, ApiCount };
+constexpr const char* kApiNames[ApiCount] = {"chat", "completions", "messages",
+                                             "responses"};
+
+inline Api api_from_str(const char* s) {
+    if (!s) return ApiChat;
+    if (!std::strcmp(s, "oai")) return ApiChat;
+    if (!std::strcmp(s, "cmpl")) return ApiCompletions;
+    if (!std::strcmp(s, "anth")) return ApiMessages;
+    if (!std::strcmp(s, "resp")) return ApiResponses;
+    return ApiChat;
+}
+
+// Histogram with fixed finite bucket edges (seconds, ascending) and an
+// implicit +Inf bucket. observe() bumps the first bucket whose le covers
+// the value; render accumulates buckets into the cumulative form Prometheus
+// expects. count is incremented per observation, sum as integer microseconds
+// (no floating-point atomics).
+struct Histogram {
+    static constexpr int kMaxBuckets = 12;
+    const double* edges = nullptr; // finite upper bounds, seconds, sorted
+    int n = 0;                     // count of finite edges; bucket[n] = +Inf
+    std::atomic<ull> bucket[kMaxBuckets] = {};
+    std::atomic<ull> count = 0;
+    std::atomic<long long> sum_us = 0;
+
+    void init(const double* e, int n_) { edges = e; n = n_; }
+
+    void observe(double seconds) {
+        if (!(seconds >= 0.0)) seconds = 0.0;
+        int i = 0;
+        while (i < n && seconds > edges[i]) i++;
+        if (i >= kMaxBuckets) i = kMaxBuckets - 1; // belt: never OOB
+        bucket[i]++;
+        count++;
+        sum_us += (long long)std::llround(seconds * 1e6);
+    }
+};
+
+// Bucket edges per histogram family (seconds).
+static constexpr double kTtftEdgesS[] = {0.010, 0.050, 0.100, 0.250, 0.500,
+                                        1.0,   2.5,   5.0}; // prefill wall
+static constexpr double kE2eEdgesS[] = {0.100, 0.250, 0.500, 1.0, 2.5, 5.0,
+                                        10.0,  30.0,  60.0}; // arrival -> gen done
+static constexpr double kItlEdgesS[] = {0.001, 0.002, 0.003, 0.004, 0.005, 0.008,
+                                        0.010, 0.015}; // dec_ms / dec per request
+
+// Cumulative per-api counters (ull sums; queue wait stored as microseconds).
+struct Counters {
+    std::atomic<ull> requests[ApiCount] = {};
+    std::atomic<ull> errors[ApiCount] = {};
+    std::atomic<ull> prompt_tokens[ApiCount] = {};
+    std::atomic<ull> prefill_computed[ApiCount] = {};
+    std::atomic<ull> prefill_cached[ApiCount] = {};
+    std::atomic<ull> decode_tokens[ApiCount] = {};
+    std::atomic<ull> queue_wait_us[ApiCount] = {};
+};
+
+// Server-state gauges, assembled by the /metrics handler under route_m.
+struct GaugeSnapshot {
+    int requests_inflight = 0;     // slots currently claimed (busy)
+    int slots_total = 0;
+    double kv_usage_perc = -1.0;   // -1 = KV pool inactive -> omit series
+    int prefix_cache_entries = -1; // -1 = prefix cache disabled -> omit
+    ull spec_draft = 0;            // cumulative MTP lanes fired (engines)
+    ull spec_accepted = 0;         // cumulative MTP lanes accepted
+    double uptime_seconds = 0.0;
+};
+
+struct Metrics {
+    Counters counters;
+    Histogram ttft[ApiCount]; // prefill wall -> first token
+    Histogram e2e[ApiCount];  // arrival -> generation complete
+    Histogram itl[ApiCount];  // per-request mean inter-token latency
+
+    Metrics() {
+        for (int a = 0; a < ApiCount; a++) {
+            ttft[a].init(kTtftEdgesS, (int)(sizeof kTtftEdgesS / sizeof kTtftEdgesS[0]));
+            e2e[a].init(kE2eEdgesS, (int)(sizeof kE2eEdgesS / sizeof kE2eEdgesS[0]));
+            itl[a].init(kItlEdgesS, (int)(sizeof kItlEdgesS / sizeof kItlEdgesS[0]));
+        }
+    }
+
+    // One call per generation request, at the [req] point. e2e_ms is wall
+    // from request arrival to the observation point.
+    void observe(Api api, bool is_error, int prompt, int hit, int pfx, int dec,
+                 double qw_ms, double pf_ms, double e2e_ms, double dec_ms) {
+        if (api < 0 || api >= ApiCount) api = ApiChat;
+        if (prompt < 0) prompt = 0;
+        if (hit < 0) hit = 0;
+        if (pfx < 0) pfx = 0;
+        if (dec < 0) dec = 0;
+        if (qw_ms < 0.0) qw_ms = 0.0;
+        if (pf_ms < 0.0) pf_ms = 0.0;
+        if (e2e_ms < 0.0) e2e_ms = 0.0;
+        if (dec_ms < 0.0) dec_ms = 0.0;
+        counters.requests[api]++;
+        if (is_error) counters.errors[api]++;
+        counters.prompt_tokens[api] += (ull)prompt;
+        counters.prefill_computed[api] += (ull)std::max(0, prompt - hit - pfx);
+        counters.prefill_cached[api] += (ull)(hit + pfx);
+        counters.decode_tokens[api] += (ull)dec;
+        counters.queue_wait_us[api] += (ull)std::llround(qw_ms * 1000.0);
+        ttft[api].observe(pf_ms / 1000.0);
+        e2e[api].observe(e2e_ms / 1000.0);
+        itl[api].observe(dec > 0 ? dec_ms / (1000.0 * dec) : 0.0);
+    }
+
+    std::string render(const GaugeSnapshot& g) const {
+        std::string s;
+        char buf[512];
+
+        auto emit_counter = [&](const char* name, const char* help, const std::atomic<ull>* v,
+                                double scale = 1.0) {
+            snprintf(buf, sizeof buf, "# HELP %s %s\n# TYPE %s counter\n", name, help, name);
+            s += buf;
+            for (int a = 0; a < ApiCount; a++) {
+                const double val = (double)v[a].load() * scale;
+                if (scale == 1.0)
+                    snprintf(buf, sizeof buf, "%s{api=\"%s\"} %llu\n", name, kApiNames[a],
+                             (ull)val);
+                else
+                    snprintf(buf, sizeof buf, "%s{api=\"%s\"} %g\n", name, kApiNames[a],
+                             val);
+                s += buf;
+            }
+        };
+        auto emit_gauge = [&](const char* name, const char* help, double v) {
+            snprintf(buf, sizeof buf, "# HELP %s %s\n# TYPE %s gauge\n%s %g\n", name, help,
+                     name, name, v);
+            s += buf;
+        };
+        auto emit_counter_scalar = [&](const char* name, const char* help, ull v) {
+            snprintf(buf, sizeof buf, "# HELP %s %s\n# TYPE %s counter\n%s %llu\n", name,
+                     help, name, name, v);
+            s += buf;
+        };
+
+        emit_counter("q27_requests_total", "Generation requests ([req] universe).",
+                     counters.requests);
+        emit_counter("q27_requests_errors_total", "Generation requests ending end=error.",
+                     counters.errors);
+        emit_counter("q27_prompt_tokens_total", "Prompt tokens sent to prefill (incl. cached).",
+                     counters.prompt_tokens);
+        emit_counter("q27_prefill_computed_tokens_total",
+                     "Prompt tokens actually computed (not served from prefix cache).",
+                     counters.prefill_computed);
+        emit_counter("q27_prefill_cached_tokens_total",
+                     "Prompt tokens served from the prefix cache (RAM or disk).",
+                     counters.prefill_cached);
+        emit_counter("q27_decode_tokens_total", "Generated tokens delivered.",
+                     counters.decode_tokens);
+        emit_counter("q27_queue_wait_seconds_total",
+                     "Sum of queue wait (slot claim) across requests.", counters.queue_wait_us,
+                     1e-6);
+
+        auto emit_histogram = [&](const char* name, const char* help, const Histogram* h) {
+            snprintf(buf, sizeof buf, "# HELP %s %s\n# TYPE %s histogram\n", name, help, name);
+            s += buf;
+            for (int a = 0; a < ApiCount; a++) {
+                const Histogram& hh = h[a];
+                ull cum = 0;
+                for (int i = 0; i < hh.n; i++) {
+                    cum += hh.bucket[i].load();
+                    snprintf(buf, sizeof buf, "%s_bucket{api=\"%s\",le=\"%.3f\"} %llu\n", name,
+                             kApiNames[a], hh.edges[i], cum);
+                    s += buf;
+                }
+                cum += hh.bucket[hh.n].load();
+                snprintf(buf, sizeof buf, "%s_bucket{api=\"%s\",le=\"+Inf\"} %llu\n", name,
+                         kApiNames[a], cum);
+                s += buf;
+                snprintf(buf, sizeof buf, "%s_sum{api=\"%s\"} %g\n%s_count{api=\"%s\"} %llu\n",
+                         name, kApiNames[a], (double)hh.sum_us.load() / 1e6, name,
+                         kApiNames[a], hh.count.load());
+                s += buf;
+            }
+        };
+
+        emit_histogram("q27_ttft_seconds",
+                       "Pre-fill wall per request (first-token latency proxy).", ttft);
+        emit_histogram("q27_e2e_seconds",
+                       "Wall from request arrival to generation complete.", e2e);
+        emit_histogram("q27_itl_seconds",
+                       "Per-request mean inter-token latency (dec_ms / dec).", itl);
+
+        emit_gauge("q27_requests_inflight", "Slots currently claimed by a generation.",
+                   g.requests_inflight);
+        emit_gauge("q27_slots_total", "Configured serving slots.", g.slots_total);
+        if (g.kv_usage_perc >= 0.0)
+            emit_gauge("q27_kv_usage_perc", "Paged KV pool occupancy (0-1).", g.kv_usage_perc);
+        if (g.prefix_cache_entries >= 0)
+            emit_gauge("q27_prefix_cache_entries", "Persistent prefix cache entries.",
+                       g.prefix_cache_entries);
+        emit_counter_scalar("q27_spec_draft_tokens_total",
+                            "Cumulative MTP draft lanes fired (accept gate).", g.spec_draft);
+        emit_counter_scalar("q27_spec_accepted_tokens_total",
+                            "Cumulative MTP draft lanes accepted (accept gate).",
+                            g.spec_accepted);
+        emit_gauge("q27_spec_accept_ratio",
+                   "Cumulative MTP accept ratio (accepted / drafted).",
+                   g.spec_draft > 0 ? (double)g.spec_accepted / (double)g.spec_draft : 0.0);
+        emit_gauge("q27_uptime_seconds", "Server uptime.", g.uptime_seconds);
+
+        return s;
+    }
+};
+
+} // namespace metrics
+} // namespace q27

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -229,6 +229,11 @@ struct Metrics {
         emit_counter_scalar("q27_spec_accepted_tokens_total",
                             "Cumulative MTP draft lanes accepted (accept gate).",
                             g.spec_accepted);
+        // q27 never preempts: admission is a FIFO queue, so this counter is
+        // honest at 0 (sparkDash's Preempts tile reads it, tooltip: "zero is
+        // normal when the server is comfortable").
+        emit_counter_scalar("q27_preemptions_total",
+                            "Cumulative preemptions (q27 never preempts; FIFO queue).", 0);
         emit_gauge("q27_spec_accept_ratio",
                    "Cumulative MTP accept ratio (accepted / drafted).",
                    g.spec_draft > 0 ? (double)g.spec_accepted / (double)g.spec_draft : 0.0);

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -11,9 +11,11 @@
 // is the intended consumer.
 //
 // Thread contract: observe() runs on request threads, render() on the
-// httplib serving thread. Everything shared is std::atomic; the gauge
-// snapshot (inflight slots, KV pool, spec counters) is assembled by the
-// caller under the server's route_m.
+// httplib serving thread. Everything shared is std::atomic; histograms
+// add a seqlock (observe CAS-in/release, render retries on a torn read)
+// so one scrape is always internally consistent (+Inf == count). The
+// gauge snapshot (inflight slots, KV pool, spec counters) is assembled
+// by the caller under the server's route_m.
 #pragma once
 
 #include <algorithm>
@@ -55,6 +57,14 @@ struct Histogram {
     std::atomic<ull> bucket[kMaxBuckets] = {};
     std::atomic<ull> count = 0;
     std::atomic<long long> sum_us = 0;
+    // Seqlock: even = quiescent, odd = an observe() is mid-update. The
+    // reader (render) retries until it reads all fields under an unchanged
+    // seq, so one scrape can never see a torn update -- in particular the
+    // +Inf-bucket == count invariant that Prometheus consumers (and the
+    // sparkDash parser) refuse to work without. Writers CAS into the odd
+    // state; the critical section is three relaxed atomics (nanoseconds),
+    // so both the writer spin and the reader retry are negligible.
+    std::atomic<long long> seq = 0;
 
     void init(const double* e, int n_) { edges = e; n = n_; }
 
@@ -63,19 +73,57 @@ struct Histogram {
         int i = 0;
         while (i < n && seconds > edges[i]) i++;
         if (i >= kMaxBuckets) i = kMaxBuckets - 1; // belt: never OOB
-        bucket[i]++;
-        count++;
-        sum_us += (long long)std::llround(seconds * 1e6);
+        const long long us = std::llround(seconds * 1e6);
+        for (;;) {
+            long long s = seq.load(std::memory_order_acquire);
+            if (s & 1) continue; // another observe() in flight
+            if (seq.compare_exchange_weak(s, s + 1, std::memory_order_acquire))
+                break;
+        }
+        bucket[i].fetch_add(1, std::memory_order_relaxed);
+        count.fetch_add(1, std::memory_order_relaxed);
+        sum_us.fetch_add(us, std::memory_order_relaxed);
+        seq.fetch_add(1, std::memory_order_release); // even: quiescent
+    }
+
+    // Read all fields under a stable seq and hand them to apply(). Retries
+    // up to 3 times on a torn read; if still torn, falls through to a
+    // best-effort read (one poll shows a null quantile, the next heals --
+    // never wrong data).
+    template <typename F>
+    bool snapshot(F&& apply) const {
+        for (int attempt = 0; attempt < 3; attempt++) {
+            const long long s1 = seq.load(std::memory_order_acquire);
+            if (s1 & 1) continue; // in flight: retry
+            ull b[kMaxBuckets] = {};
+            for (int i = 0; i < kMaxBuckets; i++)
+                b[i] = bucket[i].load(std::memory_order_relaxed);
+            const ull c = count.load(std::memory_order_relaxed);
+            const long long s = sum_us.load(std::memory_order_relaxed);
+            if (seq.load(std::memory_order_acquire) == s1) {
+                apply(b, c, s);
+                return true;
+            }
+        }
+        ull b[kMaxBuckets] = {};
+        for (int i = 0; i < kMaxBuckets; i++) b[i] = bucket[i].load(std::memory_order_relaxed);
+        const ull c = count.load(std::memory_order_relaxed);
+        const long long s = sum_us.load(std::memory_order_relaxed);
+        apply(b, c, s);
+        return false;
     }
 };
 
-// Bucket edges per histogram family (seconds).
-static constexpr double kTtftEdgesS[] = {0.010, 0.050, 0.100, 0.250, 0.500,
-                                        1.0,   2.5,   5.0}; // prefill wall
-static constexpr double kE2eEdgesS[] = {0.100, 0.250, 0.500, 1.0, 2.5, 5.0,
-                                        10.0,  30.0,  60.0}; // arrival -> gen done
+// Bucket edges per histogram family (seconds). The tails (TTFT to 60 s, E2E
+// to 300 s, ITL to 100 ms) cover extreme-but-real observations -- e.g. a
+// 60k-token prefill taking ~25 s -- so p95 stays inside finite buckets
+// instead of landing in the +Inf tail (which consumers report as "no data").
+static constexpr double kTtftEdgesS[] = {0.010, 0.050, 0.100, 0.250, 0.500, 1.0, 2.5,
+                                         5.0,  10.0,  30.0,  60.0}; // prefill wall
+static constexpr double kE2eEdgesS[] = {0.100, 0.250, 0.500, 1.0, 2.5, 5.0,  10.0, 30.0,
+                                        60.0,  300.0};               // arrival -> gen done
 static constexpr double kItlEdgesS[] = {0.001, 0.002, 0.003, 0.004, 0.005, 0.008,
-                                        0.010, 0.015}; // dec_ms / dec per request
+                                        0.010, 0.015, 0.020, 0.050, 0.100}; // dec_ms / dec per request
 
 // Cumulative per-api counters (ull sums; queue wait stored as microseconds).
 struct Counters {
@@ -157,7 +205,12 @@ struct Metrics {
                     snprintf(buf, sizeof buf, "%s{api=\"%s\"} %llu\n", name, kApiNames[a],
                              (ull)val);
                 else
-                    snprintf(buf, sizeof buf, "%s{api=\"%s\"} %g\n", name, kApiNames[a],
+                    // %.6f (not %g): keeps microsecond resolution in seconds.
+                    // %g = 6 significant digits would round away microsecond
+                    // deltas once the total passes ~10 s, corrupting rate()
+                    // on long-running servers (queue wait is the only scaled
+                    // counter today; the total reaches 1e6 s only at ~11 days).
+                    snprintf(buf, sizeof buf, "%s{api=\"%s\"} %.6f\n", name, kApiNames[a],
                              val);
                 s += buf;
             }
@@ -196,21 +249,25 @@ struct Metrics {
             s += buf;
             for (int a = 0; a < ApiCount; a++) {
                 const Histogram& hh = h[a];
-                ull cum = 0;
-                for (int i = 0; i < hh.n; i++) {
-                    cum += hh.bucket[i].load();
-                    snprintf(buf, sizeof buf, "%s_bucket{api=\"%s\",le=\"%.3f\"} %llu\n", name,
-                             kApiNames[a], hh.edges[i], cum);
+                // Seqlock snapshot: the emitted +Inf/count pair is always
+                // from one quiescent moment (see Histogram::snapshot).
+                hh.snapshot([&](const ull* b, ull c, long long s_us) {
+                    ull cum = 0;
+                    for (int i = 0; i < hh.n; i++) {
+                        cum += b[i];
+                        snprintf(buf, sizeof buf, "%s_bucket{api=\"%s\",le=\"%.3f\"} %llu\n",
+                                 name, kApiNames[a], hh.edges[i], cum);
+                        s += buf;
+                    }
+                    cum += b[hh.n];
+                    snprintf(buf, sizeof buf, "%s_bucket{api=\"%s\",le=\"+Inf\"} %llu\n", name,
+                             kApiNames[a], cum);
                     s += buf;
-                }
-                cum += hh.bucket[hh.n].load();
-                snprintf(buf, sizeof buf, "%s_bucket{api=\"%s\",le=\"+Inf\"} %llu\n", name,
-                         kApiNames[a], cum);
-                s += buf;
-                snprintf(buf, sizeof buf, "%s_sum{api=\"%s\"} %g\n%s_count{api=\"%s\"} %llu\n",
-                         name, kApiNames[a], (double)hh.sum_us.load() / 1e6, name,
-                         kApiNames[a], hh.count.load());
-                s += buf;
+                    snprintf(buf, sizeof buf, "%s_sum{api=\"%s\"} %g\n%s_count{api=\"%s\"} %llu\n",
+                             name, kApiNames[a], (double)s_us / 1e6, name,
+                             kApiNames[a], c);
+                    s += buf;
+                });
             }
         };
 

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -100,6 +100,10 @@ struct Histogram {
                 b[i] = bucket[i].load(std::memory_order_relaxed);
             const ull c = count.load(std::memory_order_relaxed);
             const long long s = sum_us.load(std::memory_order_relaxed);
+            // Acquire fence between the data reads and the re-check: on a
+            // weakly-ordered host it keeps the relaxed data loads from
+            // sliding past the closing seq read (no-op on x86).
+            std::atomic_thread_fence(std::memory_order_acquire);
             if (seq.load(std::memory_order_acquire) == s1) {
                 apply(b, c, s);
                 return true;
@@ -188,7 +192,8 @@ struct Metrics {
         counters.queue_wait_us[api] += (ull)std::llround(qw_ms * 1000.0);
         ttft[api].observe(pf_ms / 1000.0);
         e2e[api].observe(e2e_ms / 1000.0);
-        itl[api].observe(dec > 0 ? dec_ms / (1000.0 * dec) : 0.0);
+        if (dec > 0) // zero-decode requests (refused/aborted) have no ITL
+            itl[api].observe(dec_ms / (1000.0 * dec));
     }
 
     std::string render(const GaugeSnapshot& g) const {
@@ -263,7 +268,11 @@ struct Metrics {
                     snprintf(buf, sizeof buf, "%s_bucket{api=\"%s\",le=\"+Inf\"} %llu\n", name,
                              kApiNames[a], cum);
                     s += buf;
-                    snprintf(buf, sizeof buf, "%s_sum{api=\"%s\"} %g\n%s_count{api=\"%s\"} %llu\n",
+                    // %.6f, not %g: the sum grows unboundedly, and 6
+                    // significant digits would round away small deltas at
+                    // large totals (same rationale as queue_wait above).
+                    snprintf(buf, sizeof buf,
+                             "%s_sum{api=\"%s\"} %.6f\n%s_count{api=\"%s\"} %llu\n",
                              name, kApiNames[a], (double)s_us / 1e6, name,
                              kApiNames[a], c);
                     s += buf;

--- a/src/server.cu
+++ b/src/server.cu
@@ -35,6 +35,7 @@
 #include "tokenizer.h"
 #include "api_common.h"
 #include "conductor.h"
+#include "metrics.h"
 #include "toolgram.h"
 #include "toolconstrain.h"
 #include "../third_party/httplib.h"
@@ -293,7 +294,7 @@ int main(int argc, char** argv) {
                 "  Any configured key is accepted via 'Authorization: Bearer <key>'\n"
                 "  (OpenAI/llama.cpp convention) or 'x-api-key: <key>' (Anthropic\n"
                 "  convention, what Claude Code sends) on every endpoint except\n"
-                "  /health.\n"
+                "  /health and /metrics (both are infra-reachable by design).\n"
                 "  Multi-slot memory (defaults ON, both revert with =0):\n"
                 "  Q27_KV_POOL -- process-wide paged KV pool; Q27_PF_ARENA --\n"
                 "  one shared prefill scratch arena instead of ~0.75 GB per slot\n"
@@ -1264,6 +1265,10 @@ int main(int argc, char** argv) {
             no_interleave ? "OFF (Q27_NO_INTERLEAVE)" : "round-granularity");
     std::atomic<long> req_counter{0};
 
+    // Prometheus text metrics (GET /metrics, q27_* series only). Accumulated
+    // per request where the [req] line fires; gauges assembled under route_m.
+    q27::metrics::Metrics g_metrics;
+
     // R0 telemetry: one [req] stderr line per generation request, self-contained
     // so real-work anatomy (queue wait, tokenize, prefill reuse, decode, client
     // write time, conversation interleave) is measurable from the log alone.
@@ -1420,6 +1425,12 @@ int main(int argc, char** argv) {
                 // feature is off (same rule as the md/gch/ph optionals above).
                 g.pfx > 0 ? (snprintf(pfxbuf, sizeof pfxbuf, " pfx=%d", g.pfx), pfxbuf) : "",
                 phbuf, sfxbuf, extra.c_str());
+        // Prometheus metrics: accumulate this request at the [req] point,
+        // where gs is final (end=error included -- it lands in this line).
+        // E2E is wall from request arrival (rt.t0 - tok_ms) to here.
+        g_metrics.observe(q27::metrics::api_from_str(rt.api),
+                          g.end && !std::strcmp(g.end, "error"), g.prompt, g.hit, g.pfx,
+                          g.dec, qw_ms, g.pf_ms, rt.tok_ms + ms_since(rt.t0), g.dec_ms);
     };
     // R1b routing: claim a FREE engine (Slot::busy=false) that can take the
     // prompt, or block until one frees. Tiers among free engines unchanged
@@ -1797,15 +1808,18 @@ int main(int argc, char** argv) {
 
     // Opt-in API key auth (no-op, zero overhead beyond one empty-vector
     // check per request, when api_keys is empty -- the loopback-only
-    // default is unchanged). /health is intentionally exempt: infra health
-    // checks (load balancers, container orchestrators) need it reachable
-    // without distributing the secret to that infrastructure. Every other
-    // endpoint requires a valid key. Runs before route dispatch, so an
-    // invalid/missing key never reaches slot allocation, tokenization, or
-    // any generation work.
+    // default is unchanged). /health and /metrics are intentionally exempt:
+    // infra health checks (load balancers, container orchestrators) need
+    // /health reachable without distributing the secret to that
+    // infrastructure, and sparkDash-style pollers scrape /metrics without
+    // credentials (a 401/403 would mark the backend "protected" and show
+    // nothing). Every other endpoint requires a valid key. Runs before route
+    // dispatch, so an invalid/missing key never reaches slot allocation,
+    // tokenization, or any generation work.
     if (!api_keys.empty()) {
         srv.set_pre_routing_handler([&](const httplib::Request& req, httplib::Response& res) {
             if (req.path == "/health") return httplib::Server::HandlerResponse::Unhandled;
+            if (req.path == "/metrics") return httplib::Server::HandlerResponse::Unhandled;
             std::string provided = q27::extract_api_key(req.get_header_value("Authorization"),
                                                          req.get_header_value("x-api-key"));
             if (q27::api_key_valid(provided, api_keys))
@@ -1846,6 +1860,40 @@ int main(int argc, char** argv) {
                   {"data", json::array({{{"id", served_name}, {"object", "model"},
                                          {"owned_by", "q27"}}})}};
         res.set_content(j.dump(), "application/json");
+    });
+
+    // Prometheus text exposition (no Prometheus server required -- scrapers
+    // hit this directly). Auth-exempt like /health (see the pre-routing
+    // comment). Gauges that read engine/server state are snapshotted under
+    // route_m: slot busy flags and the KV pool mutate there, so the brief
+    // critical section keeps the picture coherent. Spec lane counters
+    // (gate_lane_fired/acc) are plain longs written by decode threads
+    // without atomics -- reads here are approximately atomic on x86-64 and
+    // monotonic, so a scrape can at worst see a marginally stale value
+    // (documented, accepted for monitoring).
+    srv.Get("/metrics", [&](const httplib::Request&, httplib::Response& res) {
+        q27::metrics::GaugeSnapshot g;
+        g.uptime_seconds = ms_since(srv_t0) / 1000.0;
+        g.slots_total = n_slots;
+        {
+            std::lock_guard<std::mutex> lk(route_m);
+            for (const auto& s : slots)
+                if (s.busy) g.requests_inflight++;
+            if (kv_pool.enabled()) {
+                const long free = kv_pool.free_pages(0) + kv_pool.free_pages(1);
+                const long total = kv_pool.npages[0] + kv_pool.npages[1];
+                g.kv_usage_perc = total > 0 ? 1.0 - (double)free / (double)total : 0.0;
+            }
+            for (const auto& s : slots) {
+                const Engine& e = *s.eng;
+                for (int j = 1; j < Q27_W_MAX; j++) {
+                    g.spec_draft += (q27::metrics::ull)e.gate_lane_fired[j];
+                    g.spec_accepted += (q27::metrics::ull)e.gate_lane_acc[j];
+                }
+            }
+        }
+        if (pfx_cache.enabled()) g.prefix_cache_entries = (int)pfx_cache.size();
+        res.set_content(g_metrics.render(g), "text/plain; version=0.0.4");
     });
 
     // ---------------- OpenAI chat/completions ----------------

--- a/src/server.cu
+++ b/src/server.cu
@@ -1816,9 +1816,9 @@ int main(int argc, char** argv) {
     // default is unchanged). /health and /metrics are intentionally exempt:
     // infra health checks (load balancers, container orchestrators) need
     // /health reachable without distributing the secret to that
-    // infrastructure, and sparkDash-style pollers scrape /metrics without
-    // credentials (a 401/403 would mark the backend "protected" and show
-    // nothing). Every other endpoint requires a valid key. Runs before route
+    // infrastructure, and monitoring pollers scrape /metrics without
+    // credentials (an auth wall here would break every unauthenticated
+    // scraper). Every other endpoint requires a valid key. Runs before route
     // dispatch, so an invalid/missing key never reaches slot allocation,
     // tokenization, or any generation work.
     if (!api_keys.empty()) {

--- a/src/server.cu
+++ b/src/server.cu
@@ -1892,6 +1892,12 @@ int main(int argc, char** argv) {
                     g.spec_draft += (q27::metrics::ull)e.gate_lane_fired[j];
                     g.spec_accepted += (q27::metrics::ull)e.gate_lane_acc[j];
                 }
+                // Live engine counters (atomics, relaxed reads -- monotonic).
+                g.live_decoded += e.live_decoded.load(std::memory_order_relaxed);
+                g.live_prefill_computed +=
+                    e.live_prefill_computed.load(std::memory_order_relaxed);
+                g.live_prefill_cached +=
+                    e.live_prefill_cached.load(std::memory_order_relaxed);
             }
         }
         if (pfx_cache.enabled()) g.prefix_cache_entries = (int)pfx_cache.size();

--- a/src/server.cu
+++ b/src/server.cu
@@ -294,7 +294,8 @@ int main(int argc, char** argv) {
                 "  Any configured key is accepted via 'Authorization: Bearer <key>'\n"
                 "  (OpenAI/llama.cpp convention) or 'x-api-key: <key>' (Anthropic\n"
                 "  convention, what Claude Code sends) on every endpoint except\n"
-                "  /health and /metrics (both are infra-reachable by design).\n"
+                "  /health and /metrics (both are infra-reachable by design;\n"
+                "  /metrics is opt-in via --enable-metrics, default off).\n"
                 "  Multi-slot memory (defaults ON, both revert with =0):\n"
                 "  Q27_KV_POOL -- process-wide paged KV pool; Q27_PF_ARENA --\n"
                 "  one shared prefill scratch arena instead of ~0.75 GB per slot\n"
@@ -334,6 +335,7 @@ int main(int argc, char** argv) {
     bool kv_fp16 = false;
     bool constrain_tools = false;
     bool req_think = false; // --request-think: honor per-request thinking fields (else ignored)
+    bool enable_metrics = false; // --enable-metrics: expose GET /metrics (Prometheus, opt-in)
     // --think-budget: cap on tokens generated inside a <think> block. <0
     // (default) = THINK_BUDGET_FRAC for prompt-seeded thinking only, preserving
     // speculative width on ordinary no-think requests; 0 = unbounded; >0 = an
@@ -367,6 +369,7 @@ int main(int argc, char** argv) {
         else if (!strcmp(argv[i], "--top-k") && i + 1 < argc) g_default_top_k = atoi(argv[++i]);
         else if (!strcmp(argv[i], "--min-p") && i + 1 < argc) g_default_min_p = atof(argv[++i]);
         else if (!strcmp(argv[i], "--constrain-tools")) constrain_tools = true;
+        else if (!strcmp(argv[i], "--enable-metrics")) enable_metrics = true;
         else if (!strcmp(argv[i], "--kv-fp16")) kv_fp16 = true;
         // P16 persistent prefix cache (opt-in: it writes to the user's disk)
         else if (!strcmp(argv[i], "--prefix-cache") && i + 1 < argc) pfx_cfg.root = argv[++i];
@@ -1265,8 +1268,9 @@ int main(int argc, char** argv) {
             no_interleave ? "OFF (Q27_NO_INTERLEAVE)" : "round-granularity");
     std::atomic<long> req_counter{0};
 
-    // Prometheus text metrics (GET /metrics, q27_* series only). Accumulated
-    // per request where the [req] line fires; gauges assembled under route_m.
+    // Prometheus text metrics (GET /metrics when --enable-metrics, q27_*
+    // series only). Accumulated per request where the [req] line fires
+    // (no-op while disabled); gauges assembled under route_m.
     q27::metrics::Metrics g_metrics;
 
     // R0 telemetry: one [req] stderr line per generation request, self-contained
@@ -1428,9 +1432,10 @@ int main(int argc, char** argv) {
         // Prometheus metrics: accumulate this request at the [req] point,
         // where gs is final (end=error included -- it lands in this line).
         // E2E is wall from request arrival (rt.t0 - tok_ms) to here.
-        g_metrics.observe(q27::metrics::api_from_str(rt.api),
-                          g.end && !std::strcmp(g.end, "error"), g.prompt, g.hit, g.pfx,
-                          g.dec, qw_ms, g.pf_ms, rt.tok_ms + ms_since(rt.t0), g.dec_ms);
+        if (enable_metrics) // --enable-metrics: skip all metric bookkeeping
+            g_metrics.observe(q27::metrics::api_from_str(rt.api),
+                              g.end && !std::strcmp(g.end, "error"), g.prompt, g.hit, g.pfx,
+                              g.dec, qw_ms, g.pf_ms, rt.tok_ms + ms_since(rt.t0), g.dec_ms);
     };
     // R1b routing: claim a FREE engine (Slot::busy=false) that can take the
     // prompt, or block until one frees. Tiers among free engines unchanged
@@ -1864,8 +1869,9 @@ int main(int argc, char** argv) {
         res.set_content(j.dump(), "application/json");
     });
 
-    // Prometheus text exposition (no Prometheus server required -- scrapers
-    // hit this directly). Auth-exempt like /health (see the pre-routing
+    // Prometheus text exposition, registered only with --enable-metrics
+    // (no Prometheus server required -- scrapers hit this directly).
+    // Auth-exempt like /health (see the pre-routing
     // comment). Gauges that read engine/server state are snapshotted under
     // route_m: slot busy flags and the KV pool mutate there, so the brief
     // critical section keeps the picture coherent. Spec lane counters
@@ -1873,6 +1879,7 @@ int main(int argc, char** argv) {
     // without atomics -- reads here are approximately atomic on x86-64 and
     // monotonic, so a scrape can at worst see a marginally stale value
     // (documented, accepted for monitoring).
+    if (enable_metrics)
     srv.Get("/metrics", [&](const httplib::Request&, httplib::Response& res) {
         q27::metrics::GaugeSnapshot g;
         g.uptime_seconds = ms_since(srv_t0) / 1000.0;

--- a/src/server.cu
+++ b/src/server.cu
@@ -1857,8 +1857,10 @@ int main(int argc, char** argv) {
 
     srv.Get("/v1/models", [&](const httplib::Request&, httplib::Response& res) {
         json j = {{"object", "list"},
-                  {"data", json::array({{{"id", served_name}, {"object", "model"},
-                                         {"owned_by", "q27"}}})}};
+                  {"data", json::array({{{"id", served_name},
+                                         {"object", "model"},
+                                         {"owned_by", "q27"},
+                                         {"max_model_len", max_slot_ctx}}})}};
         res.set_content(j.dump(), "application/json");
     });
 


### PR DESCRIPTION
## What

A Prometheus text-exposition `GET /metrics` for the server, opt-in behind a
new `--enable-metrics` flag (default off), plus the telemetry plumbing it
needs: `src/metrics.h` (new), accumulation in the engine, and a `/v1/models`
context-length field. Full series reference and consumer recipes in
[docs/metrics-endpoint.md](docs/metrics-endpoint.md).

**Posture.** Without the flag the handler is never registered (`/metrics`
404s; `/health` untouched) and the per-request bookkeeping is skipped
entirely -- a deployment that does not want metrics keeps the zero-overhead
shape. With the flag the route is auth-exempt like `/health`: monitoring
pollers scrape without credentials, and an auth wall here would break every
unauthenticated scraper. The endpoint carries metadata-scale telemetry only
-- counts, latencies, occupancy, uptime -- never prompt text or generated
content (dispositioned in the SECURITY-MODEL addendum of 2026-08-30).

## The series

Per-API label `api=` (`chat` / `completions` / `messages` / `responses`):

| Series | Type | Meaning |
|---|---|---|
| `q27_requests_total` / `q27_requests_errors_total` | counter | Generation requests ([req] universe); `end=error` included |
| `q27_prompt_tokens_total` | counter | Prompt tokens sent to prefill (incl. cached) |
| `q27_prefill_computed_tokens_total` | counter | Prompt tokens actually computed |
| `q27_prefill_cached_tokens_total` | counter | Prompt tokens served from cache (RAM/ckpt/disk) |
| `q27_decode_tokens_total` | counter | Generated tokens delivered |
| `q27_queue_wait_seconds_total` | counter | Sum of slot-claim wait (µs resolution) |
| `q27_ttft_seconds` / `q27_e2e_seconds` / `q27_itl_seconds` | histogram | Prefill wall; arrival -> generation complete; per-request mean ITL |
| `q27_requests_inflight` / `q27_slots_total` | gauge | Slots claimed / configured |
| `q27_kv_usage_perc` / `q27_prefix_cache_entries` | gauge | Pool occupancy (0-1); cache entries (omitted when off) |
| `q27_spec_draft_tokens_total` / `q27_spec_accepted_tokens_total` / `q27_spec_accept_ratio` | counter/gauge | MTP accept-gate lanes and cumulative ratio |
| `q27_decode_tokens_processed_total` (+ prefill computed/cached) | counter | **Live** token counters, unlabeled |
| `q27_preemptions_total` | counter | Honest constant 0 -- q27 never preempts (FIFO admission) |
| `q27_uptime_seconds` | gauge | Server uptime |

One observation per generation request at the `[req]` point (`GenStats`
final there; `end=error` included), so `/metrics` counts match the `[req]`
log line-for-line. Latency definitions: **TTFT = `pf_ms`** (the prefill
wall), **E2E = arrival -> generation complete** (stamped at `[req]`, not
last byte), **ITL = `dec_ms / dec`** per request (observed only when
`dec > 0`).

## Live vs completion counters

The per-api totals stamp at request completion, which is a step function:
during a 2000-token decode every poll reads the same value, then +2000 at
the end. The `q27_*_tokens_processed_total` series exist for dashboards --
the engine bumps them at the single delivery point (`post_round` per
delivered token, `generate_prefill`'s success exit for prefill), so a poller
sees progress *during* generation:

Measured: a poller watching a 2048-token generation reads 79-115 t/s live
where the completion-based counter showed 0 then +2048. At rest the live
counters equal the sum of the labeled totals.

<img width="3024" height="1544" alt="sparkDash-—-Multi-DGX-Spark-Monitoring-Dashboard" src="https://github.com/user-attachments/assets/2b4bdfbe-c584-4244-b497-40c9a254ca5b" />

## MTP accept telemetry on both decode modes

`gate_lane_fired/acc` -> `q27_spec_accept_ratio` were greedy-only: the
sampled path (`spec_sample_round`, and the conductor's fused
`commit_outcome(sampled=true)`) deliberately updated nothing, so a
sampled-only serving profile (`--temp 1.0`, the measured recipe) read a
constant 0 despite speculating ~2.3 tokens/round. Both sampled paths now
mirror the greedy lane accounting, monitoring-only -- no depth-controller or
EMA feed (the sampled ceiling is fixed at 4; adaptive depth is greedy-only).
Sampled traffic measures 0.42-0.74 by request mix; 0 with traffic flowing
means the gate never fired.

`q27_preemptions_total` is an honest constant 0: admission is a FIFO queue
(a request that finds no free slot waits -- visible in
`q27_queue_wait_seconds_total`), a running request is never evicted.
Non-zero would mean a code path regressed into preemption; 0 is the healthy
steady state.

<img width="3090" height="3392" alt="sparkDash-—-Multi-DGX-Spark-Monitoring-Q27" src="https://github.com/user-attachments/assets/d7bcba50-f383-492c-8c84-22ba567ee1cc" />

## Consistency and precision details

- **No torn scrapes.** `observe()` bumps separate atomics and a request can
  complete mid-render; without protection a scrape could show
  `+Inf != _count` and consumers drop the quantiles. Histograms are
  seqlocked (writer CAS-es into an odd seq -- three relaxed atomics; reader
  retries on a torn read), so the `+Inf == _count` invariant holds under
  traffic: 115/115 invariant-clean scrapes across three stress rounds.
- **Bucket tails sized for real work.** A 60k-token prefill takes ~25 s;
  TTFT edges now reach 60 s, E2E 300 s, ITL 100 ms, so p95 stays in finite
  buckets instead of the `+Inf` tail consumers report as "no data".
- **`%.6f` for scaled outputs.** Six significant digits round away
  microsecond deltas once totals grow, corrupting `rate()` on long-running
  servers.
- **Naming: `q27_*` only, no `vllm:`/`ds4_` compatibility aliases.** The
  semantics are q27's own (computed/cached prefill split, gate-lane MTP
  accounting, FIFO no-preemption) and versioned by this engine; borrowing
  another project's metric prefixes to reuse its dashboards couples this
  wire format to names it does not own.
- The MTP lane counters are plain per-engine longs (approximate-atomic
  reads, monotonic) -- documented and accepted for monitoring; everything
  else is atomic, gauges snapshot under `route_m`.

## Also in this branch

- `/v1/models` reports `max_model_len` (max slot ctx), the standard
  OpenAI-compatible context-length field.
- The Makefile server rules now depend on `src/metrics.h` (header-only edits
  previously produced stale binaries).

## Verification

- `make all` green (CLI, server, w8/w16 variants, test suites).
- Flag on/off verified on the live server: default off -> `/health` 200,
  `/metrics` 404; with the flag -> `/metrics` 200, invariant check 12
  series / 0 violations, generation unaffected (141-158 t/s, 2.3-2.9
  tokens/round).
- Percentiles finite on real traffic including two 24 s 60k-prompt prefills
  (TTFT p95 39.75 s interpolated in the 30-60 s bucket).

## Docs

- `docs/metrics-endpoint.md` -- the reference (posture, series table,
  observation semantics, consumer recipes).
- README (Serving), `docs/SECURITY.md` (Serving posture),
  `docs/SECURITY-MODEL.md` (Addendum 2026-08-30: the /metrics surface),
  `docs/BUILDLOG.md` (2026-08-30 (a)), `docs/BENCHMARKING.md` (the
  delta-accounting note).
**- As a downstream user I've already wired this endpoint into a sparkDash (https://github.com/MiaAI-Lab/sparkDash) q27 adapter — and if it lands, I plan to send MiaAI a PR for it too.**