### PR TITLE
Fix CUDA sampler filter order and speed up small top-k sampling

### DIFF
--- a/docs/perf-sampler-2026-09-10.md
+++ b/docs/perf-sampler-2026-09-10.md
@@ -1,0 +1,66 @@
+# CUDA sampler filter order and small-top-k optimization
+
+The CUDA sampler now applies top-k, top-p, then min-p to temperature-scaled
+weights. Previously min-p reduced the denominator used by top-p, which could
+remove an additional boundary token. This is enabled in the default sampler
+path; no environment variable or launch flag is required.
+
+For example, with weights `[1, .1, .055, .04]`, k=4, p=.95, and min-p=.05,
+top-p needs the first three tokens. Applying min-p before top-p incorrectly
+leaves only two. The regression checks both the surviving support and its
+renormalized probabilities.
+
+## Implementation
+
+- Stop the top-k bisection as soon as the retained support has exactly k tokens.
+- For k<=32, compact the survivors into shared memory and sort their values.
+  Compute top-p on that small support, then apply min-p.
+- Use the existing general bisection path for larger supports or compact-buffer
+  overflow from ties.
+- Continue exporting the full-softmax log normalizer and the final retained
+  mass, so speculative rejection uses probabilities for the actual served law.
+
+The single-lane and multi-lane entry points share the implementation. There
+are no new allocations, sampler parameters, or graph-capture requirements.
+Top-k retains the existing logit-threshold representation: exact ties across
+its boundary cannot be split by token ID. This change does not redefine that
+separate limitation. Temperature-last filtering is equivalent at the serving
+T=1; equivalence at other temperatures is not claimed.
+
+## Measurements
+
+The original RTX 5090 experiment compared the optimized kernel with a
+reference that already had the filter-order correction:
+
+| Measurement | Corrected reference | Optimized |
+|---|---:|---:|
+| Eight-lane nucleus, CUDA-event median | 0.7036 ms | 0.2335 ms |
+| Mean decode round, 15-request replay | 18.040 ms | 17.589 ms |
+
+Fresh-server/cache replay in reference/optimized/optimized/reference order
+produced identical hashes for all 15 requests, with 5067 output tokens and
+1214 rounds in each run. Combined decode time fell 2.50%. This is a decode
+improvement; total agent wall time also includes prefill and tool execution.
+Both corrected and optimized kernels matched the intended support on all
+36 saved production logit rows.
+
+## Integration validation
+
+This sampler-only port is based on master `bd81f73`, including incremental KV
+entitlements. It carries the sampler changes and their tests from the earlier
+performance branch, without changing proposal-temperature or head selection.
+
+- Standard `make -j2 build/test_sampling build/test_kernels build/q27-server`
+  succeeds for the default sm_86, sm_89, and sm_120 targets.
+- CPU sampling tests pass.
+- `build/test_kernels --sampling-only` passes on RTX 3090 and RTX 5090. This
+  includes filter-order support/probability checks, a ragged 248321-token
+  vocabulary, k=20/32/64, single/multi-lane identity, and speculative rejection.
+- The integrated server reproduces all 15 output hashes from the original
+  optimized sampler replay, with the same 5067 tokens and 1214 rounds.
+  Production was restored after this isolated integration check.
+
+Experiment logs and replay recordings are retained under
+`build/perf-sampler-20260909/` in the original q27 checkout. The earlier
+performance measurements are documented on `codex/perf-sampler-20260909` in
+`docs/perf-implementation-2026-09-09.md`.

--- a/docs/perf-sampler-2026-09-10.md
+++ b/docs/perf-sampler-2026-09-10.md
@@ -46,9 +46,11 @@ Both corrected and optimized kernels matched the intended support on all
 
 ## Integration validation
 
-This sampler-only port is based on master `bd81f73`, including incremental KV
-entitlements. It carries the sampler changes and their tests from the earlier
-performance branch, without changing proposal-temperature or head selection.
+This sampler-only port targets published master `86a822c`. It carries the
+sampler changes and their tests from the earlier performance branch, without
+changing proposal-temperature or head selection. The integration checks below
+were run on local master `bd81f73`, including incremental KV entitlements;
+that separate, unpublished KV change is not part of this sampler port.
 
 - Standard `make -j2 build/test_sampling build/test_kernels build/q27-server`
   succeeds for the default sm_86, sm_89, and sm_120 targets.

--- a/src/blocks.cu
+++ b/src/blocks.cu
@@ -533,12 +533,12 @@ void argmax_masked(const float* x, int n, const unsigned* pool, int words, const
 // Philox4x32-10 lives in blocks.cuh (philox_uniform / am_mulhi) since the
 // DFlash2 drafter's sampled selector walk draws from the same generator.
 
-// Single block: max M, logsumexp logZ at inv_temp, and the top-p logit
-// threshold via a fixed 12-iteration bisection on a prob cutoff (no sort, no
-// atomics -> deterministic, and graph-capturable at fixed geometry). Reads
-// inv_temp/top_p from the device param block (graph-fixed pointer). Writes
-// out[0]=logit_thresh, out[1]=M, out[2]=logZ. thresh clamped <= M so the argmax
-// token is always in the nucleus (guards degenerate/tiny top_p).
+// Single block: max M, logsumexp logZ at inv_temp, and the served logit
+// threshold. Small top-k supports use a compact sort; the general path uses
+// logit bisection. Both are deterministic and graph-capturable at fixed
+// geometry. Reads the device param block (graph-fixed pointer). Writes
+// out[0]=threshold, out[1]=M, out[2]=logZ, out[3]=retained full-softmax mass.
+// Threshold is clamped <= M so the argmax always survives.
 // Body factored out so the single-lane and multi-lane entry points cannot drift:
 // one block computes one lane, exactly as before. Every reduction is within the
 // block and no state crosses blocks, so running L lanes as L BLOCKS is bitwise
@@ -587,14 +587,10 @@ __device__ __forceinline__ void nucleus_body(const float* __restrict__ x, int n,
     }
     __syncthreads();
     const float logZ = s_logZ;
-    // --- top_k, then min_p, then top_p: llama.cpp's order, as thresholds ----
-    // Each filter only REMOVES tokens, so a chain is an intersection of kept
-    // sets, and an intersection of "x_i >= thr" sets is "x_i >= max(thr)".
-    // top_k and min_p do not depend on which other tokens survive, so they
-    // compose by max() exactly. top_p DOES depend on the surviving mass, so it
-    // is bisected below over the set the first two already left -- computing
-    // it on the full vocab instead would keep too many tokens whenever top_k
-    // binds, which for k=20 on a peaked distribution is almost always.
+    // --- top_k, then top_p, then min_p, on temperature-scaled weights ----
+    // top_p's denominator is the mass left by top_k. Although min_p's logit
+    // threshold is independent of normalization, applying it before top_p
+    // shrinks that denominator and can drop an extra boundary token.
     // s_logZp is SEPARATE from s_logZ on purpose: out[2] exports the FULL-vocab
     // logZ and out[3]'s mass is sum_{kept} softmax_full(i), which the Phase-2
     // accept test divides by. Overwriting s_logZ here would make mass ~1 and
@@ -602,16 +598,9 @@ __device__ __forceinline__ void nucleus_body(const float* __restrict__ x, int n,
     __shared__ float s_pre, s_logZp;
     if (t == 0) { s_pre = -FLT_MAX; s_logZp = s_logZ; }
     __syncthreads();
-    // min_p: p_i/p_max >= min_p  <=>  inv_temp*(x_i - M) >= log(min_p).
-    // Scale-invariant under renormalisation, so its threshold is the same
-    // whether it runs before or after any other filter -- closed form, no
-    // bisection.
-    if (t == 0 && min_p > 0.f && min_p <= 1.0f && inv_temp > 0.f)
-        s_pre = fmaxf(s_pre, M + __logf(min_p) / inv_temp);
-    __syncthreads();
-    // top_k: bisect for the k-th largest LOGIT (same window and iteration
-    // count as the top_p bisection below, counting instead of summing). The
-    // count is monotone decreasing in thr, so the invariant matches.
+    // top_k: bisect the transition from >k to <=k retained logits. This
+    // existing threshold representation cannot split exact boundary ties
+    // by token ID (unlike an explicit top-k candidate list).
     if (top_k > 0 && top_k < n) {
         if (t == 0) { s_lo = M - 40.0f * fmaxf(1.0f, 1.0f / inv_temp); s_hi = M; }
         __syncthreads();
@@ -624,17 +613,64 @@ __device__ __forceinline__ void nucleus_body(const float* __restrict__ x, int n,
                 if (t < s) sh[t] += sh[t + s];
                 __syncthreads();
             }
-            // keep the largest thr whose count still covers k
+            // Retain the upper endpoint whose count is at most k.
             if (t == 0) { if (sh[0] > (float)top_k) s_lo = thr; else s_hi = thr; }
             __syncthreads();
+            // Once the support has exactly k members, further bisection
+            // cannot change it. The shared count makes this branch uniform.
+            if (sh[0] == (float)top_k) break;
         }
         if (t == 0) s_pre = fmaxf(s_pre, s_hi); // s_hi keeps <= k tokens
         __syncthreads();
     }
     const float pre = s_pre;
+    // Serving uses k=20: select top_p from that small support instead of
+    // rereading the entire vocabulary sixteen times. Compaction order is
+    // irrelevant after the deterministic value sort. Tied top-k boundaries
+    // may retain more than k tokens; overflow takes the general path below.
+    __shared__ float candidates[32];
+    __shared__ int candidate_count;
+    bool compact = false;
+    if (top_k > 0 && top_k <= 32 && top_p < 1.f) {
+        if (t == 0) candidate_count = 0;
+        __syncthreads();
+        for (int i = t; i < n; i += B) {
+            if (x[i] >= pre) {
+                const int slot = atomicAdd(&candidate_count, 1);
+                if (slot < 32) candidates[slot] = x[i];
+            }
+        }
+        __syncthreads();
+        compact = candidate_count > 0 && candidate_count <= 32;
+        if (compact && t == 0) {
+            const int count = candidate_count;
+            for (int i = 1; i < count; i++) {
+                const float value = candidates[i];
+                int j = i;
+                while (j > 0 && candidates[j - 1] < value) {
+                    candidates[j] = candidates[j - 1];
+                    --j;
+                }
+                candidates[j] = value;
+            }
+            float weights[32], total = 0.f;
+            for (int i = 0; i < count; i++) {
+                weights[i] = expf(inv_temp * (candidates[i] - M));
+                total += weights[i];
+            }
+            const float target = top_p * total;
+            float cumulative = 0.f;
+            int last = 0;
+            do { cumulative += weights[last++]; }
+            while (last < count && cumulative < target);
+            // Every token tied at the boundary survives the logit threshold.
+            s_thresh = candidates[last - 1];
+        }
+        __syncthreads();
+    }
     // Renormalise the remaining mass so top_p's cumulative is taken over the
-    // set that survived top_k/min_p, exactly as llama.cpp does.
-    if (top_p < 1.0f && pre > -FLT_MAX) {
+    // set that survived top_k; min_p is applied only after top_p.
+    if (!compact && top_p < 1.0f && pre > -FLT_MAX) {
         float se2 = 0.f;
         for (int i = t; i < n; i += B)
             if (x[i] >= pre) se2 += expf(inv_temp * (x[i] - M));
@@ -647,7 +683,7 @@ __device__ __forceinline__ void nucleus_body(const float* __restrict__ x, int n,
         __syncthreads();
     }
     const float logZp = s_logZp;
-    if (top_p < 1.0f) {
+    if (!compact && top_p < 1.0f) {
         if (t == 0) { s_lo = M - 40.0f * fmaxf(1.0f, 1.0f / inv_temp); s_hi = M; }
         __syncthreads();
         for (int it = 0; it < 16; it++) {
@@ -666,14 +702,17 @@ __device__ __forceinline__ void nucleus_body(const float* __restrict__ x, int n,
         }
     }
     if (t == 0) {
-        float thresh = (top_p >= 1.0f) ? -FLT_MAX : s_lo; // s_lo is now the logit threshold
-        thresh = fmaxf(thresh, pre);  // intersect with top_k/min_p
+        float thresh = (top_p >= 1.0f) ? -FLT_MAX : (compact ? s_thresh : s_lo);
+        thresh = fmaxf(thresh, pre);
+        // min_p: p_i/p_max >= min_p <=> x_i >= M + log(min_p)/inv_temp.
+        if (min_p > 0.f && min_p <= 1.0f && inv_temp > 0.f)
+            thresh = fmaxf(thresh, M + __logf(min_p) / inv_temp);
         s_thresh = fminf(thresh, M);  // argmax token always in nucleus
     }
     __syncthreads();
     // out[3] = nucleus mass = sum_{x_i >= thresh} softmax_full(i) (Phase 2 accept
     // test needs the RENORMALIZED served prob p(dr)=softmax_full(dr)/mass, not
-    // softmax_full(dr); mass==1 when top_p>=1 so the plain path is unaffected).
+    // softmax_full(dr); mass==1 only when no filter removes any mass).
     // One extra grid-stride pass over the just-fixed threshold (argmax cost class).
     const float thr = s_thresh;
     float ms = 0.f;

--- a/src/blocks.cuh
+++ b/src/blocks.cuh
@@ -118,11 +118,10 @@ struct SampleParams {
     float inv_temp; // 1/T (>0)
     float top_p;    // (0,1]; >=1 => full vocab
     unsigned long long seed;
-    // 2026-08-23: llama-server's chain for Qwen3.8 is top_k 20 -> top_p 0.95
-    // -> min_p 0.05 -> temperature, and q27 had only top_p, so a "matched
-    // sampler" comparison was never actually matched. Both are expressed as
-    // logit thresholds by nucleus_body and composed in the SAME order llama
-    // applies them, so the kept set is identical rather than merely similar.
+    // Filters run top_k -> top_p -> min_p on temperature-scaled weights.
+    // top_p is normalized over top_k's support BEFORE min_p is applied.
+    // At the Qwen3.8 serving temperature T=1 this also matches the filter
+    // order of llama-server's temperature-last chain.
     // Defaults are off, and the members carry NSDMIs so existing three-field
     // brace-init sites keep compiling.
     int top_k = 0;     // <=0 or >=vocab => off

--- a/src/test_kernels.cu
+++ b/src/test_kernels.cu
@@ -2524,9 +2524,9 @@ static void test_wy_stream_isolation() {
 
 // top_k/min_p added 2026-08-23. Both are gated against the CPU reference:
 // top_k is native to q27::SamplingParams, and min_p is applied to the host's
-// kept set by its defining property (p_i >= min_p * p_max), which is
-// scale-invariant and therefore independent of where in the chain it runs --
-// the reason the kernel can compose all three as max() of logit thresholds.
+// kept set AFTER top_p, by its defining property (p_i >= min_p * p_max).
+// The min_p threshold is scale-invariant, but applying it before top_p
+// changes top_p's denominator and can remove an extra boundary token.
 // NOTE the kernel filters on the TEMPERATURE-SCALED distribution while
 // llama.cpp filters raw logits and applies temperature last; the two coincide
 // exactly at T=1.0, which is the Qwen3.8 card value and the config we serve.
@@ -2565,6 +2565,14 @@ static void check_nucleus_contract(const char* name, const std::vector<float>& l
             if (logits[token] < floor_logit) host_kept[token] = 0;
     }
 
+    double host_mass = 0.0;
+    for (size_t i = 0; i < host.tokens.size(); i++)
+        if (host_kept[host.tokens[i]]) host_mass += host.weights[i];
+    std::vector<double> host_probability(logits.size(), 0.0);
+    for (size_t i = 0; i < host.tokens.size(); i++)
+        if (host_kept[host.tokens[i]])
+            host_probability[host.tokens[i]] = host.weights[i] / host_mass;
+
     int support_mismatches = 0;
     double max_probability_error = 0.0;
     for (uint32_t token = 0; token < logits.size(); token++) {
@@ -2576,10 +2584,9 @@ static void check_nucleus_contract(const char* name, const std::vector<float>& l
                            nucleus[2]) /
                       nucleus[3]
                 : 0.0;
-        if (min_p <= 0.0f) // served_probability has no min_p notion to compare against
-            max_probability_error =
-                std::max(max_probability_error,
-                         std::fabs(device_probability - q27::served_probability(host, token)));
+        max_probability_error =
+            std::max(max_probability_error,
+                     std::fabs(device_probability - host_probability[token]));
     }
 
     char label[128];
@@ -2587,6 +2594,22 @@ static void check_nucleus_contract(const char* name, const std::vector<float>& l
     check(label, (double)support_mismatches, 0.5);
     std::snprintf(label, sizeof label, "%s probabilities", name);
     check(label, max_probability_error, 2e-5);
+
+    // The captured verify path uses the multi-lane entry point. It must
+    // share the single-lane distribution and remain deterministic despite
+    // the small-support path's atomic compaction.
+    float* d_multi;
+    CUDA_CHECK(cudaMalloc(&d_multi, 8 * 4 * sizeof(float)));
+    q27k::CP3 lanes{};
+    for (int i = 0; i < 8; i++) lanes.p[i] = d_logits;
+    q27k::nucleus_multi(lanes, (int)logits.size(), d_params, d_multi, 8);
+    float multi[8][4];
+    CUDA_CHECK(cudaMemcpy(multi, d_multi, sizeof multi, cudaMemcpyDeviceToHost));
+    int unequal = 0;
+    for (int i = 0; i < 8; i++) unequal += memcmp(multi[i], nucleus, sizeof nucleus) != 0;
+    std::snprintf(label, sizeof label, "%s multi-lane identity", name);
+    check(label, (double)unequal, 0.5);
+    CUDA_CHECK(cudaFree(d_multi));
 
     CUDA_CHECK(cudaFree(d_logits));
     CUDA_CHECK(cudaFree(d_nucleus));
@@ -2618,6 +2641,17 @@ static void test_sample() {
     check_nucleus_contract("sample host/CUDA qwen38 chain", x, 1.0f, 0.95f, 20, 0.05f);
     check_nucleus_contract("sample host/CUDA k>vocab is off", x, 1.0f, 0.95f, 100000, 0.0f);
     check_nucleus_contract("sample host/CUDA chain on ties", tied, 1.0f, 0.95f, 20, 0.05f);
+    // After top_k the weights are 1, .1, .055, .04. top_p=.95 needs the
+    // first three; pre-applying min_p=.05 incorrectly leaves only two.
+    std::vector<float> order_case = {0.f, std::log(.1f), std::log(.055f),
+                                    std::log(.04f), -20.f};
+    check_nucleus_contract("sample top_p before min_p", order_case, 1.f, .95f, 4, .05f);
+    check_nucleus_contract("sample top_p before min_p no k", order_case, 1.f, .95f, 0, .05f);
+    std::vector<float> large = rand_vec(248321, 20260909);
+    for (auto& value : large) value *= 2.5f;
+    check_nucleus_contract("sample large ragged k=20", large, 1.f, .95f, 20, .05f);
+    check_nucleus_contract("sample large ragged k=32 hot", large, 2.f, .8f, 32, .1f);
+    check_nucleus_contract("sample large ragged k=64 fallback", large, .7f, .95f, 64, .05f);
     // CPU argmax + full-softmax probs at a given inv_temp
     auto cpu_argmax = [&]() {
         int bi = 0; for (int i = 1; i < n; i++) if (x[i] > x[bi]) bi = i; return bi;


### PR DESCRIPTION
Fix CUDA sampling so top-p uses the mass retained by top-k before min-p is applied. Previously, min-p could shrink top-p's denominator and drop an extra boundary token. For weights `[1, .1, .055, .04]` with k=4, p=.95 and min-p=.05, the old chain retained two tokens instead of three.

Stop top-k bisection once exactly k tokens survive, and compute top-p from a compact sorted support for k<=32. Larger supports retain the general path. Full-softmax normalization and final retained mass remain consistent with speculative rejection. Existing top-k boundary-tie semantics remain unchanged.

On the RTX 5090, the eight-lane nucleus benchmark falls from 0.7036 ms to 0.2335 ms versus a reference with the filter-order fix already applied. A bracketed 15-request replay reduces combined decode time 2.50%, with identical output hashes, token counts and round counts. This is a decode measurement, not an end-to-end agent wall-time claim.

Validation:

- Standard server and test builds succeed for sm_86, sm_89 and sm_120.
- CPU sampling tests pass; `test_kernels --sampling-only` passes on RTX 3090 and RTX 5090.
- Regression coverage checks support and normalized probabilities, min-p ordering, ragged vocabulary size, k=20/32/64, single/multi-lane identity and speculative rejection.
- Server integration on local master `bd81f73` reproduces all 15 optimized-reference output hashes, with 5067 tokens and 1214 rounds. The PR targets published master `86a822c`; its sampler and test changes are identical to that validated port. The separate KV-admission commit is excluded.

Details and measurement limits are in `docs/perf-sampler-2026-09-10.md`.
